### PR TITLE
DOCS-593: Add `Variables` component

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,6 +14,21 @@ const config = {
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.png',
 
+  customFields: {
+    // TODO: Migrate all variables
+    variables: {
+      cloud: {
+        prodname: 'Calico Cloud',
+      },
+      enterprise: {
+        prodname: 'Calico Enterprise',
+      },
+      openSource: {
+        prodname: 'Calico Open Source',
+      },
+    },
+  },
+
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   // organizationName: 'tigera', // Usually your GitHub org/username.

--- a/src/components/Variables/index.js
+++ b/src/components/Variables/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+export default function Variables({var: variable}) {
+    const {siteConfig: {customFields: {variables}}} = useDocusaurusContext();
+
+    if (!variables || !variable) {
+        return null;
+    }
+
+    const variableValue = objProp(variables, variable);
+
+    if (!variableValue) {
+        return null;
+    }
+
+    return variableValue;
+}
+
+function objProp(obj, prop) {
+    return prop.split('.').reduce((p, prop) => {
+        return p[prop];
+    }, obj);
+}

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import MDXComponents from '@theme-original/MDXComponents';
+
+import Variables from '@site/src/components/Variables';
+
+export default {
+  ...MDXComponents,
+
+  variables: Variables,
+};


### PR DESCRIPTION
https://tigera.atlassian.net/browse/DOCS-593

This PR introduces a shared `Variables` component that incapsulates the logic of variables handling. Component is registered globally (see https://docusaurus.io/docs/markdown-features/react#mdx-component-scope for details).

How to use it:

1. Add necessary variable to `docusaurus.config.js` (field `customFields.variables`).
2. Use the following syntax construction wherever you want in MDX-files:

```
<variables var='x.y.z' />
```
3. It will be "substituted" with the appropriate variable value.

Please note that for convenience `var` prop supports nested variables (separated by `.`).