### PR TITLE
DOCS-593: Add variables plugin / update `Variables` component

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,6 +4,8 @@
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
+const variablesPlugin = require('./src/remark/variablesPlugin');
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Calico & Tigera Docs',
@@ -13,21 +15,6 @@ const config = {
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.png',
-
-  customFields: {
-    // TODO: Migrate all variables
-    variables: {
-      cloud: {
-        prodname: 'Calico Cloud',
-      },
-      enterprise: {
-        prodname: 'Calico Enterprise',
-      },
-      openSource: {
-        prodname: 'Calico Open Source',
-      },
-    },
-  },
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
@@ -53,6 +40,9 @@ const config = {
           // Remove this to remove the "edit this page" links.
           editUrl:
             'https://github.com/tigera/docs/',
+          beforeDefaultRemarkPlugins: [
+            variablesPlugin,
+          ],
         },
         blog: false,
         // {

--- a/src/components/Variables/index.js
+++ b/src/components/Variables/index.js
@@ -1,24 +1,34 @@
 import React from 'react';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {useLocation} from '@docusaurus/router';
+import variables from '@site/variables';
+import objProp from '@site/src/utils/objProp';
+
+const urlPrefixes = {
+    cloud: '/calico-cloud/',
+    enterprise: '/calico-enterprise/',
+    openSource: '/calico/',
+};
 
 export default function Variables({var: variable}) {
-    const {siteConfig: {customFields: {variables}}} = useDocusaurusContext();
+    const {pathname} = useLocation();
 
-    if (!variables || !variable) {
+    const productVariables = pathname.includes(urlPrefixes.cloud)
+        ? variables.cloud
+        : pathname.includes(urlPrefixes.enterprise)
+            ? variables.enterprise
+            : pathname.includes(urlPrefixes.openSource)
+                ? variables.openSource
+                : null;
+
+    if (!productVariables || !variable) {
         return null;
     }
 
-    const variableValue = objProp(variables, variable);
+    const variableValue = objProp(productVariables, variable);
 
     if (!variableValue) {
         return null;
     }
 
     return variableValue;
-}
-
-function objProp(obj, prop) {
-    return prop.split('.').reduce((p, prop) => {
-        return p[prop];
-    }, obj);
 }

--- a/src/remark/variablesPlugin.js
+++ b/src/remark/variablesPlugin.js
@@ -21,9 +21,9 @@ function variablesPlugin(_options) {
 					? variables.openSource
 					: null;
 
-    if (!productVariables) {
-      return;
-    }
+		if (!productVariables) {
+			return;
+		}
 
 		visit(tree, 'text', (node) => {
 			node.value = node.value.replace(

--- a/src/remark/variablesPlugin.js
+++ b/src/remark/variablesPlugin.js
@@ -15,11 +15,11 @@ function variablesPlugin(_options) {
 		const posixFriendlyPath = convertToPosixFriendlyPath(file.path);
 		const productVariables = posixFriendlyPath.includes(pathPrefixes.cloud)
 			? variables.cloud
-      : posixFriendlyPath.includes(pathPrefixes.enterprise)
-        ? variables.enterprise
-          : posixFriendlyPath.includes(pathPrefixes.openSource)
-            ? variables.openSource
-            : null;
+			: posixFriendlyPath.includes(pathPrefixes.enterprise)
+				? variables.enterprise
+				: posixFriendlyPath.includes(pathPrefixes.openSource)
+					? variables.openSource
+					: null;
 
     if (!productVariables) {
       return;

--- a/src/remark/variablesPlugin.js
+++ b/src/remark/variablesPlugin.js
@@ -1,0 +1,43 @@
+const path = require('path');
+const visit = require('unist-util-visit');
+
+const variables = require(path.resolve('variables'));
+const objProp = require(path.resolve('src/utils/objProp'));
+
+const pathPrefixes = {
+  cloud: '/calico-cloud/',
+  enterprise: '/calico-enterprise/',
+  openSource: '/calico/',
+};
+
+function variablesPlugin(_options) {
+	async function transformer(tree, file) {
+		const posixFriendlyPath = convertToPosixFriendlyPath(file.path);
+		const productVariables = posixFriendlyPath.includes(pathPrefixes.cloud)
+			? variables.cloud
+      : posixFriendlyPath.includes(pathPrefixes.enterprise)
+        ? variables.enterprise
+          : posixFriendlyPath.includes(pathPrefixes.openSource)
+            ? variables.openSource
+            : null;
+
+    if (!productVariables) {
+      return;
+    }
+
+		visit(tree, 'text', (node) => {
+			node.value = node.value.replace(
+				/{{((.)*)}}/,
+				(_match, varName) => objProp(productVariables, varName),
+			);
+		});
+	}
+
+	return transformer;
+}
+
+function convertToPosixFriendlyPath(maybeWindowsPath) {
+	return maybeWindowsPath.split(path.sep).join(path.posix.sep);
+}
+
+module.exports = variablesPlugin;

--- a/src/utils/objProp.js
+++ b/src/utils/objProp.js
@@ -1,0 +1,16 @@
+/**
+ * Gets the value at `path` of `obj`.
+ * @param {object} obj - The object to query.
+ * @param {string} path - The path of the property to get.
+ */
+function objProp(obj, path) {
+	return path.split('.').reduce((p, prop) => {
+		if (!p) {
+			return;
+		}
+
+		return p[prop];
+	}, obj);
+}
+
+module.exports = objProp;

--- a/variables.js
+++ b/variables.js
@@ -1,0 +1,13 @@
+const variables = {
+	cloud: {
+		prodname: "Calico Cloud",
+	},
+	enterprise: {
+		prodname: "Calico Enterprise",
+	},
+	openSource: {
+		prodname: "Calico Open Source",
+	},
+};
+
+module.exports = variables;


### PR DESCRIPTION
https://tigera.atlassian.net/browse/DOCS-593

1. Add a shared `variables` file.
2. Add remark plugin for variables. Now we are able to use variables as follows:

```
<...>
{{prodname}}
<...>
```

The plugin automatically detects such variables and substitutes them with appropriate product variable values. So it means that variable substitution in this case works in a build-time. At the moment it has a few drawbacks:

- Looks like we cannot use it inside JSX, e.g:

```
<TabItem value='Product name'>
    This is {{prodname}}
</TabItem>
```

it will fail with a syntax/parse error.

- Looks like we cannot use it inside a code block, e.g:

```
```bash
{{prodname}}
``
```

it will be rendered as is (just `{{prodname}}`).

- ... maybe some other cases, but generally it works fine (admonitions, lists, headings, plain text, etc.)

Definitely, we should investigate that cases and try to find satisfying solutions.

3. According to said above, I've decided to not remove `Variables` component for now since it can be used inside JSX in MDX files:

```
<TabItem value='Product name'>
    This is <variables var='prodname' />
</TabItem>
```

Please note that now the component is able to distinguish product variables - the same as the plugin, but based on the page's URL so it means that it works in run-time which is not perfect. So ideally we should remove this component.