### PR TITLE
DOCS-633: Add `componentImagePlugin`

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,6 +5,7 @@ const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
 const variablesPlugin = require('./src/remark/variablesPlugin');
+const componentImagePlugin = require('./src/remark/componentImagePlugin');
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -35,7 +36,7 @@ const config = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl: 'https://github.com/tigera/docs/',
-          beforeDefaultRemarkPlugins: [variablesPlugin],
+          beforeDefaultRemarkPlugins: [variablesPlugin, componentImagePlugin],
         },
         blog: false,
         theme: {
@@ -51,7 +52,7 @@ const config = {
   ],
 
   themeConfig:
-  /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
+    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       navbar: {
         title: 'Calico & Tigera Docs',

--- a/src/components/partials/private-registry-regular.js
+++ b/src/components/partials/private-registry-regular.js
@@ -3,10 +3,10 @@ import React from 'react';
 import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 
-import variables from '@site/variables';
+import getProductVariablesByProdname from '../../utils/getProductVariablesByProdname';
 
 export default function PrivateRegistryRegular(props) {
-  const productVariables = Object.values(variables).find((variables) => variables.prodname === props.prodname);
+  const productVariables = getProductVariablesByProdname(props.prodname);
 
   if (!productVariables) {
     console.error(`Invalid "props.prodname": ${props.prodname}`);

--- a/src/components/utils/componentImage.js
+++ b/src/components/utils/componentImage.js
@@ -1,0 +1,18 @@
+const getProductVariablesByProdname = require('../../utils/getProductVariablesByProdname');
+
+function componentImage(comp, prodname) {
+  const productVariables = getProductVariablesByProdname(prodname);
+
+  if (!productVariables) {
+    console.error(`Invalid "prodname": ${prodname}`);
+
+    return;
+  }
+
+  const component = productVariables.components[comp];
+  const registry = component.registry ? `${component.registry}/` : '';
+
+  return `${registry}${component.image}:${component.version}`;
+}
+
+module.exports = componentImage;

--- a/src/remark/componentImagePlugin.js
+++ b/src/remark/componentImagePlugin.js
@@ -1,0 +1,47 @@
+const path = require('path');
+const visit = require('unist-util-visit');
+
+const variables = require(path.resolve('variables'));
+const componentImage = require(path.resolve('src/components/utils/componentImage'));
+const convertToPosixFriendlyPath = require(path.resolve('src/utils/convertToPosixFriendlyPath'));
+
+const COMPONENT_IMAGE_REGEX = new RegExp(/{%\s+component_image\(["']([\w-]+)["']\)\s+%}/, 'g');
+
+function componentImagePlugin(_options) {
+  async function transformer(tree, file) {
+    const posixFriendlyPath = convertToPosixFriendlyPath(file.path);
+    const prodname = detectProdnameByPath(posixFriendlyPath);
+
+    visit(tree, ['code', 'inlineCode'], (node) => {
+      node.value = node.value.replaceAll(COMPONENT_IMAGE_REGEX, (match, comp) => {
+        const image = componentImage(comp, prodname);
+
+        return image || match;
+      });
+    });
+  }
+
+  return transformer;
+}
+
+function detectProdnameByPath(path) {
+  const pathPrefixes = {
+    cloud: '/calico-cloud/',
+    enterprise: '/calico-enterprise/',
+    openSource: '/calico/',
+  };
+
+  if (path.includes(pathPrefixes.cloud)) {
+    return variables.cloud.prodname;
+  }
+
+  if (path.includes(pathPrefixes.enterprise)) {
+    return variables.enterprise.prodname;
+  }
+
+  if (path.includes(pathPrefixes.openSource)) {
+    return variables.openSource.prodname;
+  }
+}
+
+module.exports = componentImagePlugin;

--- a/src/remark/componentImagePlugin.js
+++ b/src/remark/componentImagePlugin.js
@@ -26,9 +26,9 @@ function componentImagePlugin(_options) {
 
 function detectProdnameByPath(path) {
   const pathPrefixes = {
-    cloud: '/calico-cloud/',
-    enterprise: '/calico-enterprise/',
-    openSource: '/calico/',
+    cloud: '/docs/calico-cloud/',
+    enterprise: '/docs/calico-enterprise/',
+    openSource: '/docs/calico/',
   };
 
   if (path.includes(pathPrefixes.cloud)) {

--- a/src/remark/variablesPlugin.js
+++ b/src/remark/variablesPlugin.js
@@ -1,9 +1,11 @@
-const path = require("path");
-const visit = require("unist-util-visit");
+const path = require('path');
+const visit = require('unist-util-visit');
 
-const variables = require(path.resolve("variables"));
-const objProp = require(path.resolve("src/utils/objProp"));
-const varRegex = RegExp(/\{\{[ \t]*([\w.]+)[ \t]*}}/, "g");
+const variables = require(path.resolve('variables'));
+const objProp = require(path.resolve('src/utils/objProp'));
+const convertToPosixFriendlyPath = require(path.resolve('src/utils/convertToPosixFriendlyPath'));
+
+const varRegex = RegExp(/\{\{[ \t]*([\w.]+)[ \t]*}}/, 'g');
 
 // This is a remark plugin which runs before all the docusaurus plugins which
 // allows us to support variable substitution in all md/mdx files. We are
@@ -20,7 +22,7 @@ function variablesPlugin(_options) {
       (node) => {
         for (let prop in node) {
           if (!Object.prototype.hasOwnProperty.call(node, prop)) continue;
-          if (prop === "type" || typeof node[prop] !== "string") continue;
+          if (prop === 'type' || typeof node[prop] !== 'string') continue;
 
           node[prop] = node[prop].replaceAll(varRegex, (match, varName) => {
             let varValue;
@@ -47,12 +49,12 @@ function variablesPlugin(_options) {
 // variable substitution.
 function getContextVariables(file, variables) {
   let cvars = [];
-  const dpName = "docsPathPrefix";
+  const dpName = 'docsPathPrefix';
   const posixFriendlyPath = convertToPosixFriendlyPath(file.path);
 
   for (let p in variables) {
     if (!Object.prototype.hasOwnProperty.call(variables, p)) continue;
-    if (typeof variables[p] !== "object") continue;
+    if (typeof variables[p] !== 'object') continue;
     if (!Object.prototype.hasOwnProperty.call(variables[p], dpName)) continue;
     const docsPathPrefix = variables[p][dpName];
     if (!Array.isArray(docsPathPrefix)) {
@@ -66,10 +68,6 @@ function getContextVariables(file, variables) {
     }
   }
   return cvars;
-}
-
-function convertToPosixFriendlyPath(maybeWindowsPath) {
-  return maybeWindowsPath.split(path.sep).join(path.posix.sep);
 }
 
 module.exports = variablesPlugin;

--- a/src/utils/convertToPosixFriendlyPath.js
+++ b/src/utils/convertToPosixFriendlyPath.js
@@ -1,0 +1,7 @@
+const path = require('path');
+
+function convertToPosixFriendlyPath(maybeWindowsPath) {
+  return maybeWindowsPath.split(path.sep).join(path.posix.sep);
+}
+
+module.exports = convertToPosixFriendlyPath;

--- a/src/utils/getProductVariablesByProdname.js
+++ b/src/utils/getProductVariablesByProdname.js
@@ -1,0 +1,11 @@
+const variables = require('../../variables');
+
+function getProductVariablesByProdname(prodname) {
+  const productVariables = Object.values(variables)
+    .filter((variables) => !!variables.prodname)
+    .find((variables) => variables.prodname === prodname);
+
+  return productVariables;
+}
+
+module.exports = getProductVariablesByProdname;

--- a/variables.js
+++ b/variables.js
@@ -17,6 +17,237 @@ const variables = {
     nodecontainer: 'cnx-node',
     noderunning: 'calico-node',
     clouddownloadurl: 'https://installer.calicocloud.io/manifests/v3.14.1-1',
+    components: {
+      'cnx-manager': {
+        image: 'tigera/cnx-manager',
+        version: 'v3.14.1',
+      },
+      voltron: {
+        image: 'tigera/voltron',
+        version: 'v3.14.1',
+      },
+      guardian: {
+        image: 'tigera/guardian',
+        version: 'v3.14.1',
+      },
+      'cnx-apiserver': {
+        image: 'tigera/cnx-apiserver',
+        version: 'v3.14.1',
+      },
+      'cnx-queryserver': {
+        image: 'tigera/cnx-queryserver',
+        version: 'v3.14.1',
+      },
+      'cnx-kube-controllers': {
+        image: 'tigera/kube-controllers',
+        version: 'v3.14.1',
+      },
+      calicoq: {
+        image: 'tigera/calicoq',
+        version: 'v3.14.1',
+      },
+      typha: {
+        image: 'tigera/typha',
+        version: 'v3.14.1',
+      },
+      calicoctl: {
+        image: 'tigera/calicoctl',
+        version: 'v3.14.1',
+      },
+      'cnx-node': {
+        image: 'tigera/cnx-node',
+        version: 'v3.14.1',
+      },
+      dikastes: {
+        image: 'tigera/dikastes',
+        version: 'v3.14.1',
+      },
+      dex: {
+        image: 'tigera/dex',
+        version: 'v3.14.1',
+      },
+      fluentd: {
+        image: 'tigera/fluentd',
+        version: 'v3.14.1',
+      },
+      'fluentd-windows': {
+        image: 'tigera/fluentd-windows',
+        version: 'v3.14.1',
+      },
+      'es-proxy': {
+        image: 'tigera/es-proxy',
+        version: 'v3.14.1',
+      },
+      'eck-kibana': {
+        version: '7.16.2',
+      },
+      kibana: {
+        image: 'tigera/kibana',
+        version: 'v3.14.1',
+      },
+      'eck-elasticsearch': {
+        version: '7.16.2',
+      },
+      elasticsearch: {
+        image: 'tigera/elasticsearch',
+        version: 'v3.14.1',
+      },
+      'cloud-controllers': {
+        image: 'tigera/cloud-controllers',
+        version: 'v3.14.1',
+      },
+      'elastic-tsee-installer': {
+        image: 'tigera/intrusion-detection-job-installer',
+        version: 'v3.14.1',
+      },
+      'es-curator': {
+        image: 'tigera/es-curator',
+        version: 'v3.14.1',
+      },
+      'intrusion-detection-controller': {
+        image: 'tigera/intrusion-detection-controller',
+        version: 'v3.14.1',
+      },
+      'compliance-controller': {
+        image: 'tigera/compliance-controller',
+        version: 'v3.14.1',
+      },
+      'compliance-reporter': {
+        image: 'tigera/compliance-reporter',
+        version: 'v3.14.1',
+      },
+      'compliance-snapshotter': {
+        image: 'tigera/compliance-snapshotter',
+        version: 'v3.14.1',
+      },
+      'compliance-server': {
+        image: 'tigera/compliance-server',
+        version: 'v3.14.1',
+      },
+      'compliance-benchmarker': {
+        image: 'tigera/compliance-benchmarker',
+        version: 'v3.14.1',
+      },
+      'ingress-collector': {
+        image: 'tigera/ingress-collector',
+        version: 'v3.14.1',
+      },
+      'l7-collector': {
+        image: 'tigera/l7-collector',
+        version: 'v3.14.1',
+      },
+      'license-agent': {
+        image: 'tigera/license-agent',
+        version: 'v3.14.1',
+      },
+      'tigera-cni': {
+        image: 'tigera/cni',
+        version: 'v3.14.1',
+      },
+      'firewall-integration': {
+        image: 'tigera/firewall-integration',
+        version: 'v3.14.1',
+      },
+      'egress-gateway': {
+        image: 'tigera/egress-gateway',
+        version: 'v3.14.1',
+      },
+      honeypod: {
+        image: 'tigera/honeypod',
+        version: 'v3.14.1',
+      },
+      'honeypod-exp-service': {
+        image: 'tigera/honeypod-exp-service',
+        version: 'v3.14.1',
+      },
+      'honeypod-controller': {
+        image: 'tigera/honeypod-controller',
+        version: 'v3.14.1',
+      },
+      'key-cert-provisioner': {
+        image: 'tigera/key-cert-provisioner',
+        version: 'v1.1.3',
+        registry: 'quay.io',
+      },
+      anomaly_detection_jobs: {
+        image: 'tigera/anomaly_detection_jobs',
+        version: 'v3.14.1',
+      },
+      'anomaly-detection-api': {
+        image: 'tigera/anomaly-detection-api',
+        version: 'v3.14.1',
+      },
+      'elasticsearch-metrics': {
+        image: 'tigera/elasticsearch-metrics',
+        version: 'v3.14.1',
+      },
+      'packetcapture-api': {
+        image: 'tigera/packetcapture-api',
+        version: 'v3.14.1',
+      },
+      prometheus: {
+        image: 'tigera/prometheus',
+        version: 'v3.14.1',
+      },
+      'coreos-prometheus': {
+        version: 'v2.32.0',
+      },
+      'prometheus-operator': {
+        image: 'tigera/prometheus-operator',
+        version: 'v3.14.1',
+      },
+      'prometheus-config-reloader': {
+        image: 'tigera/prometheus-config-reloader',
+        version: 'v3.14.1',
+      },
+      'tigera-prometheus-service': {
+        image: 'tigera/prometheus-service',
+        version: 'v3.14.1',
+      },
+      'es-gateway': {
+        image: 'tigera/es-gateway',
+        version: 'v3.14.1',
+      },
+      'deep-packet-inspection': {
+        image: 'tigera/deep-packet-inspection',
+        version: 'v3.14.1',
+      },
+      'eck-elasticsearch-operator': {
+        version: '1.8.0',
+      },
+      'elasticsearch-operator': {
+        image: 'tigera/eck-operator',
+        version: 'v3.14.1',
+      },
+      'coreos-alertmanager': {
+        version: 'v0.23.0',
+      },
+      alertmanager: {
+        image: 'tigera/alertmanager',
+        version: 'v3.14.1',
+      },
+      envoy: {
+        image: 'tigera/envoy',
+        version: 'v3.14.1',
+      },
+      'envoy-init': {
+        image: 'tigera/envoy-init',
+        version: 'v3.14.1',
+      },
+      windows: {
+        image: 'tigera/calico-windows',
+        version: 'v3.14.1',
+      },
+      'windows-upgrade': {
+        image: 'tigera/calico-windows-upgrade',
+        version: 'v3.14.1',
+      },
+      flexvol: {
+        image: 'calico/pod2daemon-flexvol',
+        version: 'v3.23.1',
+        registry: 'quay.io',
+      },
+    },
   },
   enterprise: {
     prodname: 'Calico Enterprise',


### PR DESCRIPTION
https://tigera.atlassian.net/browse/DOCS-633

It's implemented as a plugin (not a component) due to MDX limitations: `component_image` include is used only in code blocks (defined via ```) and it's not possible to render components in such syntax constructions. 

Anyway, it's still can be used in two differented cases:

1. Use inside code blocks:

```
{% component_image("some-component") %}
```

As you see, it's a Jekyll-like syntax.

2. Use inside components (if needed):

```
import componentImage from '@site/src/components/componentImage';`
...
<div>
  {componentImage("some-component")
</div>
```

