### PR TITLE
DOCS-818: Implement dynamic (runtime) TOC

### DIFF
--- a/src/theme/DocItem/TOC/Desktop/index.js
+++ b/src/theme/DocItem/TOC/Desktop/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import { useDoc } from '@docusaurus/theme-common/internal';
+import TOC from '@theme/TOC';
+import useToc from '@site/src/utils/useToc';
+
+export default function DocItemTOCDesktop() {
+  const {
+    frontMatter: { toc_min_heading_level, toc_max_heading_level },
+  } = useDoc();
+  const toc = useToc(toc_min_heading_level, toc_max_heading_level);
+
+  return (
+    <TOC
+      toc={toc}
+      minHeadingLevel={toc_min_heading_level}
+      maxHeadingLevel={toc_max_heading_level}
+      className={ThemeClassNames.docs.docTocDesktop}
+    />
+  );
+}

--- a/src/theme/DocItem/TOC/Mobile/index.js
+++ b/src/theme/DocItem/TOC/Mobile/index.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import clsx from 'clsx';
+
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import { useDoc } from '@docusaurus/theme-common/internal';
+import TOCCollapsible from '@theme/TOCCollapsible';
+import useToc from '@site/src/utils/useToc';
+
+import styles from './styles.module.css';
+
+export default function DocItemTOCMobile() {
+  const {
+    frontMatter: { toc_min_heading_level, toc_max_heading_level },
+  } = useDoc();
+  const toc = useToc(toc_min_heading_level, toc_max_heading_level);
+
+  return (
+    <TOCCollapsible
+      toc={toc}
+      minHeadingLevel={toc_min_heading_level}
+      maxHeadingLevel={toc_max_heading_level}
+      className={clsx(ThemeClassNames.docs.docTocMobile, styles.tocMobile)}
+    />
+  );
+}

--- a/src/theme/DocItem/TOC/Mobile/styles.module.css
+++ b/src/theme/DocItem/TOC/Mobile/styles.module.css
@@ -1,0 +1,12 @@
+@media (min-width: 997px) {
+  /* Prevent hydration FOUC, as the mobile TOC needs to be server-rendered */
+  .tocMobile {
+    display: none;
+  }
+}
+
+@media print {
+  .tocMobile {
+    display: none;
+  }
+}

--- a/src/utils/useToc.js
+++ b/src/utils/useToc.js
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react';
+
+const DOCUSAURUS_DEFAULT_MIN_HEADING_LEVEL = 2;
+const DOCUSAURUS_DEFAULT_MAX_HEADING_LEVEL = 3;
+
+/**
+ * Builds a CSS-selector based on heading extremum values that can appear in TOC.
+ */
+function buildHeadingsRange(minHeadingLevel, maxHeadingLevel) {
+  let headingsRange = '';
+
+  for (let i = minHeadingLevel; i <= maxHeadingLevel; i++) {
+    headingsRange += `h${i}`;
+
+    if (i !== maxHeadingLevel) {
+      headingsRange += ', ';
+    }
+  }
+
+  return headingsRange;
+}
+
+/**
+ * Parses current page, detects all headings (h1, h2, etc.)
+ * and generates Docusaurus-compatible TOC.
+ */
+function generateToc(minHeadingLevel, maxHeadingLevel) {
+  const headingsRange = buildHeadingsRange(minHeadingLevel, maxHeadingLevel);
+  const htmlHeadings = document.querySelectorAll(headingsRange);
+  const headings = Array.from(htmlHeadings);
+
+  const toc = headings.map((heading) => {
+    return {
+      id: heading.id,
+      value: heading.innerText,
+      level: Number(heading.nodeName.charAt(1)),
+    };
+  });
+
+  return toc;
+}
+
+/**
+ * Returns TOC of current page on page load.
+ */
+export default function useToc(
+  minHeadingLevel = DOCUSAURUS_DEFAULT_MIN_HEADING_LEVEL,
+  maxHeadingLevel = DOCUSAURUS_DEFAULT_MAX_HEADING_LEVEL
+) {
+  const [toc, setToc] = useState([]);
+
+  useEffect(() => {
+    setToc(generateToc(minHeadingLevel, maxHeadingLevel));
+  }, []);
+
+  return toc;
+}


### PR DESCRIPTION
https://tigera.atlassian.net/browse/DOCS-818

> **Caution**: Since this approach is based on swizzling which is potentially [could be risky](https://docusaurus.io/docs/swizzling#what-is-safe-to-swizzle) we need to revert these changes as soon as [Docusaurus TOC issue](https://github.com/facebook/docusaurus/issues/3915) will be resolved and published.

Solution is based on [swizzling](https://docusaurus.io/docs/swizzling) - the way to "override" the behavior of built-in Docusaurus' components.

Every doc page is based on `DocItem` component which is composed of several other components like `DocItemLayout`, `DcoItemFooter`, etc. In our case, we are interested in `DocItemTOCDesktop` and `DocItemTOCMobile` components that are responsible for displaying TOC for desktop and mobile devices respectively. You can explore the source code [here](https://github.com/facebook/docusaurus/tree/main/packages/docusaurus-theme-classic/src/theme/DocItem).

Under the hood, these components are rendering TOC composed in build-time by remark plugin - we want to override it. Current changes parses the page content, detects all necessary headings (based on config/front-matter) and generates correct TOC - it's implemented via `useToc` hook. Then we use this hook inside swizzled components.

On the screenshot below I've shown the generated TOC structure for one of the pages and highlighted TOC items that were missing before the changes (since they are come from imported partials). The second screenshot shows the rendered partial and you can see the TOC item for it.

![image](https://user-images.githubusercontent.com/56426143/193295247-17588fcd-4cef-408f-b846-6ff6632bf3be.png)
![image](https://user-images.githubusercontent.com/56426143/193295265-5ef8f090-f981-4e6a-98bf-24157737e348.png)
