### PR TITLE
[DOCS-689] Fix release notes

### DIFF
--- a/src/components/partials/release-notes-calico-enterprise.js
+++ b/src/components/partials/release-notes-calico-enterprise.js
@@ -4,19 +4,32 @@ import Link from '@docusaurus/Link';
 import Heading from '@theme/Heading';
 
 import { toKebab } from '../utils/formatters';
-import { componentUrl } from '../utils/componentUrl';
 import variables from '../../../variables';
 import Highlight from '../utils/Highlight';
 
 export default function ReleaseNotesCalicoEnterprise() {
   const { prodname, version, downloadsurl } = variables.enterprise;
 
-  const releases = variables.openSource.releases.map((release) => ({
-    ...release,
-    note:
-      release.note ||
-      require(`../../../docs/calico-enterprise/_includes/release-notes/${release.title}-release-notes.mdx`).default({}),
-  }));
+  const releases = variables.enterprise.releases.map((release) => {
+    let note = release.note;
+    try {
+      if (!note) {
+        note =
+          require(`../../../docs/calico-enterprise/_includes/release-notes/_${release.title}-release-notes.mdx`).default(
+            {}
+          );
+      }
+    } catch {
+      console.error(
+        `Cannot find "docs/calico-enterprise/_includes/release-notes/_${release.title}-release-notes.mdx" file`
+      );
+    }
+
+    return {
+      ...release,
+      note,
+    };
+  });
 
   return (
     <>
@@ -69,11 +82,7 @@ export default function ReleaseNotesCalicoEnterprise() {
               {Object.keys(release.components).map((componentName) => (
                 <tr key={componentName}>
                   <td>{componentName}</td>
-                  <td>
-                    <Link href={`/release-notes/${componentUrl(componentName, release, prodname)}`}>
-                      {release.components[componentName].version}
-                    </Link>
-                  </td>
+                  <td>{release.components[componentName].version}</td>
                 </tr>
               ))}
             </tbody>

--- a/src/components/partials/release-notes-calico.js
+++ b/src/components/partials/release-notes-calico.js
@@ -10,12 +10,21 @@ import variables from '../../../variables';
 export default function ReleaseNotesCalico() {
   const { prodname, version, imageNames } = variables.openSource;
 
-  const releases = variables.openSource.releases.map((release) => ({
-    ...release,
-    note:
-      release.note ||
-      require(`../../../docs/calico/_includes/release-notes/${release.title}-release-notes.mdx`).default({}),
-  }));
+  const releases = variables.openSource.releases.map((release) => {
+    let note = release.note;
+    try {
+      if (!note) {
+        note = require(`../../../docs/calico/_includes/release-notes/_${release.title}-release-notes.mdx`).default({});
+      }
+    } catch {
+      console.error(`Cannot find "docs/calico/_includes/release-notes/_${release.title}-release-notes.mdx" file`);
+    }
+
+    return {
+      ...release,
+      note,
+    };
+  });
 
   return (
     <>
@@ -60,7 +69,7 @@ export default function ReleaseNotesCalico() {
                   <tr key={componentName}>
                     <td>{componentName}</td>
                     <td>
-                      <Link href={`/release-notes/${componentUrl(componentName, release, prodname)}`}>
+                      <Link href={componentUrl(componentName, release, prodname)}>
                         {release.components[comp].version}
                       </Link>
                     </td>

--- a/src/releases/releases-calico-enterprise.json
+++ b/src/releases/releases-calico-enterprise.json
@@ -1,6 +1,6 @@
 [
   {
-    "title": "master",
+    "title": "v3.24.0",
     "helmRelease": 0,
     "note": "",
     "manifests_url": "",

--- a/src/releases/releases-calico.json
+++ b/src/releases/releases-calico.json
@@ -36,9 +36,6 @@
       "calico/windows": {
         "version": "master"
       },
-      "networking-calico": {
-        "version": "master"
-      },
       "flannel": {
         "version": "v0.16.3"
       },

--- a/variables.js
+++ b/variables.js
@@ -81,7 +81,6 @@ const variables = {
     vppbranch: 'master',
     imageNames: {
       'calico/node': 'calico/node',
-      calicoctl: 'calico/ctl',
       typha: 'calico/typha',
       'calico/cni': 'calico/cni',
       'calico/apiserver': 'calico/apiserver',


### PR DESCRIPTION
Release notes page tries to get the content of notes from corresponding files in `_includes/_{version}-release-note.mdx`. It should work on release branch, but since docusaurus.sh pulls `master` branch, versions.yaml(releases.json) may have versions with 'master' as a title and `_includes/_master-release-note.mdx` is missed.

I added `try catch` to stop breaking the execution if file doesn't exist + I updated `releases-calico-enterprise.json` and set the version as v3.24.0, because `_includes/_v3.24.0-release-note.mdx` exists