### PR TITLE
Added proxy config for CE 3.14, 3.13, 3.12

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -141,8 +141,92 @@ package = "@netlify/plugin-lighthouse"
   headers = {X-From = "Netlify"}
 
 [[redirects]]
-  from = "/calico-enterprise/3.12/*"
+  from = "/v3.12/*"
   to = "https://tigera-v3-12.netlify.app/v3.12/:splat"
+  status = 200
+  headers = {X-From = "Netlify"}
+
+[[redirects]]
+  from = "/v3.11/*"
+  to = "https://tigera-v3-11.netlify.app/v3.11/:splat"
+  status = 200
+  headers = {X-From = "Netlify"}
+
+[[redirects]]
+  from = "/v3.10/*"
+  to = "https://tigera-v3-10.netlify.app/v3.10/:splat"
+  status = 200
+  headers = {X-From = "Netlify"}
+
+[[redirects]]
+  from = "/v3.9/*"
+  to = "https://tigera-v3-9.netlify.app/v3.9/:splat"
+  status = 200
+  headers = {X-From = "Netlify"}
+
+[[redirects]]
+  from = "/v3.8/*"
+  to = "https://tigera-v3-8.netlify.app/v3.8/:splat"
+  status = 200
+  headers = {X-From = "Netlify"}
+
+[[redirects]]
+  from = "/v3.7/*"
+  to = "https://tigera-v3-7.netlify.app/v3.7/:splat"
+  status = 200
+  headers = {X-From = "Netlify"}
+
+[[redirects]]
+  from = "/v3.6/*"
+  to = "https://tigera-v3-6.netlify.app/v3.6/:splat"
+  status = 200
+  headers = {X-From = "Netlify"}
+
+[[redirects]]
+  from = "/v3.5/*"
+  to = "https://tigera-v3-5.netlify.app/v3.5/:splat"
+  status = 200
+  headers = {X-From = "Netlify"}
+
+[[redirects]]
+  from = "/v3.4/*"
+  to = "https://tigera-v3-4.netlify.app/v3.4/:splat"
+  status = 200
+  headers = {X-From = "Netlify"}
+
+[[redirects]]
+  from = "/v3.3/*"
+  to = "https://tigera-v3-3.netlify.app/v3.3/:splat"
+  status = 200
+  headers = {X-From = "Netlify"}
+
+[[redirects]]
+  from = "/v3.2/*"
+  to = "https://tigera-v3-2.netlify.app/v3.2/:splat"
+  status = 200
+  headers = {X-From = "Netlify"}
+
+[[redirects]]
+  from = "/v3.1/*"
+  to = "https://tigera-v3-1.netlify.app/v3.1/:splat"
+  status = 200
+  headers = {X-From = "Netlify"}
+
+[[redirects]]
+  from = "/v3.0/*"
+  to = "https://tigera-v3-0.netlify.app/v3.0/:splat"
+  status = 200
+  headers = {X-From = "Netlify"}
+
+[[redirects]]
+  from = "/v2.8/*"
+  to = "https://tigera-v2-8.netlify.app/v2.8/:splat"
+  status = 200
+  headers = {X-From = "Netlify"}
+
+[[redirects]]
+  from = "/v2.7/*"
+  to = "https://tigera-v2-7.netlify.app/v2.7/:splat"
   status = 200
   headers = {X-From = "Netlify"}
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -128,6 +128,24 @@ package = "@netlify/plugin-lighthouse"
 #to = "/index.html"
 #status = 200
 
+[[redirects]]
+  from = "/calico-enterprise/3.14/*"
+  to = "https://tigera-v3-14.netlify.app/v3.14/:splat"
+  status = 200
+  headers = {X-From = "Netlify"}
+
+[[redirects]]
+  from = "/calico-enterprise/3.13/*"
+  to = "https://tigera-v3-13.netlify.app/v3.13/:splat"
+  status = 200
+  headers = {X-From = "Netlify"}
+
+[[redirects]]
+  from = "/calico-enterprise/3.12/*"
+  to = "https://tigera-v3-12.netlify.app/v3.12/:splat"
+  status = 200
+  headers = {X-From = "Netlify"}
+
 [[headers]]
 # Define which paths this specific [[headers]] block will cover.
 for = "/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -129,13 +129,13 @@ package = "@netlify/plugin-lighthouse"
 #status = 200
 
 [[redirects]]
-  from = "/calico-enterprise/v3.14/*"
+  from = "/v3.14/*"
   to = "https://tigera-v3-14.netlify.app/v3.14/:splat"
   status = 200
   headers = {X-From = "Netlify"}
 
 [[redirects]]
-  from = "/calico-enterprise/3.13/*"
+  from = "/v3.13/*"
   to = "https://tigera-v3-13.netlify.app/v3.13/:splat"
   status = 200
   headers = {X-From = "Netlify"}

--- a/netlify.toml
+++ b/netlify.toml
@@ -128,6 +128,39 @@ package = "@netlify/plugin-lighthouse"
 #to = "/index.html"
 #status = 200
 
+# Redirects for old Calico Open Source docs
+
+# proxy redirects for website and manifests for v3.24
+[[redirects]]
+  from = "/archive/v3.24/*"
+  to = "https://calico-v3-24.netlify.app/archive/v3.24/:splat"
+  status = 200
+
+# proxy redirects for website and manifests for v3.23
+[[redirects]]
+  from = "/archive/v3.23/*"
+  to = "https://calico-v3-23.netlify.app/archive/v3.23/:splat"
+  status = 200
+
+# proxy redirects for website and manifests for v3.22
+[[redirects]]
+  from = "/archive/v3.22/*"
+  to = "https://calico-v3-22.netlify.app/archive/v3.22/:splat"
+  status = 200
+
+# proxy redirects for website and manifests for v3.21
+[[redirects]]
+  from = "/archive/v3.21/*"
+  to = "https://calico-v3-21.netlify.app/archive/v3.21/:splat"
+  status = 200
+
+# proxy redirects for website and manifests for v3.20
+[[redirects]]
+  from = "/archive/v3.20/*"
+  to = "https://calico-v3-20.netlify.app/archive/v3.20/:splat"
+  status = 200
+
+# Redirects for old Calico Enterprise docs
 [[redirects]]
   from = "/v3.14/*"
   to = "https://tigera-v3-14.netlify.app/v3.14/:splat"

--- a/netlify.toml
+++ b/netlify.toml
@@ -129,7 +129,7 @@ package = "@netlify/plugin-lighthouse"
 #status = 200
 
 [[redirects]]
-  from = "/calico-enterprise/3.14/*"
+  from = "/calico-enterprise/v3.14/*"
   to = "https://tigera-v3-14.netlify.app/v3.14/:splat"
   status = 200
   headers = {X-From = "Netlify"}

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,6 +1,13 @@
-# redirect old docs to latest at root.
-# note that you can still access these old docs at https://docs.projectcalico.org/archive/*
-/latest/* /:splat 301
+
+# OS redirects
+
+/archive/v3.24 /archive/v3.24/about/about-calico 301
+/archive/v3.23 /archive/v3.23/about/about-calico 301
+/archive/v3.22 /archive/v3.22/about/about-calico 301
+/archive/v3.21 /archive/v3.21/about/about-calico 301
+/archive/v3.20 /archive/v3.20/about/about-calico 301
+
+# CE redirects
 
 # forcing the /version since it results in going back to root or 404
 /v3.14 /v3.14/about/about-calico-enterprise/ 301

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,29 @@
+# redirect old docs to latest at root.
+# note that you can still access these old docs at https://docs.projectcalico.org/archive/*
+/latest/* /:splat 301
+
+# forcing the /version since it results in going back to root or 404
+/v3.14 /v3.14/about/about-calico-enterprise/ 301
+/v3.13 /v3.13/about/about-calico-enterprise/ 301
+/v3.12 /v3.12/about/about-calico-enterprise/ 301
+/v3.11 /v3.11/about/about-calico-enterprise/ 301
+/v3.10 /v3.10/about/about-calico-enterprise/ 301
+/v3.9 /v3.9/about/about-calico-enterprise/ 301
+/v3.8 /v3.8/about/about-calico-enterprise/ 301
+/v3.7 /v3.7/about/about-calico-enterprise/ 301
+/v3.6 /v3.6/about/about-calico-enterprise/ 301
+/v3.5 /v3.5/about/about-calico-enterprise/ 301
+/v3.4 /v3.4/about/about-calico-enterprise/ 301
+/v3.3 /v3.3/about/about-calico-enterprise/ 301
+/v3.2 /v3.2/introduction/ 301
+/v3.1 /v3.1/introduction/ 301
+/v3.0 /v3.0/introduction/ 301
+/v2.8 /v2.8/introduction/ 301
+/v2.7 /v2.7/introduction/ 301
+/v2.6 /v2.6/introduction/ 301
+/v2.5 /v2.5/introduction/ 301
+/v2.4 /v2.4/introduction/ 301
+/v2.3 /v2.3/introduction/ 301
+/v2.2 /v2.2/introduction/ 301
+/v2.1 /v2.1/introduction/ 301
+/master /master/about/about-calico-enterprise/ 301


### PR DESCRIPTION
This adds proxy configurations for CE 3.14, 3.13, and 3.12.

All of our old docs sites are to follow this model. `netlify.toml` will contain proxy definitions for every Jekyll site we want to continue serving in our docs portal. 