### PR TITLE
Fix versions dropdown

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -92,7 +92,6 @@ const config = {
           {
             type: 'docsVersionDropdown',
             position: 'right',
-            docsPluginId: 'calico',
           },
           {
             label: 'Tigera',

--- a/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import DocsVersionDropdownNavbarItem from '@theme-original/NavbarItem/DocsVersionDropdownNavbarItem';
+import { useProductId } from '../../utils/useProductId';
+
+export default function DocsVersionDropdownNavbarItemWrapper(props) {
+  const productId = useProductId();
+
+  if (!productId) {
+    return null;
+  }
+
+  return (
+    <>
+      <DocsVersionDropdownNavbarItem
+        {...props}
+        docsPluginId={productId}
+      />
+    </>
+  );
+}

--- a/src/utils/useProductId.js
+++ b/src/utils/useProductId.js
@@ -1,0 +1,13 @@
+const { useLocation } = require('@docusaurus/router');
+
+export function useProductId() {
+  const { pathname } = useLocation();
+
+  if (pathname.startsWith('/calico/')) {
+    return 'calico';
+  } else if (pathname.startsWith('/calico-cloud/')) {
+    return 'calico-cloud';
+  } else if (pathname.startsWith('/calico-enterprise/')) {
+    return 'calico-enterprise';
+  }
+}

--- a/src/utils/useSwitchToTab.js
+++ b/src/utils/useSwitchToTab.js
@@ -13,7 +13,7 @@ export function useSwitchToTab() {
     const [hash] = parseLocationHash(location);
 
     const header = document.getElementById(hash.slice(1));
-    const tabPanel = header.closest('[role=tabpanel]');
+    const tabPanel = header && header.closest('[role=tabpanel]');
 
     if (!tabPanel) {
       return;


### PR DESCRIPTION
I noticed that Docusaurus allows to have versions dropdown to only one of the multi-instances and the instance must be set in docusaurus config. So, e.g. if we set Calico, then regardless of the selected product, there're will be only Calico's versions in dropdown with links to Calico.
I wrapped DocsVersionDropdownNavbarItem to pass product id based on the users current location

'+ small refactoring