### PR TITLE
DOCS-1005: Add `releases.html`

### DIFF
--- a/static/releases.html
+++ b/static/releases.html
@@ -1,0 +1,29 @@
+<style>
+  #release-list {
+    padding-inline-start: 0;
+  }
+
+  .release-list-title {
+    list-style: none;
+  }
+</style>
+
+<ul id="release-list">
+  <li class="release-list-title">Calico Open Source</li>
+  <li><a href="/archive/v3.24/">Version 3.24</a></li>
+  <li><a href="/archive/v3.23/">Version 3.23</a></li>
+  <li><a href="/archive/v3.22/">Version 3.22</a></li>
+  <li><a href="/archive/v3.21/">Version 3.21</a></li>
+  <li><a href="/archive/v3.20/">Version 3.20</a></li>
+
+  <li class="release-list-title">Calico Enterprise</li>
+  <li><a href="/v3.14/">Version 3.14</a></li>
+  <li><a href="/v3.13/">Version 3.13</a></li>
+  <li><a href="/v3.12/">Version 3.12</a></li>
+  <li><a href="/v3.11/">Version 3.11</a></li>
+  <li><a href="/v3.10/">Version 3.10</a></li>
+  <li><a href="/v3.9/">Version 3.9</a></li>
+  <li><a href="/v3.8/">Version 3.8</a></li>
+  <li><a href="/v3.7/">Version 3.7</a></li>
+  <li><a href="/v3.6/">Version 3.6</a></li>
+</ul>


### PR DESCRIPTION
It will be used for internal `/releases` request in old proxy sites.

https://tigera.atlassian.net/browse/DOCS-1005

![image](https://user-images.githubusercontent.com/56426143/204835729-9d9e793b-d9af-4a3e-96d2-b58e3f5c2dfa.png)
