### PR TITLE
DOCS-1015: Adds documentation archive page

### DIFF
--- a/src/pages/archive.md
+++ b/src/pages/archive.md
@@ -1,0 +1,32 @@
+---
+title: Documentation archive
+description: Links to all versions of product documentation for Calico, Calico Enterprise, and Calico Cloud. 
+---
+
+<!-- 
+TODO
+* Add full catalog of past documentation
+* Add recurring task to update page as part of release sequence
+-->
+
+
+# Documentation archive
+
+## Calico Open Source
+
+* [Calico 3.24](https://unified-docs.tigera.io/calico/about)
+* [Calico 3.23](https://unified-docs.tigera.io/archive/v3.23)
+* [Calico 3.22](https://unified-docs.tigera.io/archive/v3.22)
+
+## Calico Enterprise
+
+* [Calico Enterprise 3.14](https://unified-docs.tigera.io/calico-enterprise/3.14/about/about-calico-enterprise)
+* [Calico Enterprise 3.13](https://unified-docs.tigera.io/v3.13)
+* [Calico Enterprise 3.12](https://unified-docs.tigera.io/v3.12)
+* [Calico Enterprise 3.11](https://unified-docs.tigera.io/v3.11)
+* [Calico Enterprise 3.10](https://unified-docs.tigera.io/v3.10)
+* [Calico Enterprise 3.9](https://unified-docs.tigera.io/v3.9)
+
+## Calico Cloud
+
+* [Calico Cloud](https://unified-docs.tigera.io/calico-cloud)


### PR DESCRIPTION
Fixes https://tigera.atlassian.net/browse/DOCS-1015

Adds a basic page with links to supported and historical doc sets.

This is to be the primary location for links to all our docs. We'll link to this page from the bottom of our version drop-down menus.

