### PR TITLE
DOCS-994: Adds redirect rules for docs.tigera.io

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -14,6 +14,24 @@
 /calico-enterprise/3.15/ /calico-enterprise/3.15/about-calico-enterprise 301
 /calico-enterprise/3.14/ /calico-enterprise/3.15/about-calico-enterprise 301
 
+# Redirect rules for old permalinks.
+# These URLs, which contain no version marker, are redirected to the latest version of CE.
+
+/about/* /calico-enterprise/latest/about/:splat 301
+/getting-started/* /calico-enterprise/latest/getting-started/:splat 301
+/networking/* /calico-enterprise/latest/networking/:splat 301
+/policy/* /calico-enterprise/latest/network-policy/ 301
+/security/* /calico-enterprise/latest/network-policy/:splat 301
+/visibility/* /calico-enterprise/latest/visibility/:splat 301
+/multicluster/* /calico-enterprise/latest/multicluster/:splat 301
+/threat/* /calico-enterprise/latest/threat/:splat 301
+/compliance/* /calico-enterprise/latest/compliance/:splat 301
+/maintenance/* /calico-enterprise/latest/operations/:splat 301
+/reference/* /calico-enterprise/latest/reference/:splat 301
+/release-notes/* /calico-enterprise/latest/release-notes/ 301
+
+/master/manifests/* https://downloads.tigera.io/ee/master/manifests/:splat 301
+/manifests/* https://downloads.tigera.io/ee/latest/manifests/:splat 301
 
 # OS redirects
 
@@ -51,4 +69,4 @@
 /v2.3 /v2.3/introduction/ 301
 /v2.2 /v2.2/introduction/ 301
 /v2.1 /v2.1/introduction/ 301
-/master /master/about/about-calico-enterprise/ 301
+/master /calico-enterprise/next/about/about-calico-enterprise/ 301

--- a/static/releases.html
+++ b/static/releases.html
@@ -30,7 +30,7 @@ that will appear in the old proxy sites. -->
       <div style="font-weight: bold; margin-top: 4px">Calico Enterprise</div>
       <div style="padding-left: 12px">
         <a
-          href=/calico-enterprise/3.15/about-calico-enterprise"
+          href="/calico-enterprise/3.15/about-calico-enterprise"
           style="font-weight: normal; color: #333333"
         >3.15 (early preview)</a
         >


### PR DESCRIPTION
https://tigera.atlassian.net/browse/DOCS-994

Adds redirect rules for docs.tigera.io.

The PR makes the following changes to the redirect rules:
* Redirects unversioned links to docs.tigera.io/calico-enterprise/latest/:splat

Other redirect PRs:
* docs.projectcalico: https://github.com/projectcalico/calico/pull/7168
* projectcalico.docs.tigera.io: https://github.com/projectcalico/calico/pull/7169
* docs.calicocloud.io: https://github.com/tigera/calico-cloud/pull/201
* docs.tigera.io: https://github.com/tigera/docs/pull/184
