### PR TITLE
Added redirect rules for /latest/

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,3 +1,9 @@
+# Version 'latest' redirects.
+# TODO: Version numbers must change for minor releases
+/calico/latest/ /calico/3.25/:splat 301
+/calico-enterprise/latest/ /calico-enterprise/3.14/:splat 301
+/calico-cloud/latest/ /calico-cloud/:splat 301
+
 
 # OS redirects
 


### PR DESCRIPTION
A redirect rule for each product. Allows us to share 'latest' version link that will stay updated as new versions are released.