### PR TITLE
DOCS-1181: Changes to GitHub-hosted URL for ocp.tgz in OS 3.24+

### DIFF
--- a/calico/_includes/components/InstallOpenShiftManifests.js
+++ b/calico/_includes/components/InstallOpenShiftManifests.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import CodeBlock from '@theme/CodeBlock';
 
-import { prodname, filesUrl } from '../../variables';
+import { prodname, releases } from '../../variables';
 
 export default function InstallOpenShiftManifests() {
   return (
@@ -10,7 +10,7 @@ export default function InstallOpenShiftManifests() {
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
       <CodeBlock language='batch'>
         {`mkdir calico
-wget -qO- ${filesUrl}/manifests/ocp.tgz | tar xvz --strip-components=1 -C calico
+wget -qO- https://github.com/projectcalico/calico/releases/download/${releases[0].title}/ocp.tgz | tar xvz --strip-components=1 -C calico
 cp calico/* manifests/`}
       </CodeBlock>
     </>

--- a/calico_versioned_docs/version-3.24/_includes/components/InstallOpenShiftManifests.js
+++ b/calico_versioned_docs/version-3.24/_includes/components/InstallOpenShiftManifests.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import CodeBlock from '@theme/CodeBlock';
 
-import { prodname, filesUrl } from '../../variables';
+import { prodname, releases } from '../../variables';
 
 export default function InstallOpenShiftManifests() {
   return (
@@ -10,7 +10,7 @@ export default function InstallOpenShiftManifests() {
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
       <CodeBlock language='batch'>
         {`mkdir calico
-wget -qO- ${filesUrl}/manifests/ocp.tgz | tar xvz --strip-components=1 -C calico
+wget -qO- https://github.com/projectcalico/calico/releases/download/${releases[0].title}/ocp.tgz | tar xvz --strip-components=1 -C calico
 cp calico/* manifests/`}
       </CodeBlock>
     </>

--- a/calico_versioned_docs/version-3.25/_includes/components/InstallOpenShiftManifests.js
+++ b/calico_versioned_docs/version-3.25/_includes/components/InstallOpenShiftManifests.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import CodeBlock from '@theme/CodeBlock';
 
-import { prodname, filesUrl } from '../../variables';
+import { prodname, releases } from '../../variables';
 
 export default function InstallOpenShiftManifests() {
   return (
@@ -10,7 +10,7 @@ export default function InstallOpenShiftManifests() {
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
       <CodeBlock language='batch'>
         {`mkdir calico
-wget -qO- ${filesUrl}/manifests/ocp.tgz | tar xvz --strip-components=1 -C calico
+wget -qO- https://github.com/projectcalico/calico/releases/download/${releases[0].title}/ocp.tgz | tar xvz --strip-components=1 -C calico
 cp calico/* manifests/`}
       </CodeBlock>
     </>


### PR DESCRIPTION
https://tigera.atlassian.net/browse/DOCS-1181