### PR TITLE
DOCS-1202: Confines Algolia crawlers to Docusaurus-native doc sets

### DIFF
--- a/algolia-crawler-config.json
+++ b/algolia-crawler-config.json
@@ -1,6 +1,6 @@
 {
   "index_name": "calico",
-  "start_urls": ["https://unified-docs.tigera.io"],
+  "start_urls": ["https://unified-docs.tigera.io/calico", "https://unified-docs.tigera.io/calico-enterprise", "https://unified-docs.tigera.io/calico-cloud"],
   "stop_urls": [],
   "selectors": {
     "lvl0": {


### PR DESCRIPTION
https://tigera.atlassian.net/browse/DOCS-1202

The crawler crawls all of the old proxied sites. It's currently taking about 4 hours.

This config change restricts the crawler to /calico/ /calico-enterprise/ and /calico-cloud/. 

With this change, the crawler takes <MM> minutes.