### PR TITLE
For calico PR#7209: Separates taints removal commands

### DIFF
--- a/calico/getting-started/kubernetes/quickstart.mdx
+++ b/calico/getting-started/kubernetes/quickstart.mdx
@@ -130,8 +130,10 @@ The geeky details of what you get:
 
 1. Remove the taints on the master so that you can schedule pods on it.
 
-   ```
-   kubectl taint nodes --all node-role.kubernetes.io/control-plane- node-role.kubernetes.io/master-
+
+   ```batch
+   kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+   kubectl taint nodes --all node-role.kubernetes.io/master-
    ```
 
    It should return the following.

--- a/calico_versioned_docs/version-3.24/getting-started/kubernetes/quickstart.mdx
+++ b/calico_versioned_docs/version-3.24/getting-started/kubernetes/quickstart.mdx
@@ -122,8 +122,10 @@ The geeky details of what you get:
 
 1. Remove the taints on the master so that you can schedule pods on it.
 
-   ```
-   kubectl taint nodes --all node-role.kubernetes.io/control-plane- node-role.kubernetes.io/master-
+
+   ```batch
+   kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+   kubectl taint nodes --all node-role.kubernetes.io/master-
    ```
 
    It should return the following.

--- a/calico_versioned_docs/version-3.25/getting-started/kubernetes/quickstart.mdx
+++ b/calico_versioned_docs/version-3.25/getting-started/kubernetes/quickstart.mdx
@@ -130,8 +130,10 @@ The geeky details of what you get:
 
 1. Remove the taints on the master so that you can schedule pods on it.
 
-   ```
-   kubectl taint nodes --all node-role.kubernetes.io/control-plane- node-role.kubernetes.io/master-
+
+   ```batch
+   kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+   kubectl taint nodes --all node-role.kubernetes.io/master-
    ```
 
    It should return the following.


### PR DESCRIPTION
This PR replicates https://github.com/projectcalico/calico/pull/7209 by @profnandaa.

Review required: @profnandaa, @caseydavenport

Note: I've assumed this applies to OS next, OS 3.25, and OS 3.24. If that's wrong, let me know.