### PR TITLE
DOCS-1180: Fixes links to tutorial manifest files

### DIFF
--- a/calico-cloud/tutorials/kubernetes-tutorials/kubernetes-demo.mdx
+++ b/calico-cloud/tutorials/kubernetes-tutorials/kubernetes-demo.mdx
@@ -17,11 +17,11 @@ one of our [getting started guides](/getting-started/index).
 ### 1) Create the frontend, backend, client, and management-ui apps.
 
 ```shell
-kubectl create -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/manifests/00-namespace.yaml
-kubectl create -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/manifests/01-management-ui.yaml
-kubectl create -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/manifests/02-backend.yaml
-kubectl create -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/manifests/03-frontend.yaml
-kubectl create -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/manifests/04-client.yaml
+kubectl create -f {{tutorialFilesURL}}/00-namespace.yaml
+kubectl create -f {{tutorialFilesURL}}/01-management-ui.yaml
+kubectl create -f {{tutorialFilesURL}}/02-backend.yaml
+kubectl create -f {{tutorialFilesURL}}/03-frontend.yaml
+kubectl create -f {{tutorialFilesURL}}/04-client.yaml
 ```
 
 Wait for all the pods to enter `Running` state.
@@ -49,8 +49,8 @@ represented by a single node in the graph.
 Running following commands will prevent all access to the frontend, backend, and client Services.
 
 ```shell
-kubectl create -n stars -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml
-kubectl create -n client -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml
+kubectl create -n stars -f {{tutorialFilesURL}}/default-deny.yaml
+kubectl create -n client -f {{tutorialFilesURL}}/default-deny.yaml
 ```
 
 #### Confirm isolation
@@ -63,8 +63,8 @@ Now that we've enabled isolation, the UI can no longer access the pods, and so t
 Apply the following YAMLs to allow access from the management UI.
 
 ```shell
-kubectl create -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/policies/allow-ui.yaml
-kubectl create -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/policies/allow-ui-client.yaml
+kubectl create -f {{tutorialFilesURL}}/allow-ui.yaml
+kubectl create -f {{tutorialFilesURL}}/allow-ui-client.yaml
 ```
 
 After a few seconds, refresh the UI - it should now show the Services, but they should not be able to access each other any more.
@@ -72,7 +72,7 @@ After a few seconds, refresh the UI - it should now show the Services, but they 
 ### 4) Create the backend-policy.yaml file to allow traffic from the frontend to the backend
 
 ```shell
-kubectl create -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/policies/backend-policy.yaml
+kubectl create -f {{tutorialFilesURL}}/backend-policy.yaml
 ```
 
 Refresh the UI. You should see the following:
@@ -84,7 +84,7 @@ Refresh the UI. You should see the following:
 ### 5) Expose the frontend service to the client namespace
 
 ```shell
-kubectl create -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/policies/frontend-policy.yaml
+kubectl create -f {{tutorialFilesURL}}/frontend-policy.yaml
 ```
 
 The client can now access the frontend, but not the backend. Neither the frontend nor the backend

--- a/calico-cloud/variables.js
+++ b/calico-cloud/variables.js
@@ -7,6 +7,7 @@ const variables = {
   baseUrl: '/calico-cloud',
   filesUrl: 'https://docs.calicocloud.io',
   filesUrl_CE: 'https://downloads.tigera.io/ee/v3.15.0',
+  tutorialFilesURL: 'https://unified-docs.tigera.io/files',
   prodnameWindows: 'Calico Enterprise for Windows',
   rootDirWindows: 'C:\\TigeraCalico',
   nodecontainer: 'cnx-node',

--- a/calico-cloud_versioned_docs/version-3.15/tutorials/kubernetes-tutorials/kubernetes-demo.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/tutorials/kubernetes-tutorials/kubernetes-demo.mdx
@@ -17,11 +17,11 @@ one of our [getting started guides](/getting-started/index).
 ### 1) Create the frontend, backend, client, and management-ui apps.
 
 ```shell
-kubectl create -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/manifests/00-namespace.yaml
-kubectl create -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/manifests/01-management-ui.yaml
-kubectl create -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/manifests/02-backend.yaml
-kubectl create -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/manifests/03-frontend.yaml
-kubectl create -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/manifests/04-client.yaml
+kubectl create -f {{tutorialFilesURL}}/00-namespace.yaml
+kubectl create -f {{tutorialFilesURL}}/01-management-ui.yaml
+kubectl create -f {{tutorialFilesURL}}/02-backend.yaml
+kubectl create -f {{tutorialFilesURL}}/03-frontend.yaml
+kubectl create -f {{tutorialFilesURL}}/04-client.yaml
 ```
 
 Wait for all the pods to enter `Running` state.
@@ -49,8 +49,8 @@ represented by a single node in the graph.
 Running following commands will prevent all access to the frontend, backend, and client Services.
 
 ```shell
-kubectl create -n stars -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml
-kubectl create -n client -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml
+kubectl create -n stars -f {{tutorialFilesURL}}/default-deny.yaml
+kubectl create -n client -f {{tutorialFilesURL}}/default-deny.yaml
 ```
 
 #### Confirm isolation
@@ -63,8 +63,8 @@ Now that we've enabled isolation, the UI can no longer access the pods, and so t
 Apply the following YAMLs to allow access from the management UI.
 
 ```shell
-kubectl create -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/policies/allow-ui.yaml
-kubectl create -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/policies/allow-ui-client.yaml
+kubectl create -f {{tutorialFilesURL}}/allow-ui.yaml
+kubectl create -f {{tutorialFilesURL}}/allow-ui-client.yaml
 ```
 
 After a few seconds, refresh the UI - it should now show the Services, but they should not be able to access each other any more.
@@ -72,7 +72,7 @@ After a few seconds, refresh the UI - it should now show the Services, but they 
 ### 4) Create the backend-policy.yaml file to allow traffic from the frontend to the backend
 
 ```shell
-kubectl create -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/policies/backend-policy.yaml
+kubectl create -f {{tutorialFilesURL}}/backend-policy.yaml
 ```
 
 Refresh the UI. You should see the following:
@@ -84,7 +84,7 @@ Refresh the UI. You should see the following:
 ### 5) Expose the frontend service to the client namespace
 
 ```shell
-kubectl create -f {{filesUrl_CE}}/security/tutorials/kubernetes-policy-demo/policies/frontend-policy.yaml
+kubectl create -f {{tutorialFilesURL}}/frontend-policy.yaml
 ```
 
 The client can now access the frontend, but not the backend. Neither the frontend nor the backend

--- a/calico-cloud_versioned_docs/version-3.15/variables.js
+++ b/calico-cloud_versioned_docs/version-3.15/variables.js
@@ -7,6 +7,7 @@ const variables = {
   baseUrl: '/calico-cloud',
   filesUrl: 'https://docs.calicocloud.io',
   filesUrl_CE: 'https://downloads.tigera.io/ee/v3.15.0',
+  tutorialFilesURL: 'https://unified-docs.tigera.io/files',
   prodnameWindows: 'Calico Enterprise for Windows',
   rootDirWindows: 'C:\\TigeraCalico',
   nodecontainer: 'cnx-node',

--- a/calico-enterprise/network-policy/get-started/kubernetes-demo.mdx
+++ b/calico-enterprise/network-policy/get-started/kubernetes-demo.mdx
@@ -17,11 +17,11 @@ one of our [getting started guides](../../getting-started/index.mdx).
 ### 1) Create the frontend, backend, client, and management-ui apps.
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/00-namespace.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/01-management-ui.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/02-backend.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/03-frontend.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/04-client.yaml
+kubectl create -f {{tutorialFilesURL}}/00-namespace.yaml
+kubectl create -f {{tutorialFilesURL}}/01-management-ui.yaml
+kubectl create -f {{tutorialFilesURL}}/02-backend.yaml
+kubectl create -f {{tutorialFilesURL}}/03-frontend.yaml
+kubectl create -f {{tutorialFilesURL}}/04-client.yaml
 ```
 
 Wait for all the pods to enter `Running` state.
@@ -49,8 +49,8 @@ represented by a single node in the graph.
 Running following commands will prevent all access to the frontend, backend, and client Services.
 
 ```shell
-kubectl create -n stars -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml
-kubectl create -n client -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml
+kubectl create -n stars -f {{tutorialFilesURL}}/default-deny.yaml
+kubectl create -n client -f {{tutorialFilesURL}}/default-deny.yaml
 ```
 
 #### Confirm isolation
@@ -63,7 +63,7 @@ Now that we've enabled isolation, the UI can no longer access the pods, and so t
 Apply the following YAMLs to allow access from the management UI.
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/allow-ui.yaml
+kubectl create -f {{tutorialFilesURL}}/allow-ui.yaml
 kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/allow-ui-client.yaml
 ```
 
@@ -72,7 +72,7 @@ After a few seconds, refresh the UI - it should now show the Services, but they 
 ### 4) Create the backend-policy.yaml file to allow traffic from the frontend to the backend
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/backend-policy.yaml
+kubectl create -f {{tutorialFilesURL}}/backend-policy.yaml
 ```
 
 Refresh the UI. You should see the following:
@@ -84,7 +84,7 @@ Refresh the UI. You should see the following:
 ### 5) Expose the frontend service to the client namespace
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/frontend-policy.yaml
+kubectl create -f {{tutorialFilesURL}}/frontend-policy.yaml
 ```
 
 The client can now access the frontend, but not the backend. Neither the frontend nor the backend

--- a/calico-enterprise/variables.js
+++ b/calico-enterprise/variables.js
@@ -7,6 +7,7 @@ const variables = {
   version: 'master',
   baseUrl: '/calico-enterprise/next',
   filesUrl: 'https://downloads.tigera.io/ee/master',
+  tutorialFilesURL: 'https://unified-docs.tigera.io/files',
   prodnameWindows: 'Calico Enterprise for Windows',
   downloadsurl: 'https://downloads.tigera.io',
   nodecontainer: 'cnx-node',

--- a/calico-enterprise_versioned_docs/version-3.14/network-policy/get-started/kubernetes-demo.mdx
+++ b/calico-enterprise_versioned_docs/version-3.14/network-policy/get-started/kubernetes-demo.mdx
@@ -17,11 +17,11 @@ one of our [getting started guides](../../getting-started/index.mdx).
 ### 1) Create the frontend, backend, client, and management-ui apps.
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/00-namespace.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/01-management-ui.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/02-backend.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/03-frontend.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/04-client.yaml
+kubectl create -f {{tutorialFilesURL}}/00-namespace.yaml
+kubectl create -f {{tutorialFilesURL}}/01-management-ui.yaml
+kubectl create -f {{tutorialFilesURL}}/02-backend.yaml
+kubectl create -f {{tutorialFilesURL}}/03-frontend.yaml
+kubectl create -f {{tutorialFilesURL}}/04-client.yaml
 ```
 
 Wait for all the pods to enter `Running` state.
@@ -49,8 +49,8 @@ represented by a single node in the graph.
 Running following commands will prevent all access to the frontend, backend, and client Services.
 
 ```shell
-kubectl create -n stars -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml
-kubectl create -n client -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml
+kubectl create -n stars -f {{tutorialFilesURL}}/default-deny.yaml
+kubectl create -n client -f {{tutorialFilesURL}}/default-deny.yaml
 ```
 
 #### Confirm isolation
@@ -63,7 +63,7 @@ Now that we've enabled isolation, the UI can no longer access the pods, and so t
 Apply the following YAMLs to allow access from the management UI.
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/allow-ui.yaml
+kubectl create -f {{tutorialFilesURL}}/allow-ui.yaml
 kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/allow-ui-client.yaml
 ```
 
@@ -72,7 +72,7 @@ After a few seconds, refresh the UI - it should now show the Services, but they 
 ### 4) Create the backend-policy.yaml file to allow traffic from the frontend to the backend
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/backend-policy.yaml
+kubectl create -f {{tutorialFilesURL}}/backend-policy.yaml
 ```
 
 Refresh the UI. You should see the following:
@@ -84,7 +84,7 @@ Refresh the UI. You should see the following:
 ### 5) Expose the frontend service to the client namespace
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/frontend-policy.yaml
+kubectl create -f {{tutorialFilesURL}}/frontend-policy.yaml
 ```
 
 The client can now access the frontend, but not the backend. Neither the frontend nor the backend

--- a/calico-enterprise_versioned_docs/version-3.14/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.14/variables.js
@@ -7,6 +7,7 @@ const variables = {
   version: 'v3.14',
   baseUrl: '/calico-enterprise/3.14',
   filesUrl: 'https://downloads.tigera.io/ee/v3.14.4',
+  tutorialFilesURL: 'https://unified-docs.tigera.io/files',
   prodnameWindows: 'Calico Enterprise for Windows',
   downloadsurl: 'https://downloads.tigera.io',
   nodecontainer: 'cnx-node',

--- a/calico-enterprise_versioned_docs/version-3.15/network-policy/get-started/kubernetes-demo.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/network-policy/get-started/kubernetes-demo.mdx
@@ -17,11 +17,11 @@ one of our [getting started guides](../../getting-started/index.mdx).
 ### 1) Create the frontend, backend, client, and management-ui apps.
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/00-namespace.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/01-management-ui.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/02-backend.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/03-frontend.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/04-client.yaml
+kubectl create -f {{tutorialFilesURL}}/00-namespace.yaml
+kubectl create -f {{tutorialFilesURL}}/01-management-ui.yaml
+kubectl create -f {{tutorialFilesURL}}/02-backend.yaml
+kubectl create -f {{tutorialFilesURL}}/03-frontend.yaml
+kubectl create -f {{tutorialFilesURL}}/04-client.yaml
 ```
 
 Wait for all the pods to enter `Running` state.
@@ -49,8 +49,8 @@ represented by a single node in the graph.
 Running following commands will prevent all access to the frontend, backend, and client Services.
 
 ```shell
-kubectl create -n stars -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml
-kubectl create -n client -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml
+kubectl create -n stars -f {{tutorialFilesURL}}/default-deny.yaml
+kubectl create -n client -f {{tutorialFilesURL}}/default-deny.yaml
 ```
 
 #### Confirm isolation
@@ -63,7 +63,7 @@ Now that we've enabled isolation, the UI can no longer access the pods, and so t
 Apply the following YAMLs to allow access from the management UI.
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/allow-ui.yaml
+kubectl create -f {{tutorialFilesURL}}/allow-ui.yaml
 kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/allow-ui-client.yaml
 ```
 
@@ -72,7 +72,7 @@ After a few seconds, refresh the UI - it should now show the Services, but they 
 ### 4) Create the backend-policy.yaml file to allow traffic from the frontend to the backend
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/backend-policy.yaml
+kubectl create -f {{tutorialFilesURL}}/backend-policy.yaml
 ```
 
 Refresh the UI. You should see the following:
@@ -84,7 +84,7 @@ Refresh the UI. You should see the following:
 ### 5) Expose the frontend service to the client namespace
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/frontend-policy.yaml
+kubectl create -f {{tutorialFilesURL}}/frontend-policy.yaml
 ```
 
 The client can now access the frontend, but not the backend. Neither the frontend nor the backend

--- a/calico-enterprise_versioned_docs/version-3.15/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.15/variables.js
@@ -7,6 +7,7 @@ const variables = {
   version: 'v3.15',
   baseUrl: '/calico-enterprise/3.15',
   filesUrl: 'https://downloads.tigera.io/ee/v3.15.0',
+  tutorialFilesURL: 'https://unified-docs.tigera.io/files',
   prodnameWindows: 'Calico Enterprise for Windows',
   downloadsurl: 'https://downloads.tigera.io',
   nodecontainer: 'cnx-node',

--- a/calico/network-policy/get-started/kubernetes-policy/kubernetes-demo.mdx
+++ b/calico/network-policy/get-started/kubernetes-policy/kubernetes-demo.mdx
@@ -17,11 +17,11 @@ one of our [getting started guides](../../../getting-started/index.mdx).
 ### 1) Create the frontend, backend, client, and management-ui apps.
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/00-namespace.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/01-management-ui.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/02-backend.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/03-frontend.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/04-client.yaml
+kubectl create -f {{tutorialFilesURL}}/00-namespace.yaml
+kubectl create -f {{tutorialFilesURL}}/01-management-ui.yaml
+kubectl create -f {{tutorialFilesURL}}/02-backend.yaml
+kubectl create -f {{tutorialFilesURL}}/03-frontend.yaml
+kubectl create -f {{tutorialFilesURL}}/04-client.yaml
 ```
 
 Wait for all the pods to enter `Running` state.
@@ -49,8 +49,8 @@ represented by a single node in the graph.
 Running following commands will prevent all access to the frontend, backend, and client Services.
 
 ```shell
-kubectl create -n stars -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml
-kubectl create -n client -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml
+kubectl create -n stars -f {{tutorialFilesURL}}/default-deny.yaml
+kubectl create -n client -f {{tutorialFilesURL}}/default-deny.yaml
 ```
 
 #### Confirm isolation
@@ -63,7 +63,7 @@ Now that we've enabled isolation, the UI can no longer access the pods, and so t
 Apply the following YAMLs to allow access from the management UI.
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/allow-ui.yaml
+kubectl create -f {{tutorialFilesURL}}/allow-ui.yaml
 kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/allow-ui-client.yaml
 ```
 
@@ -72,7 +72,7 @@ After a few seconds, refresh the UI - it should now show the Services, but they 
 ### 4) Create the backend-policy.yaml file to allow traffic from the frontend to the backend
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/backend-policy.yaml
+kubectl create -f {{tutorialFilesURL}}/backend-policy.yaml
 ```
 
 Refresh the UI. You should see the following:
@@ -84,7 +84,7 @@ Refresh the UI. You should see the following:
 ### 5) Expose the frontend service to the client namespace
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/frontend-policy.yaml
+kubectl create -f {{tutorialFilesURL}}/frontend-policy.yaml
 ```
 
 The client can now access the frontend, but not the backend. Neither the frontend nor the backend

--- a/calico/network-policy/istio/enforce-policy-istio.mdx
+++ b/calico/network-policy/istio/enforce-policy-istio.mdx
@@ -34,7 +34,7 @@ customer-facing web application, a microservice that serves up account
 summaries, and an [etcd](https://github.com/coreos/etcd) datastore.
 
 ```batch
-kubectl apply -f https://docs.tigera.io/files/10-yaobank.yaml
+kubectl apply -f {{tutorialFilesURL}}/10-yaobank.yaml
 ```
 
 :::note
@@ -135,7 +135,7 @@ compromising private keys.
 We can mitigate both of the above deficiencies with a {{prodname}} policy.
 
 ```batch
-wget https://docs.tigera.io/files/30-policy.yaml
+wget {{tutorialFilesURL}}/30-policy.yaml
 calicoctl create -f 30-policy.yaml
 ```
 

--- a/calico/variables.js
+++ b/calico/variables.js
@@ -7,6 +7,7 @@ const variables = {
   version: 'master',
   baseUrl: '/calico/next',
   filesUrl: 'https://projectcalico.docs.tigera.io/master',
+  tutorialFilesURL: 'https://unified-docs.tigera.io/files',
   prodnameWindows: 'Calico for Windows',
   nodecontainer: 'calico/node',
   noderunning: 'calico-node',

--- a/calico_versioned_docs/version-3.24/network-policy/get-started/kubernetes-policy/kubernetes-demo.mdx
+++ b/calico_versioned_docs/version-3.24/network-policy/get-started/kubernetes-policy/kubernetes-demo.mdx
@@ -17,11 +17,11 @@ one of our [getting started guides](../../../getting-started/index.mdx).
 ### 1) Create the frontend, backend, client, and management-ui apps.
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/00-namespace.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/01-management-ui.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/02-backend.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/03-frontend.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/04-client.yaml
+kubectl create -f {{tutorialFilesURL}}/00-namespace.yaml
+kubectl create -f {{tutorialFilesURL}}/01-management-ui.yaml
+kubectl create -f {{tutorialFilesURL}}/02-backend.yaml
+kubectl create -f {{tutorialFilesURL}}/03-frontend.yaml
+kubectl create -f {{tutorialFilesURL}}/04-client.yaml
 ```
 
 Wait for all the pods to enter `Running` state.
@@ -49,8 +49,8 @@ represented by a single node in the graph.
 Running following commands will prevent all access to the frontend, backend, and client Services.
 
 ```shell
-kubectl create -n stars -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml
-kubectl create -n client -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml
+kubectl create -n stars -f {{tutorialFilesURL}}/default-deny.yaml
+kubectl create -n client -f {{tutorialFilesURL}}/default-deny.yaml
 ```
 
 #### Confirm isolation
@@ -63,7 +63,7 @@ Now that we've enabled isolation, the UI can no longer access the pods, and so t
 Apply the following YAMLs to allow access from the management UI.
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/allow-ui.yaml
+kubectl create -f {{tutorialFilesURL}}/allow-ui.yaml
 kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/allow-ui-client.yaml
 ```
 
@@ -72,7 +72,7 @@ After a few seconds, refresh the UI - it should now show the Services, but they 
 ### 4) Create the backend-policy.yaml file to allow traffic from the frontend to the backend
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/backend-policy.yaml
+kubectl create -f {{tutorialFilesURL}}/backend-policy.yaml
 ```
 
 Refresh the UI. You should see the following:
@@ -84,7 +84,7 @@ Refresh the UI. You should see the following:
 ### 5) Expose the frontend service to the client namespace
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/frontend-policy.yaml
+kubectl create -f {{tutorialFilesURL}}/frontend-policy.yaml
 ```
 
 The client can now access the frontend, but not the backend. Neither the frontend nor the backend

--- a/calico_versioned_docs/version-3.24/network-policy/istio/enforce-policy-istio.mdx
+++ b/calico_versioned_docs/version-3.24/network-policy/istio/enforce-policy-istio.mdx
@@ -34,7 +34,7 @@ customer-facing web application, a microservice that serves up account
 summaries, and an [etcd](https://github.com/coreos/etcd) datastore.
 
 ```batch
-kubectl apply -f https://docs.tigera.io/files/10-yaobank.yaml
+kubectl apply -f {{tutorialFilesURL}}/10-yaobank.yaml
 ```
 
 :::note
@@ -137,7 +137,7 @@ compromising private keys.
 We can mitigate both of the above deficiencies with a {{prodname}} policy.
 
 ```batch
-wget https://docs.tigera.io/files/30-policy.yaml
+wget {{tutorialFilesURL}}/30-policy.yaml
 calicoctl create -f 30-policy.yaml
 ```
 

--- a/calico_versioned_docs/version-3.24/variables.js
+++ b/calico_versioned_docs/version-3.24/variables.js
@@ -7,6 +7,7 @@ const variables = {
   version: 'v3.24',
   baseUrl: '/calico/3.24',
   filesUrl: 'https://projectcalico.docs.tigera.io/v3.24',
+  tutorialFilesURL: 'https://unified-docs.tigera.io/files',
   prodnameWindows: 'Calico for Windows',
   nodecontainer: 'calico/node',
   noderunning: 'calico-node',

--- a/calico_versioned_docs/version-3.25/network-policy/get-started/kubernetes-policy/kubernetes-demo.mdx
+++ b/calico_versioned_docs/version-3.25/network-policy/get-started/kubernetes-policy/kubernetes-demo.mdx
@@ -17,11 +17,11 @@ one of our [getting started guides](../../../getting-started/index.mdx).
 ### 1) Create the frontend, backend, client, and management-ui apps.
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/00-namespace.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/01-management-ui.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/02-backend.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/03-frontend.yaml
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/manifests/04-client.yaml
+kubectl create -f {{tutorialFilesURL}}/00-namespace.yaml
+kubectl create -f {{tutorialFilesURL}}/01-management-ui.yaml
+kubectl create -f {{tutorialFilesURL}}/02-backend.yaml
+kubectl create -f {{tutorialFilesURL}}/03-frontend.yaml
+kubectl create -f {{tutorialFilesURL}}/04-client.yaml
 ```
 
 Wait for all the pods to enter `Running` state.
@@ -49,8 +49,8 @@ represented by a single node in the graph.
 Running following commands will prevent all access to the frontend, backend, and client Services.
 
 ```shell
-kubectl create -n stars -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml
-kubectl create -n client -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/default-deny.yaml
+kubectl create -n stars -f {{tutorialFilesURL}}/default-deny.yaml
+kubectl create -n client -f {{tutorialFilesURL}}/default-deny.yaml
 ```
 
 #### Confirm isolation
@@ -63,7 +63,7 @@ Now that we've enabled isolation, the UI can no longer access the pods, and so t
 Apply the following YAMLs to allow access from the management UI.
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/allow-ui.yaml
+kubectl create -f {{tutorialFilesURL}}/allow-ui.yaml
 kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/allow-ui-client.yaml
 ```
 
@@ -72,7 +72,7 @@ After a few seconds, refresh the UI - it should now show the Services, but they 
 ### 4) Create the backend-policy.yaml file to allow traffic from the frontend to the backend
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/backend-policy.yaml
+kubectl create -f {{tutorialFilesURL}}/backend-policy.yaml
 ```
 
 Refresh the UI. You should see the following:
@@ -84,7 +84,7 @@ Refresh the UI. You should see the following:
 ### 5) Expose the frontend service to the client namespace
 
 ```shell
-kubectl create -f {{filesUrl}}/security/tutorials/kubernetes-policy-demo/policies/frontend-policy.yaml
+kubectl create -f {{tutorialFilesURL}}/frontend-policy.yaml
 ```
 
 The client can now access the frontend, but not the backend. Neither the frontend nor the backend

--- a/calico_versioned_docs/version-3.25/network-policy/istio/enforce-policy-istio.mdx
+++ b/calico_versioned_docs/version-3.25/network-policy/istio/enforce-policy-istio.mdx
@@ -34,7 +34,7 @@ customer-facing web application, a microservice that serves up account
 summaries, and an [etcd](https://github.com/coreos/etcd) datastore.
 
 ```batch
-kubectl apply -f https://docs.tigera.io/files/10-yaobank.yaml
+kubectl apply -f {{tutorialFilesURL}}/10-yaobank.yaml
 ```
 
 :::note
@@ -134,7 +134,7 @@ compromising private keys.
 
 We can mitigate both of the above deficiencies with a {{prodname}} policy.
 
-    wget https://docs.tigera.io/files/30-policy.yaml
+    wget {{tutorialFilesURL}}/30-policy.yaml
     calicoctl create -f 30-policy.yaml
 
 :::note

--- a/calico_versioned_docs/version-3.25/variables.js
+++ b/calico_versioned_docs/version-3.25/variables.js
@@ -7,6 +7,7 @@ const variables = {
   version: 'v3.25',
   baseUrl: '/calico/3.25',
   filesUrl: 'https://projectcalico.docs.tigera.io/v3.25',
+  tutorialFilesURL: 'https://unified-docs.tigera.io/files',
   prodnameWindows: 'Calico for Windows',
   nodecontainer: 'calico/node',
   noderunning: 'calico-node',

--- a/static/files/00-namespace.yaml
+++ b/static/files/00-namespace.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: stars

--- a/static/files/01-management-ui.yaml
+++ b/static/files/01-management-ui.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: management-ui
+  labels:
+    role: management-ui
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: management-ui
+  namespace: management-ui
+spec:
+  type: NodePort
+  ports:
+    - port: 9001
+      targetPort: 9001
+      nodePort: 30002
+  selector:
+    role: management-ui
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: management-ui
+  namespace: management-ui
+  labels:
+    role: management-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      role: management-ui
+  template:
+    metadata:
+      labels:
+        role: management-ui
+    spec:
+      containers:
+        - name: management-ui
+          image: calico/star-collect:multiarch
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 9001

--- a/static/files/02-backend.yaml
+++ b/static/files/02-backend.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: stars
+spec:
+  ports:
+    - port: 6379
+      targetPort: 6379
+  selector:
+    role: backend
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: stars
+  labels:
+    role: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      role: backend
+  template:
+    metadata:
+      labels:
+        role: backend
+    spec:
+      containers:
+        - name: backend
+          image: calico/star-probe:multiarch
+          imagePullPolicy: Always
+          command:
+            - probe
+            - --http-port=6379
+            - --urls=http://frontend.stars:80/status,http://backend.stars:6379/status,http://client.client:9000/status
+          ports:
+            - containerPort: 6379

--- a/static/files/03-frontend.yaml
+++ b/static/files/03-frontend.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: stars
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+  selector:
+    role: frontend
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: stars
+  labels:
+    role: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      role: frontend
+  template:
+    metadata:
+      labels:
+        role: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: calico/star-probe:multiarch
+          imagePullPolicy: Always
+          command:
+            - probe
+            - --http-port=80
+            - --urls=http://frontend.stars:80/status,http://backend.stars:6379/status,http://client.client:9000/status
+          ports:
+            - containerPort: 80

--- a/static/files/04-client.yaml
+++ b/static/files/04-client.yaml
@@ -1,0 +1,45 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: client
+  labels:
+    role: client
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: client
+  namespace: client
+  labels:
+    role: client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      role: client
+  template:
+    metadata:
+      labels:
+        role: client
+    spec:
+      containers:
+        - name: client
+          image: calico/star-probe:multiarch
+          imagePullPolicy: Always
+          command:
+            - probe
+            - --urls=http://frontend.stars:80/status,http://backend.stars:6379/status
+          ports:
+            - containerPort: 9000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: client
+  namespace: client
+spec:
+  ports:
+    - port: 9000
+      targetPort: 9000
+  selector:
+    role: client

--- a/static/files/allow-ui.yaml
+++ b/static/files/allow-ui.yaml
@@ -1,0 +1,13 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  namespace: stars
+  name: allow-ui
+spec:
+  podSelector:
+    matchLabels: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              role: management-ui

--- a/static/files/backend-policy.yaml
+++ b/static/files/backend-policy.yaml
@@ -1,0 +1,17 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  namespace: stars
+  name: backend-policy
+spec:
+  podSelector:
+    matchLabels:
+      role: backend
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              role: frontend
+      ports:
+        - protocol: TCP
+          port: 6379

--- a/static/files/default-deny.yaml
+++ b/static/files/default-deny.yaml
@@ -1,0 +1,7 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: default-deny
+spec:
+  podSelector:
+    matchLabels: {}

--- a/static/files/frontend-policy.yaml
+++ b/static/files/frontend-policy.yaml
@@ -1,0 +1,17 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  namespace: stars
+  name: frontend-policy
+spec:
+  podSelector:
+    matchLabels:
+      role: frontend
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              role: client
+      ports:
+        - protocol: TCP
+          port: 80


### PR DESCRIPTION
https://tigera.atlassian.net/browse/DOCS-1180

We don't need tutorial manifest files to be hosted with the proper manifest files. Here, I've added these files to `/static/files/` and changed links accordingly.

None of these files have diffs across product or version. So I'm leaving these unversioned. We can change this later if we need.

