### PR TITLE
Changes API keys for Algolia search

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-APPLICATION_ID=Q4GSZWRKBA
-# regenerate before release to prod
-API_KEY=5f7ed048f88cc96ee78760c827b27f75

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -66,7 +66,7 @@ const config = {
     ({
       algolia: {
         appId: 'Q4GSZWRKBA',
-        apiKey: '2ab3eace97419c5868153aac2e3d2e6c',
+        apiKey: '34ecd6611b6cef7a420bd30587d0d502',
         indexName: 'calico',
         contextualSearch: true,
         searchPagePath: '/search',


### PR DESCRIPTION
This PR removes an exposed API key we were testing for the Algolia crawler.

@radTuti Thanks for flagging this.

CC @doucol
