### PR TITLE
Adds CC variable 'cloudversion'

### DIFF
--- a/calico-cloud/variables.js
+++ b/calico-cloud/variables.js
@@ -11,6 +11,7 @@ const variables = {
   rootDirWindows: 'C:\\TigeraCalico',
   nodecontainer: 'cnx-node',
   noderunning: 'calico-node',
+  cloudversion: 'v3.14.1-16',
   clouddownloadurl: 'https://installer.calicocloud.io/manifests/v3.14.1-16',
   clouddownloadbase: 'https://installer.calicocloud.io',
   tigeraOperator: releases[0]['tigera-operator'],


### PR DESCRIPTION
The PR adds the `cloudversion` variable. We had broken links in scan-image-registries.mdx that used this.