### PR TITLE
DOCS-1205: Add ability to expand/collapse code block

### DIFF
--- a/src/theme/CodeBlock/index.js
+++ b/src/theme/CodeBlock/index.js
@@ -1,27 +1,23 @@
 import React from 'react';
-import ReactDOMServer from 'react-dom/server';
 import CodeBlock from '@theme-original/CodeBlock';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import { useLocation } from '@docusaurus/router';
-
-function useURLsCheck(props) {
-  const { siteConfig } = useDocusaurusContext();
-  const { pathname } = useLocation();
-
-  if (siteConfig.customFields.isTesting) {
-    const childrenStr =
-      typeof props.children === 'string' ? props.children : ReactDOMServer.renderToString(props.children);
-    const regexp = /(https(?:(?!<|>).)*?\.yaml)/g;
-    const urls = Array.from(childrenStr.matchAll(regexp)).map((matched) => matched[1]);
-
-    urls.forEach((url) => {
-      console.info(`[CodeBlock url] ${url} [location] ${pathname}`);
-    });
-  }
-}
+import Details from '@theme/Details';
+import styles from './styles.module.css';
 
 export default function CodeBlockWrapper(props) {
-  useURLsCheck(props);
+  const { collapsible, title, metastring, ...otherProps } = props;
+
+  if (collapsible) {
+    const summary = <summary className={styles.codeBlockSummary}>{title}</summary>;
+
+    return (
+      <Details
+        summary={summary}
+        className={styles.codeBlockDetails}
+      >
+        <CodeBlock {...otherProps} />
+      </Details>
+    );
+  }
 
   return (
     <>

--- a/src/theme/CodeBlock/styles.module.css
+++ b/src/theme/CodeBlock/styles.module.css
@@ -1,0 +1,15 @@
+.codeBlockDetails {
+  margin: 0 0 var(--ifm-spacing-vertical);
+  background-color: var(--ifm-color-secondary-contrast-background);
+  border-color: var(--ifm-color-secondary-dark);
+}
+
+/* Styles for details title / code block separator */
+.codeBlockSummary + div div {
+  /* TODO: Consider dark theme */
+  border-color: var(--ifm-color-secondary-dark);
+}
+
+.codeBlockSummary::before {
+  border-color: transparent transparent transparent var(--ifm-color-secondary-dark) !important;
+}


### PR DESCRIPTION
https://tigera.atlassian.net/browse/DOCS-1205

### How to use (examples)

- Triple quote syntax

<pre>
```batch <b>collapsible title="Expand!"</b>

...some-code...

```
</pre>

- React component syntax

```
<CodeBlock
  language='yaml'
  title='Expand the whole YAML'
  collapsible
>
  test test test
</CodeBlock>
```

So it's about using two new props: `collapsible` (to enable expand/collapse feature) and `title` (to specify the title of expandable element).

**CAUTION**: if you want to specify multiple words for `title` - you should use escaped space (`&nbsp;`) for that (and no quotes). It's internal Docusaurus imperfection.

### How it looks

- Code block 1: specified via triple quote syntax
- Code block 2: our place code block with title specified (https://docusaurus.io/docs/markdown-features/code-blocks#code-title)
- Code block 3: specified via component syntax

![image](https://user-images.githubusercontent.com/56426143/214877403-ecff8cd2-afae-44a8-992c-bf9bc0c783e3.png)
![image](https://user-images.githubusercontent.com/56426143/214877432-d16cf8fa-0d1b-4fcb-8452-49823329f1a3.png)
![image](https://user-images.githubusercontent.com/56426143/214877439-a0185054-33e3-4f36-b2d8-45cffb5e4de0.png)

