### PR TITLE
Adding documentation for CSINodeDriverDaemonSet Installation fields

### DIFF
--- a/calico/reference/installation/_api.mdx
+++ b/calico/reference/installation/_api.mdx
@@ -2643,23 +2643,6 @@ Resource Types:
     <tbody>
     <tr>
         <td>
-            <code>initContainers</code>
-            <br />
-            <em>
-                <a href='#operator.tigera.io/v1.CSINodeDriverDaemonSetInitContainer'>[]CSINodeDriverDaemonSetInitContainer</a>
-            </em>
-        </td>
-        <td>
-            <em>(Optional)</em>
-            <p>
-                InitContainers is a list of csi-node-driver init containers. If specified, this overrides the specified
-                csi-node-driver DaemonSet init containers. If omitted, the csi-node-driver DaemonSet will use its default values for
-                its init containers.
-            </p>
-        </td>
-    </tr>
-    <tr>
-        <td>
             <code>containers</code>
             <br />
             <em>

--- a/calico/reference/installation/_api.mdx
+++ b/calico/reference/installation/_api.mdx
@@ -2490,6 +2490,337 @@ Resource Types:
     </tr>
   </tbody>
 </table>
+<h3 id='operator.tigera.io/v1.CSINodeDriverDaemonSet'>CSINodeDriverDaemonSet</h3>
+<p>
+    (<em>Appears on:</em>
+    <a href='#operator.tigera.io/v1.InstallationSpec'>InstallationSpec</a>)
+</p>
+<p>CSINodeDriverDaemonSet is the configuration for the csi-node-driver DaemonSet.</p>
+<table>
+    <thead>
+    <tr>
+        <th>Field</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>
+            <code>metadata</code>
+            <br />
+            <em>
+                <a href='#operator.tigera.io/v1.Metadata'>Metadata</a>
+            </em>
+        </td>
+        <td>
+            <em>(Optional)</em>
+            <p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the DaemonSet.</p>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <code>spec</code>
+            <br />
+            <em>
+                <a href='#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec'>CSINodeDriverDaemonSetSpec</a>
+            </em>
+        </td>
+        <td>
+            <em>(Optional)</em>
+            <p>Spec is the specification of the csi-node-driver DaemonSet.</p>
+            <br />
+            <br />
+            <table></table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+<h3 id='operator.tigera.io/v1.CSINodeDriverDaemonSetContainer'>CSINodeDriverDaemonSetContainer</h3>
+<p>
+    (<em>Appears on:</em>
+    <a href='#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec'>CSINodeDriverDaemonSetPodSpec</a>)
+</p>
+<p>CSINodeDriverDaemonSetContainer is a csi-node-driver DaemonSet container.</p>
+<table>
+    <thead>
+    <tr>
+        <th>Field</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>
+            <code>name</code>
+            <br />
+            <em>string</em>
+        </td>
+        <td>
+            <p>Name is an enum which identifies the csi-node-driver DaemonSet container by name.</p>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <code>resources</code>
+            <br />
+            <em>
+                <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core'>
+                    Kubernetes core/v1.ResourceRequirements
+                </a>
+            </em>
+        </td>
+        <td>
+            <em>(Optional)</em>
+            <p>
+                Resources allows customization of limits and requests for compute resources such as cpu and memory. If
+                specified, this overrides the named csi-node-driver DaemonSet container&rsquo;s resources. If omitted, the
+                csi-node-driver DaemonSet will use its default value for this container&rsquo;s resources. If used in conjunction
+                with the deprecated ComponentResources, then this value takes precedence.
+            </p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+<h3 id='operator.tigera.io/v1.CSINodeDriverDaemonSetInitContainer'>CSINodeDriverDaemonSetInitContainer</h3>
+<p>
+    (<em>Appears on:</em>
+    <a href='#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec'>CSINodeDriverDaemonSetPodSpec</a>)
+</p>
+<p>CSINodeDriverDaemonSetInitContainer is a csi-node-driver DaemonSet init container.</p>
+<table>
+    <thead>
+    <tr>
+        <th>Field</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>
+            <code>name</code>
+            <br />
+            <em>string</em>
+        </td>
+        <td>
+            <p>Name is an enum which identifies the csi-node-driver DaemonSet init container by name.</p>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <code>resources</code>
+            <br />
+            <em>
+                <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core'>
+                    Kubernetes core/v1.ResourceRequirements
+                </a>
+            </em>
+        </td>
+        <td>
+            <em>(Optional)</em>
+            <p>
+                Resources allows customization of limits and requests for compute resources such as cpu and memory. If
+                specified, this overrides the named csi-node-driver DaemonSet init container&rsquo;s resources. If omitted, the
+                csi-node-driver DaemonSet will use its default value for this container&rsquo;s resources. If used in conjunction
+                with the deprecated ComponentResources, then this value takes precedence.
+            </p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+<h3 id='operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec'>CSINodeDriverDaemonSetPodSpec</h3>
+<p>
+    (<em>Appears on:</em>
+    <a href='#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec'>CSINodeDriverDaemonSetPodTemplateSpec</a>)
+</p>
+<p>CSINodeDriverDaemonSetPodSpec is the csi-node-driver DaemonSet&rsquo;s PodSpec.</p>
+<table>
+    <thead>
+    <tr>
+        <th>Field</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>
+            <code>initContainers</code>
+            <br />
+            <em>
+                <a href='#operator.tigera.io/v1.CSINodeDriverDaemonSetInitContainer'>[]CSINodeDriverDaemonSetInitContainer</a>
+            </em>
+        </td>
+        <td>
+            <em>(Optional)</em>
+            <p>
+                InitContainers is a list of csi-node-driver init containers. If specified, this overrides the specified
+                csi-node-driver DaemonSet init containers. If omitted, the csi-node-driver DaemonSet will use its default values for
+                its init containers.
+            </p>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <code>containers</code>
+            <br />
+            <em>
+                <a href='#operator.tigera.io/v1.CSINodeDriverDaemonSetContainer'>[]CSINodeDriverDaemonSetContainer</a>
+            </em>
+        </td>
+        <td>
+            <em>(Optional)</em>
+            <p>
+                Containers is a list of csi-node-driver containers. If specified, this overrides the specified csi-node-driver
+                DaemonSet containers. If omitted, the csi-node-driver DaemonSet will use its default values for its containers.
+            </p>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <code>affinity</code>
+            <br />
+            <em>
+                <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core'>
+                    Kubernetes core/v1.Affinity
+                </a>
+            </em>
+        </td>
+        <td>
+            <em>(Optional)</em>
+            <p>
+                Affinity is a group of affinity scheduling rules for the csi-node-driver pods. If specified, this overrides any
+                affinity that may be set on the csi-node-driver DaemonSet. If omitted, the csi-node-driver DaemonSet will use its
+                default value for affinity. WARNING: Please note that this field will override the default csi-node-driver
+                DaemonSet affinity.
+            </p>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <code>nodeSelector</code>
+            <br />
+            <em>map[string]string</em>
+        </td>
+        <td>
+            <em>(Optional)</em>
+            <p>
+                NodeSelector is the csi-node-driver pod&rsquo;s scheduling constraints. If specified, each of the key/value pairs
+                are added to the csi-node-driver DaemonSet nodeSelector provided the key does not already exist in the
+                object&rsquo;s nodeSelector. If omitted, the csi-node-driver DaemonSet will use its default value for
+                nodeSelector. WARNING: Please note that this field will modify the default csi-node-driver DaemonSet nodeSelector.
+            </p>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <code>tolerations</code>
+            <br />
+            <em>
+                <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core'>
+                    []Kubernetes core/v1.Toleration
+                </a>
+            </em>
+        </td>
+        <td>
+            <em>(Optional)</em>
+            <p>
+                Tolerations is the csi-node-driver pod&rsquo;s tolerations. If specified, this overrides any tolerations that may
+                be set on the csi-node-driver DaemonSet. If omitted, the csi-node-driver DaemonSet will use its default value for
+                tolerations. WARNING: Please note that this field will override the default csi-node-driver DaemonSet tolerations.
+            </p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+<h3 id='operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec'>CSINodeDriverDaemonSetPodTemplateSpec</h3>
+<p>
+    (<em>Appears on:</em>
+    <a href='#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec'>CSINodeDriverDaemonSetSpec</a>)
+</p>
+<p>CSINodeDriverDaemonSetPodTemplateSpec is the csi-node-driver DaemonSet&rsquo;s PodTemplateSpec</p>
+<table>
+    <thead>
+    <tr>
+        <th>Field</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>
+            <code>metadata</code>
+            <br />
+            <em>
+                <a href='#operator.tigera.io/v1.Metadata'>Metadata</a>
+            </em>
+        </td>
+        <td>
+            <em>(Optional)</em>
+            <p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the pod&rsquo;s metadata.</p>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <code>spec</code>
+            <br />
+            <em>
+                <a href='#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec'>CSINodeDriverDaemonSetPodSpec</a>
+            </em>
+        </td>
+        <td>
+            <em>(Optional)</em>
+            <p>Spec is the csi-node-driver DaemonSet&rsquo;s PodSpec.</p>
+            <br />
+            <br />
+            <table></table>
+        </td>
+    </tr>
+    </tbody>
+</table>
+<h3 id='operator.tigera.io/v1.CSINodeDriverDaemonSetSpec'>CSINodeDriverDaemonSetSpec</h3>
+<p>
+    (<em>Appears on:</em>
+    <a href='#operator.tigera.io/v1.CSINodeDriverDaemonSet'>CSINodeDriverDaemonSet</a>)
+</p>
+<p>CSINodeDriverDaemonSetSpec defines configuration for the csi-node-driver DaemonSet.</p>
+<table>
+    <thead>
+    <tr>
+        <th>Field</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>
+            <code>minReadySeconds</code>
+            <br />
+            <em>int32</em>
+        </td>
+        <td>
+            <em>(Optional)</em>
+            <p>
+                MinReadySeconds is the minimum number of seconds for which a newly created DaemonSet pod should be ready
+                without any of its container crashing, for it to be considered available. If specified, this overrides any
+                minReadySeconds value that may be set on the csi-node-driver DaemonSet. If omitted, the csi-node-driver DaemonSet will
+                use its default value for minReadySeconds.
+            </p>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <code>template</code>
+            <br />
+            <em>
+                <a href='#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec'>CSINodeDriverDaemonSetPodTemplateSpec</a>
+            </em>
+        </td>
+        <td>
+            <em>(Optional)</em>
+            <p>Template describes the csi-node DaemonSet pod that will be created.</p>
+        </td>
+    </tr>
+    </tbody>
+</table>
 <h3 id='operator.tigera.io/v1.CertificateManagement'>CertificateManagement</h3>
 <p>
   (<em>Appears on:</em>


### PR DESCRIPTION
A community member contributed a PR which covered a gap in our ability to modify operator-managed daemonset configuration that now requires documentation. The PR can be found here for reference: https://github.com/tigera/operator/pull/2331