### PR TITLE
From Calico PR #7238: Fixes typo in journalctl command

### DIFF
--- a/calico-enterprise/operations/troubleshoot/commands.mdx
+++ b/calico-enterprise/operations/troubleshoot/commands.mdx
@@ -163,7 +163,7 @@ systemctl status kubelet
 If there is a problem, check the journal
 
 ```batch
-journalclt -u kubelet | head
+journalctl -u kubelet | head
 ```
 
 ### Check the status of other system pods

--- a/calico-enterprise_versioned_docs/version-3.14/operations/troubleshoot/commands.mdx
+++ b/calico-enterprise_versioned_docs/version-3.14/operations/troubleshoot/commands.mdx
@@ -163,7 +163,7 @@ systemctl status kubelet
 If there is a problem, check the journal
 
 ```batch
-journalclt -u kubelet | head
+journalctl -u kubelet | head
 ```
 
 ### Check the status of other system pods

--- a/calico-enterprise_versioned_docs/version-3.15/operations/troubleshoot/commands.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/operations/troubleshoot/commands.mdx
@@ -163,7 +163,7 @@ systemctl status kubelet
 If there is a problem, check the journal
 
 ```batch
-journalclt -u kubelet | head
+journalctl -u kubelet | head
 ```
 
 ### Check the status of other system pods

--- a/calico/operations/troubleshoot/commands.mdx
+++ b/calico/operations/troubleshoot/commands.mdx
@@ -163,7 +163,7 @@ systemctl status kubelet
 If there is a problem, check the journal
 
 ```batch
-journalclt -u kubelet | head
+journalctl -u kubelet | head
 ```
 
 ### Check the status of other system pods

--- a/calico_versioned_docs/version-3.24/operations/troubleshoot/commands.mdx
+++ b/calico_versioned_docs/version-3.24/operations/troubleshoot/commands.mdx
@@ -163,7 +163,7 @@ systemctl status kubelet
 If there is a problem, check the journal
 
 ```batch
-journalclt -u kubelet | head
+journalctl -u kubelet | head
 ```
 
 ### Check the status of other system pods

--- a/calico_versioned_docs/version-3.25/operations/troubleshoot/commands.mdx
+++ b/calico_versioned_docs/version-3.25/operations/troubleshoot/commands.mdx
@@ -163,7 +163,7 @@ systemctl status kubelet
 If there is a problem, check the journal
 
 ```batch
-journalclt -u kubelet | head
+journalctl -u kubelet | head
 ```
 
 ### Check the status of other system pods


### PR DESCRIPTION
Porting this typo fix from projectcalico/calico: https://github.com/projectcalico/calico/pull/7238

* Fixes typo in command: `journalclt` --> `journalctl`
* OS next, 3.25, 3.24; CE next, 3.15, 3.14

Reviews needed:
* SME
* Docs