### PR TITLE
DOCS-1220: Add code block callouts

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -309,6 +309,18 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
         additionalLanguages: ['powershell', 'batch'],
+        magicComments: [
+          // Default highlight class name (should be specified)
+          {
+            className: 'theme-code-block-highlighted-line',
+            line: 'highlight-next-line',
+            block: { start: 'highlight-start', end: 'highlight-end' },
+          },
+          {
+            className: 'code-block-callout',
+            line: 'callout-for-next-line',
+          },
+        ],
       },
     }),
   plugins: [

--- a/src/components/Callouts/index.js
+++ b/src/components/Callouts/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import styles from './styles.module.css';
+
+export default function Callouts(props) {
+  return <div className={styles.callouts}>{props.children}</div>;
+}

--- a/src/components/Callouts/styles.module.css
+++ b/src/components/Callouts/styles.module.css
@@ -1,0 +1,35 @@
+.callouts > ol,
+.callouts > ul {
+  counter-reset: callout;
+}
+
+.callouts > ol > li,
+.callouts > ul > li {
+  counter-increment: callout;
+  position: relative;
+  list-style-type: unset;
+}
+
+.callouts > ol > li:before,
+.callouts > ul > li:before {
+  content: counter(callout);
+  text-align: center;
+  width: 20px;
+  height: fit-content;
+  border-radius: 50%;
+  background-color: var(--ifm-color-secondary-contrast-foreground);
+  color: var(--ifm-background-surface-color);
+  display: inline-block;
+  font-size: 12px;
+  line-height: 17px;
+  font-family: inherit;
+  margin-right: 8px;
+  position: absolute;
+  left: -25px;
+  top: 4px;
+}
+
+.callouts > ol > li::marker,
+.callouts > ul > li::marker {
+  content: '';
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -475,3 +475,24 @@ input[class*='searchQueryInput']:focus {
 .DocSearch-Hit-content-wrapper {
   overflow-y: hidden;
 }
+
+/* Overrides for code block callouts */
+
+pre {
+  counter-reset: callout;
+}
+
+.code-block-callout span:last-of-type::after {
+  counter-increment: callout;
+  content: counter(callout);
+  text-align: center;
+  width: 20px;
+  border-radius: 50%;
+  background-color: var(--ifm-color-secondary-contrast-foreground);
+  color: var(--ifm-background-surface-color);
+  display: inline-block;
+  font-size: 12px;
+  line-height: 17px;
+  margin-left: 8px;
+  font-family: inherit;
+}

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -5,6 +5,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import MDXComponents from '@theme-original/MDXComponents';
 
 import GeekDetails from '@site/src/components/partials/GeekDetails';
+import Callouts from '@site/src/components/Callouts';
 
 // TO REGISTER A NEW COMPONENT
 //
@@ -45,6 +46,7 @@ export default {
   ...MDXComponents,
   ...wrappedPartials,
   GeekDetails,
+  Callouts,
 };
 
 function resolveComponent(componentName) {


### PR DESCRIPTION
https://tigera.atlassian.net/browse/DOCS-1220

**How to use:**

- Using [magic comments](https://docusaurus.io/docs/markdown-features/code-blocks#custom-magic-comments), specify the line which should have a callout (it should be the next line from the comment point of view). The magic comment: `// callout-for-next-line`;
- Under the code block (wherever you want) specify the container for callouts descriptions via the `Callouts` tag (it's our custom component registered globally);
- Using markdown list syntax, specify callout descriptions. Note that extra empty lines around the list should be present.

_! Code block language should be specified !_

**Example:**

```
```batch
cat > pool1.yaml <<EOF
// callout-for-next-line
apiVersion: projectcalico.org/v3
kind: IPPool
metadata:
  name: pool1
spec:
  // callout-for-next-line
  cidr: 192.168.0.0/18
  ipipMode: Never
  // callout-for-next-line
  natOutgoing: true
  disabled: false
  // callout-for-next-line
  nodeSelector: all()
EOF
\```

<Callouts>

1. This is very long text. This is very long text. This is very long text. This is very long text. This is very long text.

1. This is small text.

1. This item has nested list.

   - Item 1
   - Item 2

1. This item has an admonition.
   :::note
   This is note
   :::

</Callouts>

```

**UI:**

![image](https://user-images.githubusercontent.com/56426143/215789925-e20e3f46-3969-416d-b472-b6795850af66.png)
![image](https://user-images.githubusercontent.com/56426143/215789975-61cfd9ce-5282-409d-8229-3ef9d2a191d1.png)



