### PR TITLE
Broke links 3

### DIFF
--- a/calico-cloud/multicluster/kubeconfig.mdx
+++ b/calico-cloud/multicluster/kubeconfig.mdx
@@ -83,7 +83,7 @@ For each cluster in the federation, follow these steps.
 
    ```batch
    kubectl apply -f \
-   {{filesUrl_CE}}/getting-started/kubernetes/installation/federation-rem-rbac-kdd.yaml
+   {{filesUrl_CE}}/manifests/federation-rem-rbac-kdd.yaml
    ```
 
 1. Apply the following manifest to create a service account called `tigera-federation-remote-cluster`.

--- a/calico-cloud_versioned_docs/version-3.15/multicluster/kubeconfig.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/multicluster/kubeconfig.mdx
@@ -83,14 +83,14 @@ For each cluster in the federation, follow these steps.
 
    ```batch
    kubectl apply -f \
-   {{filesUrl_CE}}/getting-started/kubernetes/installation/federation-rem-rbac-kdd.yaml
+   {{filesUrl_CE}}/manifests/federation-rem-rbac-kdd.yaml
    ```
 
 1. Apply the following manifest to create a service account called `tigera-federation-remote-cluster`.
 
    ```batch
    kubectl apply -f \
-   {{filesUrl_CE}}/getting-started/kubernetes/installation/federation-remote-sa.yaml
+   {{filesUrl_CE}}/manifests/federation-remote-sa.yaml
    ```
 
 1. Create a secret for service Account manually.

--- a/calico-enterprise/_includes/components/UpgradeOperatorSimple.js
+++ b/calico-enterprise/_includes/components/UpgradeOperatorSimple.js
@@ -5,7 +5,7 @@ import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 import Link from '@docusaurus/Link';
 
-import { baseUrl, filesUrl } from '../../variables';
+import { baseUrl, filesUrl, tmpScriptsURL } from '../../variables';
 
 export default function UpgradeOperatorSimple(props) {
   return (
@@ -17,7 +17,7 @@ export default function UpgradeOperatorSimple(props) {
               Switch the active operator to the one that will be installed to the new namespace. First, download the
               helper script:
             </p>
-            <CodeBlock language='batch'>curl -L -O {filesUrl}/scripts/switch-active-operator.sh</CodeBlock>
+            <CodeBlock language='batch'>curl -L -O {tmpScriptsURL}/scripts/switch-active-operator.sh</CodeBlock>
             <p>Then switch the active operator. This will deactivate the currently running operator.</p>
             <CodeBlock>
               chmod a+x ./switch-active-operator.sh{'\n'}

--- a/calico-enterprise/getting-started/install-on-clusters/windows-calico/kubernetes/standard.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/windows-calico/kubernetes/standard.mdx
@@ -42,7 +42,7 @@ The geeky details of what you get by default:
   - Download the {{prodnameWindows}} installation script:
 
   ```powershell
-  Invoke-WebRequest {{filesUrl}}/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
+  Invoke-WebRequest {{tmpScriptsURL}}/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
   ```
 
   - Run the {{prodnameWindows}} installation script:

--- a/calico-enterprise/getting-started/install-on-clusters/windows-calico/quickstart.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/windows-calico/quickstart.mdx
@@ -104,7 +104,7 @@ The following steps install a Kubernetes cluster on a single Windows node with a
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 
    ```powershell
-   Invoke-WebRequest {{filesUrl}}/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
+   Invoke-WebRequest {{tmpScriptsURL}}/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
    ```
 
 1. Install {{prodnameWindows}} for your datastore with using the default parameters or [customize installation parameters](#configure-installation-parameters).
@@ -193,7 +193,7 @@ The following steps install a Kubernetes cluster on a single Windows node with a
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 
    ```powershell
-   Invoke-WebRequest {{filesUrl}}/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
+   Invoke-WebRequest {{tmpScriptsURL}}/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
    ```
 
 1. Install {{prodnameWindows}} for your datastore with using the default parameters or [customize installation parameters](#configure-installation-parameters).
@@ -348,7 +348,7 @@ this installation method has [additional requirements](https://kubernetes.io/doc
 To install ContainerD on the Windows node and configure the ContainerD service:
 
 ```powershell
-Invoke-WebRequest {{filesUrl}}/scripts/Install-Containerd.ps1 -OutFile c:\Install-Containerd.ps1
+Invoke-WebRequest {{tmpScriptsURL}}/scripts/Install-Containerd.ps1 -OutFile c:\Install-Containerd.ps1
 c:\Install-Containerd.ps1 -ContainerDVersion 1.6.2 -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
 ```
 
@@ -359,7 +359,7 @@ To join a Windows node to a cluster provisioned with kubeadm:
 - Install kubeadm and kubelet binaries and install the kubelet service
 
 ```powershell
-Invoke-WebRequest {{filesUrl}}/scripts/PrepareNode.ps1 -OutFile c:\PrepareNode.ps1
+Invoke-WebRequest {{tmpScriptsURL}}/scripts/PrepareNode.ps1 -OutFile c:\PrepareNode.ps1
 c:\PrepareNode.ps1 -KubernetesVersion v1.23.4 -ContainerRuntime ContainerD
 ```
 

--- a/calico-enterprise/multicluster/federation/kubeconfig.mdx
+++ b/calico-enterprise/multicluster/federation/kubeconfig.mdx
@@ -83,14 +83,14 @@ For each cluster in the federation, follow these steps.
 
    ```batch
    kubectl apply -f \
-   {{filesUrl}}/getting-started/kubernetes/installation/federation-rem-rbac-kdd.yaml
+   {{filesUrl}}/manifests/federation-rem-rbac-kdd.yaml
    ```
 
 1. Apply the following manifest to create a service account called `tigera-federation-remote-cluster`.
 
    ```batch
    kubectl apply -f \
-   {{filesUrl}}/getting-started/kubernetes/installation/federation-remote-sa.yaml
+   {{filesUrl}}/manifests/federation-remote-sa.yaml
    ```
 
 1. Create a secret for service Account manually.

--- a/calico-enterprise/variables.js
+++ b/calico-enterprise/variables.js
@@ -8,6 +8,7 @@ const variables = {
   baseUrl: '/calico-enterprise/next',
   filesUrl: 'https://downloads.tigera.io/ee/master',
   tutorialFilesURL: 'https://unified-docs.tigera.io/files',
+  tmpScriptsURL: 'https://unified-docs.tigera.io/calico-enterprise/next/scripts',
   prodnameWindows: 'Calico Enterprise for Windows',
   downloadsurl: 'https://downloads.tigera.io',
   nodecontainer: 'cnx-node',

--- a/calico-enterprise_versioned_docs/version-3.14/_includes/components/UpgradeOperatorSimple.js
+++ b/calico-enterprise_versioned_docs/version-3.14/_includes/components/UpgradeOperatorSimple.js
@@ -5,7 +5,7 @@ import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 import Link from '@docusaurus/Link';
 
-import { baseUrl, filesUrl, prodname } from '../../variables';
+import { baseUrl, filesUrl, prodname, tmpScriptsURL } from '../../variables';
 
 export default function UpgradeOperatorSimple(props) {
   return (
@@ -17,7 +17,7 @@ export default function UpgradeOperatorSimple(props) {
               Switch the active operator to the one that will be installed to the new namespace. First, download the
               helper script:
             </p>
-            <CodeBlock language='batch'>curl -L -O {filesUrl}/scripts/switch-active-operator.sh</CodeBlock>
+            <CodeBlock language='batch'>curl -L -O {tmpScriptsURL}/scripts/switch-active-operator.sh</CodeBlock>
             <p>Then switch the active operator. This will deactivate the currently running operator.</p>
             <CodeBlock>
               chmod a+x ./switch-active-operator.sh{'\n'}

--- a/calico-enterprise_versioned_docs/version-3.14/getting-started/install-on-clusters/windows-calico/kubernetes/standard.mdx
+++ b/calico-enterprise_versioned_docs/version-3.14/getting-started/install-on-clusters/windows-calico/kubernetes/standard.mdx
@@ -35,7 +35,7 @@ Extend your Kubernetes deployment to Windows environments.
   - Download the {{prodnameWindows}} installation script:
 
   ```powershell
-  Invoke-WebRequest {{filesUrl}}/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
+  Invoke-WebRequest {{tmpScriptsURL}}/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
   ```
 
   - Run the {{prodnameWindows}} installation script:

--- a/calico-enterprise_versioned_docs/version-3.14/getting-started/install-on-clusters/windows-calico/quickstart.mdx
+++ b/calico-enterprise_versioned_docs/version-3.14/getting-started/install-on-clusters/windows-calico/quickstart.mdx
@@ -118,7 +118,7 @@ Note: if {{prodname}} is installed in kube-system, update the `namespace` in the
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 
    ```powershell
-   Invoke-WebRequest {{filesUrl}}/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
+   Invoke-WebRequest {{tmpScriptsURL}}/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
    ```
 
 1. Install {{prodnameWindows}} for your datastore using the default parameters or [customize installation parameters](#configure-installation-parameters).
@@ -207,7 +207,7 @@ Note: if {{prodname}} is installed in kube-system, update the `namespace` in the
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 
    ```powershell
-   Invoke-WebRequest {{filesUrl}}/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
+   Invoke-WebRequest {{tmpScriptsURL}}/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
    ```
 
 1. Install {{prodnameWindows}} for your datastore using the default parameters or [customize installation parameters](#configure-installation-parameters).
@@ -361,7 +361,7 @@ this installation method has [additional requirements](https://kubernetes.io/doc
 To install ContainerD on the Windows node and configure the ContainerD service:
 
 ```powershell
-Invoke-WebRequest {{filesUrl}}/scripts/Install-Containerd.ps1 -OutFile c:\Install-Containerd.ps1
+Invoke-WebRequest {{tmpScriptsURL}}/scripts/Install-Containerd.ps1 -OutFile c:\Install-Containerd.ps1
 c:\Install-Containerd.ps1 -ContainerDVersion 1.6.2 -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
 ```
 
@@ -372,7 +372,7 @@ To join a Windows node to a cluster provisioned with kubeadm:
 - Install kubeadm and kubelet binaries and install the kubelet service
 
 ```powershell
-Invoke-WebRequest {{filesUrl}}/scripts/PrepareNode.ps1 -OutFile c:\PrepareNode.ps1
+Invoke-WebRequest {{tmpScriptsURL}}/scripts/PrepareNode.ps1 -OutFile c:\PrepareNode.ps1
 c:\PrepareNode.ps1 -KubernetesVersion v1.23.4 -ContainerRuntime ContainerD
 ```
 

--- a/calico-enterprise_versioned_docs/version-3.14/multicluster/federation/kubeconfig.mdx
+++ b/calico-enterprise_versioned_docs/version-3.14/multicluster/federation/kubeconfig.mdx
@@ -83,14 +83,14 @@ For each cluster in the federation, follow these steps.
 
    ```batch
    kubectl apply -f \
-   {{filesUrl}}/getting-started/kubernetes/installation/federation-rem-rbac-kdd.yaml
+   {{filesUrl}}/manifests/federation-rem-rbac-kdd.yaml
    ```
 
 1. Apply the following manifest to create a service account called `tigera-federation-remote-cluster`.
 
    ```batch
    kubectl apply -f \
-   {{filesUrl}}/getting-started/kubernetes/installation/federation-remote-sa.yaml
+   {{filesUrl}}/manifests/federation-remote-sa.yaml
    ```
 
 1. Use the following command to retrieve the name of the secret containing the token associated

--- a/calico-enterprise_versioned_docs/version-3.14/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.14/variables.js
@@ -8,6 +8,7 @@ const variables = {
   baseUrl: '/calico-enterprise/3.14',
   filesUrl: 'https://downloads.tigera.io/ee/v3.14.4',
   tutorialFilesURL: 'https://unified-docs.tigera.io/files',
+  tmpScriptsURL: 'https://unified-docs.tigera.io/calico-enterprise/3.14/scripts',
   prodnameWindows: 'Calico Enterprise for Windows',
   downloadsurl: 'https://downloads.tigera.io',
   nodecontainer: 'cnx-node',

--- a/calico-enterprise_versioned_docs/version-3.15/_includes/components/UpgradeOperatorSimple.js
+++ b/calico-enterprise_versioned_docs/version-3.15/_includes/components/UpgradeOperatorSimple.js
@@ -5,7 +5,7 @@ import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 import Link from '@docusaurus/Link';
 
-import { baseUrl, filesUrl } from '../../variables';
+import { baseUrl, filesUrl, tmpScriptsURL } from '../../variables';
 
 export default function UpgradeOperatorSimple(props) {
   return (
@@ -17,7 +17,7 @@ export default function UpgradeOperatorSimple(props) {
               Switch the active operator to the one that will be installed to the new namespace. First, download the
               helper script:
             </p>
-            <CodeBlock language='batch'>curl -L -O {filesUrl}/scripts/switch-active-operator.sh</CodeBlock>
+            <CodeBlock language='batch'>curl -L -O {tmpScriptsURL}/scripts/switch-active-operator.sh</CodeBlock>
             <p>Then switch the active operator. This will deactivate the currently running operator.</p>
             <CodeBlock>
               chmod a+x ./switch-active-operator.sh{'\n'}

--- a/calico-enterprise_versioned_docs/version-3.15/getting-started/install-on-clusters/windows-calico/kubernetes/standard.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/getting-started/install-on-clusters/windows-calico/kubernetes/standard.mdx
@@ -42,7 +42,7 @@ The geeky details of what you get by default:
   - Download the {{prodnameWindows}} installation script:
 
   ```powershell
-  Invoke-WebRequest {{filesUrl}}/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
+  Invoke-WebRequest {{tmpScriptsURL}}/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
   ```
 
   - Run the {{prodnameWindows}} installation script:

--- a/calico-enterprise_versioned_docs/version-3.15/getting-started/install-on-clusters/windows-calico/quickstart.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/getting-started/install-on-clusters/windows-calico/quickstart.mdx
@@ -104,7 +104,7 @@ The following steps install a Kubernetes cluster on a single Windows node with a
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 
    ```powershell
-   Invoke-WebRequest {{filesUrl}}/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
+   Invoke-WebRequest {{tmpScriptsURL}}/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
    ```
 
 1. Install {{prodnameWindows}} for your datastore with using the default parameters or [customize installation parameters](#configure-installation-parameters).
@@ -193,7 +193,7 @@ The following steps install a Kubernetes cluster on a single Windows node with a
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 
    ```powershell
-   Invoke-WebRequest {{filesUrl}}/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
+   Invoke-WebRequest {{tmpScriptsURL}}/scripts/install-calico-windows.ps1 -OutFile c:\install-calico-windows.ps1
    ```
 
 1. Install {{prodnameWindows}} for your datastore with using the default parameters or [customize installation parameters](#configure-installation-parameters).
@@ -348,7 +348,7 @@ this installation method has [additional requirements](https://kubernetes.io/doc
 To install ContainerD on the Windows node and configure the ContainerD service:
 
 ```powershell
-Invoke-WebRequest {{filesUrl}}/scripts/Install-Containerd.ps1 -OutFile c:\Install-Containerd.ps1
+Invoke-WebRequest {{tmpScriptsURL}}/scripts/Install-Containerd.ps1 -OutFile c:\Install-Containerd.ps1
 c:\Install-Containerd.ps1 -ContainerDVersion 1.6.2 -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
 ```
 
@@ -359,7 +359,7 @@ To join a Windows node to a cluster provisioned with kubeadm:
 - Install kubeadm and kubelet binaries and install the kubelet service
 
 ```powershell
-Invoke-WebRequest {{filesUrl}}/scripts/PrepareNode.ps1 -OutFile c:\PrepareNode.ps1
+Invoke-WebRequest {{tmpScriptsURL}}/scripts/PrepareNode.ps1 -OutFile c:\PrepareNode.ps1
 c:\PrepareNode.ps1 -KubernetesVersion v1.23.4 -ContainerRuntime ContainerD
 ```
 

--- a/calico-enterprise_versioned_docs/version-3.15/multicluster/federation/kubeconfig.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/multicluster/federation/kubeconfig.mdx
@@ -83,14 +83,14 @@ For each cluster in the federation, follow these steps.
 
    ```batch
    kubectl apply -f \
-   {{filesUrl}}/getting-started/kubernetes/installation/federation-rem-rbac-kdd.yaml
+   {{filesUrl}}/manifests/federation-rem-rbac-kdd.yaml
    ```
 
 1. Apply the following manifest to create a service account called `tigera-federation-remote-cluster`.
 
    ```batch
    kubectl apply -f \
-   {{filesUrl}}/getting-started/kubernetes/installation/federation-remote-sa.yaml
+   {{filesUrl}}/manifests/federation-remote-sa.yaml
    ```
 
 1. Create a secret for service Account manually.

--- a/calico-enterprise_versioned_docs/version-3.15/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.15/variables.js
@@ -8,6 +8,7 @@ const variables = {
   baseUrl: '/calico-enterprise/3.15',
   filesUrl: 'https://downloads.tigera.io/ee/v3.15.1',
   tutorialFilesURL: 'https://unified-docs.tigera.io/files',
+  tmpScriptsURL: 'https://unified-docs.tigera.io/calico-enterprise/3.15/scripts',
   prodnameWindows: 'Calico Enterprise for Windows',
   downloadsurl: 'https://downloads.tigera.io',
   nodecontainer: 'cnx-node',

--- a/calico/getting-started/kubernetes/windows-calico/quickstart.mdx
+++ b/calico/getting-started/kubernetes/windows-calico/quickstart.mdx
@@ -444,7 +444,7 @@ this installation method has [additional requirements](https://kubernetes.io/doc
 To install ContainerD on the Windows node and configure the ContainerD service:
 
 ```powershell
-Invoke-WebRequest {{filesUrl}}/scripts/Install-Containerd.ps1 -OutFile c:\Install-Containerd.ps1
+Invoke-WebRequest {{tmpScriptsURL}}/scripts/Install-Containerd.ps1 -OutFile c:\Install-Containerd.ps1
 c:\Install-Containerd.ps1 -ContainerDVersion 1.6.2 -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
 ```
 
@@ -455,7 +455,7 @@ To join a Windows node to a cluster provisioned with kubeadm:
 - Install kubeadm and kubelet binaries and install the kubelet service
 
 ```powershell
-Invoke-WebRequest {{filesUrl}}/scripts/PrepareNode.ps1 -OutFile c:\PrepareNode.ps1
+Invoke-WebRequest {{tmpScriptsURL}}/scripts/PrepareNode.ps1 -OutFile c:\PrepareNode.ps1
 c:\PrepareNode.ps1 -KubernetesVersion v1.23.4 -ContainerRuntime ContainerD
 ```
 

--- a/calico/variables.js
+++ b/calico/variables.js
@@ -9,6 +9,7 @@ const variables = {
   filesUrl: 'https://projectcalico.docs.tigera.io/master',
   tutorialFilesURL: 'https://unified-docs.tigera.io/files',
   calicoReleasesURL: 'https://github.com/projectcalico/calico/releases/download',
+  tmpScriptsURL: 'https://unified-docs.tigera.io/calico/next/scripts',
   prodnameWindows: 'Calico for Windows',
   nodecontainer: 'calico/node',
   noderunning: 'calico-node',

--- a/calico_versioned_docs/version-3.24/getting-started/kubernetes/windows-calico/quickstart.mdx
+++ b/calico_versioned_docs/version-3.24/getting-started/kubernetes/windows-calico/quickstart.mdx
@@ -444,7 +444,7 @@ this installation method has [additional requirements](https://kubernetes.io/doc
 To install ContainerD on the Windows node and configure the ContainerD service:
 
 ```powershell
-Invoke-WebRequest {{filesUrl}}/scripts/Install-Containerd.ps1 -OutFile c:\Install-Containerd.ps1
+Invoke-WebRequest {{tmpScriptsURL}}/scripts/Install-Containerd.ps1 -OutFile c:\Install-Containerd.ps1
 c:\Install-Containerd.ps1 -ContainerDVersion 1.6.2 -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
 ```
 
@@ -455,7 +455,7 @@ To join a Windows node to a cluster provisioned with kubeadm:
 - Install kubeadm and kubelet binaries and install the kubelet service
 
 ```powershell
-Invoke-WebRequest {{filesUrl}}/scripts/PrepareNode.ps1 -OutFile c:\PrepareNode.ps1
+Invoke-WebRequest {{tmpScriptsURL}}/scripts/PrepareNode.ps1 -OutFile c:\PrepareNode.ps1
 c:\PrepareNode.ps1 -KubernetesVersion v1.23.4 -ContainerRuntime ContainerD
 ```
 

--- a/calico_versioned_docs/version-3.24/variables.js
+++ b/calico_versioned_docs/version-3.24/variables.js
@@ -9,6 +9,7 @@ const variables = {
   filesUrl: 'https://projectcalico.docs.tigera.io/v3.24',
   tutorialFilesURL: 'https://unified-docs.tigera.io/files',
   calicoReleasesURL: 'https://github.com/projectcalico/calico/releases/download',
+  tmpScriptsURL: 'https://unified-docs.tigera.io/calico/3.24/scripts',
   prodnameWindows: 'Calico for Windows',
   nodecontainer: 'calico/node',
   noderunning: 'calico-node',

--- a/calico_versioned_docs/version-3.25/getting-started/kubernetes/windows-calico/quickstart.mdx
+++ b/calico_versioned_docs/version-3.25/getting-started/kubernetes/windows-calico/quickstart.mdx
@@ -444,7 +444,7 @@ this installation method has [additional requirements](https://kubernetes.io/doc
 To install ContainerD on the Windows node and configure the ContainerD service:
 
 ```powershell
-Invoke-WebRequest {{filesUrl}}/scripts/Install-Containerd.ps1 -OutFile c:\Install-Containerd.ps1
+Invoke-WebRequest {{tmpScriptsURL}}/scripts/Install-Containerd.ps1 -OutFile c:\Install-Containerd.ps1
 c:\Install-Containerd.ps1 -ContainerDVersion 1.6.2 -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
 ```
 
@@ -455,7 +455,7 @@ To join a Windows node to a cluster provisioned with kubeadm:
 - Install kubeadm and kubelet binaries and install the kubelet service
 
 ```powershell
-Invoke-WebRequest {{filesUrl}}/scripts/PrepareNode.ps1 -OutFile c:\PrepareNode.ps1
+Invoke-WebRequest {{tmpScriptsURL}}/scripts/PrepareNode.ps1 -OutFile c:\PrepareNode.ps1
 c:\PrepareNode.ps1 -KubernetesVersion v1.23.4 -ContainerRuntime ContainerD
 ```
 

--- a/calico_versioned_docs/version-3.25/variables.js
+++ b/calico_versioned_docs/version-3.25/variables.js
@@ -9,6 +9,7 @@ const variables = {
   filesUrl: 'https://projectcalico.docs.tigera.io/v3.25',
   tutorialFilesURL: 'https://unified-docs.tigera.io/files',
   calicoReleasesURL: 'https://github.com/projectcalico/calico/releases/download',
+  tmpScriptsURL: 'https://unified-docs.tigera.io/calico/3.25/scripts',
   prodnameWindows: 'Calico for Windows',
   nodecontainer: 'calico/node',
   noderunning: 'calico-node',

--- a/static/calico-enterprise/3.14/scripts/Install-Containerd.ps1
+++ b/static/calico-enterprise/3.14/scripts/Install-Containerd.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+Installs ContainerD on a Windows machine in preparation for joining the node to a Kubernetes cluster.
+
+.DESCRIPTION
+This script
+- Verifies that Windows Features required for running containers are enabled (and enables then if they are not).
+- Downloads ContainerD binaries at the version specified.
+- Registers ContainerD as a windows service.
+
+This is originally from https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/Install-Containerd.ps1.
+It has been adapted for Calico.
+
+.PARAMETER ContainerDVersion
+ContainerD version to download and use.
+
+.EXAMPLE
+PS> .\Install-Containerd.ps1 -ContainerDVersion 1.6.2 -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
+#>
+
+Param(
+    [parameter(HelpMessage = "ContainerD version to use")]
+    [string] $ContainerDVersion = "1.6.2",
+    [parameter(HelpMessage = "Path to configure ContainerD to look for CNI config files. This should be set to the same path used for Calico for Windows.")]
+    [string] $CNIConfigPath = "c:/etc/cni/net.d",
+    [parameter(HelpMessage = "Path to configure ContainerD to look for CNI binaries. This should be set to the same path used for Calico for Windows.")]
+    [string] $CNIBinPath = "c:/opt/cni/bin"
+)
+
+$ErrorActionPreference = 'Stop'
+
+function DownloadFile($destination, $source) {
+    Write-Host("Downloading $source to $destination")
+    curl.exe --silent --fail -Lo $destination $source
+
+    if (!$?) {
+        Write-Error "Download $source failed"
+        exit 1
+    }
+}
+
+# The original script also included Hyper-V and Hyper-V-Powershell.
+# However those are not needed by Calico for Windows.
+$requiredWindowsFeatures = @(
+    "Containers")
+
+function ValidateWindowsFeatures {
+    $allFeaturesInstalled = $true
+    foreach ($feature in $requiredWindowsFeatures) {
+        $f = Get-WindowsFeature -Name $feature
+        if (-not $f.Installed) {
+            Write-Warning "Windows feature: '$feature' is not installed."
+            $allFeaturesInstalled = $false
+        }
+    }
+    return $allFeaturesInstalled
+}
+
+if (-not (ValidateWindowsFeatures)) {
+    Write-Output "Installing required windows features..."
+
+    foreach ($feature in $requiredWindowsFeatures) {
+        Install-WindowsFeature -Name $feature
+    }
+
+    Write-Output "Please reboot and re-run this script."
+    exit 0
+}
+
+# Install 7Zip
+Write-Output "Installing 7Zip"
+Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.v2.psm1 -O $env:TEMP\helper.v2.psm1
+ipmo $env:TEMP\helper.v2.psm1
+Install-7Zip
+
+Write-Output "Getting ContainerD binaries"
+$global:ContainerDPath = "$env:ProgramFiles\containerd"
+mkdir -Force $global:ContainerDPath | Out-Null
+DownloadFile "$global:ContainerDPath\containerd.tar.gz" https://github.com/containerd/containerd/releases/download/v${ContainerDVersion}/containerd-${ContainerDVersion}-windows-amd64.tar.gz
+tar.exe -xvf "$global:ContainerDPath\containerd.tar.gz" --strip=1 -C $global:ContainerDPath
+$env:Path += ";$global:ContainerDPath"
+[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
+containerd.exe config default | Out-File "$global:ContainerDPath\config.toml" -Encoding ascii
+#config file fixups
+$config = Get-Content "$global:ContainerDPath\config.toml"
+$config = $config -replace "bin_dir = (.)*$", "bin_dir = `"$CNIBinPath`""
+$config = $config -replace "conf_dir = (.)*$", "conf_dir = `"$CNIConfigPath`""
+$config | Set-Content "$global:ContainerDPath\config.toml" -Force
+
+mkdir -Force $CNIBinPath | Out-Null
+mkdir -Force $CNIConfigPath | Out-Null
+
+Write-Output "Registering ContainerD as a service"
+containerd.exe --register-service
+
+Write-Output "Starting ContainerD service"
+Start-Service containerd
+
+Write-Output "Done - please remember to add '--cri-socket `"npipe:////./pipe/containerd-containerd`"' to your kubeadm join command"

--- a/static/calico-enterprise/3.14/scripts/PrepareNode.ps1
+++ b/static/calico-enterprise/3.14/scripts/PrepareNode.ps1
@@ -1,0 +1,150 @@
+<#
+.SYNOPSIS
+Assists with preparing a Windows VM prior to calling kubeadm join
+
+.DESCRIPTION
+This script assists with joining a Windows node to a cluster.
+- Downloads Kubernetes binaries (kubelet, kubeadm) at the version specified
+- Registers kubelet as an nssm service. More info on nssm: https://nssm.cc/
+
+This is originally from https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/PrepareNode.ps1
+It has been adapted for Calico.
+
+.PARAMETER KubernetesVersion
+Kubernetes version to download and use
+
+.PARAMETER ContainerRuntime
+Container that Kubernetes will use. (Docker or ContainerD)
+
+.EXAMPLE
+PS> .\PrepareNode.ps1 -KubernetesVersion v1.23.4 -ContainerRuntime ContainerD
+
+#>
+
+Param(
+    [parameter(Mandatory = $true, HelpMessage="Kubernetes version to use")]
+    [string] $KubernetesVersion,
+    [parameter(HelpMessage="Container runtime that Kubernetes will use")]
+    [ValidateSet("ContainerD", "Docker")]
+    [string] $ContainerRuntime = "ContainerD"
+)
+$ErrorActionPreference = 'Stop'
+
+function DownloadFile($destination, $source) {
+    Write-Host("Downloading $source to $destination")
+    curl.exe --silent --fail -Lo $destination $source
+
+    if (!$?) {
+        Write-Error "Download $source failed"
+        exit 1
+    }
+}
+
+if ($ContainerRuntime -eq "Docker") {
+    if (-not(Test-Path "//./pipe/docker_engine")) {
+        Write-Error "Docker service was not detected - please install start Docker before calling PrepareNode.ps1 with -ContainerRuntime Docker"
+        exit 1
+    }
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    if (-not(Test-Path "//./pipe/containerd-containerd")) {
+        Write-Error "ContainerD service was not detected - please install and start ContainerD before calling PrepareNode.ps1 with -ContainerRuntime ContainerD"
+        exit 1
+    }
+}
+
+if (!$KubernetesVersion.StartsWith("v")) {
+    $KubernetesVersion = "v" + $KubernetesVersion
+}
+Write-Host "Using Kubernetes version: $KubernetesVersion"
+$global:Powershell = (Get-Command powershell).Source
+$global:PowershellArgs = "-ExecutionPolicy Bypass -NoProfile"
+$global:KubernetesPath = "$env:SystemDrive\k"
+$global:StartKubeletScript = "$global:KubernetesPath\StartKubelet.ps1"
+$global:NssmInstallDirectory = "$env:ProgramFiles\nssm"
+$kubeletBinPath = "$global:KubernetesPath\kubelet.exe"
+
+mkdir -force "$global:KubernetesPath"
+$env:Path += ";$global:KubernetesPath"
+[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
+
+DownloadFile $kubeletBinPath https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubelet.exe
+DownloadFile "$global:KubernetesPath\kubeadm.exe" https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubeadm.exe
+
+if ($ContainerRuntime -eq "Docker") {
+    # Create host network to allow kubelet to schedule hostNetwork pods
+    # NOTE: For containerd the 0-containerd-nat.json network config template added by
+    # Install-containerd.ps1 joins pods to the host network.
+    Write-Host "Creating Docker host network"
+    docker network create -d nat host
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    DownloadFile "c:\k\hns.psm1" https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1
+    Import-Module "c:\k\hns.psm1"
+    if ((Get-HNSNetwork | ? Type -EQ nat | ? Name -EQ nat) -eq $null) {
+        New-HnsNetwork -Type NAT -Name nat
+    }
+}
+
+$kubeletLogPath = "C:\var\log\kubelet"
+mkdir -force $kubeletLogPath
+mkdir -force C:\var\lib\kubelet\etc\kubernetes
+mkdir -force C:\etc\kubernetes\pki
+New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C:\etc\kubernetes\pki\
+
+$StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
+$global:KubeletArgs = $FileContent.TrimStart(''KUBELET_KUBEADM_ARGS='').Trim(''"'')
+
+$global:containerRuntime = {{CONTAINER_RUNTIME}}
+
+if ($global:containerRuntime -eq "Docker") {
+    $netId = docker network ls -f name=host --format "{{ .ID }}"
+
+    if ($netId.Length -lt 1) {
+    docker network create -d nat host
+    }
+}
+
+$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:3.6`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --logtostderr=false --image-pull-progress-deadline=20m"
+
+Invoke-Expression $cmd'
+$StartKubeletFileContent = $StartKubeletFileContent -replace "{{CONTAINER_RUNTIME}}", "`"$ContainerRuntime`""
+Set-Content -Path $global:StartKubeletScript -Value $StartKubeletFileContent
+
+Write-Host "Installing nssm"
+$arch = "win32"
+if ([Environment]::Is64BitOperatingSystem) {
+    $arch = "win64"
+}
+
+mkdir -Force $global:NssmInstallDirectory
+DownloadFile nssm.zip https://k8stestinfrabinaries.blob.core.windows.net/nssm-mirror/nssm-2.24.zip
+tar C $global:NssmInstallDirectory -xvf .\nssm.zip --strip-components 2 */$arch/*.exe
+Remove-Item -Force .\nssm.zip
+
+$env:path += ";$global:NssmInstallDirectory"
+$newPath = "$global:NssmInstallDirectory;" +
+[Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
+
+[Environment]::SetEnvironmentVariable("PATH", $newPath, [EnvironmentVariableTarget]::Machine)
+
+Write-Host "Registering kubelet service"
+nssm install kubelet $global:Powershell $global:PowershellArgs $global:StartKubeletScript
+nssm set kubelet AppStdout $kubeletLogPath\kubelet.out.log
+nssm set kubelet AppStderr $kubeletLogPath\kubelet.err.log
+
+# Configure online file rotation.
+nssm set kubelet AppRotateFiles 1
+nssm set kubelet AppRotateOnline 1
+# Rotate once per day.
+nssm set kubelet AppRotateSeconds 86400
+# Rotate after 10MB.
+nssm set kubelet AppRotateBytes 10485760
+
+if ($ContainerRuntime -eq "Docker") {
+    nssm set kubelet DependOnService docker
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    nssm set kubelet DependOnService containerd
+}
+
+if ((Get-NetFirewallRule | ? Name -EQ kubelet) -EQ $null) {
+    New-NetFirewallRule -Name kubelet -DisplayName 'kubelet' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 10250
+}

--- a/static/calico-enterprise/3.14/scripts/install-calico-windows.ps1
+++ b/static/calico-enterprise/3.14/scripts/install-calico-windows.ps1
@@ -1,0 +1,526 @@
+---
+layout: null
+---
+# Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+<#
+.DESCRIPTION
+    This script installs and starts {{site.prodname}} services on a Windows node.
+
+    Note: EKS requires downloading kubectl.exe to c:\k before running this script: https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
+#>
+
+Param(
+    # Note: we don't publish a release artifact for the "master" branch. To test
+    # against master, build calico-windows.zip from projectcalico/node.
+{%- if site.url contains "projectcalico" %}
+    [parameter(Mandatory = $false)] $ReleaseBaseURL="https://github.com/projectcalico/calico/releases/download/{{site.data.versions.first.components["calico/node"].version}}/",
+    [parameter(Mandatory = $false)] $ReleaseFile="calico-windows-{{site.data.versions.first.components["calico/node"].version}}.zip",
+{%- else %}
+    [parameter(Mandatory = $false)] $ReleaseBaseURL="{{site.url}}/files/windows/",
+{%- endif %}
+    [parameter(Mandatory = $false)] $KubeVersion="",
+    [parameter(Mandatory = $false)] $StartCalico="yes",
+    [parameter(Mandatory = $false)] $Datastore="kubernetes",
+    [parameter(Mandatory = $false)] $EtcdEndpoints="",
+    [parameter(Mandatory = $false)] $EtcdTlsSecretName="",
+    [parameter(Mandatory = $false)] $EtcdKey="",
+    [parameter(Mandatory = $false)] $EtcdCert="",
+    [parameter(Mandatory = $false)] $EtcdCaCert="",
+    [parameter(Mandatory = $false)] $ServiceCidr="10.96.0.0/12",
+    [parameter(Mandatory = $false)] $DNSServerIPs="10.96.0.10",
+    [parameter(Mandatory = $false)] $CalicoBackend=""
+)
+
+function DownloadFiles()
+{
+    Write-Host "Creating CNI directory"
+    md $BaseDir\cni\config -ErrorAction Ignore
+
+    Write-Host "Downloading Windows Kubernetes scripts"
+    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1 -Destination $BaseDir\hns.psm1
+}
+
+function PrepareKubernetes()
+{
+    DownloadFiles
+    ipmo C:\k\hns.psm1
+    InstallK8sBinaries
+
+    # Prepull and tag the pause image for docker
+    if (-not (Get-IsContainerdRunning)) {
+        # If containerd is not running we assume the installation should be
+        # configured for docker. But in this case, docker has to be running.
+        $svc = Get-Service | where Name -EQ 'docker'
+        if ($svc -EQ $null) {
+            Write-Host "Docker service is not installed. Cannot prepare kubernetes pause image."
+            exit 1
+        }
+        if ($svc.Status -NE 'Running') {
+            Write-Host "Docker service is not running. Cannot prepare kubernetes pause image. Run 'Start-Service docker' and try again."
+            exit 1
+        }
+        $pause = "mcr.microsoft.com/oss/kubernetes/pause:3.6"
+        docker pull $pause
+        docker tag $pause kubeletwin/pause
+    }
+}
+
+function InstallK8sBinaries()
+{
+    Install-7Zip
+    $Source = "" | Select Release
+    $Source.Release=$KubeVersion
+    InstallKubernetesBinaries -Destination $BaseDir -Source $Source
+    cp c:\k\kubernetes\node\bin\*.exe c:\k
+}
+
+function GetPlatformType()
+{
+    # AKS
+    $hnsNetwork = Get-HnsNetwork | ? Name -EQ azure
+    if ($hnsNetwork.name -EQ "azure") {
+        return ("aks")
+    }
+
+    # EKS
+    $hnsNetwork = Get-HnsNetwork | ? Name -like "vpcbr*"
+    if ($hnsNetwork.name -like "vpcbr*") {
+        return ("eks")
+    }
+
+    # EC2
+    $restError = $null
+    Try {
+        $awsNodeName=Invoke-RestMethod -uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    } Catch {
+        $restError = $_
+    }
+    if ($restError -eq $null) {
+        return ("ec2")
+    }
+
+    # GCE
+    $restError = $null
+    Try {
+        $gceNodeName = Invoke-RestMethod -UseBasicParsing -Headers @{"Metadata-Flavor"="Google"} "http://metadata.google.internal/computeMetadata/v1/instance/hostname" -ErrorAction Ignore
+    } Catch {
+        $restError = $_
+    }
+    if ($restError -eq $null) {
+        return ("gce")
+    }
+
+    return ("bare-metal")
+}
+
+function GetBackendType()
+{
+    param(
+        [parameter(Mandatory=$true)] $CalicoNamespace,
+        [parameter(Mandatory=$false)] $KubeConfigPath = "$RootDir\calico-kube-config"
+    )
+
+    if (-Not [string]::IsNullOrEmpty($CalicoBackend)) {
+        return $CalicoBackend
+    }
+
+    # For hostprocess installs, if CALICO_NETWORKING_BACKEND is set to a valid value, try to use it.
+    if ($env:CONTAINER_SANDBOX_MOUNT_POINT -and $env:CALICO_NETWORKING_BACKEND) {
+        $backend = $env:CALICO_NETWORKING_BACKEND
+        if (($backend -eq "vxlan") -or ($backend -eq "windows-bgp")) {
+            return $backend
+        }
+
+        if ($backend -NE $null) {
+            Write-Host "Invalid Calico backend type: $backend. Set CALICO_NETWORKING_BACKEND in calico-windows-config in calico-system namespace to one of: 'vxlan', 'windows-bgp'"
+            exit 1
+        }
+
+        # If CALICO_NETWORKING_BACKEND is not set we can only continue if the
+        # kubeconfig and kubectl.exe both exist.
+        if ((-not (Test-Path $KubeConfigPath)) -or (-not (Test-Path "c:\k\kubectl.exe"))) {
+            Write-Host "No CALICO_NETWORKING_BACKEND provided. Set CALICO_NETWORKING_BACKEND in calico-windows-config in calico-system namespace to one of: 'vxlan', 'windows-bgp'"
+            exit 1
+        }
+
+        # If we reach here, we can continue auto-detecting the backend type.
+    }
+
+    # Auto detect backend type
+    if ($Datastore -EQ "kubernetes") {
+        $encap=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.ipipEnabled}'
+        if ($encap -EQ "true") {
+            throw "{{site.prodname}} on Linux has IPIP enabled. IPIP is not supported on Windows nodes."
+        }
+
+        # Check FelixConfig first.
+        $encap=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.vxlanEnabled}'
+        if ($encap -EQ "true") {
+            return ("vxlan")
+        } elseif ($encap -EQ "false") {
+            return ("bgp")
+        } else {
+           # If any IPPool has IPIP enabled, we need to exit the installer. The
+           # IPIP-enabled might not be assigned to this Windows node but we can't
+           # verify that easily by looking at the nodeSelector.
+           $ipipModes = c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get ippools.crd.projectcalico.org -o jsonpath='{.items[*].spec.ipipMode}'
+           $ipipEnabled = $ipipModes | Select-String -pattern '(Always)|(CrossSubnet)'
+           if ($ipipEnabled -NE $null) {
+               throw "Failed to auto detect backend type. IPIP is not supported on Windows nodes but found IP pools with IPIP enabled. Rerun install script with the CalicoBackend param provided"
+           }
+
+           # If FelixConfig does not have vxlanEnabled then check the IPPools and see if any of them have enabled vxlan.
+           $vxlanModes=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get ippools.crd.projectcalico.org -o jsonpath='{.items[*].spec.vxlanMode}'
+           $vxlanEnabled = $vxlanModes | Select-String -pattern '(Always)|(CrossSubnet)'
+           if ($vxlanEnabled -NE $null) {
+               return ("vxlan")
+           } else {
+               return ("bgp")
+           }
+        }
+    } else {
+        $CalicoBackend=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get configmap calico-config -n $CalicoNamespace -o jsonpath='{.data.calico_backend}'
+        if ($CalicoBackend -EQ "vxlan") {
+            return ("vxlan")
+        }
+        return ("bgp")
+    }
+}
+
+function GetCalicoNamespace() {
+    param(
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    # If we are running inside a HostProcess container then return our
+    # namespace.
+    if ($env:CONTAINER_SANDBOX_MOUNT_POINT) {
+        $ns = Get-Content -Raw -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/run/secrets/kubernetes.io/serviceaccount/namespace
+        write-host ("Install script is running in a HostProcess container. This namespace is {0}" -f $ns)
+        return $ns
+    }
+
+    $name=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get ns calico-system
+    if ([string]::IsNullOrEmpty($name)) {
+        write-host "Calico running in kube-system namespace"
+        return ("kube-system")
+    }
+    write-host "Calico running in calico-system namespace"
+    return ("calico-system")
+}
+
+function GetCalicoKubeConfig()
+{
+    param(
+      [parameter(Mandatory=$true)] $CalicoNamespace,
+      [parameter(Mandatory=$false)] $SecretName = "calico-node",
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    # On EKS, we need to have AWS tools loaded for kubectl authentication.
+    $eksAWSToolsModulePath="C:\Program Files (x86)\AWS Tools\PowerShell\AWSPowerShell\AWSPowerShell.psd1"
+    if (Test-Path $eksAWSToolsModulePath) {
+        Write-Host "AWSPowerShell module exists, loading $eksAWSToolsModulePath ..."
+        Import-Module $eksAWSToolsModulePath
+    }
+
+    # If we are running inside a HostProcess container then we already have
+    # access to the serviceaccount token and ca cert.
+    if ($env:CONTAINER_SANDBOX_MOUNT_POINT) {
+        Write-Host "Install script is running in a HostProcess container, using mounted serviceaccount ca cert and token."
+        # CA needs to be base64-encoded.
+        $ca = Get-Content -Raw -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        $ca = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($ca))
+        # But not the token.
+        $token = Get-Content -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/run/secrets/kubernetes.io/serviceaccount/token
+
+        # KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT are used if both
+        # provided. If this is not the case, fallback to using $KubeConfigPath
+        # if it exists.
+        $k8sHost = $env:KUBERNETES_SERVICE_HOST
+        $k8sPort = $env:KUBERNETES_SERVICE_PORT
+        if ($k8sHost -and $k8sPort) {
+            $server = "server: https://{0}:{1}" -f $k8sHost, $k8sPort
+            Write-Host "Using KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT env variables for kubeconfig. $server"
+        } elseif (Test-Path $KubeConfigPath) {
+            $server=findstr https:// $KubeConfigPath
+            Write-Host ("Using existing kubeconfig at $KubeConfigPath for API server host and port. {0}" -f $server.Trim())
+        } else {
+            Write-Host "Cannot determine API server host and port. Add KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to calico-windows-config in calico-system namespace"
+            exit 1
+        }
+    } else {
+        $name=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret -n $CalicoNamespace --field-selector=type=kubernetes.io/service-account-token --no-headers -o custom-columns=":metadata.name" | findstr $SecretName | select -first 1
+        if ([string]::IsNullOrEmpty($name)) {
+            throw "$SecretName service account does not exist."
+        }
+        # CA from the k8s secret is already base64-encoded.
+        $ca=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$name -o jsonpath='{.data.ca\.crt}' -n $CalicoNamespace
+        # Token from the k8s secret is base64-encoded but we need the jwt token.
+        $tokenBase64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$name -o jsonpath='{.data.token}' -n $CalicoNamespace
+        $token=[System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($tokenBase64))
+
+        $server=findstr https:// $KubeConfigPath
+    }
+
+    (Get-Content $RootDir\calico-kube-config.template).replace('<ca>', $ca).replace('<server>', $server.Trim()).replace('<token>', $token) | Set-Content $RootDir\calico-kube-config -Force
+}
+
+function EnableWinDsrForEKS()
+{
+    $OSInfo = (Get-ComputerInfo  | select WindowsVersion, OsBuildNumber)
+    $supportsDSR = Get-IsDSRSupported
+
+    if (-Not $supportsDSR) {
+        Write-Host "WinDsr is not supported ($OSInfo)"
+        return
+    }
+
+    # Update and restart kube-proxy if WinDSR is not enabled by default.
+    $Path = Get-CimInstance -Query 'select * from win32_service where name="kube-proxy"' | Select -ExpandProperty pathname
+    if ($Path -like "*--enable-dsr=true*") {
+        Write-Host "WinDsr is enabled by default."
+    } else {
+        $UpdatedPath = $Path + " --enable-dsr=true --feature-gates=WinDSR=true"
+        Get-CimInstance win32_service -filter 'Name="kube-proxy"' | Invoke-CimMethod -Name Change -Arguments @{PathName=$UpdatedPath}
+        Restart-Service -name "kube-proxy"
+        Write-Host "WinDsr has been enabled for kube-proxy."
+    }
+}
+
+function SetupEtcdTlsFiles()
+{
+    param(
+      [parameter(Mandatory=$true)] $CalicoNamespace,
+      [parameter(Mandatory=$true)] $SecretName,
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    $path = "$RootDir\etcd-tls"
+
+    $found=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -n $CalicoNamespace
+    if ([string]::IsNullOrEmpty($found)) {
+        throw "$SecretName does not exist."
+    }
+
+    $keyB64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -o jsonpath='{.data.etcd-key}' -n $CalicoNamespace
+    $certB64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -o jsonpath='{.data.etcd-cert}' -n $CalicoNamespace
+    $caB64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -o jsonpath='{.data.etcd-ca}' -n $CalicoNamespace
+
+    New-Item -Type Directory -Path $path -Force
+
+    [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($keyB64)) | Set-Content "$path\server.key" -Force
+    [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($certB64)) | Set-Content "$path\server.crt" -Force
+    [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($caB64)) | Set-Content "$path\ca.crt" -Force
+
+    $script:EtcdKey = "$path\server.key"
+    $script:EtcdCert = "$path\server.crt"
+    $script:EtcdCaCert = "$path\ca.crt"
+}
+
+function SetAKSCalicoStaticRules {
+    $fileName  = [Io.path]::Combine("$RootDir", "static-rules.json")
+    echo '{
+    "Provider": "AKS",
+    "Rules": [
+        {
+            "Name": "EndpointPolicy",
+            "Rule": {
+                "Action": "Block",
+                "Direction": "Out",
+                "Id": "block-wireserver",
+                "Priority": 200,
+                "Protocol": 6,
+                "RemoteAddresses": "168.63.129.16/32",
+                "RemotePorts": "80",
+                "RuleType": "Switch",
+                "Type": "ACL"
+            }
+        }
+    ],
+    "version": "0.1.0"
+}' | Out-File -encoding ASCII -filepath $fileName
+}
+
+function InstallCalico()
+{
+    Write-Host "`nStart {{site.prodnameWindows}} install...`n"
+
+    pushd
+    cd $RootDir
+    .\install-calico.ps1
+    popd
+    Write-Host "`n{{site.prodnameWindows}} installed`n"
+}
+
+$ErrorActionPreference = "Stop"
+
+$BaseDir="c:\k"
+$RootDir="c:\TigeraCalico"
+$CalicoZipName="tigera-calico-windows.zip"
+$CalicoZipPath="c:\$CalicoZipName"
+
+# If this script is run from a HostProcess container then the installation archive
+# will be in the mount point.
+if ($env:CONTAINER_SANDBOX_MOUNT_POINT) {
+    $CalicoZipPath="$env:CONTAINER_SANDBOX_MOUNT_POINT\$CalicoZipName"
+}
+
+# Must load the helper modules before doing anything else.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$helper = "$BaseDir\helper.psm1"
+$helperv2 = "$BaseDir\helper.v2.psm1"
+md $BaseDir -ErrorAction Ignore
+if (!(Test-Path $helper))
+{
+    Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.psm1 -O $BaseDir\helper.psm1
+}
+if (!(Test-Path $helperv2))
+{
+    Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.v2.psm1 -O $BaseDir\helper.v2.psm1
+}
+ipmo -force $helper
+ipmo -force $helperv2
+
+if (!(Test-Path $CalicoZipPath))
+{
+	throw "Cannot find {{site.prodnameWindows}} zip file $CalicoZipPath."
+}
+
+$platform=GetPlatformType
+
+if ((Get-Service -exclude 'CalicoUpgrade' | where Name -Like 'Calico*' | where Status -EQ Running) -NE $null) {
+    Write-Host "Calico services are still running. In order to re-run the installation script, stop the CalicoNode and CalicoFelix services or uninstall them by running: $RootDir\uninstall-calico.ps1"
+    Exit
+}
+
+Remove-Item $RootDir -Force  -Recurse -ErrorAction SilentlyContinue
+Write-Host "Unzip {{site.prodnameWindows}} release..."
+Expand-Archive -Force $CalicoZipPath c:\
+ipmo -force $RootDir\libs\calico\calico.psm1
+
+# This comes after we import calico.psm1
+if (-Not [string]::IsNullOrEmpty($KubeVersion) -and $platform -NE "eks") {
+    PrepareKubernetes
+}
+
+Write-Host "Setup {{site.prodnameWindows}}..."
+Set-ConfigParameters -var 'CALICO_DATASTORE_TYPE' -value $Datastore
+Set-ConfigParameters -var 'ETCD_ENDPOINTS' -value $EtcdEndpoints
+
+if (-Not [string]::IsNullOrEmpty($EtcdTlsSecretName)) {
+    $calicoNs = GetCalicoNamespace
+    SetupEtcdTlsFiles -SecretName "$EtcdTlsSecretName" -CalicoNamespace $calicoNs
+}
+Set-ConfigParameters -var 'ETCD_KEY_FILE' -value $EtcdKey
+Set-ConfigParameters -var 'ETCD_CERT_FILE' -value $EtcdCert
+Set-ConfigParameters -var 'ETCD_CA_CERT_FILE' -value $EtcdCaCert
+Set-ConfigParameters -var 'K8S_SERVICE_CIDR' -value $ServiceCidr
+Set-ConfigParameters -var 'DNS_NAME_SERVERS' -value $DNSServerIPs
+
+if ($platform -EQ "aks") {
+    Write-Host "Setup {{site.prodnameWindows}} for AKS..."
+    $Backend="none"
+    Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "none"
+    Set-ConfigParameters -var 'KUBE_NETWORK' -value "azure.*"
+
+    $calicoNs = "calico-system"
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+
+    SetAKSCalicoStaticRules
+}
+if ($platform -EQ "eks") {
+    EnableWinDsrForEKS
+
+    $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
+    $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    Write-Host "Setup {{site.prodnameWindows}} for EKS, node name $awsNodeName ..."
+    $Backend = "none"
+
+    Set-ConfigParameters -var 'NODENAME' -value $awsNodeName
+    Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "none"
+    Set-ConfigParameters -var 'KUBE_NETWORK' -value "vpc.*"
+
+    $calicoNs = GetCalicoNamespace -KubeConfigPath C:\ProgramData\kubernetes\kubeconfig
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs -KubeConfigPath C:\ProgramData\kubernetes\kubeconfig
+}
+if ($platform -EQ "ec2") {
+    $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
+    $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    Write-Host "Setup {{site.prodnameWindows}} for AWS, node name $awsNodeName ..."
+    Set-ConfigParameters -var 'NODENAME' -value $awsNodeName
+
+    $calicoNs = GetCalicoNamespace
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+    $Backend = GetBackendType -CalicoNamespace $calicoNs
+
+    Write-Host "Backend networking is $Backend"
+    if ($Backend -EQ "bgp") {
+        Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "windows-bgp"
+    }
+}
+if ($platform -EQ "gce") {
+    $gceNodeName = Invoke-RestMethod -UseBasicParsing -Headers @{"Metadata-Flavor"="Google"} "http://metadata.google.internal/computeMetadata/v1/instance/hostname" -ErrorAction Ignore
+    Write-Host "Setup {{site.prodnameWindows}} for GCE, node name $gceNodeName ..."
+    $gceNodeNameQuote = """$gceNodeName"""
+    Set-ConfigParameters -var 'NODENAME' -value $gceNodeNameQuote
+
+    $calicoNs = GetCalicoNamespace
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+    $Backend = GetBackendType -CalicoNamespace $calicoNs
+
+    Write-Host "Backend networking is $Backend"
+    if ($Backend -EQ "bgp") {
+        Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "windows-bgp"
+    }
+}
+if ($platform -EQ "bare-metal") {
+    $calicoNs = GetCalicoNamespace
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+    $Backend = GetBackendType -CalicoNamespace $calicoNs
+
+    Write-Host "Backend networking is $Backend"
+    if ($Backend -EQ "bgp") {
+        Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "windows-bgp"
+    }
+}
+
+InstallCalico
+
+if ($StartCalico -EQ "yes") {
+    Write-Host "Starting Calico..."
+    Write-Host "This may take several seconds if the vSwitch needs to be created."
+
+    Start-Service CalicoNode
+    Wait-ForCalicoInit
+    Start-Service CalicoFelix
+
+    if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp")
+    {
+        Start-Service CalicoConfd
+    }
+
+    while ((Get-Service | where Name -Like 'Calico*' | where Status -NE Running) -NE $null) {
+        Write-Host "Waiting for the Calico services to be running..."
+        Start-Sleep 1
+    }
+
+    Write-Host "Done, the Calico services are running:"
+    Get-Service | where Name -Like 'Calico*'
+}
+
+if ($Backend -NE "none") {
+    New-NetFirewallRule -Name KubectlExec10250 -Description "Enable kubectl exec and log" -Action Allow -LocalPort 10250 -Enabled True -DisplayName "kubectl exec 10250" -Protocol TCP -ErrorAction SilentlyContinue
+}

--- a/static/calico-enterprise/3.14/scripts/switch-active-operator.sh
+++ b/static/calico-enterprise/3.14/scripts/switch-active-operator.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# This script switches the current operator installation to use the operator
+# running in the NEW_NAME namespace.
+#
+# Before this script is run, the new operator and its associated resources
+# should have been deployed to the NEW_NAME namespace.
+set -e
+
+NEW_NAME=$1
+
+if [ -z "${NEW_NAME}" ]; then
+  echo "Provide a NEW_NAME for the new namespace to switch the current operator to."
+  exit 1
+fi
+
+# kubectl_retry retries <args>
+kubectl_retry() {
+  RETRIES=$1
+  OUTPUT_TMP=$(mktemp)
+  shift 1
+
+  for attempt in $(seq 1 ${RETRIES}); do
+    exit_code=0
+    kubectl $@ 1> ${OUTPUT_TMP}
+    exit_code=$?
+    if [[ "${exit_code}" == "0" || "${exit_code}" == "" ]]; then
+      cat ${OUTPUT_TMP}
+      break
+    elif [[ "${attempt}" == "${RETRIES}" ]]; then
+      echo [ERROR] Failed to kubectl $@
+      return ${exit_code}
+    else
+      echo [INFO] Failed kubectl command - will sleep and retry
+      sleep 5
+    fi
+  done
+}
+
+copy_resource_to_ns (){
+  TYPE=$1
+  NAME=$2
+  NS=$3
+
+  DATA=$(kubectl get $TYPE -n tigera-operator ${NAME} -o jsonpath="{.data}")
+  OWNER_REF=$(kubectl get $TYPE -n tigera-operator ${NAME} -o jsonpath="{.metadata.ownerReferences}")
+  kubectl_retry 10 apply -f - <<EOF
+{"apiVersion":"v1","kind":"$TYPE",
+"data":${DATA},
+"metadata":{"name":"${NAME}","namespace":"${NS}",
+"ownerReferences": ${OWNER_REF} }}
+EOF
+}
+
+if kubectl get ns ${NEW_NAME} 2>&1 > /dev/null ; then
+  echo "The namespace ${NEW_NAME} already exists. Cannot continue switching the active operator."
+  exit 1
+fi
+
+kubectl_retry 10 create ns ${NEW_NAME}
+
+# Copy over the secrets in the tigera-operator namespace to the new namespace to ensure
+# switching the active operator is non-disruptive.
+for x in node-certs typha-certs; do
+  copy_resource_to_ns Secret $x ${NEW_NAME}
+done
+copy_resource_to_ns ConfigMap typha-ca ${NEW_NAME}
+
+# Switch the active operator
+PATCH_FILE=$(mktemp)
+cat <<EOF > ${PATCH_FILE}
+{"data":{"active-namespace": "${NEW_NAME}"}}
+EOF
+kubectl_retry 10 patch configmap -n calico-system active-operator --type=merge --patch-file "${PATCH_FILE}"

--- a/static/calico-enterprise/3.15/scripts/Install-Containerd.ps1
+++ b/static/calico-enterprise/3.15/scripts/Install-Containerd.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+Installs ContainerD on a Windows machine in preparation for joining the node to a Kubernetes cluster.
+
+.DESCRIPTION
+This script
+- Verifies that Windows Features required for running containers are enabled (and enables then if they are not).
+- Downloads ContainerD binaries at the version specified.
+- Registers ContainerD as a windows service.
+
+This is originally from https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/Install-Containerd.ps1.
+It has been adapted for Calico.
+
+.PARAMETER ContainerDVersion
+ContainerD version to download and use.
+
+.EXAMPLE
+PS> .\Install-Containerd.ps1 -ContainerDVersion 1.6.2 -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
+#>
+
+Param(
+    [parameter(HelpMessage = "ContainerD version to use")]
+    [string] $ContainerDVersion = "1.6.2",
+    [parameter(HelpMessage = "Path to configure ContainerD to look for CNI config files. This should be set to the same path used for Calico for Windows.")]
+    [string] $CNIConfigPath = "c:/etc/cni/net.d",
+    [parameter(HelpMessage = "Path to configure ContainerD to look for CNI binaries. This should be set to the same path used for Calico for Windows.")]
+    [string] $CNIBinPath = "c:/opt/cni/bin"
+)
+
+$ErrorActionPreference = 'Stop'
+
+function DownloadFile($destination, $source) {
+    Write-Host("Downloading $source to $destination")
+    curl.exe --silent --fail -Lo $destination $source
+
+    if (!$?) {
+        Write-Error "Download $source failed"
+        exit 1
+    }
+}
+
+# The original script also included Hyper-V and Hyper-V-Powershell.
+# However those are not needed by Calico for Windows.
+$requiredWindowsFeatures = @(
+    "Containers")
+
+function ValidateWindowsFeatures {
+    $allFeaturesInstalled = $true
+    foreach ($feature in $requiredWindowsFeatures) {
+        $f = Get-WindowsFeature -Name $feature
+        if (-not $f.Installed) {
+            Write-Warning "Windows feature: '$feature' is not installed."
+            $allFeaturesInstalled = $false
+        }
+    }
+    return $allFeaturesInstalled
+}
+
+if (-not (ValidateWindowsFeatures)) {
+    Write-Output "Installing required windows features..."
+
+    foreach ($feature in $requiredWindowsFeatures) {
+        Install-WindowsFeature -Name $feature
+    }
+
+    Write-Output "Please reboot and re-run this script."
+    exit 0
+}
+
+# Install 7Zip
+Write-Output "Installing 7Zip"
+Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.v2.psm1 -O $env:TEMP\helper.v2.psm1
+ipmo $env:TEMP\helper.v2.psm1
+Install-7Zip
+
+Write-Output "Getting ContainerD binaries"
+$global:ContainerDPath = "$env:ProgramFiles\containerd"
+mkdir -Force $global:ContainerDPath | Out-Null
+DownloadFile "$global:ContainerDPath\containerd.tar.gz" https://github.com/containerd/containerd/releases/download/v${ContainerDVersion}/containerd-${ContainerDVersion}-windows-amd64.tar.gz
+tar.exe -xvf "$global:ContainerDPath\containerd.tar.gz" --strip=1 -C $global:ContainerDPath
+$env:Path += ";$global:ContainerDPath"
+[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
+containerd.exe config default | Out-File "$global:ContainerDPath\config.toml" -Encoding ascii
+#config file fixups
+$config = Get-Content "$global:ContainerDPath\config.toml"
+$config = $config -replace "bin_dir = (.)*$", "bin_dir = `"$CNIBinPath`""
+$config = $config -replace "conf_dir = (.)*$", "conf_dir = `"$CNIConfigPath`""
+$config | Set-Content "$global:ContainerDPath\config.toml" -Force
+
+mkdir -Force $CNIBinPath | Out-Null
+mkdir -Force $CNIConfigPath | Out-Null
+
+Write-Output "Registering ContainerD as a service"
+containerd.exe --register-service
+
+Write-Output "Starting ContainerD service"
+Start-Service containerd
+
+Write-Output "Done - please remember to add '--cri-socket `"npipe:////./pipe/containerd-containerd`"' to your kubeadm join command"

--- a/static/calico-enterprise/3.15/scripts/PrepareNode.ps1
+++ b/static/calico-enterprise/3.15/scripts/PrepareNode.ps1
@@ -1,0 +1,150 @@
+<#
+.SYNOPSIS
+Assists with preparing a Windows VM prior to calling kubeadm join
+
+.DESCRIPTION
+This script assists with joining a Windows node to a cluster.
+- Downloads Kubernetes binaries (kubelet, kubeadm) at the version specified
+- Registers kubelet as an nssm service. More info on nssm: https://nssm.cc/
+
+This is originally from https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/PrepareNode.ps1
+It has been adapted for Calico.
+
+.PARAMETER KubernetesVersion
+Kubernetes version to download and use
+
+.PARAMETER ContainerRuntime
+Container that Kubernetes will use. (Docker or ContainerD)
+
+.EXAMPLE
+PS> .\PrepareNode.ps1 -KubernetesVersion v1.23.4 -ContainerRuntime ContainerD
+
+#>
+
+Param(
+    [parameter(Mandatory = $true, HelpMessage="Kubernetes version to use")]
+    [string] $KubernetesVersion,
+    [parameter(HelpMessage="Container runtime that Kubernetes will use")]
+    [ValidateSet("ContainerD", "Docker")]
+    [string] $ContainerRuntime = "ContainerD"
+)
+$ErrorActionPreference = 'Stop'
+
+function DownloadFile($destination, $source) {
+    Write-Host("Downloading $source to $destination")
+    curl.exe --silent --fail -Lo $destination $source
+
+    if (!$?) {
+        Write-Error "Download $source failed"
+        exit 1
+    }
+}
+
+if ($ContainerRuntime -eq "Docker") {
+    if (-not(Test-Path "//./pipe/docker_engine")) {
+        Write-Error "Docker service was not detected - please install start Docker before calling PrepareNode.ps1 with -ContainerRuntime Docker"
+        exit 1
+    }
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    if (-not(Test-Path "//./pipe/containerd-containerd")) {
+        Write-Error "ContainerD service was not detected - please install and start ContainerD before calling PrepareNode.ps1 with -ContainerRuntime ContainerD"
+        exit 1
+    }
+}
+
+if (!$KubernetesVersion.StartsWith("v")) {
+    $KubernetesVersion = "v" + $KubernetesVersion
+}
+Write-Host "Using Kubernetes version: $KubernetesVersion"
+$global:Powershell = (Get-Command powershell).Source
+$global:PowershellArgs = "-ExecutionPolicy Bypass -NoProfile"
+$global:KubernetesPath = "$env:SystemDrive\k"
+$global:StartKubeletScript = "$global:KubernetesPath\StartKubelet.ps1"
+$global:NssmInstallDirectory = "$env:ProgramFiles\nssm"
+$kubeletBinPath = "$global:KubernetesPath\kubelet.exe"
+
+mkdir -force "$global:KubernetesPath"
+$env:Path += ";$global:KubernetesPath"
+[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
+
+DownloadFile $kubeletBinPath https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubelet.exe
+DownloadFile "$global:KubernetesPath\kubeadm.exe" https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubeadm.exe
+
+if ($ContainerRuntime -eq "Docker") {
+    # Create host network to allow kubelet to schedule hostNetwork pods
+    # NOTE: For containerd the 0-containerd-nat.json network config template added by
+    # Install-containerd.ps1 joins pods to the host network.
+    Write-Host "Creating Docker host network"
+    docker network create -d nat host
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    DownloadFile "c:\k\hns.psm1" https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1
+    Import-Module -DisableNameChecking "c:\k\hns.psm1"
+    if ((Get-HNSNetwork | ? Type -EQ nat | ? Name -EQ nat) -eq $null) {
+        New-HnsNetwork -Type NAT -Name nat
+    }
+}
+
+$kubeletLogPath = "C:\var\log\kubelet"
+mkdir -force $kubeletLogPath
+mkdir -force C:\var\lib\kubelet\etc\kubernetes
+mkdir -force C:\etc\kubernetes\pki
+New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C:\etc\kubernetes\pki\
+
+$StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
+$global:KubeletArgs = $FileContent.TrimStart(''KUBELET_KUBEADM_ARGS='').Trim(''"'')
+
+$global:containerRuntime = {{CONTAINER_RUNTIME}}
+
+if ($global:containerRuntime -eq "Docker") {
+    $netId = docker network ls -f name=host --format "{{ .ID }}"
+
+    if ($netId.Length -lt 1) {
+    docker network create -d nat host
+    }
+}
+
+$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:3.6`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --logtostderr=false --image-pull-progress-deadline=20m"
+
+Invoke-Expression $cmd'
+$StartKubeletFileContent = $StartKubeletFileContent -replace "{{CONTAINER_RUNTIME}}", "`"$ContainerRuntime`""
+Set-Content -Path $global:StartKubeletScript -Value $StartKubeletFileContent
+
+Write-Host "Installing nssm"
+$arch = "win32"
+if ([Environment]::Is64BitOperatingSystem) {
+    $arch = "win64"
+}
+
+mkdir -Force $global:NssmInstallDirectory
+DownloadFile nssm.zip https://k8stestinfrabinaries.blob.core.windows.net/nssm-mirror/nssm-2.24.zip
+tar C $global:NssmInstallDirectory -xvf .\nssm.zip --strip-components 2 */$arch/*.exe
+Remove-Item -Force .\nssm.zip
+
+$env:path += ";$global:NssmInstallDirectory"
+$newPath = "$global:NssmInstallDirectory;" +
+[Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
+
+[Environment]::SetEnvironmentVariable("PATH", $newPath, [EnvironmentVariableTarget]::Machine)
+
+Write-Host "Registering kubelet service"
+nssm install kubelet $global:Powershell $global:PowershellArgs $global:StartKubeletScript
+nssm set kubelet AppStdout $kubeletLogPath\kubelet.out.log
+nssm set kubelet AppStderr $kubeletLogPath\kubelet.err.log
+
+# Configure online file rotation.
+nssm set kubelet AppRotateFiles 1
+nssm set kubelet AppRotateOnline 1
+# Rotate once per day.
+nssm set kubelet AppRotateSeconds 86400
+# Rotate after 10MB.
+nssm set kubelet AppRotateBytes 10485760
+
+if ($ContainerRuntime -eq "Docker") {
+    nssm set kubelet DependOnService docker
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    nssm set kubelet DependOnService containerd
+}
+
+if ((Get-NetFirewallRule | ? Name -EQ kubelet) -EQ $null) {
+    New-NetFirewallRule -Name kubelet -DisplayName 'kubelet' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 10250
+}

--- a/static/calico-enterprise/3.15/scripts/install-calico-windows.ps1
+++ b/static/calico-enterprise/3.15/scripts/install-calico-windows.ps1
@@ -1,0 +1,571 @@
+---
+layout: null
+---
+# Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+<#
+.DESCRIPTION
+    This script installs and starts {{site.prodname}} services on a Windows node.
+
+    Note: EKS requires downloading kubectl.exe to c:\k before running this script: https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
+#>
+
+Param(
+    # Note: we don't publish a release artifact for the "master" branch. To test
+    # against master, build calico-windows.zip from projectcalico/node.
+{%- if site.url contains "projectcalico" %}
+    [parameter(Mandatory = $false)] $ReleaseBaseURL="https://github.com/projectcalico/calico/releases/download/{{site.data.versions.first.components["calico/node"].version}}/",
+    [parameter(Mandatory = $false)] $ReleaseFile="calico-windows-{{site.data.versions.first.components["calico/node"].version}}.zip",
+{%- else %}
+    [parameter(Mandatory = $false)] $ReleaseBaseURL="{{site.url}}/files/windows/",
+{%- endif %}
+    [parameter(Mandatory = $false)] $KubeVersion="",
+    [parameter(Mandatory = $false)] $StartCalico="yes",
+    # As of Kubernetes version v1.24.0, service account token secrets are no longer automatically created. But this installation script uses that secret
+    # to generate a kubeconfig so default to creating the calico-node token secret if it doesn't exist.
+    [parameter(Mandatory = $false)] $AutoCreateServiceAccountTokenSecret="yes",
+    [parameter(Mandatory = $false)] $Datastore="kubernetes",
+    [parameter(Mandatory = $false)] $EtcdEndpoints="",
+    [parameter(Mandatory = $false)] $EtcdTlsSecretName="",
+    [parameter(Mandatory = $false)] $EtcdKey="",
+    [parameter(Mandatory = $false)] $EtcdCert="",
+    [parameter(Mandatory = $false)] $EtcdCaCert="",
+    [parameter(Mandatory = $false)] $ServiceCidr="10.96.0.0/12",
+    [parameter(Mandatory = $false)] $DNSServerIPs="10.96.0.10",
+    [parameter(Mandatory = $false)] $CalicoBackend=""
+)
+
+function DownloadFiles()
+{
+    Write-Host "Creating CNI directory"
+    md $BaseDir\cni\config -ErrorAction Ignore
+
+    Write-Host "Downloading Windows Kubernetes scripts"
+    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1 -Destination $BaseDir\hns.psm1
+}
+
+function PrepareKubernetes()
+{
+    DownloadFiles
+    ipmo -DisableNameChecking C:\k\hns.psm1
+    InstallK8sBinaries
+
+    # Prepull and tag the pause image for docker
+    if (-not (Get-IsContainerdRunning)) {
+        # If containerd is not running we assume the installation should be
+        # configured for docker. But in this case, docker has to be running.
+        $svc = Get-Service | where Name -EQ 'docker'
+        if ($svc -EQ $null) {
+            Write-Host "Docker service is not installed. Cannot prepare kubernetes pause image."
+            exit 1
+        }
+        if ($svc.Status -NE 'Running') {
+            Write-Host "Docker service is not running. Cannot prepare kubernetes pause image. Run 'Start-Service docker' and try again."
+            exit 1
+        }
+        $pause = "mcr.microsoft.com/oss/kubernetes/pause:3.6"
+        docker pull $pause
+        docker tag $pause kubeletwin/pause
+    }
+}
+
+function InstallK8sBinaries()
+{
+    Install-7Zip
+    $Source = "" | Select Release
+    $Source.Release=$KubeVersion
+    InstallKubernetesBinaries -Destination $BaseDir -Source $Source
+    cp c:\k\kubernetes\node\bin\*.exe c:\k
+}
+
+function GetPlatformType()
+{
+    # AKS
+    $hnsNetwork = Get-HnsNetwork | ? Name -EQ azure
+    if ($hnsNetwork.name -EQ "azure") {
+        return ("aks")
+    }
+
+    # EKS
+    $hnsNetwork = Get-HnsNetwork | ? Name -like "vpcbr*"
+    if ($hnsNetwork.name -like "vpcbr*") {
+        return ("eks")
+    }
+
+    # EC2
+    $restError = $null
+    Try {
+        $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
+        $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    } Catch {
+        $restError = $_
+    }
+    if ($restError -eq $null) {
+        return ("ec2")
+    }
+
+    # GCE
+    $restError = $null
+    Try {
+        $gceNodeName = Invoke-RestMethod -UseBasicParsing -Headers @{"Metadata-Flavor"="Google"} "http://metadata.google.internal/computeMetadata/v1/instance/hostname" -ErrorAction Ignore
+    } Catch {
+        $restError = $_
+    }
+    if ($restError -eq $null) {
+        return ("gce")
+    }
+
+    return ("bare-metal")
+}
+
+function GetBackendType()
+{
+    param(
+        [parameter(Mandatory=$true)] $CalicoNamespace,
+        [parameter(Mandatory=$false)] $KubeConfigPath = "$RootDir\calico-kube-config"
+    )
+
+    if (-Not [string]::IsNullOrEmpty($CalicoBackend)) {
+        return $CalicoBackend
+    }
+
+    # For hostprocess installs, if CALICO_NETWORKING_BACKEND is set to a valid value, try to use it.
+    if ($env:CONTAINER_SANDBOX_MOUNT_POINT -and $env:CALICO_NETWORKING_BACKEND) {
+        $backend = $env:CALICO_NETWORKING_BACKEND
+        if (($backend -eq "vxlan") -or ($backend -eq "windows-bgp")) {
+            return $backend
+        }
+
+        if ($backend -NE $null) {
+            Write-Host "Invalid Calico backend type: $backend. Set CALICO_NETWORKING_BACKEND in calico-windows-config in calico-system namespace to one of: 'vxlan', 'windows-bgp'"
+            exit 1
+        }
+
+        # If CALICO_NETWORKING_BACKEND is not set we can only continue if the
+        # kubeconfig and kubectl.exe both exist.
+        if ((-not (Test-Path $KubeConfigPath)) -or (-not (Test-Path "c:\k\kubectl.exe"))) {
+            Write-Host "No CALICO_NETWORKING_BACKEND provided. Set CALICO_NETWORKING_BACKEND in calico-windows-config in calico-system namespace to one of: 'vxlan', 'windows-bgp'"
+            exit 1
+        }
+
+        # If we reach here, we can continue auto-detecting the backend type.
+    }
+
+    # Auto detect backend type
+    if ($Datastore -EQ "kubernetes") {
+        $encap=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.ipipEnabled}'
+        if ($encap -EQ "true") {
+            throw "{{site.prodname}} on Linux has IPIP enabled. IPIP is not supported on Windows nodes."
+        }
+
+        # Check FelixConfig first.
+        $encap=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.vxlanEnabled}'
+        if ($encap -EQ "true") {
+            return ("vxlan")
+        } elseif ($encap -EQ "false") {
+            return ("bgp")
+        } else {
+           # If any IPPool has IPIP enabled, we need to exit the installer. The
+           # IPIP-enabled might not be assigned to this Windows node but we can't
+           # verify that easily by looking at the nodeSelector.
+           $ipipModes = c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get ippools.crd.projectcalico.org -o jsonpath='{.items[*].spec.ipipMode}'
+           $ipipEnabled = $ipipModes | Select-String -pattern '(Always)|(CrossSubnet)'
+           if ($ipipEnabled -NE $null) {
+               throw "Failed to auto detect backend type. IPIP is not supported on Windows nodes but found IP pools with IPIP enabled. Rerun install script with the CalicoBackend param provided"
+           }
+
+           # If FelixConfig does not have vxlanEnabled then check the IPPools and see if any of them have enabled vxlan.
+           $vxlanModes=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get ippools.crd.projectcalico.org -o jsonpath='{.items[*].spec.vxlanMode}'
+           $vxlanEnabled = $vxlanModes | Select-String -pattern '(Always)|(CrossSubnet)'
+           if ($vxlanEnabled -NE $null) {
+               return ("vxlan")
+           } else {
+               return ("bgp")
+           }
+        }
+    } else {
+        $CalicoBackend=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get configmap calico-config -n $CalicoNamespace -o jsonpath='{.data.calico_backend}'
+        if ($CalicoBackend -EQ "vxlan") {
+            return ("vxlan")
+        }
+        return ("bgp")
+    }
+}
+
+function GetCalicoNamespace() {
+    param(
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    # If we are running inside a HostProcess container then return our
+    # namespace.
+    if ($env:CONTAINER_SANDBOX_MOUNT_POINT) {
+        $ns = Get-Content -Raw -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/run/secrets/kubernetes.io/serviceaccount/namespace
+        write-host ("Install script is running in a HostProcess container. This namespace is {0}" -f $ns)
+        return $ns
+    }
+
+    $ErrorActionPreference = 'Continue'
+    $name=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get ns calico-system
+    $ErrorActionPreference = 'Stop'
+    if ([string]::IsNullOrEmpty($name)) {
+        write-host "Calico running in kube-system namespace"
+        return ("kube-system")
+    }
+    write-host "Calico running in calico-system namespace"
+    return ("calico-system")
+}
+
+function GetCalicoKubeConfig()
+{
+    param(
+      [parameter(Mandatory=$true)] $CalicoNamespace,
+      [parameter(Mandatory=$false)] $SecretNamePrefix = "calico-node",
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    # On EKS, we need to have AWS tools loaded for kubectl authentication.
+    $eksAWSToolsModulePath="C:\Program Files (x86)\AWS Tools\PowerShell\AWSPowerShell\AWSPowerShell.psd1"
+    if (Test-Path $eksAWSToolsModulePath) {
+        Write-Host "AWSPowerShell module exists, loading $eksAWSToolsModulePath ..."
+        Import-Module $eksAWSToolsModulePath
+    }
+
+    # If we are running inside a HostProcess container then we already have
+    # access to the serviceaccount token and ca cert.
+    if ($env:CONTAINER_SANDBOX_MOUNT_POINT) {
+        Write-Host "Install script is running in a HostProcess container, using mounted serviceaccount ca cert and token."
+        # CA needs to be base64-encoded.
+        $ca = Get-Content -Raw -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        $ca = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($ca))
+        # But not the token.
+        $token = Get-Content -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/run/secrets/kubernetes.io/serviceaccount/token
+
+        # KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT are used if both
+        # provided. If this is not the case, fallback to using $KubeConfigPath
+        # if it exists.
+        $k8sHost = $env:KUBERNETES_SERVICE_HOST
+        $k8sPort = $env:KUBERNETES_SERVICE_PORT
+        if ($k8sHost -and $k8sPort) {
+            $server = "server: https://{0}:{1}" -f $k8sHost, $k8sPort
+            Write-Host "Using KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT env variables for kubeconfig. $server"
+        } elseif (Test-Path $KubeConfigPath) {
+            $server=findstr https:// $KubeConfigPath
+            Write-Host ("Using existing kubeconfig at $KubeConfigPath for API server host and port. {0}" -f $server.Trim())
+        } else {
+            Write-Host "Cannot determine API server host and port. Add KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to calico-windows-config in calico-system namespace"
+            exit 1
+        }
+    } else {
+        $ErrorActionPreference = 'Continue'
+        $secretName=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret -n $CalicoNamespace --field-selector=type=kubernetes.io/service-account-token --no-headers -o custom-columns=":metadata.name" | findstr $SecretNamePrefix | select -first 1
+        $ErrorActionPreference = 'Stop'
+        if ([string]::IsNullOrEmpty($secretName)) {
+            if (-Not $AutoCreateServiceAccountTokenSecret) {
+                throw "$SecretName service account token secret does not exist."
+            } else {
+                # Otherwise create the serviceaccount token secret.
+                $secretName = "calico-node-token"
+                CreateTokenAccountSecret -Name $secretName -Namespace $CalicoNamespace -KubeConfigPath $KubeConfigPath
+            }
+        }
+        # CA from the k8s secret is already base64-encoded.
+        $ca=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$secretName -o jsonpath='{.data.ca\.crt}' -n $CalicoNamespace
+        # Token from the k8s secret is base64-encoded but we need the jwt token.
+        $tokenBase64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$secretName -o jsonpath='{.data.token}' -n $CalicoNamespace
+        $token=[System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($tokenBase64))
+
+        $server=findstr https:// $KubeConfigPath
+    }
+
+    (Get-Content $RootDir\calico-kube-config.template).replace('<ca>', $ca).replace('<server>', $server.Trim()).replace('<token>', $token) | Set-Content $RootDir\calico-kube-config -Force
+}
+
+function CreateTokenAccountSecret()
+{
+    param(
+      [parameter(Mandatory=$true)] $Name,
+      [parameter(Mandatory=$true)] $Namespace,
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    $tempFile = New-TemporaryFile
+    Write-Host "Created temp file ${tempFile}"
+
+    $yaml=@"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: $Name
+  namespace: $Namespace
+  annotations:
+    kubernetes.io/service-account.name: calico-node
+type: kubernetes.io/service-account-token
+"@
+    Set-Content -Path $tempFile.FullName -value $yaml
+    c:\k\kubectl --kubeconfig $KubeConfigPath apply -f $tempFile.FullName
+}
+
+function EnableWinDsrForEKS()
+{
+    $OSInfo = (Get-ComputerInfo  | select WindowsVersion, OsBuildNumber)
+    $supportsDSR = Get-IsDSRSupported
+
+    if (-Not $supportsDSR) {
+        Write-Host "WinDsr is not supported ($OSInfo)"
+        return
+    }
+
+    # Update and restart kube-proxy if WinDSR is not enabled by default.
+    $Path = Get-CimInstance -Query 'select * from win32_service where name="kube-proxy"' | Select -ExpandProperty pathname
+    if ($Path -like "*--enable-dsr=true*") {
+        Write-Host "WinDsr is enabled by default."
+    } else {
+        $UpdatedPath = $Path + " --enable-dsr=true --feature-gates=WinDSR=true"
+        Get-CimInstance win32_service -filter 'Name="kube-proxy"' | Invoke-CimMethod -Name Change -Arguments @{PathName=$UpdatedPath}
+        Restart-Service -name "kube-proxy"
+        Write-Host "WinDsr has been enabled for kube-proxy."
+    }
+}
+
+function SetupEtcdTlsFiles()
+{
+    param(
+      [parameter(Mandatory=$true)] $CalicoNamespace,
+      [parameter(Mandatory=$true)] $SecretName,
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    $path = "$RootDir\etcd-tls"
+
+    $ErrorActionPreference = 'Continue'
+    $found=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -n $CalicoNamespace
+    $ErrorActionPreference = 'Stop'
+    if ([string]::IsNullOrEmpty($found)) {
+        throw "$SecretName does not exist."
+    }
+
+    $keyB64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -o jsonpath='{.data.etcd-key}' -n $CalicoNamespace
+    $certB64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -o jsonpath='{.data.etcd-cert}' -n $CalicoNamespace
+    $caB64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -o jsonpath='{.data.etcd-ca}' -n $CalicoNamespace
+
+    New-Item -Type Directory -Path $path -Force
+
+    [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($keyB64)) | Set-Content "$path\server.key" -Force
+    [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($certB64)) | Set-Content "$path\server.crt" -Force
+    [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($caB64)) | Set-Content "$path\ca.crt" -Force
+
+    $script:EtcdKey = "$path\server.key"
+    $script:EtcdCert = "$path\server.crt"
+    $script:EtcdCaCert = "$path\ca.crt"
+}
+
+function SetAKSCalicoStaticRules {
+    $fileName  = [Io.path]::Combine("$RootDir", "static-rules.json")
+    echo '{
+    "Provider": "AKS",
+    "Rules": [
+        {
+            "Name": "EndpointPolicy",
+            "Rule": {
+                "Action": "Block",
+                "Direction": "Out",
+                "Id": "block-wireserver",
+                "Priority": 200,
+                "Protocol": 6,
+                "RemoteAddresses": "168.63.129.16/32",
+                "RemotePorts": "80",
+                "RuleType": "Switch",
+                "Type": "ACL"
+            }
+        }
+    ],
+    "version": "0.1.0"
+}' | Out-File -encoding ASCII -filepath $fileName
+}
+
+function InstallCalico()
+{
+    Write-Host "`nStart {{site.prodnameWindows}} install...`n"
+
+    pushd
+    cd $RootDir
+    .\install-calico.ps1
+    popd
+    Write-Host "`n{{site.prodnameWindows}} installed`n"
+}
+
+# kubectl errors are expected, so there are places where this is reset to "Continue" temporarily
+$ErrorActionPreference = "Stop"
+
+$BaseDir="c:\k"
+$RootDir="c:\TigeraCalico"
+$CalicoZipName="tigera-calico-windows.zip"
+$CalicoZipPath="c:\$CalicoZipName"
+
+# If this script is run from a HostProcess container then the installation archive
+# will be in the mount point.
+if ($env:CONTAINER_SANDBOX_MOUNT_POINT) {
+    $CalicoZipPath="$env:CONTAINER_SANDBOX_MOUNT_POINT\$CalicoZipName"
+}
+
+# Must load the helper modules before doing anything else.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$helper = "$BaseDir\helper.psm1"
+$helperv2 = "$BaseDir\helper.v2.psm1"
+md $BaseDir -ErrorAction Ignore
+if (!(Test-Path $helper))
+{
+    Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.psm1 -O $BaseDir\helper.psm1
+}
+if (!(Test-Path $helperv2))
+{
+    Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.v2.psm1 -O $BaseDir\helper.v2.psm1
+}
+ipmo -force -DisableNameChecking $helper
+ipmo -force -DisableNameChecking $helperv2
+
+if (!(Test-Path $CalicoZipPath))
+{
+	throw "Cannot find {{site.prodnameWindows}} zip file $CalicoZipPath."
+}
+
+$platform=GetPlatformType
+
+if ((Get-Service -exclude 'CalicoUpgrade' | where Name -Like 'Calico*' | where Status -EQ Running) -NE $null) {
+    Write-Host "Calico services are still running. In order to re-run the installation script, stop the CalicoNode and CalicoFelix services or uninstall them by running: $RootDir\uninstall-calico.ps1"
+    Exit
+}
+
+Remove-Item $RootDir -Force  -Recurse -ErrorAction SilentlyContinue
+Write-Host "Unzip {{site.prodnameWindows}} release..."
+Expand-Archive -Force $CalicoZipPath c:\
+# This is a temporary fix to make sure nssm binary is in the correct path.
+$nssmDir = Get-ChildItem $RootDir -filter "nssm*" -Directory
+mv $nssmDir.fullname $RootDir\nssm-2.24
+
+ipmo -force $RootDir\libs\calico\calico.psm1
+
+# This comes after we import calico.psm1
+if (-Not [string]::IsNullOrEmpty($KubeVersion) -and $platform -NE "eks") {
+    PrepareKubernetes
+}
+
+Write-Host "Setup {{site.prodnameWindows}}..."
+Set-ConfigParameters -var 'CALICO_DATASTORE_TYPE' -value $Datastore
+Set-ConfigParameters -var 'ETCD_ENDPOINTS' -value $EtcdEndpoints
+
+if (-Not [string]::IsNullOrEmpty($EtcdTlsSecretName)) {
+    $calicoNs = GetCalicoNamespace
+    SetupEtcdTlsFiles -SecretName "$EtcdTlsSecretName" -CalicoNamespace $calicoNs
+}
+Set-ConfigParameters -var 'ETCD_KEY_FILE' -value $EtcdKey
+Set-ConfigParameters -var 'ETCD_CERT_FILE' -value $EtcdCert
+Set-ConfigParameters -var 'ETCD_CA_CERT_FILE' -value $EtcdCaCert
+Set-ConfigParameters -var 'K8S_SERVICE_CIDR' -value $ServiceCidr
+Set-ConfigParameters -var 'DNS_NAME_SERVERS' -value $DNSServerIPs
+
+if ($platform -EQ "aks") {
+    Write-Host "Setup {{site.prodnameWindows}} for AKS..."
+    $Backend="none"
+    Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "none"
+    Set-ConfigParameters -var 'KUBE_NETWORK' -value "azure.*"
+
+    $calicoNs = "calico-system"
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+
+    SetAKSCalicoStaticRules
+}
+if ($platform -EQ "eks") {
+    EnableWinDsrForEKS
+
+    $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
+    $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    Write-Host "Setup {{site.prodnameWindows}} for EKS, node name $awsNodeName ..."
+    $Backend = "none"
+
+    Set-ConfigParameters -var 'NODENAME' -value $awsNodeName
+    Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "none"
+    Set-ConfigParameters -var 'KUBE_NETWORK' -value "vpc.*"
+
+    $calicoNs = GetCalicoNamespace -KubeConfigPath C:\ProgramData\kubernetes\kubeconfig
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs -KubeConfigPath C:\ProgramData\kubernetes\kubeconfig
+}
+if ($platform -EQ "ec2") {
+    $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
+    $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    Write-Host "Setup {{site.prodnameWindows}} for AWS, node name $awsNodeName ..."
+    Set-ConfigParameters -var 'NODENAME' -value $awsNodeName
+
+    $calicoNs = GetCalicoNamespace
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+    $Backend = GetBackendType -CalicoNamespace $calicoNs
+
+    Write-Host "Backend networking is $Backend"
+    if ($Backend -EQ "bgp") {
+        Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "windows-bgp"
+    }
+}
+if ($platform -EQ "gce") {
+    $gceNodeName = Invoke-RestMethod -UseBasicParsing -Headers @{"Metadata-Flavor"="Google"} "http://metadata.google.internal/computeMetadata/v1/instance/hostname" -ErrorAction Ignore
+    Write-Host "Setup {{site.prodnameWindows}} for GCE, node name $gceNodeName ..."
+    Set-ConfigParameters -var 'NODENAME' -value $gceNodeName
+
+    $calicoNs = GetCalicoNamespace
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+    $Backend = GetBackendType -CalicoNamespace $calicoNs
+
+    Write-Host "Backend networking is $Backend"
+    if ($Backend -EQ "bgp") {
+        Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "windows-bgp"
+    }
+}
+if ($platform -EQ "bare-metal") {
+    $calicoNs = GetCalicoNamespace
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+    $Backend = GetBackendType -CalicoNamespace $calicoNs
+
+    Write-Host "Backend networking is $Backend"
+    if ($Backend -EQ "bgp") {
+        Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "windows-bgp"
+    }
+}
+
+InstallCalico
+
+if ($StartCalico -EQ "yes") {
+    Write-Host "Starting Calico..."
+    Write-Host "This may take several seconds if the vSwitch needs to be created."
+
+    Start-Service CalicoNode
+    Wait-ForCalicoInit
+    Start-Service CalicoFelix
+
+    if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp")
+    {
+        Start-Service CalicoConfd
+    }
+
+    while ((Get-Service | where Name -Like 'Calico*' | where Status -NE Running) -NE $null) {
+        Write-Host "Waiting for the Calico services to be running..."
+        Start-Sleep 1
+    }
+
+    Write-Host "Done, the Calico services are running:"
+    Get-Service | where Name -Like 'Calico*'
+}
+
+if ($Backend -NE "none") {
+    New-NetFirewallRule -Name KubectlExec10250 -Description "Enable kubectl exec and log" -Action Allow -LocalPort 10250 -Enabled True -DisplayName "kubectl exec 10250" -Protocol TCP -ErrorAction SilentlyContinue
+}

--- a/static/calico-enterprise/3.15/scripts/switch-active-operator.sh
+++ b/static/calico-enterprise/3.15/scripts/switch-active-operator.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# This script switches the current operator installation to use the operator
+# running in the NEW_NAME namespace.
+#
+# Before this script is run, the new operator and its associated resources
+# should have been deployed to the NEW_NAME namespace.
+set -e
+
+NEW_NAME=$1
+
+if [ -z "${NEW_NAME}" ]; then
+  echo "Provide a NEW_NAME for the new namespace to switch the current operator to."
+  exit 1
+fi
+
+# kubectl_retry retries <args>
+kubectl_retry() {
+  RETRIES=$1
+  OUTPUT_TMP=$(mktemp)
+  shift 1
+
+  for attempt in $(seq 1 ${RETRIES}); do
+    exit_code=0
+    kubectl $@ 1> ${OUTPUT_TMP}
+    exit_code=$?
+    if [[ "${exit_code}" == "0" || "${exit_code}" == "" ]]; then
+      cat ${OUTPUT_TMP}
+      break
+    elif [[ "${attempt}" == "${RETRIES}" ]]; then
+      echo [ERROR] Failed to kubectl $@
+      return ${exit_code}
+    else
+      echo [INFO] Failed kubectl command - will sleep and retry
+      sleep 5
+    fi
+  done
+}
+
+copy_resource_to_ns (){
+  TYPE=$1
+  NAME=$2
+  NS=$3
+
+  DATA=$(kubectl get $TYPE -n tigera-operator ${NAME} -o jsonpath="{.data}")
+  OWNER_REF=$(kubectl get $TYPE -n tigera-operator ${NAME} -o jsonpath="{.metadata.ownerReferences}")
+  kubectl_retry 10 apply -f - <<EOF
+{"apiVersion":"v1","kind":"$TYPE",
+"data":${DATA},
+"metadata":{"name":"${NAME}","namespace":"${NS}",
+"ownerReferences": ${OWNER_REF} }}
+EOF
+}
+
+if kubectl get ns ${NEW_NAME} 2>&1 > /dev/null ; then
+  echo "The namespace ${NEW_NAME} already exists. Cannot continue switching the active operator."
+  exit 1
+fi
+
+kubectl_retry 10 create ns ${NEW_NAME}
+
+# Copy over the secrets in the tigera-operator namespace to the new namespace to ensure
+# switching the active operator is non-disruptive.
+for x in node-certs typha-certs; do
+  copy_resource_to_ns Secret $x ${NEW_NAME}
+done
+copy_resource_to_ns ConfigMap typha-ca ${NEW_NAME}
+
+# Switch the active operator
+PATCH_FILE=$(mktemp)
+cat <<EOF > ${PATCH_FILE}
+{"data":{"active-namespace": "${NEW_NAME}"}}
+EOF
+kubectl_retry 10 patch configmap -n calico-system active-operator --type=merge --patch-file "${PATCH_FILE}"

--- a/static/calico-enterprise/3.16/scripts/Install-Containerd.ps1
+++ b/static/calico-enterprise/3.16/scripts/Install-Containerd.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+Installs ContainerD on a Windows machine in preparation for joining the node to a Kubernetes cluster.
+
+.DESCRIPTION
+This script
+- Verifies that Windows Features required for running containers are enabled (and enables then if they are not).
+- Downloads ContainerD binaries at the version specified.
+- Registers ContainerD as a windows service.
+
+This is originally from https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/Install-Containerd.ps1.
+It has been adapted for Calico.
+
+.PARAMETER ContainerDVersion
+ContainerD version to download and use.
+
+.EXAMPLE
+PS> .\Install-Containerd.ps1 -ContainerDVersion 1.6.2 -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
+#>
+
+Param(
+    [parameter(HelpMessage = "ContainerD version to use")]
+    [string] $ContainerDVersion = "1.6.2",
+    [parameter(HelpMessage = "Path to configure ContainerD to look for CNI config files. This should be set to the same path used for Calico for Windows.")]
+    [string] $CNIConfigPath = "c:/etc/cni/net.d",
+    [parameter(HelpMessage = "Path to configure ContainerD to look for CNI binaries. This should be set to the same path used for Calico for Windows.")]
+    [string] $CNIBinPath = "c:/opt/cni/bin"
+)
+
+$ErrorActionPreference = 'Stop'
+
+function DownloadFile($destination, $source) {
+    Write-Host("Downloading $source to $destination")
+    curl.exe --silent --fail -Lo $destination $source
+
+    if (!$?) {
+        Write-Error "Download $source failed"
+        exit 1
+    }
+}
+
+# The original script also included Hyper-V and Hyper-V-Powershell.
+# However those are not needed by Calico for Windows.
+$requiredWindowsFeatures = @(
+    "Containers")
+
+function ValidateWindowsFeatures {
+    $allFeaturesInstalled = $true
+    foreach ($feature in $requiredWindowsFeatures) {
+        $f = Get-WindowsFeature -Name $feature
+        if (-not $f.Installed) {
+            Write-Warning "Windows feature: '$feature' is not installed."
+            $allFeaturesInstalled = $false
+        }
+    }
+    return $allFeaturesInstalled
+}
+
+if (-not (ValidateWindowsFeatures)) {
+    Write-Output "Installing required windows features..."
+
+    foreach ($feature in $requiredWindowsFeatures) {
+        Install-WindowsFeature -Name $feature
+    }
+
+    Write-Output "Please reboot and re-run this script."
+    exit 0
+}
+
+# Install 7Zip
+Write-Output "Installing 7Zip"
+Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.v2.psm1 -O $env:TEMP\helper.v2.psm1
+ipmo $env:TEMP\helper.v2.psm1
+Install-7Zip
+
+Write-Output "Getting ContainerD binaries"
+$global:ContainerDPath = "$env:ProgramFiles\containerd"
+mkdir -Force $global:ContainerDPath | Out-Null
+DownloadFile "$global:ContainerDPath\containerd.tar.gz" https://github.com/containerd/containerd/releases/download/v${ContainerDVersion}/containerd-${ContainerDVersion}-windows-amd64.tar.gz
+tar.exe -xvf "$global:ContainerDPath\containerd.tar.gz" --strip=1 -C $global:ContainerDPath
+$env:Path += ";$global:ContainerDPath"
+[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
+containerd.exe config default | Out-File "$global:ContainerDPath\config.toml" -Encoding ascii
+#config file fixups
+$config = Get-Content "$global:ContainerDPath\config.toml"
+$config = $config -replace "bin_dir = (.)*$", "bin_dir = `"$CNIBinPath`""
+$config = $config -replace "conf_dir = (.)*$", "conf_dir = `"$CNIConfigPath`""
+$config | Set-Content "$global:ContainerDPath\config.toml" -Force
+
+mkdir -Force $CNIBinPath | Out-Null
+mkdir -Force $CNIConfigPath | Out-Null
+
+Write-Output "Registering ContainerD as a service"
+containerd.exe --register-service
+
+Write-Output "Starting ContainerD service"
+Start-Service containerd
+
+Write-Output "Done - please remember to add '--cri-socket `"npipe:////./pipe/containerd-containerd`"' to your kubeadm join command"

--- a/static/calico-enterprise/3.16/scripts/PrepareNode.ps1
+++ b/static/calico-enterprise/3.16/scripts/PrepareNode.ps1
@@ -1,0 +1,150 @@
+<#
+.SYNOPSIS
+Assists with preparing a Windows VM prior to calling kubeadm join
+
+.DESCRIPTION
+This script assists with joining a Windows node to a cluster.
+- Downloads Kubernetes binaries (kubelet, kubeadm) at the version specified
+- Registers kubelet as an nssm service. More info on nssm: https://nssm.cc/
+
+This is originally from https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/PrepareNode.ps1
+It has been adapted for Calico.
+
+.PARAMETER KubernetesVersion
+Kubernetes version to download and use
+
+.PARAMETER ContainerRuntime
+Container that Kubernetes will use. (Docker or ContainerD)
+
+.EXAMPLE
+PS> .\PrepareNode.ps1 -KubernetesVersion v1.23.4 -ContainerRuntime ContainerD
+
+#>
+
+Param(
+    [parameter(Mandatory = $true, HelpMessage="Kubernetes version to use")]
+    [string] $KubernetesVersion,
+    [parameter(HelpMessage="Container runtime that Kubernetes will use")]
+    [ValidateSet("ContainerD", "Docker")]
+    [string] $ContainerRuntime = "ContainerD"
+)
+$ErrorActionPreference = 'Stop'
+
+function DownloadFile($destination, $source) {
+    Write-Host("Downloading $source to $destination")
+    curl.exe --silent --fail -Lo $destination $source
+
+    if (!$?) {
+        Write-Error "Download $source failed"
+        exit 1
+    }
+}
+
+if ($ContainerRuntime -eq "Docker") {
+    if (-not(Test-Path "//./pipe/docker_engine")) {
+        Write-Error "Docker service was not detected - please install start Docker before calling PrepareNode.ps1 with -ContainerRuntime Docker"
+        exit 1
+    }
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    if (-not(Test-Path "//./pipe/containerd-containerd")) {
+        Write-Error "ContainerD service was not detected - please install and start ContainerD before calling PrepareNode.ps1 with -ContainerRuntime ContainerD"
+        exit 1
+    }
+}
+
+if (!$KubernetesVersion.StartsWith("v")) {
+    $KubernetesVersion = "v" + $KubernetesVersion
+}
+Write-Host "Using Kubernetes version: $KubernetesVersion"
+$global:Powershell = (Get-Command powershell).Source
+$global:PowershellArgs = "-ExecutionPolicy Bypass -NoProfile"
+$global:KubernetesPath = "$env:SystemDrive\k"
+$global:StartKubeletScript = "$global:KubernetesPath\StartKubelet.ps1"
+$global:NssmInstallDirectory = "$env:ProgramFiles\nssm"
+$kubeletBinPath = "$global:KubernetesPath\kubelet.exe"
+
+mkdir -force "$global:KubernetesPath"
+$env:Path += ";$global:KubernetesPath"
+[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
+
+DownloadFile $kubeletBinPath https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubelet.exe
+DownloadFile "$global:KubernetesPath\kubeadm.exe" https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubeadm.exe
+
+if ($ContainerRuntime -eq "Docker") {
+    # Create host network to allow kubelet to schedule hostNetwork pods
+    # NOTE: For containerd the 0-containerd-nat.json network config template added by
+    # Install-containerd.ps1 joins pods to the host network.
+    Write-Host "Creating Docker host network"
+    docker network create -d nat host
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    DownloadFile "c:\k\hns.psm1" https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1
+    Import-Module -DisableNameChecking "c:\k\hns.psm1"
+    if ((Get-HNSNetwork | ? Type -EQ nat | ? Name -EQ nat) -eq $null) {
+        New-HnsNetwork -Type NAT -Name nat
+    }
+}
+
+$kubeletLogPath = "C:\var\log\kubelet"
+mkdir -force $kubeletLogPath
+mkdir -force C:\var\lib\kubelet\etc\kubernetes
+mkdir -force C:\etc\kubernetes\pki
+New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C:\etc\kubernetes\pki\
+
+$StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
+$global:KubeletArgs = $FileContent.TrimStart(''KUBELET_KUBEADM_ARGS='').Trim(''"'')
+
+$global:containerRuntime = {{CONTAINER_RUNTIME}}
+
+if ($global:containerRuntime -eq "Docker") {
+    $netId = docker network ls -f name=host --format "{{ .ID }}"
+
+    if ($netId.Length -lt 1) {
+    docker network create -d nat host
+    }
+}
+
+$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:3.6`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --logtostderr=false --image-pull-progress-deadline=20m"
+
+Invoke-Expression $cmd'
+$StartKubeletFileContent = $StartKubeletFileContent -replace "{{CONTAINER_RUNTIME}}", "`"$ContainerRuntime`""
+Set-Content -Path $global:StartKubeletScript -Value $StartKubeletFileContent
+
+Write-Host "Installing nssm"
+$arch = "win32"
+if ([Environment]::Is64BitOperatingSystem) {
+    $arch = "win64"
+}
+
+mkdir -Force $global:NssmInstallDirectory
+DownloadFile nssm.zip https://k8stestinfrabinaries.blob.core.windows.net/nssm-mirror/nssm-2.24.zip
+tar C $global:NssmInstallDirectory -xvf .\nssm.zip --strip-components 2 */$arch/*.exe
+Remove-Item -Force .\nssm.zip
+
+$env:path += ";$global:NssmInstallDirectory"
+$newPath = "$global:NssmInstallDirectory;" +
+[Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
+
+[Environment]::SetEnvironmentVariable("PATH", $newPath, [EnvironmentVariableTarget]::Machine)
+
+Write-Host "Registering kubelet service"
+nssm install kubelet $global:Powershell $global:PowershellArgs $global:StartKubeletScript
+nssm set kubelet AppStdout $kubeletLogPath\kubelet.out.log
+nssm set kubelet AppStderr $kubeletLogPath\kubelet.err.log
+
+# Configure online file rotation.
+nssm set kubelet AppRotateFiles 1
+nssm set kubelet AppRotateOnline 1
+# Rotate once per day.
+nssm set kubelet AppRotateSeconds 86400
+# Rotate after 10MB.
+nssm set kubelet AppRotateBytes 10485760
+
+if ($ContainerRuntime -eq "Docker") {
+    nssm set kubelet DependOnService docker
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    nssm set kubelet DependOnService containerd
+}
+
+if ((Get-NetFirewallRule | ? Name -EQ kubelet) -EQ $null) {
+    New-NetFirewallRule -Name kubelet -DisplayName 'kubelet' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 10250
+}

--- a/static/calico-enterprise/3.16/scripts/install-calico-windows.ps1
+++ b/static/calico-enterprise/3.16/scripts/install-calico-windows.ps1
@@ -1,0 +1,567 @@
+---
+layout: null
+---
+# Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+<#
+.DESCRIPTION
+    This script installs and starts {{site.prodname}} services on a Windows node.
+
+    Note: EKS requires downloading kubectl.exe to c:\k before running this script: https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
+#>
+
+Param(
+    # Note: we don't publish a release artifact for the "master" branch. To test
+    # against master, build calico-windows.zip from projectcalico/node.
+{%- if site.url contains "projectcalico" %}
+    [parameter(Mandatory = $false)] $ReleaseBaseURL="https://github.com/projectcalico/calico/releases/download/{{site.data.versions.first.components["calico/node"].version}}/",
+    [parameter(Mandatory = $false)] $ReleaseFile="calico-windows-{{site.data.versions.first.components["calico/node"].version}}.zip",
+{%- else %}
+    [parameter(Mandatory = $false)] $ReleaseBaseURL="{{site.url}}/files/windows/",
+{%- endif %}
+    [parameter(Mandatory = $false)] $KubeVersion="",
+    [parameter(Mandatory = $false)] $StartCalico="yes",
+    # As of Kubernetes version v1.24.0, service account token secrets are no longer automatically created. But this installation script uses that secret
+    # to generate a kubeconfig so default to creating the calico-node token secret if it doesn't exist.
+    [parameter(Mandatory = $false)] $AutoCreateServiceAccountTokenSecret="yes",
+    [parameter(Mandatory = $false)] $Datastore="kubernetes",
+    [parameter(Mandatory = $false)] $EtcdEndpoints="",
+    [parameter(Mandatory = $false)] $EtcdTlsSecretName="",
+    [parameter(Mandatory = $false)] $EtcdKey="",
+    [parameter(Mandatory = $false)] $EtcdCert="",
+    [parameter(Mandatory = $false)] $EtcdCaCert="",
+    [parameter(Mandatory = $false)] $ServiceCidr="10.96.0.0/12",
+    [parameter(Mandatory = $false)] $DNSServerIPs="10.96.0.10",
+    [parameter(Mandatory = $false)] $CalicoBackend=""
+)
+
+function DownloadFiles()
+{
+    Write-Host "Creating CNI directory"
+    md $BaseDir\cni\config -ErrorAction Ignore
+
+    Write-Host "Downloading Windows Kubernetes scripts"
+    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1 -Destination $BaseDir\hns.psm1
+}
+
+function PrepareKubernetes()
+{
+    DownloadFiles
+    ipmo -DisableNameChecking C:\k\hns.psm1
+    InstallK8sBinaries
+
+    # Prepull and tag the pause image for docker
+    if (-not (Get-IsContainerdRunning)) {
+        # If containerd is not running we assume the installation should be
+        # configured for docker. But in this case, docker has to be running.
+        $svc = Get-Service | where Name -EQ 'docker'
+        if ($svc -EQ $null) {
+            Write-Host "Docker service is not installed. Cannot prepare kubernetes pause image."
+            exit 1
+        }
+        if ($svc.Status -NE 'Running') {
+            Write-Host "Docker service is not running. Cannot prepare kubernetes pause image. Run 'Start-Service docker' and try again."
+            exit 1
+        }
+        $pause = "mcr.microsoft.com/oss/kubernetes/pause:3.6"
+        docker pull $pause
+        docker tag $pause kubeletwin/pause
+    }
+}
+
+function InstallK8sBinaries()
+{
+    Install-7Zip
+    $Source = "" | Select Release
+    $Source.Release=$KubeVersion
+    InstallKubernetesBinaries -Destination $BaseDir -Source $Source
+    cp c:\k\kubernetes\node\bin\*.exe c:\k
+}
+
+function GetPlatformType()
+{
+    # AKS
+    $hnsNetwork = Get-HnsNetwork | ? Name -EQ azure
+    if ($hnsNetwork.name -EQ "azure") {
+        return ("aks")
+    }
+
+    # EKS
+    $hnsNetwork = Get-HnsNetwork | ? Name -like "vpcbr*"
+    if ($hnsNetwork.name -like "vpcbr*") {
+        return ("eks")
+    }
+
+    # EC2
+    $restError = $null
+    Try {
+        $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
+        $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    } Catch {
+        $restError = $_
+    }
+    if ($restError -eq $null) {
+        return ("ec2")
+    }
+
+    # GCE
+    $restError = $null
+    Try {
+        $gceNodeName = Invoke-RestMethod -UseBasicParsing -Headers @{"Metadata-Flavor"="Google"} "http://metadata.google.internal/computeMetadata/v1/instance/hostname" -ErrorAction Ignore
+    } Catch {
+        $restError = $_
+    }
+    if ($restError -eq $null) {
+        return ("gce")
+    }
+
+    return ("bare-metal")
+}
+
+function GetBackendType()
+{
+    param(
+        [parameter(Mandatory=$true)] $CalicoNamespace,
+        [parameter(Mandatory=$false)] $KubeConfigPath = "$RootDir\calico-kube-config"
+    )
+
+    if (-Not [string]::IsNullOrEmpty($CalicoBackend)) {
+        return $CalicoBackend
+    }
+
+    # For hostprocess installs, if CALICO_NETWORKING_BACKEND is set to a valid value, try to use it.
+    if ($env:CONTAINER_SANDBOX_MOUNT_POINT -and $env:CALICO_NETWORKING_BACKEND) {
+        $backend = $env:CALICO_NETWORKING_BACKEND
+        if (($backend -eq "vxlan") -or ($backend -eq "windows-bgp")) {
+            return $backend
+        }
+
+        if ($backend -NE $null) {
+            Write-Host "Invalid Calico backend type: $backend. Set CALICO_NETWORKING_BACKEND in calico-windows-config in calico-system namespace to one of: 'vxlan', 'windows-bgp'"
+            exit 1
+        }
+
+        # If CALICO_NETWORKING_BACKEND is not set we can only continue if the
+        # kubeconfig and kubectl.exe both exist.
+        if ((-not (Test-Path $KubeConfigPath)) -or (-not (Test-Path "c:\k\kubectl.exe"))) {
+            Write-Host "No CALICO_NETWORKING_BACKEND provided. Set CALICO_NETWORKING_BACKEND in calico-windows-config in calico-system namespace to one of: 'vxlan', 'windows-bgp'"
+            exit 1
+        }
+
+        # If we reach here, we can continue auto-detecting the backend type.
+    }
+
+    # Auto detect backend type
+    if ($Datastore -EQ "kubernetes") {
+        $encap=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.ipipEnabled}'
+        if ($encap -EQ "true") {
+            throw "{{site.prodname}} on Linux has IPIP enabled. IPIP is not supported on Windows nodes."
+        }
+
+        # Check FelixConfig first.
+        $encap=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.vxlanEnabled}'
+        if ($encap -EQ "true") {
+            return ("vxlan")
+        } elseif ($encap -EQ "false") {
+            return ("bgp")
+        } else {
+           # If any IPPool has IPIP enabled, we need to exit the installer. The
+           # IPIP-enabled might not be assigned to this Windows node but we can't
+           # verify that easily by looking at the nodeSelector.
+           $ipipModes = c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get ippools.crd.projectcalico.org -o jsonpath='{.items[*].spec.ipipMode}'
+           $ipipEnabled = $ipipModes | Select-String -pattern '(Always)|(CrossSubnet)'
+           if ($ipipEnabled -NE $null) {
+               throw "Failed to auto detect backend type. IPIP is not supported on Windows nodes but found IP pools with IPIP enabled. Rerun install script with the CalicoBackend param provided"
+           }
+
+           # If FelixConfig does not have vxlanEnabled then check the IPPools and see if any of them have enabled vxlan.
+           $vxlanModes=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get ippools.crd.projectcalico.org -o jsonpath='{.items[*].spec.vxlanMode}'
+           $vxlanEnabled = $vxlanModes | Select-String -pattern '(Always)|(CrossSubnet)'
+           if ($vxlanEnabled -NE $null) {
+               return ("vxlan")
+           } else {
+               return ("bgp")
+           }
+        }
+    } else {
+        $CalicoBackend=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get configmap calico-config -n $CalicoNamespace -o jsonpath='{.data.calico_backend}'
+        if ($CalicoBackend -EQ "vxlan") {
+            return ("vxlan")
+        }
+        return ("bgp")
+    }
+}
+
+function GetCalicoNamespace() {
+    param(
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    # If we are running inside a HostProcess container then return our
+    # namespace.
+    if ($env:CONTAINER_SANDBOX_MOUNT_POINT) {
+        $ns = Get-Content -Raw -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/run/secrets/kubernetes.io/serviceaccount/namespace
+        write-host ("Install script is running in a HostProcess container. This namespace is {0}" -f $ns)
+        return $ns
+    }
+
+    $ErrorActionPreference = 'Continue'
+    $name=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get ns calico-system
+    $ErrorActionPreference = 'Stop'
+    if ([string]::IsNullOrEmpty($name)) {
+        write-host "Calico running in kube-system namespace"
+        return ("kube-system")
+    }
+    write-host "Calico running in calico-system namespace"
+    return ("calico-system")
+}
+
+function GetCalicoKubeConfig()
+{
+    param(
+      [parameter(Mandatory=$true)] $CalicoNamespace,
+      [parameter(Mandatory=$false)] $SecretNamePrefix = "calico-node",
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    # On EKS, we need to have AWS tools loaded for kubectl authentication.
+    $eksAWSToolsModulePath="C:\Program Files (x86)\AWS Tools\PowerShell\AWSPowerShell\AWSPowerShell.psd1"
+    if (Test-Path $eksAWSToolsModulePath) {
+        Write-Host "AWSPowerShell module exists, loading $eksAWSToolsModulePath ..."
+        Import-Module $eksAWSToolsModulePath
+    }
+
+    # If we are running inside a HostProcess container then we already have
+    # access to the serviceaccount token and ca cert.
+    if ($env:CONTAINER_SANDBOX_MOUNT_POINT) {
+        Write-Host "Install script is running in a HostProcess container, using mounted serviceaccount ca cert and token."
+        # CA needs to be base64-encoded.
+        $ca = Get-Content -Raw -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        $ca = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($ca))
+        # But not the token.
+        $token = Get-Content -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/run/secrets/kubernetes.io/serviceaccount/token
+
+        # KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT are used if both
+        # provided. If this is not the case, fallback to using $KubeConfigPath
+        # if it exists.
+        $k8sHost = $env:KUBERNETES_SERVICE_HOST
+        $k8sPort = $env:KUBERNETES_SERVICE_PORT
+        if ($k8sHost -and $k8sPort) {
+            $server = "server: https://{0}:{1}" -f $k8sHost, $k8sPort
+            Write-Host "Using KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT env variables for kubeconfig. $server"
+        } elseif (Test-Path $KubeConfigPath) {
+            $server=findstr https:// $KubeConfigPath
+            Write-Host ("Using existing kubeconfig at $KubeConfigPath for API server host and port. {0}" -f $server.Trim())
+        } else {
+            Write-Host "Cannot determine API server host and port. Add KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to calico-windows-config in calico-system namespace"
+            exit 1
+        }
+    } else {
+        $ErrorActionPreference = 'Continue'
+        $secretName=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret -n $CalicoNamespace --field-selector=type=kubernetes.io/service-account-token --no-headers -o custom-columns=":metadata.name" | findstr $SecretNamePrefix | select -first 1
+        $ErrorActionPreference = 'Stop'
+        if ([string]::IsNullOrEmpty($secretName)) {
+            if (-Not $AutoCreateServiceAccountTokenSecret) {
+                throw "$SecretName service account token secret does not exist."
+            } else {
+                # Otherwise create the serviceaccount token secret.
+                $secretName = "calico-node-token"
+                CreateTokenAccountSecret -Name $secretName -Namespace $CalicoNamespace -KubeConfigPath $KubeConfigPath
+            }
+        }
+        # CA from the k8s secret is already base64-encoded.
+        $ca=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$secretName -o jsonpath='{.data.ca\.crt}' -n $CalicoNamespace
+        # Token from the k8s secret is base64-encoded but we need the jwt token.
+        $tokenBase64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$secretName -o jsonpath='{.data.token}' -n $CalicoNamespace
+        $token=[System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($tokenBase64))
+
+        $server=findstr https:// $KubeConfigPath
+    }
+
+    (Get-Content $RootDir\calico-kube-config.template).replace('<ca>', $ca).replace('<server>', $server.Trim()).replace('<token>', $token) | Set-Content $RootDir\calico-kube-config -Force
+}
+
+function CreateTokenAccountSecret()
+{
+    param(
+      [parameter(Mandatory=$true)] $Name,
+      [parameter(Mandatory=$true)] $Namespace,
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    $tempFile = New-TemporaryFile
+    Write-Host "Created temp file ${tempFile}"
+
+    $yaml=@"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: $Name
+  namespace: $Namespace
+  annotations:
+    kubernetes.io/service-account.name: calico-node
+type: kubernetes.io/service-account-token
+"@
+    Set-Content -Path $tempFile.FullName -value $yaml
+    c:\k\kubectl --kubeconfig $KubeConfigPath apply -f $tempFile.FullName
+}
+
+function EnableWinDsrForEKS()
+{
+    $OSInfo = (Get-ComputerInfo  | select WindowsVersion, OsBuildNumber)
+    $supportsDSR = Get-IsDSRSupported
+
+    if (-Not $supportsDSR) {
+        Write-Host "WinDsr is not supported ($OSInfo)"
+        return
+    }
+
+    # Update and restart kube-proxy if WinDSR is not enabled by default.
+    $Path = Get-CimInstance -Query 'select * from win32_service where name="kube-proxy"' | Select -ExpandProperty pathname
+    if ($Path -like "*--enable-dsr=true*") {
+        Write-Host "WinDsr is enabled by default."
+    } else {
+        $UpdatedPath = $Path + " --enable-dsr=true --feature-gates=WinDSR=true"
+        Get-CimInstance win32_service -filter 'Name="kube-proxy"' | Invoke-CimMethod -Name Change -Arguments @{PathName=$UpdatedPath}
+        Restart-Service -name "kube-proxy"
+        Write-Host "WinDsr has been enabled for kube-proxy."
+    }
+}
+
+function SetupEtcdTlsFiles()
+{
+    param(
+      [parameter(Mandatory=$true)] $CalicoNamespace,
+      [parameter(Mandatory=$true)] $SecretName,
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    $path = "$RootDir\etcd-tls"
+
+    $ErrorActionPreference = 'Continue'
+    $found=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -n $CalicoNamespace
+    $ErrorActionPreference = 'Stop'
+    if ([string]::IsNullOrEmpty($found)) {
+        throw "$SecretName does not exist."
+    }
+
+    $keyB64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -o jsonpath='{.data.etcd-key}' -n $CalicoNamespace
+    $certB64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -o jsonpath='{.data.etcd-cert}' -n $CalicoNamespace
+    $caB64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -o jsonpath='{.data.etcd-ca}' -n $CalicoNamespace
+
+    New-Item -Type Directory -Path $path -Force
+
+    [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($keyB64)) | Set-Content "$path\server.key" -Force
+    [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($certB64)) | Set-Content "$path\server.crt" -Force
+    [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($caB64)) | Set-Content "$path\ca.crt" -Force
+
+    $script:EtcdKey = "$path\server.key"
+    $script:EtcdCert = "$path\server.crt"
+    $script:EtcdCaCert = "$path\ca.crt"
+}
+
+function SetAKSCalicoStaticRules {
+    $fileName  = [Io.path]::Combine("$RootDir", "static-rules.json")
+    echo '{
+    "Provider": "AKS",
+    "Rules": [
+        {
+            "Name": "EndpointPolicy",
+            "Rule": {
+                "Action": "Block",
+                "Direction": "Out",
+                "Id": "block-wireserver",
+                "Priority": 200,
+                "Protocol": 6,
+                "RemoteAddresses": "168.63.129.16/32",
+                "RemotePorts": "80",
+                "RuleType": "Switch",
+                "Type": "ACL"
+            }
+        }
+    ],
+    "version": "0.1.0"
+}' | Out-File -encoding ASCII -filepath $fileName
+}
+
+function InstallCalico()
+{
+    Write-Host "`nStart {{site.prodnameWindows}} install...`n"
+
+    pushd
+    cd $RootDir
+    .\install-calico.ps1
+    popd
+    Write-Host "`n{{site.prodnameWindows}} installed`n"
+}
+
+# kubectl errors are expected, so there are places where this is reset to "Continue" temporarily
+$ErrorActionPreference = "Stop"
+
+$BaseDir="c:\k"
+$RootDir="c:\TigeraCalico"
+$CalicoZipName="tigera-calico-windows.zip"
+$CalicoZipPath="c:\$CalicoZipName"
+
+# If this script is run from a HostProcess container then the installation archive
+# will be in the mount point.
+if ($env:CONTAINER_SANDBOX_MOUNT_POINT) {
+    $CalicoZipPath="$env:CONTAINER_SANDBOX_MOUNT_POINT\$CalicoZipName"
+}
+
+# Must load the helper modules before doing anything else.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$helper = "$BaseDir\helper.psm1"
+$helperv2 = "$BaseDir\helper.v2.psm1"
+md $BaseDir -ErrorAction Ignore
+if (!(Test-Path $helper))
+{
+    Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.psm1 -O $BaseDir\helper.psm1
+}
+if (!(Test-Path $helperv2))
+{
+    Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.v2.psm1 -O $BaseDir\helper.v2.psm1
+}
+ipmo -force -DisableNameChecking $helper
+ipmo -force -DisableNameChecking $helperv2
+
+if (!(Test-Path $CalicoZipPath))
+{
+	throw "Cannot find {{site.prodnameWindows}} zip file $CalicoZipPath."
+}
+
+$platform=GetPlatformType
+
+if ((Get-Service -exclude 'CalicoUpgrade' | where Name -Like 'Calico*' | where Status -EQ Running) -NE $null) {
+    Write-Host "Calico services are still running. In order to re-run the installation script, stop the CalicoNode and CalicoFelix services or uninstall them by running: $RootDir\uninstall-calico.ps1"
+    Exit
+}
+
+Remove-Item $RootDir -Force  -Recurse -ErrorAction SilentlyContinue
+Write-Host "Unzip {{site.prodnameWindows}} release..."
+Expand-Archive -Force $CalicoZipPath c:\
+ipmo -force $RootDir\libs\calico\calico.psm1
+
+# This comes after we import calico.psm1
+if (-Not [string]::IsNullOrEmpty($KubeVersion) -and $platform -NE "eks") {
+    PrepareKubernetes
+}
+
+Write-Host "Setup {{site.prodnameWindows}}..."
+Set-ConfigParameters -var 'CALICO_DATASTORE_TYPE' -value $Datastore
+Set-ConfigParameters -var 'ETCD_ENDPOINTS' -value $EtcdEndpoints
+
+if (-Not [string]::IsNullOrEmpty($EtcdTlsSecretName)) {
+    $calicoNs = GetCalicoNamespace
+    SetupEtcdTlsFiles -SecretName "$EtcdTlsSecretName" -CalicoNamespace $calicoNs
+}
+Set-ConfigParameters -var 'ETCD_KEY_FILE' -value $EtcdKey
+Set-ConfigParameters -var 'ETCD_CERT_FILE' -value $EtcdCert
+Set-ConfigParameters -var 'ETCD_CA_CERT_FILE' -value $EtcdCaCert
+Set-ConfigParameters -var 'K8S_SERVICE_CIDR' -value $ServiceCidr
+Set-ConfigParameters -var 'DNS_NAME_SERVERS' -value $DNSServerIPs
+
+if ($platform -EQ "aks") {
+    Write-Host "Setup {{site.prodnameWindows}} for AKS..."
+    $Backend="none"
+    Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "none"
+    Set-ConfigParameters -var 'KUBE_NETWORK' -value "azure.*"
+
+    $calicoNs = "calico-system"
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+
+    SetAKSCalicoStaticRules
+}
+if ($platform -EQ "eks") {
+    EnableWinDsrForEKS
+
+    $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
+    $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    Write-Host "Setup {{site.prodnameWindows}} for EKS, node name $awsNodeName ..."
+    $Backend = "none"
+
+    Set-ConfigParameters -var 'NODENAME' -value $awsNodeName
+    Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "none"
+    Set-ConfigParameters -var 'KUBE_NETWORK' -value "vpc.*"
+
+    $calicoNs = GetCalicoNamespace -KubeConfigPath C:\ProgramData\kubernetes\kubeconfig
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs -KubeConfigPath C:\ProgramData\kubernetes\kubeconfig
+}
+if ($platform -EQ "ec2") {
+    $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
+    $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    Write-Host "Setup {{site.prodnameWindows}} for AWS, node name $awsNodeName ..."
+    Set-ConfigParameters -var 'NODENAME' -value $awsNodeName
+
+    $calicoNs = GetCalicoNamespace
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+    $Backend = GetBackendType -CalicoNamespace $calicoNs
+
+    Write-Host "Backend networking is $Backend"
+    if ($Backend -EQ "bgp") {
+        Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "windows-bgp"
+    }
+}
+if ($platform -EQ "gce") {
+    $gceNodeName = Invoke-RestMethod -UseBasicParsing -Headers @{"Metadata-Flavor"="Google"} "http://metadata.google.internal/computeMetadata/v1/instance/hostname" -ErrorAction Ignore
+    Write-Host "Setup {{site.prodnameWindows}} for GCE, node name $gceNodeName ..."
+    Set-ConfigParameters -var 'NODENAME' -value $gceNodeName
+
+    $calicoNs = GetCalicoNamespace
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+    $Backend = GetBackendType -CalicoNamespace $calicoNs
+
+    Write-Host "Backend networking is $Backend"
+    if ($Backend -EQ "bgp") {
+        Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "windows-bgp"
+    }
+}
+if ($platform -EQ "bare-metal") {
+    $calicoNs = GetCalicoNamespace
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+    $Backend = GetBackendType -CalicoNamespace $calicoNs
+
+    Write-Host "Backend networking is $Backend"
+    if ($Backend -EQ "bgp") {
+        Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "windows-bgp"
+    }
+}
+
+InstallCalico
+
+if ($StartCalico -EQ "yes") {
+    Write-Host "Starting Calico..."
+    Write-Host "This may take several seconds if the vSwitch needs to be created."
+
+    Start-Service CalicoNode
+    Wait-ForCalicoInit
+    Start-Service CalicoFelix
+
+    if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp")
+    {
+        Start-Service CalicoConfd
+    }
+
+    while ((Get-Service | where Name -Like 'Calico*' | where Status -NE Running) -NE $null) {
+        Write-Host "Waiting for the Calico services to be running..."
+        Start-Sleep 1
+    }
+
+    Write-Host "Done, the Calico services are running:"
+    Get-Service | where Name -Like 'Calico*'
+}
+
+if ($Backend -NE "none") {
+    New-NetFirewallRule -Name KubectlExec10250 -Description "Enable kubectl exec and log" -Action Allow -LocalPort 10250 -Enabled True -DisplayName "kubectl exec 10250" -Protocol TCP -ErrorAction SilentlyContinue
+}

--- a/static/calico-enterprise/3.16/scripts/switch-active-operator.sh
+++ b/static/calico-enterprise/3.16/scripts/switch-active-operator.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# This script switches the current operator installation to use the operator
+# running in the NEW_NAME namespace.
+#
+# Before this script is run, the new operator and its associated resources
+# should have been deployed to the NEW_NAME namespace.
+set -e
+
+NEW_NAME=$1
+
+if [ -z "${NEW_NAME}" ]; then
+  echo "Provide a NEW_NAME for the new namespace to switch the current operator to."
+  exit 1
+fi
+
+# kubectl_retry retries <args>
+kubectl_retry() {
+  RETRIES=$1
+  OUTPUT_TMP=$(mktemp)
+  shift 1
+
+  for attempt in $(seq 1 ${RETRIES}); do
+    exit_code=0
+    kubectl $@ 1> ${OUTPUT_TMP}
+    exit_code=$?
+    if [[ "${exit_code}" == "0" || "${exit_code}" == "" ]]; then
+      cat ${OUTPUT_TMP}
+      break
+    elif [[ "${attempt}" == "${RETRIES}" ]]; then
+      echo [ERROR] Failed to kubectl $@
+      return ${exit_code}
+    else
+      echo [INFO] Failed kubectl command - will sleep and retry
+      sleep 5
+    fi
+  done
+}
+
+copy_resource_to_ns (){
+  TYPE=$1
+  NAME=$2
+  NS=$3
+
+  DATA=$(kubectl get $TYPE -n tigera-operator ${NAME} -o jsonpath="{.data}")
+  OWNER_REF=$(kubectl get $TYPE -n tigera-operator ${NAME} -o jsonpath="{.metadata.ownerReferences}")
+  kubectl_retry 10 apply -f - <<EOF
+{"apiVersion":"v1","kind":"$TYPE",
+"data":${DATA},
+"metadata":{"name":"${NAME}","namespace":"${NS}",
+"ownerReferences": ${OWNER_REF} }}
+EOF
+}
+
+if kubectl get ns ${NEW_NAME} 2>&1 > /dev/null ; then
+  echo "The namespace ${NEW_NAME} already exists. Cannot continue switching the active operator."
+  exit 1
+fi
+
+kubectl_retry 10 create ns ${NEW_NAME}
+
+# Copy over the secrets in the tigera-operator namespace to the new namespace to ensure
+# switching the active operator is non-disruptive.
+for x in node-certs typha-certs; do
+  copy_resource_to_ns Secret $x ${NEW_NAME}
+done
+
+# Switch the active operator
+PATCH_FILE=$(mktemp)
+cat <<EOF > ${PATCH_FILE}
+{"data":{"active-namespace": "${NEW_NAME}"}}
+EOF
+kubectl_retry 10 patch configmap -n calico-system active-operator --type=merge --patch-file "${PATCH_FILE}"

--- a/static/calico-enterprise/next/scripts/Install-Containerd.ps1
+++ b/static/calico-enterprise/next/scripts/Install-Containerd.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+Installs ContainerD on a Windows machine in preparation for joining the node to a Kubernetes cluster.
+
+.DESCRIPTION
+This script
+- Verifies that Windows Features required for running containers are enabled (and enables then if they are not).
+- Downloads ContainerD binaries at the version specified.
+- Registers ContainerD as a windows service.
+
+This is originally from https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/Install-Containerd.ps1.
+It has been adapted for Calico.
+
+.PARAMETER ContainerDVersion
+ContainerD version to download and use.
+
+.EXAMPLE
+PS> .\Install-Containerd.ps1 -ContainerDVersion 1.6.2 -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
+#>
+
+Param(
+    [parameter(HelpMessage = "ContainerD version to use")]
+    [string] $ContainerDVersion = "1.6.2",
+    [parameter(HelpMessage = "Path to configure ContainerD to look for CNI config files. This should be set to the same path used for Calico for Windows.")]
+    [string] $CNIConfigPath = "c:/etc/cni/net.d",
+    [parameter(HelpMessage = "Path to configure ContainerD to look for CNI binaries. This should be set to the same path used for Calico for Windows.")]
+    [string] $CNIBinPath = "c:/opt/cni/bin"
+)
+
+$ErrorActionPreference = 'Stop'
+
+function DownloadFile($destination, $source) {
+    Write-Host("Downloading $source to $destination")
+    curl.exe --silent --fail -Lo $destination $source
+
+    if (!$?) {
+        Write-Error "Download $source failed"
+        exit 1
+    }
+}
+
+# The original script also included Hyper-V and Hyper-V-Powershell.
+# However those are not needed by Calico for Windows.
+$requiredWindowsFeatures = @(
+    "Containers")
+
+function ValidateWindowsFeatures {
+    $allFeaturesInstalled = $true
+    foreach ($feature in $requiredWindowsFeatures) {
+        $f = Get-WindowsFeature -Name $feature
+        if (-not $f.Installed) {
+            Write-Warning "Windows feature: '$feature' is not installed."
+            $allFeaturesInstalled = $false
+        }
+    }
+    return $allFeaturesInstalled
+}
+
+if (-not (ValidateWindowsFeatures)) {
+    Write-Output "Installing required windows features..."
+
+    foreach ($feature in $requiredWindowsFeatures) {
+        Install-WindowsFeature -Name $feature
+    }
+
+    Write-Output "Please reboot and re-run this script."
+    exit 0
+}
+
+# Install 7Zip
+Write-Output "Installing 7Zip"
+Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.v2.psm1 -O $env:TEMP\helper.v2.psm1
+ipmo $env:TEMP\helper.v2.psm1
+Install-7Zip
+
+Write-Output "Getting ContainerD binaries"
+$global:ContainerDPath = "$env:ProgramFiles\containerd"
+mkdir -Force $global:ContainerDPath | Out-Null
+DownloadFile "$global:ContainerDPath\containerd.tar.gz" https://github.com/containerd/containerd/releases/download/v${ContainerDVersion}/containerd-${ContainerDVersion}-windows-amd64.tar.gz
+tar.exe -xvf "$global:ContainerDPath\containerd.tar.gz" --strip=1 -C $global:ContainerDPath
+$env:Path += ";$global:ContainerDPath"
+[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
+containerd.exe config default | Out-File "$global:ContainerDPath\config.toml" -Encoding ascii
+#config file fixups
+$config = Get-Content "$global:ContainerDPath\config.toml"
+$config = $config -replace "bin_dir = (.)*$", "bin_dir = `"$CNIBinPath`""
+$config = $config -replace "conf_dir = (.)*$", "conf_dir = `"$CNIConfigPath`""
+$config | Set-Content "$global:ContainerDPath\config.toml" -Force
+
+mkdir -Force $CNIBinPath | Out-Null
+mkdir -Force $CNIConfigPath | Out-Null
+
+Write-Output "Registering ContainerD as a service"
+containerd.exe --register-service
+
+Write-Output "Starting ContainerD service"
+Start-Service containerd
+
+Write-Output "Done - please remember to add '--cri-socket `"npipe:////./pipe/containerd-containerd`"' to your kubeadm join command"

--- a/static/calico-enterprise/next/scripts/PrepareNode.ps1
+++ b/static/calico-enterprise/next/scripts/PrepareNode.ps1
@@ -1,0 +1,150 @@
+<#
+.SYNOPSIS
+Assists with preparing a Windows VM prior to calling kubeadm join
+
+.DESCRIPTION
+This script assists with joining a Windows node to a cluster.
+- Downloads Kubernetes binaries (kubelet, kubeadm) at the version specified
+- Registers kubelet as an nssm service. More info on nssm: https://nssm.cc/
+
+This is originally from https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/PrepareNode.ps1
+It has been adapted for Calico.
+
+.PARAMETER KubernetesVersion
+Kubernetes version to download and use
+
+.PARAMETER ContainerRuntime
+Container that Kubernetes will use. (Docker or ContainerD)
+
+.EXAMPLE
+PS> .\PrepareNode.ps1 -KubernetesVersion v1.23.4 -ContainerRuntime ContainerD
+
+#>
+
+Param(
+    [parameter(Mandatory = $true, HelpMessage="Kubernetes version to use")]
+    [string] $KubernetesVersion,
+    [parameter(HelpMessage="Container runtime that Kubernetes will use")]
+    [ValidateSet("ContainerD", "Docker")]
+    [string] $ContainerRuntime = "ContainerD"
+)
+$ErrorActionPreference = 'Stop'
+
+function DownloadFile($destination, $source) {
+    Write-Host("Downloading $source to $destination")
+    curl.exe --silent --fail -Lo $destination $source
+
+    if (!$?) {
+        Write-Error "Download $source failed"
+        exit 1
+    }
+}
+
+if ($ContainerRuntime -eq "Docker") {
+    if (-not(Test-Path "//./pipe/docker_engine")) {
+        Write-Error "Docker service was not detected - please install start Docker before calling PrepareNode.ps1 with -ContainerRuntime Docker"
+        exit 1
+    }
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    if (-not(Test-Path "//./pipe/containerd-containerd")) {
+        Write-Error "ContainerD service was not detected - please install and start ContainerD before calling PrepareNode.ps1 with -ContainerRuntime ContainerD"
+        exit 1
+    }
+}
+
+if (!$KubernetesVersion.StartsWith("v")) {
+    $KubernetesVersion = "v" + $KubernetesVersion
+}
+Write-Host "Using Kubernetes version: $KubernetesVersion"
+$global:Powershell = (Get-Command powershell).Source
+$global:PowershellArgs = "-ExecutionPolicy Bypass -NoProfile"
+$global:KubernetesPath = "$env:SystemDrive\k"
+$global:StartKubeletScript = "$global:KubernetesPath\StartKubelet.ps1"
+$global:NssmInstallDirectory = "$env:ProgramFiles\nssm"
+$kubeletBinPath = "$global:KubernetesPath\kubelet.exe"
+
+mkdir -force "$global:KubernetesPath"
+$env:Path += ";$global:KubernetesPath"
+[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
+
+DownloadFile $kubeletBinPath https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubelet.exe
+DownloadFile "$global:KubernetesPath\kubeadm.exe" https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubeadm.exe
+
+if ($ContainerRuntime -eq "Docker") {
+    # Create host network to allow kubelet to schedule hostNetwork pods
+    # NOTE: For containerd the 0-containerd-nat.json network config template added by
+    # Install-containerd.ps1 joins pods to the host network.
+    Write-Host "Creating Docker host network"
+    docker network create -d nat host
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    DownloadFile "c:\k\hns.psm1" https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1
+    Import-Module -DisableNameChecking "c:\k\hns.psm1"
+    if ((Get-HNSNetwork | ? Type -EQ nat | ? Name -EQ nat) -eq $null) {
+        New-HnsNetwork -Type NAT -Name nat
+    }
+}
+
+$kubeletLogPath = "C:\var\log\kubelet"
+mkdir -force $kubeletLogPath
+mkdir -force C:\var\lib\kubelet\etc\kubernetes
+mkdir -force C:\etc\kubernetes\pki
+New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C:\etc\kubernetes\pki\
+
+$StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
+$global:KubeletArgs = $FileContent.TrimStart(''KUBELET_KUBEADM_ARGS='').Trim(''"'')
+
+$global:containerRuntime = {{CONTAINER_RUNTIME}}
+
+if ($global:containerRuntime -eq "Docker") {
+    $netId = docker network ls -f name=host --format "{{ .ID }}"
+
+    if ($netId.Length -lt 1) {
+    docker network create -d nat host
+    }
+}
+
+$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:3.6`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --logtostderr=false --image-pull-progress-deadline=20m"
+
+Invoke-Expression $cmd'
+$StartKubeletFileContent = $StartKubeletFileContent -replace "{{CONTAINER_RUNTIME}}", "`"$ContainerRuntime`""
+Set-Content -Path $global:StartKubeletScript -Value $StartKubeletFileContent
+
+Write-Host "Installing nssm"
+$arch = "win32"
+if ([Environment]::Is64BitOperatingSystem) {
+    $arch = "win64"
+}
+
+mkdir -Force $global:NssmInstallDirectory
+DownloadFile nssm.zip https://k8stestinfrabinaries.blob.core.windows.net/nssm-mirror/nssm-2.24.zip
+tar C $global:NssmInstallDirectory -xvf .\nssm.zip --strip-components 2 */$arch/*.exe
+Remove-Item -Force .\nssm.zip
+
+$env:path += ";$global:NssmInstallDirectory"
+$newPath = "$global:NssmInstallDirectory;" +
+[Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
+
+[Environment]::SetEnvironmentVariable("PATH", $newPath, [EnvironmentVariableTarget]::Machine)
+
+Write-Host "Registering kubelet service"
+nssm install kubelet $global:Powershell $global:PowershellArgs $global:StartKubeletScript
+nssm set kubelet AppStdout $kubeletLogPath\kubelet.out.log
+nssm set kubelet AppStderr $kubeletLogPath\kubelet.err.log
+
+# Configure online file rotation.
+nssm set kubelet AppRotateFiles 1
+nssm set kubelet AppRotateOnline 1
+# Rotate once per day.
+nssm set kubelet AppRotateSeconds 86400
+# Rotate after 10MB.
+nssm set kubelet AppRotateBytes 10485760
+
+if ($ContainerRuntime -eq "Docker") {
+    nssm set kubelet DependOnService docker
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    nssm set kubelet DependOnService containerd
+}
+
+if ((Get-NetFirewallRule | ? Name -EQ kubelet) -EQ $null) {
+    New-NetFirewallRule -Name kubelet -DisplayName 'kubelet' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 10250
+}

--- a/static/calico-enterprise/next/scripts/install-calico-windows.ps1
+++ b/static/calico-enterprise/next/scripts/install-calico-windows.ps1
@@ -1,0 +1,567 @@
+---
+layout: null
+---
+# Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+<#
+.DESCRIPTION
+    This script installs and starts {{site.prodname}} services on a Windows node.
+
+    Note: EKS requires downloading kubectl.exe to c:\k before running this script: https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
+#>
+
+Param(
+    # Note: we don't publish a release artifact for the "master" branch. To test
+    # against master, build calico-windows.zip from projectcalico/node.
+{%- if site.url contains "projectcalico" %}
+    [parameter(Mandatory = $false)] $ReleaseBaseURL="https://github.com/projectcalico/calico/releases/download/{{site.data.versions.first.components["calico/node"].version}}/",
+    [parameter(Mandatory = $false)] $ReleaseFile="calico-windows-{{site.data.versions.first.components["calico/node"].version}}.zip",
+{%- else %}
+    [parameter(Mandatory = $false)] $ReleaseBaseURL="{{site.url}}/files/windows/",
+{%- endif %}
+    [parameter(Mandatory = $false)] $KubeVersion="",
+    [parameter(Mandatory = $false)] $StartCalico="yes",
+    # As of Kubernetes version v1.24.0, service account token secrets are no longer automatically created. But this installation script uses that secret
+    # to generate a kubeconfig so default to creating the calico-node token secret if it doesn't exist.
+    [parameter(Mandatory = $false)] $AutoCreateServiceAccountTokenSecret="yes",
+    [parameter(Mandatory = $false)] $Datastore="kubernetes",
+    [parameter(Mandatory = $false)] $EtcdEndpoints="",
+    [parameter(Mandatory = $false)] $EtcdTlsSecretName="",
+    [parameter(Mandatory = $false)] $EtcdKey="",
+    [parameter(Mandatory = $false)] $EtcdCert="",
+    [parameter(Mandatory = $false)] $EtcdCaCert="",
+    [parameter(Mandatory = $false)] $ServiceCidr="10.96.0.0/12",
+    [parameter(Mandatory = $false)] $DNSServerIPs="10.96.0.10",
+    [parameter(Mandatory = $false)] $CalicoBackend=""
+)
+
+function DownloadFiles()
+{
+    Write-Host "Creating CNI directory"
+    md $BaseDir\cni\config -ErrorAction Ignore
+
+    Write-Host "Downloading Windows Kubernetes scripts"
+    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1 -Destination $BaseDir\hns.psm1
+}
+
+function PrepareKubernetes()
+{
+    DownloadFiles
+    ipmo -DisableNameChecking C:\k\hns.psm1
+    InstallK8sBinaries
+
+    # Prepull and tag the pause image for docker
+    if (-not (Get-IsContainerdRunning)) {
+        # If containerd is not running we assume the installation should be
+        # configured for docker. But in this case, docker has to be running.
+        $svc = Get-Service | where Name -EQ 'docker'
+        if ($svc -EQ $null) {
+            Write-Host "Docker service is not installed. Cannot prepare kubernetes pause image."
+            exit 1
+        }
+        if ($svc.Status -NE 'Running') {
+            Write-Host "Docker service is not running. Cannot prepare kubernetes pause image. Run 'Start-Service docker' and try again."
+            exit 1
+        }
+        $pause = "mcr.microsoft.com/oss/kubernetes/pause:3.6"
+        docker pull $pause
+        docker tag $pause kubeletwin/pause
+    }
+}
+
+function InstallK8sBinaries()
+{
+    Install-7Zip
+    $Source = "" | Select Release
+    $Source.Release=$KubeVersion
+    InstallKubernetesBinaries -Destination $BaseDir -Source $Source
+    cp c:\k\kubernetes\node\bin\*.exe c:\k
+}
+
+function GetPlatformType()
+{
+    # AKS
+    $hnsNetwork = Get-HnsNetwork | ? Name -EQ azure
+    if ($hnsNetwork.name -EQ "azure") {
+        return ("aks")
+    }
+
+    # EKS
+    $hnsNetwork = Get-HnsNetwork | ? Name -like "vpcbr*"
+    if ($hnsNetwork.name -like "vpcbr*") {
+        return ("eks")
+    }
+
+    # EC2
+    $restError = $null
+    Try {
+        $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
+        $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    } Catch {
+        $restError = $_
+    }
+    if ($restError -eq $null) {
+        return ("ec2")
+    }
+
+    # GCE
+    $restError = $null
+    Try {
+        $gceNodeName = Invoke-RestMethod -UseBasicParsing -Headers @{"Metadata-Flavor"="Google"} "http://metadata.google.internal/computeMetadata/v1/instance/hostname" -ErrorAction Ignore
+    } Catch {
+        $restError = $_
+    }
+    if ($restError -eq $null) {
+        return ("gce")
+    }
+
+    return ("bare-metal")
+}
+
+function GetBackendType()
+{
+    param(
+        [parameter(Mandatory=$true)] $CalicoNamespace,
+        [parameter(Mandatory=$false)] $KubeConfigPath = "$RootDir\calico-kube-config"
+    )
+
+    if (-Not [string]::IsNullOrEmpty($CalicoBackend)) {
+        return $CalicoBackend
+    }
+
+    # For hostprocess installs, if CALICO_NETWORKING_BACKEND is set to a valid value, try to use it.
+    if ($env:CONTAINER_SANDBOX_MOUNT_POINT -and $env:CALICO_NETWORKING_BACKEND) {
+        $backend = $env:CALICO_NETWORKING_BACKEND
+        if (($backend -eq "vxlan") -or ($backend -eq "windows-bgp")) {
+            return $backend
+        }
+
+        if ($backend -NE $null) {
+            Write-Host "Invalid Calico backend type: $backend. Set CALICO_NETWORKING_BACKEND in calico-windows-config in calico-system namespace to one of: 'vxlan', 'windows-bgp'"
+            exit 1
+        }
+
+        # If CALICO_NETWORKING_BACKEND is not set we can only continue if the
+        # kubeconfig and kubectl.exe both exist.
+        if ((-not (Test-Path $KubeConfigPath)) -or (-not (Test-Path "c:\k\kubectl.exe"))) {
+            Write-Host "No CALICO_NETWORKING_BACKEND provided. Set CALICO_NETWORKING_BACKEND in calico-windows-config in calico-system namespace to one of: 'vxlan', 'windows-bgp'"
+            exit 1
+        }
+
+        # If we reach here, we can continue auto-detecting the backend type.
+    }
+
+    # Auto detect backend type
+    if ($Datastore -EQ "kubernetes") {
+        $encap=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.ipipEnabled}'
+        if ($encap -EQ "true") {
+            throw "{{site.prodname}} on Linux has IPIP enabled. IPIP is not supported on Windows nodes."
+        }
+
+        # Check FelixConfig first.
+        $encap=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.vxlanEnabled}'
+        if ($encap -EQ "true") {
+            return ("vxlan")
+        } elseif ($encap -EQ "false") {
+            return ("bgp")
+        } else {
+           # If any IPPool has IPIP enabled, we need to exit the installer. The
+           # IPIP-enabled might not be assigned to this Windows node but we can't
+           # verify that easily by looking at the nodeSelector.
+           $ipipModes = c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get ippools.crd.projectcalico.org -o jsonpath='{.items[*].spec.ipipMode}'
+           $ipipEnabled = $ipipModes | Select-String -pattern '(Always)|(CrossSubnet)'
+           if ($ipipEnabled -NE $null) {
+               throw "Failed to auto detect backend type. IPIP is not supported on Windows nodes but found IP pools with IPIP enabled. Rerun install script with the CalicoBackend param provided"
+           }
+
+           # If FelixConfig does not have vxlanEnabled then check the IPPools and see if any of them have enabled vxlan.
+           $vxlanModes=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get ippools.crd.projectcalico.org -o jsonpath='{.items[*].spec.vxlanMode}'
+           $vxlanEnabled = $vxlanModes | Select-String -pattern '(Always)|(CrossSubnet)'
+           if ($vxlanEnabled -NE $null) {
+               return ("vxlan")
+           } else {
+               return ("bgp")
+           }
+        }
+    } else {
+        $CalicoBackend=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get configmap calico-config -n $CalicoNamespace -o jsonpath='{.data.calico_backend}'
+        if ($CalicoBackend -EQ "vxlan") {
+            return ("vxlan")
+        }
+        return ("bgp")
+    }
+}
+
+function GetCalicoNamespace() {
+    param(
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    # If we are running inside a HostProcess container then return our
+    # namespace.
+    if ($env:CONTAINER_SANDBOX_MOUNT_POINT) {
+        $ns = Get-Content -Raw -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/run/secrets/kubernetes.io/serviceaccount/namespace
+        write-host ("Install script is running in a HostProcess container. This namespace is {0}" -f $ns)
+        return $ns
+    }
+
+    $ErrorActionPreference = 'Continue'
+    $name=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get ns calico-system
+    $ErrorActionPreference = 'Stop'
+    if ([string]::IsNullOrEmpty($name)) {
+        write-host "Calico running in kube-system namespace"
+        return ("kube-system")
+    }
+    write-host "Calico running in calico-system namespace"
+    return ("calico-system")
+}
+
+function GetCalicoKubeConfig()
+{
+    param(
+      [parameter(Mandatory=$true)] $CalicoNamespace,
+      [parameter(Mandatory=$false)] $SecretNamePrefix = "calico-node",
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    # On EKS, we need to have AWS tools loaded for kubectl authentication.
+    $eksAWSToolsModulePath="C:\Program Files (x86)\AWS Tools\PowerShell\AWSPowerShell\AWSPowerShell.psd1"
+    if (Test-Path $eksAWSToolsModulePath) {
+        Write-Host "AWSPowerShell module exists, loading $eksAWSToolsModulePath ..."
+        Import-Module $eksAWSToolsModulePath
+    }
+
+    # If we are running inside a HostProcess container then we already have
+    # access to the serviceaccount token and ca cert.
+    if ($env:CONTAINER_SANDBOX_MOUNT_POINT) {
+        Write-Host "Install script is running in a HostProcess container, using mounted serviceaccount ca cert and token."
+        # CA needs to be base64-encoded.
+        $ca = Get-Content -Raw -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        $ca = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($ca))
+        # But not the token.
+        $token = Get-Content -Path $env:CONTAINER_SANDBOX_MOUNT_POINT/var/run/secrets/kubernetes.io/serviceaccount/token
+
+        # KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT are used if both
+        # provided. If this is not the case, fallback to using $KubeConfigPath
+        # if it exists.
+        $k8sHost = $env:KUBERNETES_SERVICE_HOST
+        $k8sPort = $env:KUBERNETES_SERVICE_PORT
+        if ($k8sHost -and $k8sPort) {
+            $server = "server: https://{0}:{1}" -f $k8sHost, $k8sPort
+            Write-Host "Using KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT env variables for kubeconfig. $server"
+        } elseif (Test-Path $KubeConfigPath) {
+            $server=findstr https:// $KubeConfigPath
+            Write-Host ("Using existing kubeconfig at $KubeConfigPath for API server host and port. {0}" -f $server.Trim())
+        } else {
+            Write-Host "Cannot determine API server host and port. Add KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to calico-windows-config in calico-system namespace"
+            exit 1
+        }
+    } else {
+        $ErrorActionPreference = 'Continue'
+        $secretName=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret -n $CalicoNamespace --field-selector=type=kubernetes.io/service-account-token --no-headers -o custom-columns=":metadata.name" | findstr $SecretNamePrefix | select -first 1
+        $ErrorActionPreference = 'Stop'
+        if ([string]::IsNullOrEmpty($secretName)) {
+            if (-Not $AutoCreateServiceAccountTokenSecret) {
+                throw "$SecretName service account token secret does not exist."
+            } else {
+                # Otherwise create the serviceaccount token secret.
+                $secretName = "calico-node-token"
+                CreateTokenAccountSecret -Name $secretName -Namespace $CalicoNamespace -KubeConfigPath $KubeConfigPath
+            }
+        }
+        # CA from the k8s secret is already base64-encoded.
+        $ca=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$secretName -o jsonpath='{.data.ca\.crt}' -n $CalicoNamespace
+        # Token from the k8s secret is base64-encoded but we need the jwt token.
+        $tokenBase64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$secretName -o jsonpath='{.data.token}' -n $CalicoNamespace
+        $token=[System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($tokenBase64))
+
+        $server=findstr https:// $KubeConfigPath
+    }
+
+    (Get-Content $RootDir\calico-kube-config.template).replace('<ca>', $ca).replace('<server>', $server.Trim()).replace('<token>', $token) | Set-Content $RootDir\calico-kube-config -Force
+}
+
+function CreateTokenAccountSecret()
+{
+    param(
+      [parameter(Mandatory=$true)] $Name,
+      [parameter(Mandatory=$true)] $Namespace,
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    $tempFile = New-TemporaryFile
+    Write-Host "Created temp file ${tempFile}"
+
+    $yaml=@"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: $Name
+  namespace: $Namespace
+  annotations:
+    kubernetes.io/service-account.name: calico-node
+type: kubernetes.io/service-account-token
+"@
+    Set-Content -Path $tempFile.FullName -value $yaml
+    c:\k\kubectl --kubeconfig $KubeConfigPath apply -f $tempFile.FullName
+}
+
+function EnableWinDsrForEKS()
+{
+    $OSInfo = (Get-ComputerInfo  | select WindowsVersion, OsBuildNumber)
+    $supportsDSR = Get-IsDSRSupported
+
+    if (-Not $supportsDSR) {
+        Write-Host "WinDsr is not supported ($OSInfo)"
+        return
+    }
+
+    # Update and restart kube-proxy if WinDSR is not enabled by default.
+    $Path = Get-CimInstance -Query 'select * from win32_service where name="kube-proxy"' | Select -ExpandProperty pathname
+    if ($Path -like "*--enable-dsr=true*") {
+        Write-Host "WinDsr is enabled by default."
+    } else {
+        $UpdatedPath = $Path + " --enable-dsr=true --feature-gates=WinDSR=true"
+        Get-CimInstance win32_service -filter 'Name="kube-proxy"' | Invoke-CimMethod -Name Change -Arguments @{PathName=$UpdatedPath}
+        Restart-Service -name "kube-proxy"
+        Write-Host "WinDsr has been enabled for kube-proxy."
+    }
+}
+
+function SetupEtcdTlsFiles()
+{
+    param(
+      [parameter(Mandatory=$true)] $CalicoNamespace,
+      [parameter(Mandatory=$true)] $SecretName,
+      [parameter(Mandatory=$false)] $KubeConfigPath = "c:\\k\\config"
+    )
+
+    $path = "$RootDir\etcd-tls"
+
+    $ErrorActionPreference = 'Continue'
+    $found=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -n $CalicoNamespace
+    $ErrorActionPreference = 'Stop'
+    if ([string]::IsNullOrEmpty($found)) {
+        throw "$SecretName does not exist."
+    }
+
+    $keyB64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -o jsonpath='{.data.etcd-key}' -n $CalicoNamespace
+    $certB64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -o jsonpath='{.data.etcd-cert}' -n $CalicoNamespace
+    $caB64=c:\k\kubectl.exe --kubeconfig=$KubeConfigPath get secret/$SecretName -o jsonpath='{.data.etcd-ca}' -n $CalicoNamespace
+
+    New-Item -Type Directory -Path $path -Force
+
+    [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($keyB64)) | Set-Content "$path\server.key" -Force
+    [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($certB64)) | Set-Content "$path\server.crt" -Force
+    [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($caB64)) | Set-Content "$path\ca.crt" -Force
+
+    $script:EtcdKey = "$path\server.key"
+    $script:EtcdCert = "$path\server.crt"
+    $script:EtcdCaCert = "$path\ca.crt"
+}
+
+function SetAKSCalicoStaticRules {
+    $fileName  = [Io.path]::Combine("$RootDir", "static-rules.json")
+    echo '{
+    "Provider": "AKS",
+    "Rules": [
+        {
+            "Name": "EndpointPolicy",
+            "Rule": {
+                "Action": "Block",
+                "Direction": "Out",
+                "Id": "block-wireserver",
+                "Priority": 200,
+                "Protocol": 6,
+                "RemoteAddresses": "168.63.129.16/32",
+                "RemotePorts": "80",
+                "RuleType": "Switch",
+                "Type": "ACL"
+            }
+        }
+    ],
+    "version": "0.1.0"
+}' | Out-File -encoding ASCII -filepath $fileName
+}
+
+function InstallCalico()
+{
+    Write-Host "`nStart {{site.prodnameWindows}} install...`n"
+
+    pushd
+    cd $RootDir
+    .\install-calico.ps1
+    popd
+    Write-Host "`n{{site.prodnameWindows}} installed`n"
+}
+
+# kubectl errors are expected, so there are places where this is reset to "Continue" temporarily
+$ErrorActionPreference = "Stop"
+
+$BaseDir="c:\k"
+$RootDir="c:\TigeraCalico"
+$CalicoZipName="tigera-calico-windows.zip"
+$CalicoZipPath="c:\$CalicoZipName"
+
+# If this script is run from a HostProcess container then the installation archive
+# will be in the mount point.
+if ($env:CONTAINER_SANDBOX_MOUNT_POINT) {
+    $CalicoZipPath="$env:CONTAINER_SANDBOX_MOUNT_POINT\$CalicoZipName"
+}
+
+# Must load the helper modules before doing anything else.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$helper = "$BaseDir\helper.psm1"
+$helperv2 = "$BaseDir\helper.v2.psm1"
+md $BaseDir -ErrorAction Ignore
+if (!(Test-Path $helper))
+{
+    Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.psm1 -O $BaseDir\helper.psm1
+}
+if (!(Test-Path $helperv2))
+{
+    Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.v2.psm1 -O $BaseDir\helper.v2.psm1
+}
+ipmo -force -DisableNameChecking $helper
+ipmo -force -DisableNameChecking $helperv2
+
+if (!(Test-Path $CalicoZipPath))
+{
+	throw "Cannot find {{site.prodnameWindows}} zip file $CalicoZipPath."
+}
+
+$platform=GetPlatformType
+
+if ((Get-Service -exclude 'CalicoUpgrade' | where Name -Like 'Calico*' | where Status -EQ Running) -NE $null) {
+    Write-Host "Calico services are still running. In order to re-run the installation script, stop the CalicoNode and CalicoFelix services or uninstall them by running: $RootDir\uninstall-calico.ps1"
+    Exit
+}
+
+Remove-Item $RootDir -Force  -Recurse -ErrorAction SilentlyContinue
+Write-Host "Unzip {{site.prodnameWindows}} release..."
+Expand-Archive -Force $CalicoZipPath c:\
+ipmo -force $RootDir\libs\calico\calico.psm1
+
+# This comes after we import calico.psm1
+if (-Not [string]::IsNullOrEmpty($KubeVersion) -and $platform -NE "eks") {
+    PrepareKubernetes
+}
+
+Write-Host "Setup {{site.prodnameWindows}}..."
+Set-ConfigParameters -var 'CALICO_DATASTORE_TYPE' -value $Datastore
+Set-ConfigParameters -var 'ETCD_ENDPOINTS' -value $EtcdEndpoints
+
+if (-Not [string]::IsNullOrEmpty($EtcdTlsSecretName)) {
+    $calicoNs = GetCalicoNamespace
+    SetupEtcdTlsFiles -SecretName "$EtcdTlsSecretName" -CalicoNamespace $calicoNs
+}
+Set-ConfigParameters -var 'ETCD_KEY_FILE' -value $EtcdKey
+Set-ConfigParameters -var 'ETCD_CERT_FILE' -value $EtcdCert
+Set-ConfigParameters -var 'ETCD_CA_CERT_FILE' -value $EtcdCaCert
+Set-ConfigParameters -var 'K8S_SERVICE_CIDR' -value $ServiceCidr
+Set-ConfigParameters -var 'DNS_NAME_SERVERS' -value $DNSServerIPs
+
+if ($platform -EQ "aks") {
+    Write-Host "Setup {{site.prodnameWindows}} for AKS..."
+    $Backend="none"
+    Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "none"
+    Set-ConfigParameters -var 'KUBE_NETWORK' -value "azure.*"
+
+    $calicoNs = "calico-system"
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+
+    SetAKSCalicoStaticRules
+}
+if ($platform -EQ "eks") {
+    EnableWinDsrForEKS
+
+    $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
+    $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    Write-Host "Setup {{site.prodnameWindows}} for EKS, node name $awsNodeName ..."
+    $Backend = "none"
+
+    Set-ConfigParameters -var 'NODENAME' -value $awsNodeName
+    Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "none"
+    Set-ConfigParameters -var 'KUBE_NETWORK' -value "vpc.*"
+
+    $calicoNs = GetCalicoNamespace -KubeConfigPath C:\ProgramData\kubernetes\kubeconfig
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs -KubeConfigPath C:\ProgramData\kubernetes\kubeconfig
+}
+if ($platform -EQ "ec2") {
+    $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
+    $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
+    Write-Host "Setup {{site.prodnameWindows}} for AWS, node name $awsNodeName ..."
+    Set-ConfigParameters -var 'NODENAME' -value $awsNodeName
+
+    $calicoNs = GetCalicoNamespace
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+    $Backend = GetBackendType -CalicoNamespace $calicoNs
+
+    Write-Host "Backend networking is $Backend"
+    if ($Backend -EQ "bgp") {
+        Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "windows-bgp"
+    }
+}
+if ($platform -EQ "gce") {
+    $gceNodeName = Invoke-RestMethod -UseBasicParsing -Headers @{"Metadata-Flavor"="Google"} "http://metadata.google.internal/computeMetadata/v1/instance/hostname" -ErrorAction Ignore
+    Write-Host "Setup {{site.prodnameWindows}} for GCE, node name $gceNodeName ..."
+    Set-ConfigParameters -var 'NODENAME' -value $gceNodeName
+
+    $calicoNs = GetCalicoNamespace
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+    $Backend = GetBackendType -CalicoNamespace $calicoNs
+
+    Write-Host "Backend networking is $Backend"
+    if ($Backend -EQ "bgp") {
+        Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "windows-bgp"
+    }
+}
+if ($platform -EQ "bare-metal") {
+    $calicoNs = GetCalicoNamespace
+    GetCalicoKubeConfig -CalicoNamespace $calicoNs
+    $Backend = GetBackendType -CalicoNamespace $calicoNs
+
+    Write-Host "Backend networking is $Backend"
+    if ($Backend -EQ "bgp") {
+        Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "windows-bgp"
+    }
+}
+
+InstallCalico
+
+if ($StartCalico -EQ "yes") {
+    Write-Host "Starting Calico..."
+    Write-Host "This may take several seconds if the vSwitch needs to be created."
+
+    Start-Service CalicoNode
+    Wait-ForCalicoInit
+    Start-Service CalicoFelix
+
+    if ($env:CALICO_NETWORKING_BACKEND -EQ "windows-bgp")
+    {
+        Start-Service CalicoConfd
+    }
+
+    while ((Get-Service | where Name -Like 'Calico*' | where Status -NE Running) -NE $null) {
+        Write-Host "Waiting for the Calico services to be running..."
+        Start-Sleep 1
+    }
+
+    Write-Host "Done, the Calico services are running:"
+    Get-Service | where Name -Like 'Calico*'
+}
+
+if ($Backend -NE "none") {
+    New-NetFirewallRule -Name KubectlExec10250 -Description "Enable kubectl exec and log" -Action Allow -LocalPort 10250 -Enabled True -DisplayName "kubectl exec 10250" -Protocol TCP -ErrorAction SilentlyContinue
+}

--- a/static/calico-enterprise/next/scripts/switch-active-operator.sh
+++ b/static/calico-enterprise/next/scripts/switch-active-operator.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# This script switches the current operator installation to use the operator
+# running in the NEW_NAME namespace.
+#
+# Before this script is run, the new operator and its associated resources
+# should have been deployed to the NEW_NAME namespace.
+set -e
+
+NEW_NAME=$1
+
+if [ -z "${NEW_NAME}" ]; then
+  echo "Provide a NEW_NAME for the new namespace to switch the current operator to."
+  exit 1
+fi
+
+# kubectl_retry retries <args>
+kubectl_retry() {
+  RETRIES=$1
+  OUTPUT_TMP=$(mktemp)
+  shift 1
+
+  for attempt in $(seq 1 ${RETRIES}); do
+    exit_code=0
+    kubectl $@ 1> ${OUTPUT_TMP}
+    exit_code=$?
+    if [[ "${exit_code}" == "0" || "${exit_code}" == "" ]]; then
+      cat ${OUTPUT_TMP}
+      break
+    elif [[ "${attempt}" == "${RETRIES}" ]]; then
+      echo [ERROR] Failed to kubectl $@
+      return ${exit_code}
+    else
+      echo [INFO] Failed kubectl command - will sleep and retry
+      sleep 5
+    fi
+  done
+}
+
+copy_resource_to_ns (){
+  TYPE=$1
+  NAME=$2
+  NS=$3
+
+  DATA=$(kubectl get $TYPE -n tigera-operator ${NAME} -o jsonpath="{.data}")
+  OWNER_REF=$(kubectl get $TYPE -n tigera-operator ${NAME} -o jsonpath="{.metadata.ownerReferences}")
+  kubectl_retry 10 apply -f - <<EOF
+{"apiVersion":"v1","kind":"$TYPE",
+"data":${DATA},
+"metadata":{"name":"${NAME}","namespace":"${NS}",
+"ownerReferences": ${OWNER_REF} }}
+EOF
+}
+
+if kubectl get ns ${NEW_NAME} 2>&1 > /dev/null ; then
+  echo "The namespace ${NEW_NAME} already exists. Cannot continue switching the active operator."
+  exit 1
+fi
+
+kubectl_retry 10 create ns ${NEW_NAME}
+
+# Copy over the secrets in the tigera-operator namespace to the new namespace to ensure
+# switching the active operator is non-disruptive.
+for x in node-certs typha-certs; do
+  copy_resource_to_ns Secret $x ${NEW_NAME}
+done
+
+# Switch the active operator
+PATCH_FILE=$(mktemp)
+cat <<EOF > ${PATCH_FILE}
+{"data":{"active-namespace": "${NEW_NAME}"}}
+EOF
+kubectl_retry 10 patch configmap -n calico-system active-operator --type=merge --patch-file "${PATCH_FILE}"

--- a/static/calico/3.24/scripts/Install-Containerd.ps1
+++ b/static/calico/3.24/scripts/Install-Containerd.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+Installs ContainerD on a Windows machine in preparation for joining the node to a Kubernetes cluster.
+
+.DESCRIPTION
+This script
+- Verifies that Windows Features required for running containers are enabled (and enables then if they are not).
+- Downloads ContainerD binaries at the version specified.
+- Registers ContainerD as a windows service.
+
+This is originally from https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/Install-Containerd.ps1.
+It has been adapted for Calico.
+
+.PARAMETER ContainerDVersion
+ContainerD version to download and use.
+
+.EXAMPLE
+PS> .\Install-Containerd.ps1 -ContainerDVersion 1.6.2 -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
+#>
+
+Param(
+    [parameter(HelpMessage = "ContainerD version to use")]
+    [string] $ContainerDVersion = "1.6.2",
+    [parameter(HelpMessage = "Path to configure ContainerD to look for CNI config files. This should be set to the same path used for Calico for Windows.")]
+    [string] $CNIConfigPath = "c:/etc/cni/net.d",
+    [parameter(HelpMessage = "Path to configure ContainerD to look for CNI binaries. This should be set to the same path used for Calico for Windows.")]
+    [string] $CNIBinPath = "c:/opt/cni/bin"
+)
+
+$ErrorActionPreference = 'Stop'
+
+function DownloadFile($destination, $source) {
+    Write-Host("Downloading $source to $destination")
+    curl.exe --silent --fail -Lo $destination $source
+
+    if (!$?) {
+        Write-Error "Download $source failed"
+        exit 1
+    }
+}
+
+# The original script also included Hyper-V and Hyper-V-Powershell.
+# However those are not needed by Calico for Windows.
+$requiredWindowsFeatures = @(
+    "Containers")
+
+function ValidateWindowsFeatures {
+    $allFeaturesInstalled = $true
+    foreach ($feature in $requiredWindowsFeatures) {
+        $f = Get-WindowsFeature -Name $feature
+        if (-not $f.Installed) {
+            Write-Warning "Windows feature: '$feature' is not installed."
+            $allFeaturesInstalled = $false
+        }
+    }
+    return $allFeaturesInstalled
+}
+
+if (-not (ValidateWindowsFeatures)) {
+    Write-Output "Installing required windows features..."
+
+    foreach ($feature in $requiredWindowsFeatures) {
+        Install-WindowsFeature -Name $feature
+    }
+
+    Write-Output "Please reboot and re-run this script."
+    exit 0
+}
+
+# Install 7Zip
+Write-Output "Installing 7Zip"
+Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.v2.psm1 -O $env:TEMP\helper.v2.psm1
+ipmo $env:TEMP\helper.v2.psm1
+Install-7Zip
+
+Write-Output "Getting ContainerD binaries"
+$global:ContainerDPath = "$env:ProgramFiles\containerd"
+mkdir -Force $global:ContainerDPath | Out-Null
+DownloadFile "$global:ContainerDPath\containerd.tar.gz" https://github.com/containerd/containerd/releases/download/v${ContainerDVersion}/containerd-${ContainerDVersion}-windows-amd64.tar.gz
+tar.exe -xvf "$global:ContainerDPath\containerd.tar.gz" --strip=1 -C $global:ContainerDPath
+$env:Path += ";$global:ContainerDPath"
+[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
+containerd.exe config default | Out-File "$global:ContainerDPath\config.toml" -Encoding ascii
+#config file fixups
+$config = Get-Content "$global:ContainerDPath\config.toml"
+$config = $config -replace "bin_dir = (.)*$", "bin_dir = `"$CNIBinPath`""
+$config = $config -replace "conf_dir = (.)*$", "conf_dir = `"$CNIConfigPath`""
+$config | Set-Content "$global:ContainerDPath\config.toml" -Force
+
+mkdir -Force $CNIBinPath | Out-Null
+mkdir -Force $CNIConfigPath | Out-Null
+
+Write-Output "Registering ContainerD as a service"
+containerd.exe --register-service
+
+Write-Output "Starting ContainerD service"
+Start-Service containerd
+
+Write-Output "Done - please remember to add '--cri-socket `"npipe:////./pipe/containerd-containerd`"' to your kubeadm join command"

--- a/static/calico/3.24/scripts/PrepareNode.ps1
+++ b/static/calico/3.24/scripts/PrepareNode.ps1
@@ -1,0 +1,150 @@
+<#
+.SYNOPSIS
+Assists with preparing a Windows VM prior to calling kubeadm join
+
+.DESCRIPTION
+This script assists with joining a Windows node to a cluster.
+- Downloads Kubernetes binaries (kubelet, kubeadm) at the version specified
+- Registers kubelet as an nssm service. More info on nssm: https://nssm.cc/
+
+This is originally from https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/PrepareNode.ps1
+It has been adapted for Calico.
+
+.PARAMETER KubernetesVersion
+Kubernetes version to download and use
+
+.PARAMETER ContainerRuntime
+Container that Kubernetes will use. (Docker or ContainerD)
+
+.EXAMPLE
+PS> .\PrepareNode.ps1 -KubernetesVersion v1.23.4 -ContainerRuntime ContainerD
+
+#>
+
+Param(
+    [parameter(Mandatory = $true, HelpMessage="Kubernetes version to use")]
+    [string] $KubernetesVersion,
+    [parameter(HelpMessage="Container runtime that Kubernetes will use")]
+    [ValidateSet("ContainerD", "Docker")]
+    [string] $ContainerRuntime = "ContainerD"
+)
+$ErrorActionPreference = 'Stop'
+
+function DownloadFile($destination, $source) {
+    Write-Host("Downloading $source to $destination")
+    curl.exe --silent --fail -Lo $destination $source
+
+    if (!$?) {
+        Write-Error "Download $source failed"
+        exit 1
+    }
+}
+
+if ($ContainerRuntime -eq "Docker") {
+    if (-not(Test-Path "//./pipe/docker_engine")) {
+        Write-Error "Docker service was not detected - please install start Docker before calling PrepareNode.ps1 with -ContainerRuntime Docker"
+        exit 1
+    }
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    if (-not(Test-Path "//./pipe/containerd-containerd")) {
+        Write-Error "ContainerD service was not detected - please install and start ContainerD before calling PrepareNode.ps1 with -ContainerRuntime ContainerD"
+        exit 1
+    }
+}
+
+if (!$KubernetesVersion.StartsWith("v")) {
+    $KubernetesVersion = "v" + $KubernetesVersion
+}
+Write-Host "Using Kubernetes version: $KubernetesVersion"
+$global:Powershell = (Get-Command powershell).Source
+$global:PowershellArgs = "-ExecutionPolicy Bypass -NoProfile"
+$global:KubernetesPath = "$env:SystemDrive\k"
+$global:StartKubeletScript = "$global:KubernetesPath\StartKubelet.ps1"
+$global:NssmInstallDirectory = "$env:ProgramFiles\nssm"
+$kubeletBinPath = "$global:KubernetesPath\kubelet.exe"
+
+mkdir -force "$global:KubernetesPath"
+$env:Path += ";$global:KubernetesPath"
+[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
+
+DownloadFile $kubeletBinPath https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubelet.exe
+DownloadFile "$global:KubernetesPath\kubeadm.exe" https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubeadm.exe
+
+if ($ContainerRuntime -eq "Docker") {
+    # Create host network to allow kubelet to schedule hostNetwork pods
+    # NOTE: For containerd the 0-containerd-nat.json network config template added by
+    # Install-containerd.ps1 joins pods to the host network.
+    Write-Host "Creating Docker host network"
+    docker network create -d nat host
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    DownloadFile "c:\k\hns.psm1" https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1
+    Import-Module -DisableNameChecking "c:\k\hns.psm1"
+    if ((Get-HNSNetwork | ? Type -EQ nat | ? Name -EQ nat) -eq $null) {
+        New-HnsNetwork -Type NAT -Name nat
+    }
+}
+
+$kubeletLogPath = "C:\var\log\kubelet"
+mkdir -force $kubeletLogPath
+mkdir -force C:\var\lib\kubelet\etc\kubernetes
+mkdir -force C:\etc\kubernetes\pki
+New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C:\etc\kubernetes\pki\
+
+$StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
+$global:KubeletArgs = $FileContent.TrimStart(''KUBELET_KUBEADM_ARGS='').Trim(''"'')
+
+$global:containerRuntime = {{CONTAINER_RUNTIME}}
+
+if ($global:containerRuntime -eq "Docker") {
+    $netId = docker network ls -f name=host --format "{{ .ID }}"
+
+    if ($netId.Length -lt 1) {
+    docker network create -d nat host
+    }
+}
+
+$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:3.6`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --logtostderr=false --image-pull-progress-deadline=20m"
+
+Invoke-Expression $cmd'
+$StartKubeletFileContent = $StartKubeletFileContent -replace "{{CONTAINER_RUNTIME}}", "`"$ContainerRuntime`""
+Set-Content -Path $global:StartKubeletScript -Value $StartKubeletFileContent
+
+Write-Host "Installing nssm"
+$arch = "win32"
+if ([Environment]::Is64BitOperatingSystem) {
+    $arch = "win64"
+}
+
+mkdir -Force $global:NssmInstallDirectory
+DownloadFile nssm.zip https://k8stestinfrabinaries.blob.core.windows.net/nssm-mirror/nssm-2.24.zip
+tar C $global:NssmInstallDirectory -xvf .\nssm.zip --strip-components 2 */$arch/*.exe
+Remove-Item -Force .\nssm.zip
+
+$env:path += ";$global:NssmInstallDirectory"
+$newPath = "$global:NssmInstallDirectory;" +
+[Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
+
+[Environment]::SetEnvironmentVariable("PATH", $newPath, [EnvironmentVariableTarget]::Machine)
+
+Write-Host "Registering kubelet service"
+nssm install kubelet $global:Powershell $global:PowershellArgs $global:StartKubeletScript
+nssm set kubelet AppStdout $kubeletLogPath\kubelet.out.log
+nssm set kubelet AppStderr $kubeletLogPath\kubelet.err.log
+
+# Configure online file rotation.
+nssm set kubelet AppRotateFiles 1
+nssm set kubelet AppRotateOnline 1
+# Rotate once per day.
+nssm set kubelet AppRotateSeconds 86400
+# Rotate after 10MB.
+nssm set kubelet AppRotateBytes 10485760
+
+if ($ContainerRuntime -eq "Docker") {
+    nssm set kubelet DependOnService docker
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    nssm set kubelet DependOnService containerd
+}
+
+if ((Get-NetFirewallRule | ? Name -EQ kubelet) -EQ $null) {
+    New-NetFirewallRule -Name kubelet -DisplayName 'kubelet' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 10250
+}

--- a/static/calico/3.25/scripts/Install-Containerd.ps1
+++ b/static/calico/3.25/scripts/Install-Containerd.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+Installs ContainerD on a Windows machine in preparation for joining the node to a Kubernetes cluster.
+
+.DESCRIPTION
+This script
+- Verifies that Windows Features required for running containers are enabled (and enables then if they are not).
+- Downloads ContainerD binaries at the version specified.
+- Registers ContainerD as a windows service.
+
+This is originally from https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/Install-Containerd.ps1.
+It has been adapted for Calico.
+
+.PARAMETER ContainerDVersion
+ContainerD version to download and use.
+
+.EXAMPLE
+PS> .\Install-Containerd.ps1 -ContainerDVersion 1.6.2 -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
+#>
+
+Param(
+    [parameter(HelpMessage = "ContainerD version to use")]
+    [string] $ContainerDVersion = "1.6.2",
+    [parameter(HelpMessage = "Path to configure ContainerD to look for CNI config files. This should be set to the same path used for Calico for Windows.")]
+    [string] $CNIConfigPath = "c:/etc/cni/net.d",
+    [parameter(HelpMessage = "Path to configure ContainerD to look for CNI binaries. This should be set to the same path used for Calico for Windows.")]
+    [string] $CNIBinPath = "c:/opt/cni/bin"
+)
+
+$ErrorActionPreference = 'Stop'
+
+function DownloadFile($destination, $source) {
+    Write-Host("Downloading $source to $destination")
+    curl.exe --silent --fail -Lo $destination $source
+
+    if (!$?) {
+        Write-Error "Download $source failed"
+        exit 1
+    }
+}
+
+# The original script also included Hyper-V and Hyper-V-Powershell.
+# However those are not needed by Calico for Windows.
+$requiredWindowsFeatures = @(
+    "Containers")
+
+function ValidateWindowsFeatures {
+    $allFeaturesInstalled = $true
+    foreach ($feature in $requiredWindowsFeatures) {
+        $f = Get-WindowsFeature -Name $feature
+        if (-not $f.Installed) {
+            Write-Warning "Windows feature: '$feature' is not installed."
+            $allFeaturesInstalled = $false
+        }
+    }
+    return $allFeaturesInstalled
+}
+
+if (-not (ValidateWindowsFeatures)) {
+    Write-Output "Installing required windows features..."
+
+    foreach ($feature in $requiredWindowsFeatures) {
+        Install-WindowsFeature -Name $feature
+    }
+
+    Write-Output "Please reboot and re-run this script."
+    exit 0
+}
+
+# Install 7Zip
+Write-Output "Installing 7Zip"
+Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.v2.psm1 -O $env:TEMP\helper.v2.psm1
+ipmo $env:TEMP\helper.v2.psm1
+Install-7Zip
+
+Write-Output "Getting ContainerD binaries"
+$global:ContainerDPath = "$env:ProgramFiles\containerd"
+mkdir -Force $global:ContainerDPath | Out-Null
+DownloadFile "$global:ContainerDPath\containerd.tar.gz" https://github.com/containerd/containerd/releases/download/v${ContainerDVersion}/containerd-${ContainerDVersion}-windows-amd64.tar.gz
+tar.exe -xvf "$global:ContainerDPath\containerd.tar.gz" --strip=1 -C $global:ContainerDPath
+$env:Path += ";$global:ContainerDPath"
+[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
+containerd.exe config default | Out-File "$global:ContainerDPath\config.toml" -Encoding ascii
+#config file fixups
+$config = Get-Content "$global:ContainerDPath\config.toml"
+$config = $config -replace "bin_dir = (.)*$", "bin_dir = `"$CNIBinPath`""
+$config = $config -replace "conf_dir = (.)*$", "conf_dir = `"$CNIConfigPath`""
+$config | Set-Content "$global:ContainerDPath\config.toml" -Force
+
+mkdir -Force $CNIBinPath | Out-Null
+mkdir -Force $CNIConfigPath | Out-Null
+
+Write-Output "Registering ContainerD as a service"
+containerd.exe --register-service
+
+Write-Output "Starting ContainerD service"
+Start-Service containerd
+
+Write-Output "Done - please remember to add '--cri-socket `"npipe:////./pipe/containerd-containerd`"' to your kubeadm join command"

--- a/static/calico/3.25/scripts/PrepareNode.ps1
+++ b/static/calico/3.25/scripts/PrepareNode.ps1
@@ -1,0 +1,150 @@
+<#
+.SYNOPSIS
+Assists with preparing a Windows VM prior to calling kubeadm join
+
+.DESCRIPTION
+This script assists with joining a Windows node to a cluster.
+- Downloads Kubernetes binaries (kubelet, kubeadm) at the version specified
+- Registers kubelet as an nssm service. More info on nssm: https://nssm.cc/
+
+This is originally from https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/PrepareNode.ps1
+It has been adapted for Calico.
+
+.PARAMETER KubernetesVersion
+Kubernetes version to download and use
+
+.PARAMETER ContainerRuntime
+Container that Kubernetes will use. (Docker or ContainerD)
+
+.EXAMPLE
+PS> .\PrepareNode.ps1 -KubernetesVersion v1.23.4 -ContainerRuntime ContainerD
+
+#>
+
+Param(
+    [parameter(Mandatory = $true, HelpMessage="Kubernetes version to use")]
+    [string] $KubernetesVersion,
+    [parameter(HelpMessage="Container runtime that Kubernetes will use")]
+    [ValidateSet("ContainerD", "Docker")]
+    [string] $ContainerRuntime = "ContainerD"
+)
+$ErrorActionPreference = 'Stop'
+
+function DownloadFile($destination, $source) {
+    Write-Host("Downloading $source to $destination")
+    curl.exe --silent --fail -Lo $destination $source
+
+    if (!$?) {
+        Write-Error "Download $source failed"
+        exit 1
+    }
+}
+
+if ($ContainerRuntime -eq "Docker") {
+    if (-not(Test-Path "//./pipe/docker_engine")) {
+        Write-Error "Docker service was not detected - please install start Docker before calling PrepareNode.ps1 with -ContainerRuntime Docker"
+        exit 1
+    }
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    if (-not(Test-Path "//./pipe/containerd-containerd")) {
+        Write-Error "ContainerD service was not detected - please install and start ContainerD before calling PrepareNode.ps1 with -ContainerRuntime ContainerD"
+        exit 1
+    }
+}
+
+if (!$KubernetesVersion.StartsWith("v")) {
+    $KubernetesVersion = "v" + $KubernetesVersion
+}
+Write-Host "Using Kubernetes version: $KubernetesVersion"
+$global:Powershell = (Get-Command powershell).Source
+$global:PowershellArgs = "-ExecutionPolicy Bypass -NoProfile"
+$global:KubernetesPath = "$env:SystemDrive\k"
+$global:StartKubeletScript = "$global:KubernetesPath\StartKubelet.ps1"
+$global:NssmInstallDirectory = "$env:ProgramFiles\nssm"
+$kubeletBinPath = "$global:KubernetesPath\kubelet.exe"
+
+mkdir -force "$global:KubernetesPath"
+$env:Path += ";$global:KubernetesPath"
+[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
+
+DownloadFile $kubeletBinPath https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubelet.exe
+DownloadFile "$global:KubernetesPath\kubeadm.exe" https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubeadm.exe
+
+if ($ContainerRuntime -eq "Docker") {
+    # Create host network to allow kubelet to schedule hostNetwork pods
+    # NOTE: For containerd the 0-containerd-nat.json network config template added by
+    # Install-containerd.ps1 joins pods to the host network.
+    Write-Host "Creating Docker host network"
+    docker network create -d nat host
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    DownloadFile "c:\k\hns.psm1" https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1
+    Import-Module -DisableNameChecking "c:\k\hns.psm1"
+    if ((Get-HNSNetwork | ? Type -EQ nat | ? Name -EQ nat) -eq $null) {
+        New-HnsNetwork -Type NAT -Name nat
+    }
+}
+
+$kubeletLogPath = "C:\var\log\kubelet"
+mkdir -force $kubeletLogPath
+mkdir -force C:\var\lib\kubelet\etc\kubernetes
+mkdir -force C:\etc\kubernetes\pki
+New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C:\etc\kubernetes\pki\
+
+$StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
+$global:KubeletArgs = $FileContent.TrimStart(''KUBELET_KUBEADM_ARGS='').Trim(''"'')
+
+$global:containerRuntime = {{CONTAINER_RUNTIME}}
+
+if ($global:containerRuntime -eq "Docker") {
+    $netId = docker network ls -f name=host --format "{{ .ID }}"
+
+    if ($netId.Length -lt 1) {
+    docker network create -d nat host
+    }
+}
+
+$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:3.6`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --logtostderr=false --image-pull-progress-deadline=20m"
+
+Invoke-Expression $cmd'
+$StartKubeletFileContent = $StartKubeletFileContent -replace "{{CONTAINER_RUNTIME}}", "`"$ContainerRuntime`""
+Set-Content -Path $global:StartKubeletScript -Value $StartKubeletFileContent
+
+Write-Host "Installing nssm"
+$arch = "win32"
+if ([Environment]::Is64BitOperatingSystem) {
+    $arch = "win64"
+}
+
+mkdir -Force $global:NssmInstallDirectory
+DownloadFile nssm.zip https://k8stestinfrabinaries.blob.core.windows.net/nssm-mirror/nssm-2.24.zip
+tar C $global:NssmInstallDirectory -xvf .\nssm.zip --strip-components 2 */$arch/*.exe
+Remove-Item -Force .\nssm.zip
+
+$env:path += ";$global:NssmInstallDirectory"
+$newPath = "$global:NssmInstallDirectory;" +
+[Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
+
+[Environment]::SetEnvironmentVariable("PATH", $newPath, [EnvironmentVariableTarget]::Machine)
+
+Write-Host "Registering kubelet service"
+nssm install kubelet $global:Powershell $global:PowershellArgs $global:StartKubeletScript
+nssm set kubelet AppStdout $kubeletLogPath\kubelet.out.log
+nssm set kubelet AppStderr $kubeletLogPath\kubelet.err.log
+
+# Configure online file rotation.
+nssm set kubelet AppRotateFiles 1
+nssm set kubelet AppRotateOnline 1
+# Rotate once per day.
+nssm set kubelet AppRotateSeconds 86400
+# Rotate after 10MB.
+nssm set kubelet AppRotateBytes 10485760
+
+if ($ContainerRuntime -eq "Docker") {
+    nssm set kubelet DependOnService docker
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    nssm set kubelet DependOnService containerd
+}
+
+if ((Get-NetFirewallRule | ? Name -EQ kubelet) -EQ $null) {
+    New-NetFirewallRule -Name kubelet -DisplayName 'kubelet' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 10250
+}

--- a/static/calico/next/scripts/Install-Containerd.ps1
+++ b/static/calico/next/scripts/Install-Containerd.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+Installs ContainerD on a Windows machine in preparation for joining the node to a Kubernetes cluster.
+
+.DESCRIPTION
+This script
+- Verifies that Windows Features required for running containers are enabled (and enables then if they are not).
+- Downloads ContainerD binaries at the version specified.
+- Registers ContainerD as a windows service.
+
+This is originally from https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/Install-Containerd.ps1.
+It has been adapted for Calico.
+
+.PARAMETER ContainerDVersion
+ContainerD version to download and use.
+
+.EXAMPLE
+PS> .\Install-Containerd.ps1 -ContainerDVersion 1.6.2 -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
+#>
+
+Param(
+    [parameter(HelpMessage = "ContainerD version to use")]
+    [string] $ContainerDVersion = "1.6.2",
+    [parameter(HelpMessage = "Path to configure ContainerD to look for CNI config files. This should be set to the same path used for Calico for Windows.")]
+    [string] $CNIConfigPath = "c:/etc/cni/net.d",
+    [parameter(HelpMessage = "Path to configure ContainerD to look for CNI binaries. This should be set to the same path used for Calico for Windows.")]
+    [string] $CNIBinPath = "c:/opt/cni/bin"
+)
+
+$ErrorActionPreference = 'Stop'
+
+function DownloadFile($destination, $source) {
+    Write-Host("Downloading $source to $destination")
+    curl.exe --silent --fail -Lo $destination $source
+
+    if (!$?) {
+        Write-Error "Download $source failed"
+        exit 1
+    }
+}
+
+# The original script also included Hyper-V and Hyper-V-Powershell.
+# However those are not needed by Calico for Windows.
+$requiredWindowsFeatures = @(
+    "Containers")
+
+function ValidateWindowsFeatures {
+    $allFeaturesInstalled = $true
+    foreach ($feature in $requiredWindowsFeatures) {
+        $f = Get-WindowsFeature -Name $feature
+        if (-not $f.Installed) {
+            Write-Warning "Windows feature: '$feature' is not installed."
+            $allFeaturesInstalled = $false
+        }
+    }
+    return $allFeaturesInstalled
+}
+
+if (-not (ValidateWindowsFeatures)) {
+    Write-Output "Installing required windows features..."
+
+    foreach ($feature in $requiredWindowsFeatures) {
+        Install-WindowsFeature -Name $feature
+    }
+
+    Write-Output "Please reboot and re-run this script."
+    exit 0
+}
+
+# Install 7Zip
+Write-Output "Installing 7Zip"
+Invoke-WebRequest https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.v2.psm1 -O $env:TEMP\helper.v2.psm1
+ipmo $env:TEMP\helper.v2.psm1
+Install-7Zip
+
+Write-Output "Getting ContainerD binaries"
+$global:ContainerDPath = "$env:ProgramFiles\containerd"
+mkdir -Force $global:ContainerDPath | Out-Null
+DownloadFile "$global:ContainerDPath\containerd.tar.gz" https://github.com/containerd/containerd/releases/download/v${ContainerDVersion}/containerd-${ContainerDVersion}-windows-amd64.tar.gz
+tar.exe -xvf "$global:ContainerDPath\containerd.tar.gz" --strip=1 -C $global:ContainerDPath
+$env:Path += ";$global:ContainerDPath"
+[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
+containerd.exe config default | Out-File "$global:ContainerDPath\config.toml" -Encoding ascii
+#config file fixups
+$config = Get-Content "$global:ContainerDPath\config.toml"
+$config = $config -replace "bin_dir = (.)*$", "bin_dir = `"$CNIBinPath`""
+$config = $config -replace "conf_dir = (.)*$", "conf_dir = `"$CNIConfigPath`""
+$config | Set-Content "$global:ContainerDPath\config.toml" -Force
+
+mkdir -Force $CNIBinPath | Out-Null
+mkdir -Force $CNIConfigPath | Out-Null
+
+Write-Output "Registering ContainerD as a service"
+containerd.exe --register-service
+
+Write-Output "Starting ContainerD service"
+Start-Service containerd
+
+Write-Output "Done - please remember to add '--cri-socket `"npipe:////./pipe/containerd-containerd`"' to your kubeadm join command"

--- a/static/calico/next/scripts/PrepareNode.ps1
+++ b/static/calico/next/scripts/PrepareNode.ps1
@@ -1,0 +1,150 @@
+<#
+.SYNOPSIS
+Assists with preparing a Windows VM prior to calling kubeadm join
+
+.DESCRIPTION
+This script assists with joining a Windows node to a cluster.
+- Downloads Kubernetes binaries (kubelet, kubeadm) at the version specified
+- Registers kubelet as an nssm service. More info on nssm: https://nssm.cc/
+
+This is originally from https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/PrepareNode.ps1
+It has been adapted for Calico.
+
+.PARAMETER KubernetesVersion
+Kubernetes version to download and use
+
+.PARAMETER ContainerRuntime
+Container that Kubernetes will use. (Docker or ContainerD)
+
+.EXAMPLE
+PS> .\PrepareNode.ps1 -KubernetesVersion v1.23.4 -ContainerRuntime ContainerD
+
+#>
+
+Param(
+    [parameter(Mandatory = $true, HelpMessage="Kubernetes version to use")]
+    [string] $KubernetesVersion,
+    [parameter(HelpMessage="Container runtime that Kubernetes will use")]
+    [ValidateSet("ContainerD", "Docker")]
+    [string] $ContainerRuntime = "ContainerD"
+)
+$ErrorActionPreference = 'Stop'
+
+function DownloadFile($destination, $source) {
+    Write-Host("Downloading $source to $destination")
+    curl.exe --silent --fail -Lo $destination $source
+
+    if (!$?) {
+        Write-Error "Download $source failed"
+        exit 1
+    }
+}
+
+if ($ContainerRuntime -eq "Docker") {
+    if (-not(Test-Path "//./pipe/docker_engine")) {
+        Write-Error "Docker service was not detected - please install start Docker before calling PrepareNode.ps1 with -ContainerRuntime Docker"
+        exit 1
+    }
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    if (-not(Test-Path "//./pipe/containerd-containerd")) {
+        Write-Error "ContainerD service was not detected - please install and start ContainerD before calling PrepareNode.ps1 with -ContainerRuntime ContainerD"
+        exit 1
+    }
+}
+
+if (!$KubernetesVersion.StartsWith("v")) {
+    $KubernetesVersion = "v" + $KubernetesVersion
+}
+Write-Host "Using Kubernetes version: $KubernetesVersion"
+$global:Powershell = (Get-Command powershell).Source
+$global:PowershellArgs = "-ExecutionPolicy Bypass -NoProfile"
+$global:KubernetesPath = "$env:SystemDrive\k"
+$global:StartKubeletScript = "$global:KubernetesPath\StartKubelet.ps1"
+$global:NssmInstallDirectory = "$env:ProgramFiles\nssm"
+$kubeletBinPath = "$global:KubernetesPath\kubelet.exe"
+
+mkdir -force "$global:KubernetesPath"
+$env:Path += ";$global:KubernetesPath"
+[Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
+
+DownloadFile $kubeletBinPath https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubelet.exe
+DownloadFile "$global:KubernetesPath\kubeadm.exe" https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubeadm.exe
+
+if ($ContainerRuntime -eq "Docker") {
+    # Create host network to allow kubelet to schedule hostNetwork pods
+    # NOTE: For containerd the 0-containerd-nat.json network config template added by
+    # Install-containerd.ps1 joins pods to the host network.
+    Write-Host "Creating Docker host network"
+    docker network create -d nat host
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    DownloadFile "c:\k\hns.psm1" https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1
+    Import-Module -DisableNameChecking "c:\k\hns.psm1"
+    if ((Get-HNSNetwork | ? Type -EQ nat | ? Name -EQ nat) -eq $null) {
+        New-HnsNetwork -Type NAT -Name nat
+    }
+}
+
+$kubeletLogPath = "C:\var\log\kubelet"
+mkdir -force $kubeletLogPath
+mkdir -force C:\var\lib\kubelet\etc\kubernetes
+mkdir -force C:\etc\kubernetes\pki
+New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C:\etc\kubernetes\pki\
+
+$StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
+$global:KubeletArgs = $FileContent.TrimStart(''KUBELET_KUBEADM_ARGS='').Trim(''"'')
+
+$global:containerRuntime = {{CONTAINER_RUNTIME}}
+
+if ($global:containerRuntime -eq "Docker") {
+    $netId = docker network ls -f name=host --format "{{ .ID }}"
+
+    if ($netId.Length -lt 1) {
+    docker network create -d nat host
+    }
+}
+
+$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:3.6`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --resolv-conf=`"`" --logtostderr=false"
+
+Invoke-Expression $cmd'
+$StartKubeletFileContent = $StartKubeletFileContent -replace "{{CONTAINER_RUNTIME}}", "`"$ContainerRuntime`""
+Set-Content -Path $global:StartKubeletScript -Value $StartKubeletFileContent
+
+Write-Host "Installing nssm"
+$arch = "win32"
+if ([Environment]::Is64BitOperatingSystem) {
+    $arch = "win64"
+}
+
+mkdir -Force $global:NssmInstallDirectory
+DownloadFile nssm.zip https://k8stestinfrabinaries.blob.core.windows.net/nssm-mirror/nssm-2.24.zip
+tar C $global:NssmInstallDirectory -xvf .\nssm.zip --strip-components 2 */$arch/*.exe
+Remove-Item -Force .\nssm.zip
+
+$env:path += ";$global:NssmInstallDirectory"
+$newPath = "$global:NssmInstallDirectory;" +
+[Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
+
+[Environment]::SetEnvironmentVariable("PATH", $newPath, [EnvironmentVariableTarget]::Machine)
+
+Write-Host "Registering kubelet service"
+nssm install kubelet $global:Powershell $global:PowershellArgs $global:StartKubeletScript
+nssm set kubelet AppStdout $kubeletLogPath\kubelet.out.log
+nssm set kubelet AppStderr $kubeletLogPath\kubelet.err.log
+
+# Configure online file rotation.
+nssm set kubelet AppRotateFiles 1
+nssm set kubelet AppRotateOnline 1
+# Rotate once per day.
+nssm set kubelet AppRotateSeconds 86400
+# Rotate after 10MB.
+nssm set kubelet AppRotateBytes 10485760
+
+if ($ContainerRuntime -eq "Docker") {
+    nssm set kubelet DependOnService docker
+} elseif ($ContainerRuntime -eq "ContainerD") {
+    nssm set kubelet DependOnService containerd
+}
+
+if ((Get-NetFirewallRule | ? Name -EQ kubelet) -EQ $null) {
+    New-NetFirewallRule -Name kubelet -DisplayName 'kubelet' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 10250
+}


### PR DESCRIPTION
1) Fixes some manifest links in kubeconfig.mdx.
* FYI @rene-dekker RE https://github.com/tigera/calico-private/pull/5766

2) Adds Windows scripts to `static` and changes links to files.
* This is temporary until we get these files hosted elsewhere
* These files were copied from their respective branches in the code repositories at around 1100 GMT 2023/02/03.
* These files must be updated manually if necessary.
* Plan is to revert `bd0580e` after work has been done to get new file location 

FYI @caseydavenport @song @doucol  