### PR TITLE
Fix IPPools in EGW docs.

### DIFF
--- a/calico-enterprise/networking/egress/egress-gateway-aws.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-aws.mdx
@@ -501,16 +501,16 @@ For the "west-1" availability zone:
 - IP pool "egress-red-west-1", CIDR `100.64.0.4/30` (the first non-reserved /30 CIDR in the VPC subnet). These
   addresses will be used for "red" egress gateways in the "west-1" AZ.
 
-- IP pool "egress-blue-west-1", CIDR `100.64.0.6/30` (the next 4 IPs from the "west-1" subnet). These addresses
+- IP pool "egress-blue-west-1", CIDR `100.64.0.8/30` (the next 4 IPs from the "west-1" subnet). These addresses
   will be used for "blue" egress gateways in the "west-1" AZ.
 
 For the "west-2" availability zone:
 
 - IP pool "egress-red-west-2", CIDR `100.64.4.4/30` (the first non-reserved /30 CIDR in the VPC subnet). These
-  addresses will be used for "red" egress gateways in the "west-1" AZ.
+  addresses will be used for "red" egress gateways in the "west-2" AZ.
 
-- IP pool "egress-blue-west-2", CIDR `100.64.4.6/30` (the next 4 IPs from the "west-2" subnet). These addresses
-  will be used for "blue" egress gateways in the "west-1" AZ.
+- IP pool "egress-blue-west-2", CIDR `100.64.4.8/30` (the next 4 IPs from the "west-2" subnet). These addresses
+  will be used for "blue" egress gateways in the "west-2" AZ.
 
 Converting this to `IPPool` resources:
 
@@ -532,7 +532,7 @@ kind: IPPool
 metadata:
   name: egress-blue-west-1
 spec:
-  cidr: 100.64.0.6/30
+  cidr: 100.64.0.8/30
   allowedUses: ['Workload']
   awsSubnetID: subnet-000000000000000001
   blockSize: 32
@@ -556,7 +556,7 @@ kind: IPPool
 metadata:
   name: egress-blue-west-2
 spec:
-  cidr: 100.64.4.6/30
+  cidr: 100.64.4.8/30
   allowedUses: ['Workload']
   awsSubnetID: subnet-000000000000000002
   blockSize: 32
@@ -613,7 +613,7 @@ For the "west-1" availability zone:
 
   - These addresses will be used for "red" egress gateways in the "west-1" AZ.
 
-- IP pool "egress-blue-west-1", CIDR `100.64.0.130/30` (the next 4 IPs from the "west-1" subnet).
+- IP pool "egress-blue-west-1", CIDR `100.64.0.132/30` (the next 4 IPs from the "west-1" subnet).
 
   - These addresses will be used for "blue" egress gateways in the "west-1" AZ.
 
@@ -626,11 +626,11 @@ For the "west-2" availability zone:
 
 - IP pool "egress-red-west-2", CIDR `100.64.4.128/30` (the next 4 IPs from the "west-2" subnet).
 
-  - These addresses will be used for "red" egress gateways in the "west-1" AZ.
+  - These addresses will be used for "red" egress gateways in the "west-2" AZ.
 
-- IP pool "egress-blue-west-2", CIDR `100.64.4.130/30` (the next 4 IPs from the "west-2" subnet).
+- IP pool "egress-blue-west-2", CIDR `100.64.4.132/30` (the next 4 IPs from the "west-2" subnet).
 
-  - These addresses will be used for "blue" egress gateways in the "west-1" AZ.
+  - These addresses will be used for "blue" egress gateways in the "west-2" AZ.
 
 Converting this to `IPPool` resources:
 
@@ -663,7 +663,7 @@ kind: IPPool
 metadata:
   name: egress-blue-west-1
 spec:
-  cidr: 100.64.0.130/30
+  cidr: 100.64.0.132/30
   allowedUses: ['Workload']
   awsSubnetID: subnet-000000000000000001
   blockSize: 32
@@ -698,7 +698,7 @@ kind: IPPool
 metadata:
   name: egress-blue-west-2
 spec:
-  cidr: 100.64.4.130/30
+  cidr: 100.64.4.132/30
   allowedUses: ['Workload']
   awsSubnetID: subnet-000000000000000002
   blockSize: 32

--- a/calico-enterprise/networking/egress/egress-gateway-aws.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-aws.mdx
@@ -498,18 +498,18 @@ it will take an IP from the appropriate pool.
 
 For the "west-1" availability zone:
 
-- IP pool "egress-red-west-1", CIDR `100.64.0.4/31` (the first non-reserved /31 CIDR in the VPC subnet). These
+- IP pool "egress-red-west-1", CIDR `100.64.0.4/30` (the first non-reserved /31 CIDR in the VPC subnet). These
   addresses will be used for "red" egress gateways in the "west-1" AZ.
 
-- IP pool "egress-blue-west-1", CIDR `100.64.0.6/31` (the next 2 IPs from the "west-1" subnet). These addresses
+- IP pool "egress-blue-west-1", CIDR `100.64.0.6/30` (the next 2 IPs from the "west-1" subnet). These addresses
   will be used for "blue" egress gateways in the "west-1" AZ.
 
 For the "west-2" availability zone:
 
-- IP pool "egress-red-west-2", CIDR `100.64.4.4/31` (the first non-reserved /31 CIDR in the VPC subnet). These
+- IP pool "egress-red-west-2", CIDR `100.64.4.4/30` (the first non-reserved /31 CIDR in the VPC subnet). These
   addresses will be used for "red" egress gateways in the "west-1" AZ.
 
-- IP pool "egress-blue-west-2", CIDR `100.64.4.6/31` (the next 2 IPs from the "west-2" subnet). These addresses
+- IP pool "egress-blue-west-2", CIDR `100.64.4.6/30` (the next 2 IPs from the "west-2" subnet). These addresses
   will be used for "blue" egress gateways in the "west-1" AZ.
 
 Converting this to `IPPool` resources:
@@ -520,7 +520,7 @@ kind: IPPool
 metadata:
   name: egress-red-west-1
 spec:
-  cidr: 100.64.0.4/31
+  cidr: 100.64.0.4/30
   allowedUses: ['Workload']
   awsSubnetID: subnet-000000000000000001
   blockSize: 32
@@ -532,7 +532,7 @@ kind: IPPool
 metadata:
   name: egress-blue-west-1
 spec:
-  cidr: 100.64.0.6/31
+  cidr: 100.64.0.6/30
   allowedUses: ['Workload']
   awsSubnetID: subnet-000000000000000001
   blockSize: 32
@@ -544,7 +544,7 @@ kind: IPPool
 metadata:
   name: egress-red-west-2
 spec:
-  cidr: 100.64.4.4/31
+  cidr: 100.64.4.4/30
   allowedUses: ['Workload']
   awsSubnetID: subnet-000000000000000002
   blockSize: 32
@@ -556,7 +556,7 @@ kind: IPPool
 metadata:
   name: egress-blue-west-2
 spec:
-  cidr: 100.64.4.6/31
+  cidr: 100.64.4.6/30
   allowedUses: ['Workload']
   awsSubnetID: subnet-000000000000000002
   blockSize: 32
@@ -609,11 +609,11 @@ For the "west-1" availability zone:
   - `100.64.0.0/25` covers the addresses from `100.64.0.0` to `100.64.0.127` (but addresses `100.64.0.0` to `100.64.0.3`
     were reserved above).
 
-- IP pool "egress-red-west-1", CIDR `100.64.0.128/31` (the next 2 IPs from the "west-1" subnet).
+- IP pool "egress-red-west-1", CIDR `100.64.0.128/30` (the next 2 IPs from the "west-1" subnet).
 
   - These addresses will be used for "red" egress gateways in the "west-1" AZ.
 
-- IP pool "egress-blue-west-1", CIDR `100.64.0.130/31` (the next 2 IPs from the "west-1" subnet).
+- IP pool "egress-blue-west-1", CIDR `100.64.0.130/30` (the next 2 IPs from the "west-1" subnet).
 
   - These addresses will be used for "blue" egress gateways in the "west-1" AZ.
 
@@ -624,11 +624,11 @@ For the "west-2" availability zone:
   - `100.64.4.0/25` covers the addresses from `100.64.4.0` to `100.64.4.127` (but addresses `100.64.4.0` to `100.64.4.3`
     were reserved above).
 
-- IP pool "egress-red-west-2", CIDR `100.64.4.128/31` (the next 2 IPs from the "west-2" subnet).
+- IP pool "egress-red-west-2", CIDR `100.64.4.128/30` (the next 2 IPs from the "west-2" subnet).
 
   - These addresses will be used for "red" egress gateways in the "west-1" AZ.
 
-- IP pool "egress-blue-west-2", CIDR `100.64.4.130/31` (the next 2 IPs from the "west-2" subnet).
+- IP pool "egress-blue-west-2", CIDR `100.64.4.130/30` (the next 2 IPs from the "west-2" subnet).
 
   - These addresses will be used for "blue" egress gateways in the "west-1" AZ.
 
@@ -651,7 +651,7 @@ kind: IPPool
 metadata:
   name: egress-red-west-1
 spec:
-  cidr: 100.64.0.128/31
+  cidr: 100.64.0.128/30
   allowedUses: ['Workload']
   awsSubnetID: subnet-000000000000000001
   blockSize: 32
@@ -663,7 +663,7 @@ kind: IPPool
 metadata:
   name: egress-blue-west-1
 spec:
-  cidr: 100.64.0.130/31
+  cidr: 100.64.0.130/30
   allowedUses: ['Workload']
   awsSubnetID: subnet-000000000000000001
   blockSize: 32
@@ -686,7 +686,7 @@ kind: IPPool
 metadata:
   name: egress-red-west-2
 spec:
-  cidr: 100.64.4.128/31
+  cidr: 100.64.4.128/30
   allowedUses: ['Workload']
   awsSubnetID: subnet-000000000000000002
   blockSize: 32
@@ -698,7 +698,7 @@ kind: IPPool
 metadata:
   name: egress-blue-west-2
 spec:
-  cidr: 100.64.4.130/31
+  cidr: 100.64.4.130/30
   allowedUses: ['Workload']
   awsSubnetID: subnet-000000000000000002
   blockSize: 32

--- a/calico-enterprise/networking/egress/egress-gateway-aws.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-aws.mdx
@@ -498,18 +498,18 @@ it will take an IP from the appropriate pool.
 
 For the "west-1" availability zone:
 
-- IP pool "egress-red-west-1", CIDR `100.64.0.4/30` (the first non-reserved /31 CIDR in the VPC subnet). These
+- IP pool "egress-red-west-1", CIDR `100.64.0.4/30` (the first non-reserved /30 CIDR in the VPC subnet). These
   addresses will be used for "red" egress gateways in the "west-1" AZ.
 
-- IP pool "egress-blue-west-1", CIDR `100.64.0.6/30` (the next 2 IPs from the "west-1" subnet). These addresses
+- IP pool "egress-blue-west-1", CIDR `100.64.0.6/30` (the next 4 IPs from the "west-1" subnet). These addresses
   will be used for "blue" egress gateways in the "west-1" AZ.
 
 For the "west-2" availability zone:
 
-- IP pool "egress-red-west-2", CIDR `100.64.4.4/30` (the first non-reserved /31 CIDR in the VPC subnet). These
+- IP pool "egress-red-west-2", CIDR `100.64.4.4/30` (the first non-reserved /30 CIDR in the VPC subnet). These
   addresses will be used for "red" egress gateways in the "west-1" AZ.
 
-- IP pool "egress-blue-west-2", CIDR `100.64.4.6/30` (the next 2 IPs from the "west-2" subnet). These addresses
+- IP pool "egress-blue-west-2", CIDR `100.64.4.6/30` (the next 4 IPs from the "west-2" subnet). These addresses
   will be used for "blue" egress gateways in the "west-1" AZ.
 
 Converting this to `IPPool` resources:
@@ -609,11 +609,11 @@ For the "west-1" availability zone:
   - `100.64.0.0/25` covers the addresses from `100.64.0.0` to `100.64.0.127` (but addresses `100.64.0.0` to `100.64.0.3`
     were reserved above).
 
-- IP pool "egress-red-west-1", CIDR `100.64.0.128/30` (the next 2 IPs from the "west-1" subnet).
+- IP pool "egress-red-west-1", CIDR `100.64.0.128/30` (the next 4 IPs from the "west-1" subnet).
 
   - These addresses will be used for "red" egress gateways in the "west-1" AZ.
 
-- IP pool "egress-blue-west-1", CIDR `100.64.0.130/30` (the next 2 IPs from the "west-1" subnet).
+- IP pool "egress-blue-west-1", CIDR `100.64.0.130/30` (the next 4 IPs from the "west-1" subnet).
 
   - These addresses will be used for "blue" egress gateways in the "west-1" AZ.
 
@@ -624,11 +624,11 @@ For the "west-2" availability zone:
   - `100.64.4.0/25` covers the addresses from `100.64.4.0` to `100.64.4.127` (but addresses `100.64.4.0` to `100.64.4.3`
     were reserved above).
 
-- IP pool "egress-red-west-2", CIDR `100.64.4.128/30` (the next 2 IPs from the "west-2" subnet).
+- IP pool "egress-red-west-2", CIDR `100.64.4.128/30` (the next 4 IPs from the "west-2" subnet).
 
   - These addresses will be used for "red" egress gateways in the "west-1" AZ.
 
-- IP pool "egress-blue-west-2", CIDR `100.64.4.130/30` (the next 2 IPs from the "west-2" subnet).
+- IP pool "egress-blue-west-2", CIDR `100.64.4.130/30` (the next 4 IPs from the "west-2" subnet).
 
   - These addresses will be used for "blue" egress gateways in the "west-1" AZ.
 

--- a/calico-enterprise/networking/egress/egress-gateway-azure.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-azure.mdx
@@ -215,7 +215,7 @@ kind: IPPool
 metadata:
   name: egress-ippool-1
 spec:
-  cidr: 10.10.10.0/31
+  cidr: 10.10.10.0/30
   blockSize: 31
   nodeSelector: "!all()"
   vxlanMode: Never

--- a/calico-enterprise/networking/egress/egress-gateway-maintenance.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-maintenance.mdx
@@ -110,6 +110,7 @@ Success! Our workload's annotations mark a 60-second maintenance window for the 
 :::note
 
 - Adjusting egress deployments, say, by modifying the `terminationGracePeriodSeconds` field, will trigger a new rollout.
+- IPPool specified should be large enough to include terminating pods.
 - Egress pods terminating due to a new rollout will behave the same as if they were deleted for maintenance - dependent workloads will receive gateway maintenance annotations, and gateway pods will terminate after their termination grace period has elapsed.
 - Deleting an egress gateway in a way that overrides the termination grace period, say, by using `kubectl delete pod my-pod --grace-period=0`, will result in the gateway going down immediately, and dependent workloads will not have any time to react to the termination.
 

--- a/calico-enterprise/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-on-prem.mdx
@@ -227,7 +227,7 @@ kind: IPPool
 metadata:
   name: egress-ippool-1
 spec:
-  cidr: 10.10.10.0/31
+  cidr: 10.10.10.0/30
   blockSize: 31
   nodeSelector: "!all()"
 EOF


### PR DESCRIPTION
EGW docs mention the ippool cidr as /31. As a result, we can have only 2 EGW pods. Whenever a change is made to the EGW resource, a roll-out is triggered. This results in a new pod, but the IPPool doesn't have enough IPs. 

Hence the IPPools should be large enough to include terminating pods.