### PR TITLE
update Rancher UI insatallation steps to also accomodate  upgrades

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/rancher-ui.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/rancher-ui.mdx
@@ -24,12 +24,12 @@ The geeky details of what you get:
 
 <GeekDetails
   prodname='{{prodname}}'
-  details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:VXLAN,Routing:BGP,Datastore:Kubernetes'
+  details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:VXLAN,Routing:Calico,Datastore:Kubernetes'
 />
 
 **Required**
 
-- A compatible cluster that can host the Rancher Manager.
+- A compatible cluster that can host the Rancher Manager with v2.6.5 or later
 
   For help, see [Rancher](https://ranchermanager.docs.rancher.com/).
 
@@ -40,32 +40,25 @@ The geeky details of what you get:
 
 ## How to
 
-- [Prepare a base opensource Calico cluster](#prepare-a-base-opensource-calico-cluster)
+- [Prepare a base Calico Open Source cluster](#prepare-a-base-calico-open-source-cluster)
 - [Upgrade to {{prodname}}](#install-calico-enterprise)
 
-### Prepare a base opensource Calico cluster
+### Prepare a base Calico Open Source cluster
 
 1. [Provision a RKE2 cluster using Calico as CNI and default config options](https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher)
 2. Validate the RKE2 cluster is setup and running.
-3. Update the Cluster Config by adding the following `HelmChartConfig` to the Additional Manifest section. In the UI navigate to Edit Config > Add on config > Additional Manifest.
-   ```yaml
-   apiVersion: helm.cattle.io/v1
-   kind: HelmChartConfig
-   metadata:
-     name: rke2-calico
-     namespace: kube-system
-   spec:
-     valuesContent: |-
-      installation:
-        imagePath: ""
-        imagePrefix: ""
-      calicoctl:
-        enabled: false
+3. Open a `kubectl` shell in the Rancher UI for the cluster under consideration, and perform the remaining steps in it.
+4. Annotate the Calico HelmChart with `helmcharts.helm.cattle.io/unmanaged=true`. This avoids Rancher resetting the CNI to Calico when the RKE2 cluster is either shut down or upgraded.
+   ```batch
+   kubectl annotate helmchart -n kube-system rke2-calico helmcharts.helm.cattle.io/unmanaged=true
    ```
-4. Wait for Config update to take effect and Cluster change state to Active .
 5. SSH to all the Control plane nodes and rename `rke2-calico.yaml` in the `/var/lib/rancher/rke2/server/manifests/` directory to `rke2-calico.yaml.skip`.
    ```batch
    sudo mv /var/lib/rancher/rke2/server/manifests/rke2-calico.yaml /var/lib/rancher/rke2/server/manifests/rke2-calico.yaml.skip
+   ```
+6. Patch the Calico `Installation` resource to remove the image path prefix.
+   ```batch
+   kubectl patch installation default --type='json' -p='[{"op": "remove", "path": "/spec/imagePath"},{"op": "remove", "path": "/spec/imagePrefix"}]'
    ```
 
 ### Upgrade {{prodname}}

--- a/calico-enterprise/getting-started/install-on-clusters/rke2.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/rke2.mdx
@@ -18,7 +18,7 @@ The geeky details of what you get:
 
 <GeekDetails
   prodname='{{prodname}}'
-  details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:VXLAN,Routing:BGP,Datastore:Kubernetes'
+  details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:VXLAN,Routing:Calico,Datastore:Kubernetes'
 />
 
 **Required**


### PR DESCRIPTION
There was an issue identified when a cluster is upgraded by Rancher.
This condition is handled by adding a `unmanaged` annotation to Rancher's Helm Charts for Calico.
This change documents those steps and removes the usage of `HelmChartConfig`.