### PR TITLE
Fixes bad xref in calico cloud

### DIFF
--- a/calico-cloud/visibility/elastic/flow/aggregation.mdx
+++ b/calico-cloud/visibility/elastic/flow/aggregation.mdx
@@ -487,5 +487,4 @@ If you turn off aggregation, your log storage may be overwhelmed. Be sure to pro
 ## Above and beyond
 
 - [Archive logs to storage](../archive-storage.mdx)
-- [Configure RBAC for Elasticsearch logs](../rbac-elasticsearch.mdx)
 - [Configure data retention](/visibility/elastic/retention)

--- a/calico-cloud/visibility/elastic/flow/filtering.mdx
+++ b/calico-cloud/visibility/elastic/flow/filtering.mdx
@@ -113,4 +113,3 @@ This example filters inbound internet traffic to the deployment with pods named,
 
 - [Flow log aggregation](aggregation.mdx)
 - [Archive logs to storage](../archive-storage.mdx)
-- [Configure RBAC for Elasticsearch logs](../rbac-elasticsearch.mdx)

--- a/calico-cloud/visibility/elastic/overview.mdx
+++ b/calico-cloud/visibility/elastic/overview.mdx
@@ -96,7 +96,6 @@ verbs: ['get']
 ## Above and beyond
 
 - [Log storage recommendations](/operations/logstorage/log-storage-recommendations)
-- [Configure RBAC for Elasticsearch logs](rbac-elasticsearch.mdx)
 - [Configure flow log aggregation](flow/aggregation.mdx)
 - [Audit logs](audit-overview.mdx)
 - [BGP logs](bgp.mdx)

--- a/calico-cloud_versioned_docs/version-3.15/visibility/elastic/flow/aggregation.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/visibility/elastic/flow/aggregation.mdx
@@ -487,5 +487,4 @@ If you turn off aggregation, your log storage may be overwhelmed. Be sure to pro
 ## Above and beyond
 
 - [Archive logs to storage](../archive-storage.mdx)
-- [Configure RBAC for Elasticsearch logs](../rbac-elasticsearch.mdx)
 - [Configure data retention](/visibility/elastic/retention)

--- a/calico-cloud_versioned_docs/version-3.15/visibility/elastic/flow/filtering.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/visibility/elastic/flow/filtering.mdx
@@ -113,4 +113,3 @@ This example filters inbound internet traffic to the deployment with pods named,
 
 - [Flow log aggregation](aggregation.mdx)
 - [Archive logs to storage](../archive-storage.mdx)
-- [Configure RBAC for Elasticsearch logs](../rbac-elasticsearch.mdx)

--- a/calico-cloud_versioned_docs/version-3.15/visibility/elastic/overview.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/visibility/elastic/overview.mdx
@@ -96,7 +96,6 @@ verbs: ['get']
 ## Above and beyond
 
 - [Log storage recommendations](/operations/logstorage/log-storage-recommendations)
-- [Configure RBAC for Elasticsearch logs](rbac-elasticsearch.mdx)
 - [Configure flow log aggregation](flow/aggregation.mdx)
 - [Audit logs](audit-overview.mdx)
 - [BGP logs](bgp.mdx)


### PR DESCRIPTION
We removed a file. But there were still cross reference to that file. The PR removes the cross references.