### PR TITLE
PUBLISH 3.16.0: Adds config to publish CE 3.16.0

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.16/_includes/release-notes/_v3.16.0-release-notes.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/_includes/release-notes/_v3.16.0-release-notes.mdx
@@ -1,4 +1,4 @@
-10 January 2023
+15 February 2023
 
 ### What's new {#whats-new-3.16.0}
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -359,8 +359,7 @@ const config = {
         path: 'calico-enterprise',
         routeBasePath: 'calico-enterprise',
         editCurrentVersion: true,
-        //Add '3.16' to next line to publish 3.16 early preview
-        onlyIncludeVersions: ['current','3.15','3.14'],
+        onlyIncludeVersions: ['current','3.16','3.15','3.14'],
         lastVersion: '3.15',
         versions: {
           current: {

--- a/src/pages/archive.md
+++ b/src/pages/archive.md
@@ -24,7 +24,8 @@ description: Links to all versions of product documentation for Calico, Calico E
 
 ## Calico Enterprise
 
-* [Calico Enterprise 3.14](https://docs.tigera.io/calico-enterprise/3.14/)
+* [Calico Enterprise 3.15](https://docs.tigera.io/calico-enterprise/3.15)
+* [Calico Enterprise 3.14](https://docs.tigera.io/calico-enterprise/3.14)
 * [Calico Enterprise 3.13](https://docs.tigera.io/v3.13)
 * [Calico Enterprise 3.12](https://docs.tigera.io/v3.12)
 * [Calico Enterprise 3.11](https://docs.tigera.io/v3.11)

--- a/static/releases.html
+++ b/static/releases.html
@@ -30,16 +30,23 @@ that will appear in the old proxy sites. -->
       <div style="font-weight: bold; margin-top: 4px">Calico Enterprise</div>
       <div style="padding-left: 12px">
         <a
+          href="/calico-enterprise/3.16/about-calico-enterprise"
+          style="font-weight: normal; color: #333333"
+        >3.16 (early preview)</a
+        >
+      </div>
+      <div style="padding-left: 12px">
+        <a
           href="/calico-enterprise/3.15/about-calico-enterprise"
           style="font-weight: normal; color: #333333"
-        >3.15 (early preview)</a
+        >3.15 (latest)</a
         >
       </div>
       <div style="padding-left: 12px">
         <a
           href="/calico-enterprise/3.14/about-calico-enterprise"
           style="font-weight: normal; color: #333333"
-          >3.14 (latest)</a
+          >3.14</a
         >
       </div>
       <div style="padding-left: 12px">


### PR DESCRIPTION
This PR publishes the CE 3.16.0 docs.

Three changes:
* docusaurus.config.js is changed to allow 3.16 to build 
* static/releases.html, which serves the version picker for our proxied sites, is updated
* archive.md is updated 