### PR TITLE
Always use calico kubeconfig for eks as eks set KUBECONFIG env by

### DIFF
--- a/static/calico-enterprise/3.15/scripts/install-calico-windows.ps1
+++ b/static/calico-enterprise/3.15/scripts/install-calico-windows.ps1
@@ -406,6 +406,16 @@ function InstallCalico()
     Write-Host "`n{{site.prodnameWindows}} installed`n"
 }
 
+function SetConfig {
+    param(
+        [parameter(Mandatory=$true)] $RootDir,
+        [parameter(Mandatory=$true)] $OldString,
+        [parameter(Mandatory=$true)] $NewString
+    )
+
+    (Get-Content $RootDir\config.ps1).replace($OldString, $NewString) | Set-Content $RootDir\config.ps1 -Force
+}
+
 # kubectl errors are expected, so there are places where this is reset to "Continue" temporarily
 $ErrorActionPreference = "Stop"
 
@@ -501,6 +511,7 @@ if ($platform -EQ "eks") {
 
     $calicoNs = GetCalicoNamespace -KubeConfigPath C:\ProgramData\kubernetes\kubeconfig
     GetCalicoKubeConfig -CalicoNamespace $calicoNs -KubeConfigPath C:\ProgramData\kubernetes\kubeconfig
+    SetConfig -RootDir $RootDir -OldString "Set-EnvVarIfNotSet -var `"KUBECONFIG`" -defaultValue `"`$PSScriptRoot\calico-kube-config`"" -NewString "`$env:KUBECONFIG = `"`$PSScriptRoot\calico-kube-config`""
 }
 if ($platform -EQ "ec2") {
     $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore

--- a/static/calico-enterprise/3.16/scripts/install-calico-windows.ps1
+++ b/static/calico-enterprise/3.16/scripts/install-calico-windows.ps1
@@ -406,6 +406,16 @@ function InstallCalico()
     Write-Host "`n{{site.prodnameWindows}} installed`n"
 }
 
+function SetConfig {
+    param(
+        [parameter(Mandatory=$true)] $RootDir,
+        [parameter(Mandatory=$true)] $OldString,
+        [parameter(Mandatory=$true)] $NewString
+    )
+
+    (Get-Content $RootDir\config.ps1).replace($OldString, $NewString) | Set-Content $RootDir\config.ps1 -Force
+}
+
 # kubectl errors are expected, so there are places where this is reset to "Continue" temporarily
 $ErrorActionPreference = "Stop"
 
@@ -497,6 +507,7 @@ if ($platform -EQ "eks") {
 
     $calicoNs = GetCalicoNamespace -KubeConfigPath C:\ProgramData\kubernetes\kubeconfig
     GetCalicoKubeConfig -CalicoNamespace $calicoNs -KubeConfigPath C:\ProgramData\kubernetes\kubeconfig
+    SetConfig -RootDir $RootDir -OldString "Set-EnvVarIfNotSet -var `"KUBECONFIG`" -defaultValue `"`$PSScriptRoot\calico-kube-config`"" -NewString "`$env:KUBECONFIG = `"`$PSScriptRoot\calico-kube-config`""
 }
 if ($platform -EQ "ec2") {
     $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore


### PR DESCRIPTION
Since EKS v1.23, Windows nodes set KUBECONFIG Env by default and point it to c:\ProgramData\kubernetes\kubeconfig. 
We need to set calico-kube-config explicitly in our config.ps1, otherwise it will take the default ENV variable. 

We can modify config.ps1 but that means we need to have a patch release. This PR walk around the issue by modifying install-windows-scripts.ps1 only. 
