### PR TITLE
CE-RKE2-updates-3.16

### DIFF
--- a/calico-cloud/get-started/connect/requirements/rke2.mdx
+++ b/calico-cloud/get-started/connect/requirements/rke2.mdx
@@ -2,7 +2,7 @@
 description: RKE2-specific requirements.
 ---
 
-# RKE2 requirements
+# RKE2 (Rancher Government) requirements
 
 ## Verify system requirements
 
@@ -14,7 +14,7 @@ Although {{prodname}} checks that your cluster meets [System requirements](syste
 
 ## Verify RKE2 settings
 
-1. Verify you have a compatible [RKE2 cluster](https://docs.rke2.io/).
+1. Verify you have a compatible [RKE2 cluster](https://docs.rke2.io/), with 2.6.5 or later
 
 1. On your RKE2 cluster, configure the plugin setting to: `no CNI plugin` using any of the following methods. For help, see [Configure your cluster with a CNI plugin](https://docs.rke2.io/install/configuration).
 

--- a/calico-enterprise/getting-started/install-on-clusters/rancher-ui.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/rancher-ui.mdx
@@ -2,17 +2,17 @@
 description: Install Calico Enterprise on a RKE2 cluster using the Rancher UI.
 ---
 
-# Rancher Manager - (Rancher UI)
+# Rancher UI
 
 ## Big picture
 
-Install {{prodname}} on RKE2 using the Rancher UI.
+Install {{prodname}} on RKE2 using the Rancher UI (Rancher Manager).
 
 ## Before you begin
 
 :::note
 
-Rancher UI does not explicitly provide an option to set the RKE2 CNI value as `none`. This is a requirement for installing a non-default CNI on RKE2. To install {{prodname}} using Rancher UI, a base RKE2 cluster with opensource Calico needs to be provisioned by Rancher first. This cluster can then be upgraded to {{prodname}}.
+To install {{prodname}} using Rancher UI, you must provision a base RKE2 cluster with Calico Open Source, then upgrade to {{prodname}}. This is required because Rancher UI does not provide an option to set the RKE2 CNI value as `none`, which is required to install a non-default CNI like {{prodname}}. 
 
 :::
 
@@ -24,7 +24,7 @@ The geeky details of what you get:
 
 <GeekDetails
   prodname='{{prodname}}'
-  details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:VXLAN,Routing:Calico,Datastore:Kubernetes'
+  details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:VXLAN,Routing:BGP,Datastore:Kubernetes'
 />
 
 **Required**
@@ -40,19 +40,19 @@ The geeky details of what you get:
 
 ## How to
 
-- [Prepare a base Calico Open Source cluster](#prepare-a-base-calico-open-source-cluster)
+- [Prepare a Calico Open Source cluster](#prepare-a-calico-open-source-cluster)
 - [Upgrade to {{prodname}}](#install-calico-enterprise)
 
-### Prepare a base Calico Open Source cluster
+### Prepare a Calico Open Source cluster
 
-1. [Provision a RKE2 cluster using Calico as CNI and default config options](https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher)
-2. Validate the RKE2 cluster is setup and running.
-3. Open a `kubectl` shell in the Rancher UI for the cluster under consideration, and perform the remaining steps in it.
-4. Annotate the Calico HelmChart with `helmcharts.helm.cattle.io/unmanaged=true`. This avoids Rancher resetting the CNI to Calico when the RKE2 cluster is either shut down or upgraded.
+1. [Provision an RKE2 cluster using Calico as the CNI and default config options](https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher).
+2. Validate that the RKE2 cluster is set up and running.
+3. In Rancher UI, open a `kubectl` shell for the cluster, and perform the next steps.
+4. Annotate the Calico HelmChart with `helmcharts.helm.cattle.io/unmanaged=true`. (This avoids Rancher resetting the CNI to Calico when the RKE2 cluster is shut down or upgraded.)
    ```batch
    kubectl annotate helmchart -n kube-system rke2-calico helmcharts.helm.cattle.io/unmanaged=true
    ```
-5. SSH to all the Control plane nodes and rename `rke2-calico.yaml` in the `/var/lib/rancher/rke2/server/manifests/` directory to `rke2-calico.yaml.skip`.
+5. SSH to all the control plane nodes and rename `rke2-calico.yaml` in the `/var/lib/rancher/rke2/server/manifests/` directory to `rke2-calico.yaml.skip`.
    ```batch
    sudo mv /var/lib/rancher/rke2/server/manifests/rke2-calico.yaml /var/lib/rancher/rke2/server/manifests/rke2-calico.yaml.skip
    ```
@@ -61,9 +61,9 @@ The geeky details of what you get:
    kubectl patch installation default --type='json' -p='[{"op": "remove", "path": "/spec/imagePath"},{"op": "remove", "path": "/spec/imagePrefix"}]'
    ```
 
-### Upgrade {{prodname}}
+### Upgrade to {{prodname}}
 
-1. Open a `kubectl` shell in the Rancher UI for the cluster.
+1. In Rancher UI, open a `kubectl` shell for the cluster.
 
 2. Follow the [steps to upgrade Calico to {{prodname}} in the `kubectl` shell](../upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/standard.mdx)
 

--- a/calico-enterprise/getting-started/install-on-clusters/rke2.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/rke2.mdx
@@ -2,11 +2,11 @@
 description: Install Calico Enterprise on an RKE2 cluster.
 ---
 
-# RKE2 - Rancher's Next Generation Kubernetes Distribution
+# RKE2
 
 ## Big picture
 
-Install {{prodname}} on Rancher's Next-generation Kubernetes Distribution (RKE2) clusters.
+Install {{prodname}} on RKE2 (RKE Government) clusters.
 
 ## Before you begin
 
@@ -18,12 +18,12 @@ The geeky details of what you get:
 
 <GeekDetails
   prodname='{{prodname}}'
-  details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:VXLAN,Routing:Calico,Datastore:Kubernetes'
+  details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:VXLAN,Routing:BGP,Datastore:Kubernetes'
 />
 
 **Required**
 
-- A [compatible RKE2 cluster](../compatibility.mdx#rke2)
+- A [compatible RKE2 cluster](../compatibility.mdx#rke2) with 2.6.5 or later
 
   For help, see [Rancher Kubernetes Engine cluster](https://rancher.com/docs/rke/latest/en/).
 
@@ -33,19 +33,13 @@ The geeky details of what you get:
   - Install script: `RKE2_CNI=none`
   - [Configuration file](https://docs.rke2.io/install/configuration#configuration-file): `cni: none`
 
-  :::note
-
-  Rancher UI does not explicitly provide an option to set the RKE2 CNI value as `none`. This is a requirement for installing a non-default CNI on RKE2. To install {{prodname}} using the Rancher UI follow [these instructions](rancher-ui.mdx).
-
-  :::
-
 - Cluster meets [system requirements](requirements.mdx)
 
 - A [Tigera license key and credentials](calico-enterprise.mdx).
 
 - A `kubectl` environment with access to your cluster
 
-  - Ensure you have the [Kubeconfig file that was generated when you created the cluster](https://docs.rke2.io/cluster_access).
+  Ensure you have the [Kubeconfig file that was generated when you created the cluster](https://docs.rke2.io/cluster_access).
 
 - If using a Kubeconfig file locally, [install and set up the Kubectl CLI tool](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 
@@ -58,7 +52,7 @@ The geeky details of what you get:
 
 1. [Configure a storage class for {{prodname}}.](../../operations/logstorage/create-storage.mdx).
 
-1. For RKE2 [CIS hardened clusters](https://docs.rke2.io/security/hardening_guide) with v1.24 or earlier, if the Tigera operator PSP is not installed, add it now.
+1. If you are using RKE2 [CIS hardened clusters](https://docs.rke2.io/security/hardening_guide) with v1.24 or earlier, install the required Tigera operator PSP.
 
    ```batch
    kubectl create -f {{filesUrl}}/manifests/psp-tigera-operator.yaml
@@ -70,7 +64,7 @@ The geeky details of what you get:
    kubectl create -f {{filesUrl}}/manifests/tigera-operator.yaml
    ```
 
-1. Install the Prometheus operator and related custom resource definitions. The Prometheus operator will be used to deploy Prometheus server and Alertmanager to monitor {{prodname}} metrics.
+1. Install the Prometheus operator and related custom resource definitions. The Prometheus operator is used to deploy Prometheus server and Alertmanager to monitor {{prodname}} metrics.
 
    :::note
 

--- a/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/rancher-ui.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/rancher-ui.mdx
@@ -2,17 +2,17 @@
 description: Install Calico Enterprise on a RKE2 cluster using the Rancher UI.
 ---
 
-# Rancher Manager - (Rancher UI)
+# Rancher UI
 
 ## Big picture
 
-Install {{prodname}} on RKE2 using the Rancher UI.
+Install {{prodname}} on RKE2 using the Rancher UI (Rancher Manager).
 
 ## Before you begin
 
 :::note
 
-Rancher UI does not explicitly provide an option to set the RKE2 CNI value as `none`. This is a requirement for installing a non-default CNI on RKE2. To install {{prodname}} using Rancher UI, a base RKE2 cluster with opensource Calico needs to be provisioned by Rancher first. This cluster can then be upgraded to {{prodname}}.
+To install {{prodname}} using Rancher UI, you must provision a base RKE2 cluster with Calico Open Source, then upgrade to {{prodname}}. This is required because Rancher UI does not provide an option to set the RKE2 CNI value as `none`, which is required to install a non-default CNI like {{prodname}}. 
 
 :::
 
@@ -24,7 +24,7 @@ The geeky details of what you get:
 
 <GeekDetails
   prodname='{{prodname}}'
-  details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:VXLAN,Routing:Calico,Datastore:Kubernetes'
+  details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:VXLAN,Routing:BGP,Datastore:Kubernetes'
 />
 
 **Required**
@@ -40,19 +40,19 @@ The geeky details of what you get:
 
 ## How to
 
-- [Prepare a base Calico Open Source cluster](#prepare-a-base-calico-open-source-cluster)
+- [Prepare a Calico Open Source cluster](#prepare-a-calico-open-source-cluster)
 - [Upgrade to {{prodname}}](#install-calico-enterprise)
 
-### Prepare a base Calico Open Source cluster
+### Prepare a Calico Open Source cluster
 
-1. [Provision a RKE2 cluster using Calico as CNI and default config options](https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher)
-2. Validate the RKE2 cluster is setup and running.
-3. Open a `kubectl` shell in the Rancher UI for the cluster under consideration, and perform the remaining steps in it.
-4. Annotate the Calico HelmChart with `helmcharts.helm.cattle.io/unmanaged=true`. This avoids Rancher resetting the CNI to Calico when the RKE2 cluster is either shut down or upgraded.
+1. [Provision an RKE2 cluster using Calico as the CNI and default config options](https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher).
+2. Validate that the RKE2 cluster is set up and running.
+3. In Rancher UI, open a `kubectl` shell for the cluster, and perform the next steps.
+4. Annotate the Calico HelmChart with `helmcharts.helm.cattle.io/unmanaged=true`. (This avoids Rancher resetting the CNI to Calico when the RKE2 cluster is shut down or upgraded.)
    ```batch
    kubectl annotate helmchart -n kube-system rke2-calico helmcharts.helm.cattle.io/unmanaged=true
    ```
-5. SSH to all the Control plane nodes and rename `rke2-calico.yaml` in the `/var/lib/rancher/rke2/server/manifests/` directory to `rke2-calico.yaml.skip`.
+5. SSH to all the control plane nodes and rename `rke2-calico.yaml` in the `/var/lib/rancher/rke2/server/manifests/` directory to `rke2-calico.yaml.skip`.
    ```batch
    sudo mv /var/lib/rancher/rke2/server/manifests/rke2-calico.yaml /var/lib/rancher/rke2/server/manifests/rke2-calico.yaml.skip
    ```
@@ -61,9 +61,9 @@ The geeky details of what you get:
    kubectl patch installation default --type='json' -p='[{"op": "remove", "path": "/spec/imagePath"},{"op": "remove", "path": "/spec/imagePrefix"}]'
    ```
 
-### Upgrade {{prodname}}
+### Upgrade to {{prodname}}
 
-1. Open a `kubectl` shell in the Rancher UI for the cluster.
+1. In Rancher UI, open a `kubectl` shell for the cluster.
 
 2. Follow the [steps to upgrade Calico to {{prodname}} in the `kubectl` shell](../upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/standard.mdx)
 

--- a/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/rke2.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/rke2.mdx
@@ -2,11 +2,11 @@
 description: Install Calico Enterprise on an RKE2 cluster.
 ---
 
-# RKE2 - Rancher's Next Generation Kubernetes Distribution
+# RKE2
 
 ## Big picture
 
-Install {{prodname}} on Rancher's Next-generation Kubernetes Distribution (RKE2) clusters.
+Install {{prodname}} on RKE2 (RKE Government) clusters.
 
 ## Before you begin
 
@@ -18,12 +18,12 @@ The geeky details of what you get:
 
 <GeekDetails
   prodname='{{prodname}}'
-  details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:VXLAN,Routing:Calico,Datastore:Kubernetes'
+  details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:VXLAN,Routing:BGP,Datastore:Kubernetes'
 />
 
 **Required**
 
-- A [compatible RKE2 cluster](../compatibility.mdx#rke2)
+- A [compatible RKE2 cluster](../compatibility.mdx#rke2) with 2.6.5 or later
 
   For help, see [Rancher Kubernetes Engine cluster](https://rancher.com/docs/rke/latest/en/).
 
@@ -33,19 +33,13 @@ The geeky details of what you get:
   - Install script: `RKE2_CNI=none`
   - [Configuration file](https://docs.rke2.io/install/configuration#configuration-file): `cni: none`
 
-  :::note
-
-  Rancher UI does not explicitly provide an option to set the RKE2 CNI value as `none`. This is a requirement for installing a non-default CNI on RKE2. To install {{prodname}} using the Rancher UI follow [these instructions](rancher-ui.mdx).
-
-  :::
-
 - Cluster meets [system requirements](requirements.mdx)
 
 - A [Tigera license key and credentials](calico-enterprise.mdx).
 
 - A `kubectl` environment with access to your cluster
 
-  - Ensure you have the [Kubeconfig file that was generated when you created the cluster](https://docs.rke2.io/cluster_access).
+  Ensure you have the [Kubeconfig file that was generated when you created the cluster](https://docs.rke2.io/cluster_access).
 
 - If using a Kubeconfig file locally, [install and set up the Kubectl CLI tool](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 
@@ -58,7 +52,7 @@ The geeky details of what you get:
 
 1. [Configure a storage class for {{prodname}}.](../../operations/logstorage/create-storage.mdx).
 
-1. For RKE2 [CIS hardened clusters](https://docs.rke2.io/security/hardening_guide) with v1.24 or earlier, if the Tigera operator PSP is not installed, add it now.
+1. If you are using RKE2 [CIS hardened clusters](https://docs.rke2.io/security/hardening_guide) with v1.24 or earlier, install the required Tigera operator PSP.
 
    ```batch
    kubectl create -f {{filesUrl}}/manifests/psp-tigera-operator.yaml
@@ -70,7 +64,7 @@ The geeky details of what you get:
    kubectl create -f {{filesUrl}}/manifests/tigera-operator.yaml
    ```
 
-1. Install the Prometheus operator and related custom resource definitions. The Prometheus operator will be used to deploy Prometheus server and Alertmanager to monitor {{prodname}} metrics.
+1. Install the Prometheus operator and related custom resource definitions. The Prometheus operator is used to deploy Prometheus server and Alertmanager to monitor {{prodname}} metrics.
 
    :::note
 


### PR DESCRIPTION
### RKE2 updates for 3.16
https://deploy-preview-378--tigera.netlify.app/calico-enterprise/3.16/getting-started/install-on-clusters/rke2

- Update version per QE to 2.6.5 and later (CC and CE)
- Update RKE2 product name (exposed only in CE)
- CE 3.16/next
- CC RKE2 version only, 3.16