### PR TITLE
DOCS-724: Fixes broke xrefs

### DIFF
--- a/calico-cloud/_includes/components/EnvironmentFile.js
+++ b/calico-cloud/_includes/components/EnvironmentFile.js
@@ -9,17 +9,18 @@ import { baseUrl } from '../../variables';
 export default function EnvironmentFile(props) {
   return (
     <>
-      <p>
-        <span>
-          Use the following guidelines and sample file to define the environment variables for starting Calico on the
-          host. For more help, see the{' '}
-        </span>
-        {props.install === 'container' ? (
-          <Link href={`${baseUrl}/reference/component-resources/node/configuration`}>{props.nodecontainer} configuration reference</Link>
-        ) : (
-          <Link href={`${baseUrl}/reference/felix/configuration`}>Felix configuration reference</Link>
-        )}
-      </p>
+        <p>
+            {props.install === 'container' ? (
+                <span>
+                    Use the following guidelines and sample file to define the environment variables for starting Calico on the host.
+                    For more help, see the <Link href={`${baseUrl}/reference/component-resources/node/configuration`}>{props.nodecontainer} configuration reference</Link>
+                </span>
+            ) : (
+                <span>
+                    Use the following guidelines and sample file to define the environment variables for starting Calico on the host.
+                </span>
+            )}
+        </p>
       <p>For the Kubernetes datastore set the following:</p>
       <table>
         <thead>

--- a/calico-cloud/_includes/components/ReqsSys.js
+++ b/calico-cloud/_includes/components/ReqsSys.js
@@ -56,6 +56,7 @@ function NodeRequirementsEnt(props) {
             interfaces. When VXLAN is enabled, {prodname} also needs to be able to manage the <code>vxlan.calico</code>{' '}
             interface.
           </p>
+          {/*}
           <Admonition type='note'>
             <p>
               Many Linux distributions, such as most of the above, include NetworkManager. By default, NetworkManager
@@ -67,6 +68,7 @@ function NodeRequirementsEnt(props) {
               before installing {prodname}.
             </p>
           </Admonition>
+          */}
         </li>
         <li>
           <p>
@@ -190,10 +192,9 @@ function NetworkRequirementsEnt(props) {
         Network requirements
       </Heading>
       <p>
-        Ensure that your hosts and firewalls allow the necessary traffic based on your configuration. See{' '}
-        <Link href={`${baseUrl}/reference/architecture/overview`}>Component architecture</Link> to view the following
-        components.
+        Ensure that your hosts and firewalls allow the necessary traffic based on your configuration.
       </p>
+      {/*Above TODO-XREFS-CC */}
       <table>
         <colgroup>
           <col style={{ width: '27%' }} />

--- a/calico-cloud/_includes/content/_non-cluster-binary-install.mdx
+++ b/calico-cloud/_includes/content/_non-cluster-binary-install.mdx
@@ -117,7 +117,9 @@ service calico-felix start
 <TabItem label="Manually configure Felix" value="Manually configure Felix-1">
 
 Configure Felix by creating a file at `/kubernetes/calico/felix.cfg`.
+<!--TODO-XREFS-CC
 See [Felix configuration](/reference/felix/configuration) for help with environment variables.
+-->
 
 :::note
 

--- a/calico-cloud/_includes/release-notes/_master-release-notes.mdx
+++ b/calico-cloud/_includes/release-notes/_master-release-notes.mdx
@@ -1,0 +1,3 @@
+_Dateline_
+
+## Undefined feature X

--- a/calico-cloud/compliance/encrypt-cluster-pod-traffic.mdx
+++ b/calico-cloud/compliance/encrypt-cluster-pod-traffic.mdx
@@ -165,7 +165,7 @@ To enable both IPv4 and IPv6 WireGuard encryption across all the nodes, use the 
 kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"wireguardEnabled":true,"wireguardEnabledV6":true}}'
 ```
 
-For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources](/getting-started/install-on-clusters/openshift/installation/#provide-additional-configuration).
+<!--TODO-CC-XREFS For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources](/getting-started/install-on-clusters/openshift/installation/#provide-additional-configuration).-->
 
 :::note
 

--- a/calico-cloud/image-assurance/install-the-admission-controller.mdx
+++ b/calico-cloud/image-assurance/install-the-admission-controller.mdx
@@ -98,7 +98,7 @@ Container admission policies are custom Kubernetes resources that allow you to c
 
 ## Create container admission policies
 
-Container admission policies are used to define criteria for the Admission Controller to admit or reject admission for resources that create pods. For details, see [ContainerAdmissionPolicies](/reference/resources/containeradmissionpolicy).
+Container admission policies are used to define criteria for the Admission Controller to admit or reject admission for resources that create pods. For details, see [ContainerAdmissionPolicies](../reference/resources/containeradmissionpolicy.mdx).
 
 **Sample container admission policies**
 
@@ -155,7 +155,7 @@ images that have been scanned within the last three days. So, we use the gt oper
 attempt was made to create the Kubernetes resource. If the Allow rule does not match, then the second action rule
 (Reject) is evaluated, which denies everything.
 
-You can also use modify the Allow rule to match an absolute time. For help, see [ContainerAdmissionPolicies](/reference/resources/containeradmissionpolicy).
+You can also use modify the Allow rule to match an absolute time. For help, see [ContainerAdmissionPolicies](../reference/resources/containeradmissionpolicy.mdx).
 
 ## Troubleshoot
 

--- a/calico-cloud/multicluster/kubeconfig.mdx
+++ b/calico-cloud/multicluster/kubeconfig.mdx
@@ -63,10 +63,12 @@ cannot be used, because OpenShift currently does not allow users to disable the 
 - {{prodname}} with BGP
 - AKS/Azure, EKS/AWS, and GKE with VPC
 
+<!--//TODO-CC-XREFS
 **Required**
 
 - [Install {{prodname}}](/getting-started/install-on-clusters/kubernetes/index)
 - [Install and configure calicoq](/operations/clis/calicoq/installing)
+-->
 
 ## How to
 

--- a/calico-cloud/network-policy/beginners/calico-network-policy.mdx
+++ b/calico-cloud/network-policy/beginners/calico-network-policy.mdx
@@ -93,11 +93,13 @@ The Kubernetes network policy specification defines the following behavior:
 
 For compatibility with Kubernetes, **Calico network policy** follows the same behavior for Kubernetes pods. For other endpoint types (VMs, host interfaces), Calico network policy is default deny. That is, only traffic specifically allowed by network policy is allowed, even if no network policies apply to the endpoint.
 
+<!--//TODO-CC-XREFS
 ## Before you begin
 
 `calicoctl` must be **installed** and **configured** before use. `calicoctl` will use Kubernetes as the datastore. You can find more information on how to configure `calicoctl` in the following link:
 
 - [Configure `calicoctl`](/operations/clis/calicoctl/configure/overview)
+-->
 
 ## How to
 

--- a/calico-cloud/network-policy/beginners/simple-policy-cnx.mdx
+++ b/calico-cloud/network-policy/beginners/simple-policy-cnx.mdx
@@ -8,11 +8,13 @@ This guide is a variation of the [simple policy demo](../../tutorials/kubernetes
 
 It requires a Kubernetes cluster configured with Calico networking and {{prodname}}, and expects that you have `kubectl` configured to interact with the cluster.
 
+<!--//TODO-CC-XREFS
 You can quickly and easily obtain such a cluster by following one of the
 [installation guides](/getting-started/install-on-clusters/kubernetes/index),
 or by [upgrading an existing cluster](/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/index).
 
 The key steps in moving to {{prodname}} are to change to the {{prodname}} version of calico-node, update its configuration, download [calicoq](/reference/clis/calicoq/index) and deploy Prometheus.
+-->
 
 This guide assumes that you have installed all the {{prodname}} components from the
 guides above and that your cluster consists of the following nodes:
@@ -79,7 +81,7 @@ We'll use Kubernetes `Deployment` objects to easily create pods in the namespace
    calicoq complements calicoctl by inspecting the
    dynamic aspects of {{prodname}} Policy: in particular displaying the endpoints actually affected by policies,
    and the policies that actually apply to endpoints.
-   The full calicoq documentation is [here](/reference/clis/calicoq/index).
+   <!--//TODO-CC-XREFS The full calicoq documentation is [here](/reference/clis/calicoq/index). -->
 
    :::
 

--- a/calico-cloud/network-policy/hosts/protect-hosts.mdx
+++ b/calico-cloud/network-policy/hosts/protect-hosts.mdx
@@ -58,7 +58,7 @@ No. {{prodname}} allows connections the host makes to the workloads running on t
 
 ## Before you begin...
 
-If you are already running {{prodname}} for Kubernetes, you are good to go. If you want to install {{prodname}} on a non-cluster machine for host protection only, see [Non-cluster hosts](/getting-started/bare-metal/index).
+If you are already running {{prodname}} for Kubernetes, you are good to go. If you want to install {{prodname}} on a non-cluster machine for host protection only, see [Install network policy on non-cluster hosts](../../network-policy/hosts/about.mdx).
 
 ## How to
 

--- a/calico-cloud/network-policy/policy-firewalls/aws-integration/aws-security-group-integration.mdx
+++ b/calico-cloud/network-policy/policy-firewalls/aws-integration/aws-security-group-integration.mdx
@@ -48,14 +48,16 @@ AWS security group integration for {{prodname}} allows you to combine AWS securi
   kubectl get pod -n kube-system -l k8s-app=aws-node -o wide
   ```
 
+<!--//TODO-CC-XREFS Note: The multiline comment and text must be aligned in col 1.
 - You have installed [{{prodname}} for EKS](/getting-started/install-on-clusters/eks/)
-  on your cluster, or kubeadm/kops.
+on your cluster, or kubeadm/kops.
 
-  Verify {{prodname}} has been installed by confirming that all tigerastatuses are available:
+Verify {{prodname}} has been installed by confirming that all tigerastatuses are available:
 
-  ```batch
-  kubectl get tigerastatus
+```batch
+kubectl get tigerastatus
   ```
+-->
 
 - You have installed {{prodname}} configured to work with the AWS CNI Plugin. This is done by following the installation guide for EKS on your cluster or configuring the Installation resource during installation and setting the CNI.Type to `AmazonVPC`.
 

--- a/calico-cloud/network-policy/policy-firewalls/fortinet-integration/firewall-integration.mdx
+++ b/calico-cloud/network-policy/policy-firewalls/fortinet-integration/firewall-integration.mdx
@@ -42,7 +42,7 @@ The basic workflow is:
 
 **Required**
 
-- Pull secret that you used during [{{prodname}} installation](/getting-started/install-on-clusters/index)
+<!--//TODO-CC-XREFS - Pull secret that you used during [{{prodname}} installation](/getting-started/install-on-clusters/index)-->
 - IPv4 CIDR’s or IP addresses of all Kubernetes nodes; this is required for FortiManager to treat Kubernetes nodes as trusted hosts.
 
 **Recommended**

--- a/calico-cloud/network-policy/policy-firewalls/fortinet-integration/fortimgr-integration.mdx
+++ b/calico-cloud/network-policy/policy-firewalls/fortinet-integration/fortimgr-integration.mdx
@@ -49,9 +49,12 @@ The default value for reading FortiManager firewall policies is three seconds. T
 
 **Required**
 
-- Pull secret that you used during [{{prodname}} installation](/getting-started/install-on-clusters/index)
 - IPv4 CIDR’s or IP addresses of all Kubernetes nodes; this is required for FortiManager to treat Kubernetes nodes as trusted hosts.
+
+<!--//TODO-CC-XREF
+- Pull secret that you used during [{{prodname}} installation](/getting-started/install-on-clusters/index)
 - Login access to [{{prodname}} Manager UI](/operations/cnx/access-the-manager/)
+-->
 
 **Recommended**
 

--- a/calico-cloud/networking/configuring/bgp.mdx
+++ b/calico-cloud/networking/configuring/bgp.mdx
@@ -62,7 +62,8 @@ For a deeper look at common on-premises deployment models, see [Calico over IP F
 **Required**
 
 - Calico CNI
-- [calicoctl](/operations/clis/calicoctl/install.mdx) must be installed and configured
+
+<!--//TODO-CC-XREF- [calicoctl] (/operations/clis/calicoctl/install) must be installed and configured-->
 
 ## How to
 
@@ -228,9 +229,11 @@ Where `<NODE_NAME>` is the resource name for one of the Calico node pods within 
 
 :::note
 
-The above command can be run from anywhere you have access to kubectl. We recommend running it as a kubectl plugin. [Follow these instructions](/operations/clis/calicoctl/install.mdx#install-calicoctl-as-a-kubectl-plugin-on-a-single-host) for how to install `calicoctl` as a kubectl plugin.
+The above command can be run from anywhere you have access to kubectl. We recommend running it as a kubectl plugin.
+<!--//TODO-CC-XREFS [Follow these instructions] (../../operations/clis/calicoctl/install.mdx#install-calicoctl-as-a-kubectl-plugin-on-a-single-host) for how to install `calicoctl` as a kubectl plugin.-->
 
 :::
+
 If you install the binary as a kubectl plugin using the above instructions, you can then run the command as follows:
 
 ```

--- a/calico-cloud/networking/configuring/custom-bgp-config.mdx
+++ b/calico-cloud/networking/configuring/custom-bgp-config.mdx
@@ -34,7 +34,7 @@ for the BGP configuration using these resources:
 
 - [BGP Configuration](../../reference/resources/bgpconfig.mdx)
 - [BGP Peer](../../reference/resources/bgppeer.mdx)
-- [calicoctl](/reference/clis/calicoctl/index)
+<!-- //TODO-CC-XREFS - [calicoctl](/reference/clis/calicoctl/index)-->
 
 ### Apply BGP Customizations
 

--- a/calico-cloud/networking/configuring/dual-tor.mdx
+++ b/calico-cloud/networking/configuring/dual-tor.mdx
@@ -601,8 +601,9 @@ at two examples: with OpenShift, and when adding Calico to an existing Kubernete
 
 **OpenShift**
 
-With OpenShift, follow [our documentation](/getting-started/install-on-clusters/openshift/index) as
-far as the option to [provide additional configuration](/getting-started/install-on-clusters/openshift/installation/).
+With OpenShift, follow our documentation as
+far as the option to provide additional configuration.
+<!--TODO-XREFS-CC -->
 Then use `kubectl create configmap ...`, as that documentation says, to combine the
 prepared BGPPeer, BGPConfiguration and IPPool resources into a `calico-resources`
 ConfigMap. Place the generated file in the manifests directory for the OpenShift install.
@@ -614,7 +615,9 @@ resources into the datastore as early as possible.
 
 **Adding to an existing Kubernetes cluster**
 
-Follow [our documentation](/getting-started/install-on-clusters/kubernetes/generic-install/) as
+Follow our documentation
+<!--TODO-XREFS-CC -->
+as
 far as the option for installing any custom Calico resources. Then use `calicoctl`, as
 that documentation says, to install the prepared BGPPeer, BGPConfiguration and IPPool
 resources.

--- a/calico-cloud/networking/configuring/multiple-networks.mdx
+++ b/calico-cloud/networking/configuring/multiple-networks.mdx
@@ -71,7 +71,7 @@ Although the following {{prodname}} features are supported for your default {{pr
 
   :::
 
-- [Install and configure calicoctl](/operations/clis/calicoctl/index) or configure access to [Calico Enterprise Manager UI](/operations/cnx//access-the-manager/)
+<!--//TODO-CC-XREFS- [Install and configure calicoctl](/operations/clis/calicoctl/index) or configure access to [Calico Enterprise Manager UI](/operations/cnx//access-the-manager/)-->
 
 ## How to
 

--- a/calico-cloud/networking/configuring/workloads-outside-cluster.mdx
+++ b/calico-cloud/networking/configuring/workloads-outside-cluster.mdx
@@ -74,7 +74,3 @@ spec:
   cidr: 10.0.0.0/8
   disabled: true
 ```
-
-## Above and beyond
-
-To learn about inbound connectivity, see [External connectivity](/networking/external-connectivity)

--- a/calico-cloud/networking/egress/troubleshoot.mdx
+++ b/calico-cloud/networking/egress/troubleshoot.mdx
@@ -181,7 +181,7 @@ If the outbound connection cannot be established, the policy may be denying the 
 - From the gateway pod, egress
 - Any relevant HostEndpoints that are configured in your cluster
 
-In [Manager UI](/visibility/get-started-cem), check for dropped packets because of policy on the outbound connection path. If you are using the iptables dataplane, you can also run the following command on the client and gateway nodes to look at a lower level.
+In [Manager UI](../../tutorials/calico-cloud-features/tour.mdx), check for dropped packets because of policy on the outbound connection path. If you are using the iptables dataplane, you can also run the following command on the client and gateway nodes to look at a lower level.
 
 ```
 watch iptables-save -c | grep DROP | grep -v 0:0

--- a/calico-cloud/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico-cloud/networking/ipam/get-started-ip-addresses.mdx
@@ -88,5 +88,6 @@ There are several other ways to leverage {{prodname}} IPAM including:
 - [Use a specific address for a pod](use-specific-ip.mdx)
 - [Migrate from one IP pool to another](migrate-pools.mdx)
 - [Restrict a pod to use an IP address in a specific range](legacy-firewalls.mdx)
-- [View IP address utilization](/reference/clis/calicoctl/ipam/show/)
 - [Change IP address block size](../../reference/resources/ippool.mdx)
+
+<!--TODO-XREFS-CC - [View IP address utilization](/reference/clis/calicoctl/ipam/show/)-->

--- a/calico-cloud/networking/ipam/initial-ippool.mdx
+++ b/calico-cloud/networking/ipam/initial-ippool.mdx
@@ -38,7 +38,7 @@ resource and configures the default Calico IP pool. Note the following:
   - NodeSelector: all()
   - NATOutgoing: Enabled
 - IP pools are only used when Calico is used for pod networking, IP pools are not utilized when using other pod networking solutions.
-- To make changes to the IP pools after Tigera Operator install, you may use [calicoctl](/reference/clis/calicoctl/index) or kubectl. If you make the changes to the IP Pool in the Installation resource (Operator IPPool) after installation, the the changes are not applied.
+- To make changes to the IP pools after Tigera Operator install, you may use calicoctl or kubectl. If you make the changes to the IP Pool in the Installation resource (Operator IPPool) after installation, the the changes are not applied.
 
 ## Before you begin...
 
@@ -72,4 +72,7 @@ resource and configures the default Calico IP pool. Note the following:
 ## Above and beyond
 
 - [IP pool resource](../../reference/resources/ippool.mdx)
+
+<!--TODO-XREFS-CC
 - Use [calicoctl](/reference/clis/calicoctl/index) or `kubectl` to edit the IPPool resource.
+-->

--- a/calico-cloud/networking/ipam/ip-autodetection.mdx
+++ b/calico-cloud/networking/ipam/ip-autodetection.mdx
@@ -243,4 +243,4 @@ calicoctl patch node kind-control-plane \
 - For details on autodetection methods, see the [node configuration](../../reference/component-resources/node/configuration.mdx) reference.
 - For calicoctl environment variables, see [Configuring {{nodecontainer}}](../../reference/component-resources/node/configuration.mdx)
 - [Node resource](../../reference/resources/node.mdx)
-- [Reference documentation for calicoctl patch](/reference/clis/calicoctl/patch/)
+<!--//TODO-CC-XREFS- [Reference documentation for calicoctl patch](/reference/clis/calicoctl/patch/)-->

--- a/calico-cloud/networking/training/about-kubernetes-networking.mdx
+++ b/calico-cloud/networking/training/about-kubernetes-networking.mdx
@@ -57,9 +57,11 @@ There are lots of different kinds of CNI plugins, but the two main ones are:
 
 {{prodname}} provides both network and IPAM plugins, but can also integrate and work seamlessly with some other CNI
 plugins, including AWS, Azure, and Google network CNI plugins, and the host local IPAM plugin. This flexibility allows
-you to choose the best networking options for your specific needs and deployment environment. You can read more about
+you to choose the best networking options for your specific needs and deployment environment.
+<!--//TODO-CC-XREFS You can read more about
 this in the {{prodname}} [determine best networking option](/networking/determine-best-networking)
 guide.
+-->
 
 ## Kubernetes Services
 
@@ -115,8 +117,12 @@ node IP is routable). Return packets on the connection are automatically mapped 
 with the pod IP before forwarding the packet to the pod.
 
 When using {{prodname}}, depending on your environment, you can generally choose whether you prefer to run an
-overlay network, or prefer to have fully routable pod IPs. You can read more about this in the {{prodname}}
-[determine best networking option](/networking/determine-best-networking) guide. {{prodname}} also
+overlay network, or prefer to have fully routable pod IPs.
+<!--TODO-XREFS-CC
+You can read more about this in the {{prodname}}
+[determine best networking option](/networking/determine-best-networking) guide.
+-->
+{{prodname}} also
 allows you to [configure outgoing NAT](../configuring/workloads-outside-cluster.mdx) for specific IP address
 ranges if more granularity is desired.
 

--- a/calico-cloud/networking/training/about-networking.mdx
+++ b/calico-cloud/networking/training/about-networking.mdx
@@ -10,8 +10,8 @@ This guide provides educational material that is not specific to {{prodname}}.
 
 :::
 
-You can get up and running with {{prodname}} by following any of the {{prodname}} [install
-guides](/getting-started/index) without needing to be a networking expert. {{prodname}} hides the complexities for
+You can get up and running with {{prodname}} by following any of the {{prodname}} install
+guides without needing to be a networking expert. {{prodname}} hides the complexities for
 you. However, if you would like to learn more about networking so you can better understand what is happening under the
 covers, this guide provides a short introduction to some of the key fundamental networking concepts for anyone who is
 not already familiar with them.
@@ -117,8 +117,11 @@ the downsides of:
   are required to bridge between the overlay and the underlay network for any ingress to, or egress from, the overlay.
 
 {{prodname}} networking options are exceptionally flexible, so in general you can choose whether you prefer
-{{prodname}} to provide an overlay network, or non-overlay network. You can read more about this in the {{prodname}}
+{{prodname}} to provide an overlay network, or non-overlay network.
+<!--TODO-XREFS-CC
+You can read more about this in the {{prodname}}
 [determine best networking option](/networking/determine-best-networking) guide.
+-->
 
 ## DNS
 

--- a/calico-cloud/operations/comms/apiserver-tls.mdx
+++ b/calico-cloud/operations/comms/apiserver-tls.mdx
@@ -47,6 +47,8 @@ If the {{prodname}} API server is already running, updating the secret restarts 
 
 :::
 
+<!--TODO-XREFS-CC
 ## Above and beyond
 
-Additional documentation is available for securing [{{prodname}} manager connections](crypto-auth.mdx#connections-from-calico-enterprise-components-to-kube-apiserver-kubernetes-and-openshift).
+Additional documentation is available for securing [{{prodname}} manager connections](crypto-auth.mdx).
+-->

--- a/calico-cloud/operations/comms/certificate-management.mdx
+++ b/calico-cloud/operations/comms/certificate-management.mdx
@@ -22,8 +22,9 @@ If your cluster is already running {{prodname}} and you would like to enable cer
 temporarily remove [the logstorage resource](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
 before following the steps to enable certificate management and then re-apply afterwards.
 
+<!--TODO-XREFS-CC
 Currently, this feature is not supported in combination with [Multi-cluster management](/multicluster/create-a-management-cluster/).
-
+-->
 **Supported algorithms**
 
 - Private Key Pair: RSA (size: 2048, 4096, 8192), ECDSA (curve: 256, 384, 521)

--- a/calico-cloud/operations/comms/crypto-auth.mdx
+++ b/calico-cloud/operations/comms/crypto-auth.mdx
@@ -22,9 +22,9 @@ For clusters installed using operator, see how to [provide TLS certificates for 
 
 For detailed reference information on TLS configuration parameters, refer to:
 
-- **Typha**: [Node-Typha TLS configuration](/reference/component-resources/typha/configuration#felix-typha-tls-configuration)
-
 - **Node**: [Node-Typha TLS configuration](../../reference/component-resources/node/felix/configuration.mdx#felix-typha-tls-configuration)
+
+<!--TODO-XREFS-CC - **Typha**: [Node-Typha TLS configuration](../../reference/component-resources/typha/configuration#felix-typha-tls-configuration)-->
 
 # {{prodname}} Manager connections
 

--- a/calico-cloud/operations/comms/manager-tls.mdx
+++ b/calico-cloud/operations/comms/manager-tls.mdx
@@ -15,8 +15,11 @@ By default, the {{prodname}} manager UI uses self-signed TLS certificates on con
 ## Before you begin...
 
 - **Get the certificate and key pair for the {{prodname}} Manager UI**
-  Generate the certificate using any X.509-compatible tool or from your organization's Certificate Authority. The certificate must have Common Name or Subject Alternate Names that match the IPs or DNS names that will be used to [access the manager UI](/operations/cnx/access-the-manager/).
+  Generate the certificate using any X.509-compatible tool or from your organization's Certificate Authority.
 
+<!--TODO-XREFS-CC
+The certificate must have Common Name or Subject Alternate Names that match the IPs or DNS names that will be used to [access the manager UI](/operations/cnx/access-the-manager/).
+-->
 ## How to
 
 To provide certificates for use during deployment you must create a secret before applying the 'custom-resource.yaml' or before creating the Installation resource. To specify certificates for use in the manager, create a secret using the following command:

--- a/calico-cloud/operations/comms/secure-metrics.mdx
+++ b/calico-cloud/operations/comms/secure-metrics.mdx
@@ -12,8 +12,10 @@ to limit access to {{prodname}}'s metrics endpoints.
 ## Prerequisites
 
 - {{prodname}} is installed with Prometheus metrics reporting enabled.
-- `calicoctl` is [installed in your PATH and configured to access the data store](/operations/clis/calicoctl/install).
 
+<!--TODO-XREFS-CC
+- `calicoctl` is [installed in your PATH and configured to access the data store](/operations/clis/calicoctl/install).
+-->
 ## Choosing an approach
 
 This guide provides two example workflows for creating network policies to limit access

--- a/calico-cloud/operations/decommissioning-a-node.mdx
+++ b/calico-cloud/operations/decommissioning-a-node.mdx
@@ -31,8 +31,9 @@ information.
 - Prior to removing any Node resource from the datastore the `{{nodecontainer}}`
   container should be stopped on the corresponding host and it should be
   ensured that it will not be restarted.
-- You must have [calicoctl configured](/operations/clis/calicoctl/install/) and operational to run
-  the commands listed here.
+- You must have calicoctl configured and operational to run
+the commands listed here.
+<!--TODO-XREFS-CC -->
 
 ## Removing a node resource
 

--- a/calico-cloud/operations/ebpf/install.mdx
+++ b/calico-cloud/operations/ebpf/install.mdx
@@ -42,7 +42,8 @@ and in particular, pushing the networking capabilities of the latest Linux kerne
 
   - Ubuntu 20.04.
   - Red Hat v8.2 with Linux kernel v4.18.0-193 or above (Red Hat have backported the required features to that build).
-  - Another [supported distribution](/getting-started/install-on-clusters/requirements/) with Linux kernel v5.3 or above.
+  - Another supported distribution with Linux kernel v5.3 or above.
+<!--TODO-XREFS-CC -->
 
 - An underlying network fabric that allows VXLAN traffic between hosts. In eBPF mode, VXLAN is used to forward Kubernetes NodePort traffic.
 
@@ -55,7 +56,8 @@ and in particular, pushing the networking capabilities of the latest Linux kerne
 
 :::note
 
-eBPF supports AKS with Calico CNI and {{prodname}} network policy. However, with [AKS with Azure CNI and {{prodname}} network policy](/getting-started/install-on-clusters/aks/#install-with-azure-cni-networking), kube-proxy cannot be disabled so the performance benefits of eBPF are lost. However, there are other reasons to use eBPF other than performance gains, as described in [eBPF use cases](use-cases-ebpf.mdx).
+eBPF supports AKS with Calico CNI and {{prodname}} network policy. However, with AKS with Azure CNI and {{prodname}} network policy, kube-proxy cannot be disabled so the performance benefits of eBPF are lost. However, there are other reasons to use eBPF other than performance gains, as described in [eBPF use cases](use-cases-ebpf.mdx).
+<!--TODO-XREFS-CC -->
 
 :::
 

--- a/calico-cloud/operations/fips.mdx
+++ b/calico-cloud/operations/fips.mdx
@@ -52,7 +52,8 @@ agencies and government contractors. {{prodname}} FIPS mode is enabled during in
 
 To install {{prodname}} in FIPS mode follow these steps.
 
-1. Follow [the installation steps](/getting-started/install-on-clusters/kubernetes/index) for your platform.
+1. Follow the installation steps for your platform.
+<!--TODO-XREFS-CC -->
 
    - In the step for installing custom resources, edit `custom-resources.yaml` and enable FIPS mode in the installation spec.
 
@@ -66,7 +67,7 @@ To install {{prodname}} in FIPS mode follow these steps.
    ```
 
    - For more information on configuration options available in this manifest, see [the installation reference](../reference/installation/api.mdx).
-     We strongly recommend that you [adjust log storage](/operations/logstorage/adjust-log-storage-size) according to the example.
+     <!--TODO-XREFS-CC We strongly recommend that you [adjust log storage](/operations/logstorage/adjust-log-storage-size) according to the example.-->
 
 2. Upgrade to the required Elasticsearch Platinum license to run FIPS mode.
 

--- a/calico-cloud/reference/architecture/design/l3-interconnect-fabric.mdx
+++ b/calico-cloud/reference/architecture/design/l3-interconnect-fabric.mdx
@@ -29,11 +29,12 @@ fabrics.
 ## Background
 
 ### Basic {{prodname}} architecture overview
-
+<!--TODO-XREFS-CC
 A description of the {{prodname}} architecture can be found in our
 [architectural overview](/reference/architecture/overview).
 However, a brief discussion of the routing and data paths is useful for
 the discussion.
+-->
 
 In a {{prodname}} network, each compute server acts as a router for all of the
 endpoints that are hosted on that compute server. We call that function
@@ -109,7 +110,7 @@ The two methods are:
 
 1.  A BGP fabric where each of the TOR switches (and their subsidiary
     compute servers) are a unique [Autonomous
-    System (AS)](/reference/architecture/design/<https:/en.wikipedia.org/wiki/Autonomous_System_(Internet)>)
+    System (AS)](https:/en.wikipedia.org/wiki/Autonomous_System_(Internet)>)
     and they are interconnected via either an Ethernet switching plane
     provided by the spine switches in a
     [leaf/spine](http://bradhedlund.com/2012/10/24/video-a-basic-introduction-to-the-leafspine-data-center-networking-fabric-design/)

--- a/calico-cloud/reference/faq.mdx
+++ b/calico-cloud/reference/faq.mdx
@@ -269,7 +269,7 @@ If a host's containers are connected to the `docker0` bridge interface, {{prodna
 would be unable to enforce security rules between workloads on the same host;
 all containers on the bridge would be able to communicate with one other.
 
-You can securely configure port mapping by following [External connectivity](/networking/external-connectivity).
+You can securely configure port mapping by following [Configure outgoing NAT](../networking/configuring/workloads-outside-cluster.mdx.
 
 ## Can {{prodname}} containers use any IP address within a pool, even subnet network/broadcast addresses?
 
@@ -293,7 +293,7 @@ center. Access to that network is via a router, which also is the default
 router for all the container hosts.
 
 If this describes your infrastructure,
-[External connectivity](/networking/external-connectivity) explains in more detail
+[Configure outgoing NAT](../networking/configuring/workloads-outside-cluster.mdx explains in more detail
 what to do. Otherwise, if you have a layer 3 (IP) fabric, then there are
 detailed datacenter networking recommendations given
 in [{{prodname}} over IP fabrics](architecture/design/l3-interconnect-fabric.mdx).

--- a/calico-cloud/reference/public-cloud/aws.mdx
+++ b/calico-cloud/reference/public-cloud/aws.mdx
@@ -173,4 +173,4 @@ Install the AWS VPC CNI plugin in your Kubernetes cluster as follows.
    kubectl apply -f aws-k8s-cni.yaml
    ```
 
-1. Follow the instructions to install [{{prodname}} on AWS](/getting-started/install-on-clusters/aws/).
+1. Follow the instructions to install {{prodname}} on AWS.

--- a/calico-cloud/reference/resources/containeradmissionpolicy.mdx
+++ b/calico-cloud/reference/resources/containeradmissionpolicy.mdx
@@ -1,0 +1,194 @@
+---
+description: Resource definition.
+---
+# Container admission policy
+
+A container admission policy (`ContainerAdmissionPolicy`) represents an ordered set of rules which are applied to a
+collection of containers that match a [label selector](#selector).
+
+`ContainerAdmissionPolicy` is a cluster resource. `ContainerAdmissionPolicy` can be restricted to a set of namespaces
+using a [namespace selector](#selector).
+
+## Sample YAML
+
+This sample policy allows admission requests for pod creating resources whose image is in the registry / repository
+`gcr.io/company/production-repository/*` with a scan status of either `Pass` or `Warn`, and rejects all other admission
+requests.
+
+```yaml
+apiVersion: containersecurity.tigera.io/v1beta1
+kind: ContainerAdmissionPolicy
+metadata:
+  name: reject-failed-and-non-gcr
+spec:
+  selector: all()
+  namespaceSelector: all()
+  order: 10
+  rules:
+  - action: "Reject"
+    imagePath:
+      operator: IsNoneOf
+      values:
+      - "^gcr.io/company/production-repository/.*"
+  - action: Allow
+    imageScanStatus:
+      operator: IsOneOf
+      values:
+      - Pass
+      - Warn
+  - action: Reject
+```
+
+## Container admission policy definition
+
+### Metadata
+
+| Field     | Description                                                        | Accepted Values                                     | Schema | Default   |
+|-----------|--------------------------------------------------------------------|-----------------------------------------------------|--------|-----------|
+| name      | The name of the network policy. Required.                          | Alphanumeric string with optional `.`, `_`, or `-`. | string |           |
+
+### Spec
+
+| Field             | Description                                                                                         | Accepted Values | Schema                | Default |
+|-------------------|-----------------------------------------------------------------------------------------------------|-----------------|-----------------------|---------|
+| order             | Controls the order of precedence. {{site.prodname}} applies the policy with the lowest value first. |                 | float                 |         |
+| selector          | Selects the resources to which this policy applies.                                                 |                 | [selector](#selector) | all()   |
+| namespaceSelector | Selects the namespace to which this policy applies.                                                 |                 | [selector](#selector) | all()   |
+| rules             | Ordered list of rules applied by this policy.                                                       |                 | List of [Rule](#rule) |         |
+
+### Rule
+
+A single rule matches a set of pod creating resources and applies some action to them.  Multiple rules are executed in order.
+
+| Field             | Description                                | Accepted Values                                                   | Schema                                     | Default    |
+|-------------------|---------------------------------------------------------------------|------------------------------------------|--------------------------------------------|------------|
+| action            | Action to perform when matching this rule.                    | `Allow`, `Reject`                        | string                                     |            |
+| imagePath         | Image path matching criteria.                                 |                                          | [String Values Match](#stringvaluematch)   |            |
+| imageScanStatus   | Vulnerability scan status criteria.                           |                                          | [String Values Match](#stringvaluematch)   |            |
+| imageLastScan     | Criteria for the last time the containers image was scanned.  |                                          | [Time Match](#timematch)                   |            |
+
+### Selector
+
+A label selector is an expression which either matches or does not match a resource based on its labels.
+
+{{site.prodname}} label selectors support a number of operators, which can be combined into larger expressions
+using the boolean operators and parentheses.
+
+| Expression                | Meaning                     |
+|---------------------------|-----------------------------|
+| **Logical operators**     |
+| `( <expression> )`        | Matches if and only if `<expression>` matches.  (Parentheses are used for grouping expressions.)
+| `! <expression>`          | Matches if and only if `<expression>` does not match.  **Tip:** `!` is a special character at the start of a YAML string, if you need to use `!` at the start of a YAML string, enclose the string in quotes.
+| `<expression 1> && <expression 2>` | "And": matches if and only if both `<expression 1>`, and, `<expression 2>` matches
+| <code><expression 1> &#124;&#124; <expression 2></code> | "Or": matches if and only if either `<expression 1>`, or, `<expression 2>` matches.
+| **Match operators**       |
+| `all()`                   | Match all in-scope resources.  To match _no_ resources, combine this operator with `!` to form `!all()`.
+| `global()`                | Match all non-namespaced resources.  Useful in a `namespaceSelector` to select global resources such as global network sets.
+| `k == 'v'`                | Matches resources with the label 'k' and value 'v'.
+| `k != 'v'`                | Matches resources without label 'k' or with label 'k' and value _not_ equal to `v`
+| `has(k)`                  | Matches resources with label 'k', independent of value. To match pods that do not have label `k`, combine this operator with `!` to form `!has(k)`
+| `k in { 'v1', 'v2' }`     | Matches resources with label 'k' and value in the given set
+| `k not in { 'v1', 'v2' }` | Matches resources without label 'k' or with label 'k' and value _not_ in the given set
+| `k contains 's'`          | Matches resources with label 'k' and value containing the substring 's'
+| `k starts with 's'`       | Matches resources with label 'k' and value starting with the substring 's'
+| `k ends with 's'`         | Matches resources with label 'k' and value ending with the substring 's'
+
+Operators have the following precedence:
+
+* **Highest**: all the match operators
+* Parentheses `( ... )`
+* Negation with `!`
+* Conjunction with `&&`
+* **Lowest**: Disjunction with `||`
+
+For example, the expression
+
+```
+! has(my-label) || my-label starts with 'prod' && role in {'frontend','business'}
+```
+
+Would be "bracketed" like this:
+
+```
+((!(has(my-label)) || ((my-label starts with 'prod') && (role in {'frontend','business'}))
+```
+
+It would match:
+* Any resource that did not have label "my-label".
+* Any resource that both:
+* Has a value for `my-label` that starts with "prod", and,
+* Has a role label with value either "frontend", or "business".
+
+Understanding scopes and the `all()` and `global()` operators:  selectors have a scope of resources
+that they are matched against, which depends on the context in which they are used.  For example:
+
+* The `nodeSelector` in an `IPPool` selects over `Node` resources.
+
+* The top-level selector in a `NetworkPolicy` selects over the workloads _in the same namespace_ as the
+`NetworkPolicy`.
+
+* The top-level selector in a `GlobalNetworkPolicy` doesn't have the same restriction, it selects over all endpoints
+including namespaced `WorkloadEndpoint`s and non-namespaced `HostEndpoint`s.
+
+* The `namespaceSelector` in a `NetworkPolicy` (or `GlobalNetworkPolicy`) _rule_ selects over the labels on namespaces
+rather than workloads.
+
+* The `namespaceSelector` determines the scope of the accompanying `selector` in the entity rule.  If no `namespaceSelector`
+is present then the rule's `selector` matches the default scope for that type of policy.  (This is the same namespace
+for `NetworkPolicy` and all endpoints/network sets for `GlobalNetworkPolicy`)
+
+* The `global()` operator can be used (only) in a `namespaceSelector` to change the scope of the main `selector` to
+include non-namespaced resources such as [GlobalNetworkSet]({{ site.baseurl }}/reference/resources/globalnetworkset).
+This allows namespaced `NetworkPolicy` resources to refer to global non-namespaced resources, which would otherwise
+be impossible.
+
+
+### StringValueMatch
+A string values match does a match or negative match on a target against a set of values.
+
+| Field     | Description                                       | Accepted Values       | Schema            | Default    |
+|-----------|---------------------------------------------------|-----------------------|-------------------|------------|
+| operator  | Match operator to use against the list of values  | `IsOneOf`, `IsNoneOf` | string            |            |
+| values    | List of values to match against.                  |                       | list of strings   |            |
+
+### TimeMatch
+A time match does a match or negative match against a time or duration.
+
+Duration is the length of time into the past from the current time to match against. As an example,
+
+```yaml
+  operator: "gt"
+  duration:
+    days: 3
+```
+
+is false for 4 days prior to the current date time, and true for 2 days prior to current date time.
+
+Time is the absolute time to match a given time against. As an example,
+
+```yaml
+  operator: "gt"
+  time: "2022-01-02T0:00:00Z"
+```
+
+is false for "2022-01-01T0:00:00Z", and true for "2022-01-03T0:00:00Z".
+
+| Field     | Description                                           | Accepted Values       | Schema                                            | Default    |
+|-----------|-------------------------------------------------------|-----------------------|---------------------------------------------------|------------|
+| operator  | Match operator to use against the duration or time.   | `gt`, `lt`    | string                                            |            |
+| duration  | The duration that this operator matches within.       |               | [Duration](#duration)                             |            |
+| time      | List of values to match against.                      |               | String of the format "2006-01-02T15:04:05Z07:00"  |            |
+
+### Duration
+
+| Field     | Description                                   | Accepted Values   | Schema    | Default    |
+|-----------|-----------------------------------------------|-------------------|-----------|------------|
+| days      | Number of days past from the current time.    |                   | integer   |            |
+| months    | Number of months past from the current time.  |                   | integer   |            |
+| years     | Number of years past from the current time.   |                   | integer   |            |
+
+## Supported operations
+
+| Datastore type           | Create/Delete | Update | Get/List | Notes
+|--------------------------|---------------|--------|----------|------
+| Kubernetes API datastore | Yes           | Yes    | Yes      |

--- a/calico-cloud/reference/resources/felixconfig.mdx
+++ b/calico-cloud/reference/resources/felixconfig.mdx
@@ -4,7 +4,7 @@ description: API for this Calico Enterprise resource.
 
 # Felix configuration
 
-A [Felix](/reference/architecture/overview#felix) configuration resource (`FelixConfiguration`) represents Felix configuration options for the cluster.
+A Felix configuration resource (`FelixConfiguration`) represents Felix configuration options for the cluster.
 
 For `kubectl` commands, the following case-insensitive aliases may be used to specify the resource type on the CLI: `felixconfiguration.projectcalico.org`, `felixconfigurations.projectcalico.org` as well as abbreviations such as `felixconfiguration.p` and `felixconfigurations.p`.
 
@@ -31,7 +31,8 @@ spec:
 | ----- | --------------------------------------------------------- | --------------------------------------------------- | ------ |
 | name  | Unique name to describe this resource instance. Required. | Alphanumeric string with optional `.`, `_`, or `-`. | string |
 
-- {{prodname}} automatically creates a resource named `default` containing the global default configuration settings for Felix. You can use [calicoctl](/reference/clis/calicoctl/overview/) to view and edit these settings
+- {{prodname}} automatically creates a resource named `default` containing the global default configuration settings for Felix.
+<!--TODO-XREF-CC You can use [calicoctl](/reference/clis/calicoctl/overview/) to view and edit these settings-->
 - The resources with the name `node.<nodename>` contain the node-specific overrides, and will be applied to the node `<nodename>`. When deleting a node the FelixConfiguration resource associated with the node will also be deleted.
 
 ### Spec

--- a/calico-cloud/reference/resources/globalnetworkpolicy.mdx
+++ b/calico-cloud/reference/resources/globalnetworkpolicy.mdx
@@ -29,8 +29,10 @@ Select a namespace in a `GlobalNetworkPolicy` in the standard selector by using
 value to compare against, e.g., `projectcalico.org/namespace == "default"`.
 See [network policy resource](networkpolicy.mdx) for namespaced network policy.
 
-`GlobalNetworkPolicy` resources can be used to define network connectivity rules between groups of {{prodname}} endpoints and host endpoints, and
-take precedence over [Profile resources](/reference/resources/profile) if any are defined.
+`GlobalNetworkPolicy` resources can be used to define network connectivity rules between groups of {{prodname}} endpoints and host endpoints.
+<!--TODO-XREF-CC
+and take precedence over [Profile resources](/reference/resources/profile) if any are defined.
+-->
 
 GlobalNetworkPolicies are organized into [tiers](tier.mdx), which provide an additional layer of ordering—in particular, note that the `Pass` action skips to the
 next [tier](tier.mdx), to enable hierarchical security policy.

--- a/calico-cloud/reference/resources/kubecontrollersconfig.mdx
+++ b/calico-cloud/reference/resources/kubecontrollersconfig.mdx
@@ -34,7 +34,8 @@ spec:
 | ----- | --------------------------------------------------------- | ----------------- | ------ |
 | name  | Unique name to describe this resource instance. Required. | Must be `default` | string |
 
-- {{prodname}} automatically creates a resource named `default` containing the configuration settings, only the name `default` is used and only one object of this type is allowed. You can use [calicoctl](/reference/clis/calicoctl/overview/) to view and edit these settings
+- {{prodname}} automatically creates a resource named `default` containing the configuration settings, only the name `default` is used and only one object of this type is allowed.
+<!--TODO-XREF-CC You can use [calicoctl](/reference/clis/calicoctl/overview/) to view and edit these settings.-->
 
 ### Spec
 

--- a/calico-cloud/reference/resources/managedcluster.mdx
+++ b/calico-cloud/reference/resources/managedcluster.mdx
@@ -68,5 +68,3 @@ plane and managed plane will be reported as following:
 | ------ | ------------------------------------------------------------------------- | ------------------------- | ------ | ------------------------- |
 | type   | Type of status that is being reported                                     | -                         | string | `ManagedClusterConnected` |
 | status | Status of the connection between a Managed cluster and management cluster | `Unkown`, `True`, `False` | string | `Unknown`                 |
-
-[Multi-cluster management](/multicluster/create-a-management-cluster/)

--- a/calico-cloud/reference/resources/networkpolicy.mdx
+++ b/calico-cloud/reference/resources/networkpolicy.mdx
@@ -29,8 +29,11 @@ in that namespace. Two resources are in the same namespace if the `namespace`
 value is set the same on both.
 See [global network policy resource](globalnetworkpolicy.mdx) for non-namespaced network policy.
 
-`NetworkPolicy` resources can be used to define network connectivity rules between groups of {{prodname}} endpoints and host endpoints, and
-take precedence over [profile resources](/reference/resources/profile) if any are defined.
+`NetworkPolicy` resources can be used to define network connectivity rules between groups of {{prodname}} endpoints and host endpoints.
+
+<!--TODO-XREF-CC
+and take precedence over [profile resources](/reference/resources/profile) if any are defined.
+-->
 
 NetworkPolicies are organized into [tiers](tier.mdx), which provide an additional layer of ordering—in particular, note that the `Pass` action skips to the
 next [tier](tier.mdx), to enable hierarchical security policy.

--- a/calico-cloud/reference/resources/overview.mdx
+++ b/calico-cloud/reference/resources/overview.mdx
@@ -65,7 +65,7 @@ The following resources are supported:
 - [NetworkSet](networkset.mdx)
 - [Node](node.mdx)
 - [PacketCapture](packetcapture.mdx)
-- [Profile](/reference/resources/profile)
+<!--TODO-XREF-CC [Profile](/reference/resources/profile)-->
 - [RemoteClusterConfiguration](remoteclusterconfiguration.mdx)
 - [StagedGlobalNetworkPolicy](stagedglobalnetworkpolicy.mdx)
 - [StagedKubernetesNetworkPolicy](stagedkubernetesnetworkpolicy.mdx)

--- a/calico-cloud/reference/resources/remoteclusterconfiguration.mdx
+++ b/calico-cloud/reference/resources/remoteclusterconfiguration.mdx
@@ -14,14 +14,14 @@ A remote cluster configuration causes Typha and `calicoq` to retrieve the follow
 
 - [Workload endpoints](workloadendpoint.mdx)
 - [Host endpoints](hostendpoint.mdx)
-- [Profiles](/reference/resources/profile) (rules are not retrieved from remote profiles, only the `LabelsToApply` field is used)
+<!--TODO-XREF-CC- [Profiles](/reference/resources/profile) (rules are not retrieved from remote profiles, only the `LabelsToApply` field is used)-->
 
 When using the Kubernetes API datastore with RBAC enabled on the remote cluster, the RBAC rules must be configured to
 allow access to these resources.
 
 For more details on the federation feature refer to the [Overview](../../multicluster/overview.mdx).
 
-For the meaning of the fields matches the configuration used for configuring `calicoctl`, see [Kubernetes datastore](/operations/clis/calicoctl/configure/datastore) instructions for more details.
+<!--TODO-XREF-CC For the meaning of the fields matches the configuration used for configuring `calicoctl`, see [Kubernetes datastore](/operations/clis/calicoctl/configure/datastore) instructions for more details.-->
 
 This resource is not supported in `kubectl`.
 

--- a/calico-cloud/reference/resources/stagedglobalnetworkpolicy.mdx
+++ b/calico-cloud/reference/resources/stagedglobalnetworkpolicy.mdx
@@ -28,8 +28,10 @@ Select a namespace in a `StagedGlobalNetworkPolicy` in the standard selector by 
 value to compare against, e.g., `projectcalico.org/namespace == "default"`.
 See [staged network policy resource](stagednetworkpolicy.mdx) for staged namespaced network policy.
 
-`StagedGlobalNetworkPolicy` resources can be used to define network connectivity rules between groups of {{prodname}} endpoints and host endpoints, and
-take precedence over [Profile resources](/reference/resources/profile) if any are defined.
+`StagedGlobalNetworkPolicy` resources can be used to define network connectivity rules between groups of {{prodname}} endpoints and host endpoints.
+<!--TODO-XREF-CC
+and take precedence over [Profile resources](/reference/resources/profile) if any are defined.
+-->
 
 StagedGlobalNetworkPolicies are organized into [tiers](tier.mdx), which provide an additional layer of ordering—in particular, note that the `Pass` action skips to the
 next [tier](tier.mdx), to enable hierarchical security policy.

--- a/calico-cloud/reference/resources/stagednetworkpolicy.mdx
+++ b/calico-cloud/reference/resources/stagednetworkpolicy.mdx
@@ -28,8 +28,10 @@ in that namespace. Two resources are in the same namespace if the `namespace`
 value is set the same on both.
 See [staged global network policy resource](stagedglobalnetworkpolicy.mdx) for staged non-namespaced network policy.
 
-`StagedNetworkPolicy` resources can be used to define network connectivity rules between groups of {{prodname}} endpoints and host endpoints, and
-take precedence over [profile resources](/reference/resources/profile) if any are defined.
+`StagedNetworkPolicy` resources can be used to define network connectivity rules between groups of {{prodname}} endpoints and host endpoints.
+<!--TODO-XREF-CC
+and take precedence over [profile resources](/reference/resources/profile) if any are defined.
+-->
 
 StagedNetworkPolicies are organized into [tiers](tier.mdx), which provide an additional layer of ordering—in particular, note that the `Pass` action skips to the
 next [tier](tier.mdx), to enable hierarchical security policy.

--- a/calico-cloud/reference/resources/tier.mdx
+++ b/calico-cloud/reference/resources/tier.mdx
@@ -30,7 +30,9 @@ Policies in each Tier are then processed in order.
 
 If the Tier applies to the endpoint, but takes no action on the packet the packet is dropped.
 
+<!--TODO-XREF-CC
 If the last Tier applying to the endpoint `Pass`es the packet, that endpoint's [Profiles](/reference/resources/profile) are evaluated.
+-->
 
 ## Sample YAML
 

--- a/calico-cloud/release-notes/index.mdx
+++ b/calico-cloud/release-notes/index.mdx
@@ -122,7 +122,7 @@ Calico Cloud uses eBPF-based monitoring to log file hashes of programs running i
 If there's a match to known malware from our threat intelligence library, you receive an alert.
 You can view your alerts on the _Alerts_ page on Manager UI.
 
-To get started see, [Malware Detection](/threat/malware-detection)
+To get started see, [Malware Detection](../threat/container-threat-detection.mdx))
 
 ## July 27, 2022
 

--- a/calico-cloud/threat/security-anomalies.mdx
+++ b/calico-cloud/threat/security-anomalies.mdx
@@ -96,10 +96,12 @@ For a list of anomalies that are enabled by default, see [Anomaly detection refe
 
 - To use L7/HTTP anomaly detectors, you must enable [L7 logs](../visibility/elastic/l7/configure.mdx) on the cluster
 
+<!--TODO-XREFS-CC
 **Optional**
 
 By default models created from anomaly detection's training cycle are stored in ephemeral storage.
 To persist storage for the training models [configure a storage class](/threat/anomaly-detection/storage)
+-->
 
 ## How To
 

--- a/calico-cloud/threat/suspicious-external-ips.mdx
+++ b/calico-cloud/threat/suspicious-external-ips.mdx
@@ -136,7 +136,7 @@ the directions based on your orchestrator.
 
 **Prerequisites**:
 
-- [{{prodname}} installed](/getting-started/index)
+<!--TODO-XREFS-CC - [{{prodname}} installed](/getting-started/index)-->
 
 Ingress flow log correlation requires the Policy Sync API to be enabled on Felix. To do this cluster-wide, modify the `default`
 FelixConfiguration to set the field `policySyncPathPrefix` to `/var/run/nodeagent`.

--- a/calico-cloud/tutorials/about-calico-enterprise.mdx
+++ b/calico-cloud/tutorials/about-calico-enterprise.mdx
@@ -98,7 +98,7 @@ Connectivity issues between microservices are difficult to troubleshoot. Trouble
 
 **Documentation**
 
-- [Flow visualizer](/visibility/get-started-cem)
+<!--TODO-XREFS-CC - [Flow visualizer](/visibility/get-started-cem)-->
 - [Flow logs in Kibana](../visibility/elastic/index.mdx)
 - [Alerts](../visibility/alerts.mdx)
 - [Packet capture](../visibility/packetcapture.mdx)
@@ -181,7 +181,7 @@ When deploying a new microservice to a secure cluster, it needs to be deployed a
 - [Tiered network policy](../network-policy/policy-tiers/tiered-policy.mdx)
 - [RBAC for tiered network policy](../network-policy/policy-tiers/rbac-tiered-policies.mdx)
 - [Policy recommendations](../network-policy/generate-policy-recommendation.mdx)
-- [Policy impact preview](/network-policy/policy-impact-preview)
+<!--TODO-XREFS-CC - [Policy impact preview](/network-policy/policy-impact-preview)-->
 - [Staged network policies](../network-policy/staged-network-policies.mdx)
 
 ## Microsegmentation
@@ -203,7 +203,7 @@ Every cloud and hosting environment has a unique approach to segmentation, which
 
 **Documentation**
 
-- [Install Calico Enterprise on non-cluster hosts](/getting-started/bare-metal/index)
+<!--TODO-XREFS-CC - [Install Calico Enterprise on non-cluster hosts](/getting-started/bare-metal/index)-->
 
 ## Intrusion detection
 

--- a/calico-cloud/tutorials/kubernetes-tutorials/kubernetes-demo.mdx
+++ b/calico-cloud/tutorials/kubernetes-tutorials/kubernetes-demo.mdx
@@ -7,10 +7,12 @@ description: An interactive demo that visually shows how applying Kubernetes pol
 The included demo sets up a frontend and backend service, as well as a client service, all
 running on Kubernetes. It then configures network policy on each service.
 
+<!--TODO-XREFS-CC
 ## Prerequisites
 
 To create a Kubernetes cluster which supports the Kubernetes network policy API, follow
 one of our [getting started guides](/getting-started/index).
+-->
 
 ## Running the stars example
 

--- a/calico-cloud/tutorials/kubernetes-tutorials/kubernetes-policy-basic.mdx
+++ b/calico-cloud/tutorials/kubernetes-tutorials/kubernetes-policy-basic.mdx
@@ -6,7 +6,9 @@ description: Learn how to use basic Kubernetes network policy to securely restri
 
 This guide provides a simple way to try out Kubernetes `NetworkPolicy` with {{prodname}}. It requires a Kubernetes cluster configured with {{prodname}} networking, and expects that you have `kubectl` configured to interact with the cluster.
 
+<!--TODO-XREFS-CC
 You can quickly and easily deploy such a cluster by following one of the [installation guides](/getting-started/install-on-clusters/kubernetes/index).
+-->
 
 ## Configure namespaces
 

--- a/calico-cloud/tutorials/training/about-kubernetes-egress.mdx
+++ b/calico-cloud/tutorials/training/about-kubernetes-egress.mdx
@@ -45,7 +45,7 @@ traffic.
 One limitation when using Kubernetes Network Policy to restrict access to specific external resources, is that the external
 resources need to be specified as IP addresses (or IP address ranges) within the policy rules. If the IP addresses
 associated with an external resource change, then every policy that referenced those IP addresses needs to be updated with
-the new IP addresses. This limitation can be circumvented using {{prodname}} [Use external IPs or networks rules in policy](/network-policy/beginners/external-ips-policy/), or [DNS policy](/network-policy/beginners/domain-based-policy/) in policy rules.
+the new IP addresses. This limitation can be circumvented using {{prodname}} [Use external IPs or networks rules in policy](../../network-policy/beginners/policy-rules/external-ips-policy.mdx), or [DNS policy](../../network-policy/domain-based-policy.mdx) in policy rules.
 
 In addition to using network policy, service meshes typically allow you to configure which external services each pod
 can access. In the case of Istio, {{prodname}} can be integrated to enforce network policy at the service mesh
@@ -101,7 +101,7 @@ deployments. In these scenarios, using egress gateways is likely to be a better 
 
 ## Above and beyond
 
-- [Use external IPs or networks rules in policy](/network-policy/beginners/external-ips-policy/)
+- [Use external IPs or networks rules in policy](../../network-policy/beginners/policy-rules/external-ips-policy.mdx)
 - [Restrict a pod to use an IP address in a specific range](../../networking/ipam/legacy-firewalls.mdx)
 - [Assign IP addresses based on topology](../../networking/ipam/assign-ip-addresses-topology.mdx)
 - [Egress gateways](../../networking/egress/index.mdx)

--- a/calico-cloud/tutorials/training/about-network-policy.mdx
+++ b/calico-cloud/tutorials/training/about-network-policy.mdx
@@ -87,8 +87,10 @@ network plugins implement the mainline elements of Kubernetes network policies, 
 of the specification. ({{prodname}} does implement every feature, and was the original reference implementation of Kubernetes
 network policies.)
 
+<!--TODO-XREFS-CC
 To learn more about Kubernetes network policies, read the [Get started with Kubernetes network
 policy](/tutorials/training/tutorials/kubernetes-network-policy/) guide.
+-->
 
 ## {{prodname}} network policy
 

--- a/calico-cloud/visibility/alerts.mdx
+++ b/calico-cloud/visibility/alerts.mdx
@@ -230,7 +230,7 @@ kubectl delete globalalert <global-alert-name>
 - [GlobalAlert and templates](../reference/resources/globalalert.mdx)
 - Alerts for [honeypods](../threat/honeypod/index.mdx)
 - Alerts for [Deep packet inspection](../threat/deeppacketinspection.mdx)
-- Alerts for [anomaly detection](/threat/anomaly-detection/index)
+- Alerts for [anomaly detection](../threat/security-anomalies.mdx)
 - Alerts for [suspicious IPs](../threat/suspicious-ips.mdx)
 - Alerts for [suspicious domains](../threat/suspicious-domains.mdx)
 - Alerts for [Web Application Firewall](../threat/web-application-firewall.mdx)

--- a/calico-cloud/visibility/elastic/flow/aggregation.mdx
+++ b/calico-cloud/visibility/elastic/flow/aggregation.mdx
@@ -487,4 +487,3 @@ If you turn off aggregation, your log storage may be overwhelmed. Be sure to pro
 ## Above and beyond
 
 - [Archive logs to storage](../archive-storage.mdx)
-- [Configure data retention](/visibility/elastic/retention)

--- a/calico-cloud/visibility/elastic/l7/configure.mdx
+++ b/calico-cloud/visibility/elastic/l7/configure.mdx
@@ -46,13 +46,9 @@ L7 logs are visible in the Manager UI, service graph, in the HTTP tab.
 - L7 log collection is not supported for host-networked client pods.
 - When selecting and deselecting traffic for L7 log collection, active connections may be disrupted.
 
-**Log storage requirements**
-
-:::note
-
-L7 logs require a minimum of 1 additional GB of log storage per node, per one-day retention period. Adjust your [Log Storage](../../operations/logstorage/adjust-log-storage-size) before you start tasks in the next section.
-
-:::
+<!--TODO-XREFS-CC
+Note removed for CC
+-->
 
 ## How to
 

--- a/calico-cloud/visibility/elastic/overview.mdx
+++ b/calico-cloud/visibility/elastic/overview.mdx
@@ -95,7 +95,6 @@ verbs: ['get']
 
 ## Above and beyond
 
-- [Log storage recommendations](/operations/logstorage/log-storage-recommendations)
 - [Configure flow log aggregation](flow/aggregation.mdx)
 - [Audit logs](audit-overview.mdx)
 - [BGP logs](bgp.mdx)

--- a/calico-cloud_versioned_docs/version-3.15/_includes/components/EnvironmentFile.js
+++ b/calico-cloud_versioned_docs/version-3.15/_includes/components/EnvironmentFile.js
@@ -9,17 +9,18 @@ import { baseUrl } from '../../variables';
 export default function EnvironmentFile(props) {
   return (
     <>
-      <p>
-        <span>
-          Use the following guidelines and sample file to define the environment variables for starting Calico on the
-          host. For more help, see the{' '}
-        </span>
-        {props.install === 'container' ? (
-          <Link href={`${baseUrl}/reference/component-resources/node/configuration`}>{props.nodecontainer} configuration reference</Link>
-        ) : (
-          <Link href={`${baseUrl}/reference/felix/configuration`}>Felix configuration reference</Link>
-        )}
-      </p>
+        <p>
+            {props.install === 'container' ? (
+                <span>
+                    Use the following guidelines and sample file to define the environment variables for starting Calico on the host.
+                    For more help, see the <Link href={`${baseUrl}/reference/component-resources/node/configuration`}>{props.nodecontainer} configuration reference</Link>
+                </span>
+            ) : (
+                <span>
+                    Use the following guidelines and sample file to define the environment variables for starting Calico on the host.
+                </span>
+            )}
+        </p>
       <p>For the Kubernetes datastore set the following:</p>
       <table>
         <thead>

--- a/calico-cloud_versioned_docs/version-3.15/_includes/components/ReqsSys.js
+++ b/calico-cloud_versioned_docs/version-3.15/_includes/components/ReqsSys.js
@@ -56,6 +56,7 @@ function NodeRequirementsEnt(props) {
             interfaces. When VXLAN is enabled, {prodname} also needs to be able to manage the <code>vxlan.calico</code>{' '}
             interface.
           </p>
+          {/*
           <Admonition type='note'>
             <p>
               Many Linux distributions, such as most of the above, include NetworkManager. By default, NetworkManager
@@ -67,6 +68,7 @@ function NodeRequirementsEnt(props) {
               before installing {prodname}.
             </p>
           </Admonition>
+          */}
         </li>
         <li>
           <p>
@@ -190,10 +192,9 @@ function NetworkRequirementsEnt(props) {
         Network requirements
       </Heading>
       <p>
-        Ensure that your hosts and firewalls allow the necessary traffic based on your configuration. See{' '}
-        <Link href={`${baseUrl}/reference/architecture/overview`}>Component architecture</Link> to view the following
-        components.
+        Ensure that your hosts and firewalls allow the necessary traffic based on your configuration.
       </p>
+      {/*Above TODO-XREFS-CC */}
       <table>
         <colgroup>
           <col style={{ width: '27%' }} />

--- a/calico-cloud_versioned_docs/version-3.15/_includes/content/_non-cluster-binary-install.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/_includes/content/_non-cluster-binary-install.mdx
@@ -117,7 +117,9 @@ service calico-felix start
 <TabItem label="Manually configure Felix" value="Manually configure Felix-1">
 
 Configure Felix by creating a file at `/kubernetes/calico/felix.cfg`.
+<!--TODO-XREF-CC
 See [Felix configuration](/reference/felix/configuration) for help with environment variables.
+-->
 
 :::note
 

--- a/calico-cloud_versioned_docs/version-3.15/compliance/encrypt-cluster-pod-traffic.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/compliance/encrypt-cluster-pod-traffic.mdx
@@ -165,7 +165,7 @@ To enable both IPv4 and IPv6 WireGuard encryption across all the nodes, use the 
 kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"wireguardEnabled":true,"wireguardEnabledV6":true}}'
 ```
 
-For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources](/getting-started/install-on-clusters/openshift/installation/#provide-additional-configuration).
+<!--//TODO-CC-XREFS For OpenShift, add the Felix configuration with WireGuard enabled [under custom resources](/getting-started/install-on-clusters/openshift/installation/#provide-additional-configuration).-->
 
 :::note
 

--- a/calico-cloud_versioned_docs/version-3.15/image-assurance/install-the-admission-controller.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/image-assurance/install-the-admission-controller.mdx
@@ -98,7 +98,7 @@ Container admission policies are custom Kubernetes resources that allow you to c
 
 ## Create container admission policies
 
-Container admission policies are used to define criteria for the Admission Controller to admit or reject admission for resources that create pods. For details, see [ContainerAdmissionPolicies](/reference/resources/containeradmissionpolicy).
+Container admission policies are used to define criteria for the Admission Controller to admit or reject admission for resources that create pods. For details, see [ContainerAdmissionPolicies](../reference/resources/containeradmissionpolicy.mdx).
 
 **Sample container admission policies**
 
@@ -155,7 +155,7 @@ images that have been scanned within the last three days. So, we use the gt oper
 attempt was made to create the Kubernetes resource. If the Allow rule does not match, then the second action rule
 (Reject) is evaluated, which denies everything.
 
-You can also use modify the Allow rule to match an absolute time. For help, see [ContainerAdmissionPolicies](/reference/resources/containeradmissionpolicy).
+You can also use modify the Allow rule to match an absolute time. For help, see [ContainerAdmissionPolicies](../reference/resources/containeradmissionpolicy.mdx).
 
 ## Troubleshoot
 

--- a/calico-cloud_versioned_docs/version-3.15/multicluster/kubeconfig.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/multicluster/kubeconfig.mdx
@@ -63,10 +63,12 @@ cannot be used, because OpenShift currently does not allow users to disable the 
 - {{prodname}} with BGP
 - AKS/Azure, EKS/AWS, and GKE with VPC
 
+<!--//TODO-CC-XREFS
 **Required**
 
 - [Install {{prodname}}](/getting-started/install-on-clusters/kubernetes/index)
 - [Install and configure calicoq](/operations/clis/calicoq/installing)
+-->
 
 ## How to
 

--- a/calico-cloud_versioned_docs/version-3.15/network-policy/beginners/calico-network-policy.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/network-policy/beginners/calico-network-policy.mdx
@@ -93,11 +93,13 @@ The Kubernetes network policy specification defines the following behavior:
 
 For compatibility with Kubernetes, **Calico network policy** follows the same behavior for Kubernetes pods. For other endpoint types (VMs, host interfaces), Calico network policy is default deny. That is, only traffic specifically allowed by network policy is allowed, even if no network policies apply to the endpoint.
 
+<!--//TODO-CC-XREFS
 ## Before you begin
 
 `calicoctl` must be **installed** and **configured** before use. `calicoctl` will use Kubernetes as the datastore. You can find more information on how to configure `calicoctl` in the following link:
 
 - [Configure `calicoctl`](/operations/clis/calicoctl/configure/overview)
+-->
 
 ## How to
 

--- a/calico-cloud_versioned_docs/version-3.15/network-policy/beginners/simple-policy-cnx.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/network-policy/beginners/simple-policy-cnx.mdx
@@ -8,11 +8,13 @@ This guide is a variation of the [simple policy demo](../../tutorials/kubernetes
 
 It requires a Kubernetes cluster configured with Calico networking and {{prodname}}, and expects that you have `kubectl` configured to interact with the cluster.
 
+<!--//TODO-CC-XREFS
 You can quickly and easily obtain such a cluster by following one of the
 [installation guides](/getting-started/install-on-clusters/kubernetes/index),
 or by [upgrading an existing cluster](/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/index).
 
 The key steps in moving to {{prodname}} are to change to the {{prodname}} version of calico-node, update its configuration, download [calicoq](/reference/clis/calicoq/index) and deploy Prometheus.
+-->
 
 This guide assumes that you have installed all the {{prodname}} components from the
 guides above and that your cluster consists of the following nodes:
@@ -79,7 +81,7 @@ We'll use Kubernetes `Deployment` objects to easily create pods in the namespace
    calicoq complements calicoctl by inspecting the
    dynamic aspects of {{prodname}} Policy: in particular displaying the endpoints actually affected by policies,
    and the policies that actually apply to endpoints.
-   The full calicoq documentation is [here](/reference/clis/calicoq/index).
+   <!--//TODO-CC-XREFS The full calicoq documentation is [here](/reference/clis/calicoq/index). -->
 
    :::
 

--- a/calico-cloud_versioned_docs/version-3.15/network-policy/hosts/protect-hosts.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/network-policy/hosts/protect-hosts.mdx
@@ -58,7 +58,7 @@ No. {{prodname}} allows connections the host makes to the workloads running on t
 
 ## Before you begin...
 
-If you are already running {{prodname}} for Kubernetes, you are good to go. If you want to install {{prodname}} on a non-cluster machine for host protection only, see [Non-cluster hosts](/getting-started/bare-metal/index).
+If you are already running {{prodname}} for Kubernetes, you are good to go. If you want to install {{prodname}} on a non-cluster machine for host protection only, see [Install network policy on non-cluster hosts](../../network-policy/hosts/about.mdx).
 
 ## How to
 

--- a/calico-cloud_versioned_docs/version-3.15/network-policy/policy-firewalls/aws-integration/aws-security-group-integration.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/network-policy/policy-firewalls/aws-integration/aws-security-group-integration.mdx
@@ -48,14 +48,16 @@ AWS security group integration for {{prodname}} allows you to combine AWS securi
   kubectl get pod -n kube-system -l k8s-app=aws-node -o wide
   ```
 
+<!--//TODO-CC-XREFS Note: The multiline comment and text must be aligned in col 1.
 - You have installed [{{prodname}} for EKS](/getting-started/install-on-clusters/eks/)
-  on your cluster, or kubeadm/kops.
+on your cluster, or kubeadm/kops.
 
-  Verify {{prodname}} has been installed by confirming that all tigerastatuses are available:
+Verify {{prodname}} has been installed by confirming that all tigerastatuses are available:
 
-  ```batch
-  kubectl get tigerastatus
+```batch
+kubectl get tigerastatus
   ```
+-->
 
 - You have installed {{prodname}} configured to work with the AWS CNI Plugin. This is done by following the installation guide for EKS on your cluster or configuring the Installation resource during installation and setting the CNI.Type to `AmazonVPC`.
 

--- a/calico-cloud_versioned_docs/version-3.15/network-policy/policy-firewalls/fortinet-integration/firewall-integration.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/network-policy/policy-firewalls/fortinet-integration/firewall-integration.mdx
@@ -42,7 +42,7 @@ The basic workflow is:
 
 **Required**
 
-- Pull secret that you used during [{{prodname}} installation](/getting-started/install-on-clusters/index)
+<!--//TODO-CC-XREFS - Pull secret that you used during [{{prodname}} installation](/getting-started/install-on-clusters/index)-->
 - IPv4 CIDR’s or IP addresses of all Kubernetes nodes; this is required for FortiManager to treat Kubernetes nodes as trusted hosts.
 
 **Recommended**

--- a/calico-cloud_versioned_docs/version-3.15/network-policy/policy-firewalls/fortinet-integration/fortimgr-integration.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/network-policy/policy-firewalls/fortinet-integration/fortimgr-integration.mdx
@@ -49,9 +49,12 @@ The default value for reading FortiManager firewall policies is three seconds. T
 
 **Required**
 
-- Pull secret that you used during [{{prodname}} installation](/getting-started/install-on-clusters/index)
 - IPv4 CIDR’s or IP addresses of all Kubernetes nodes; this is required for FortiManager to treat Kubernetes nodes as trusted hosts.
+
+<!--//TODO-CC-XREF
+- Pull secret that you used during [{{prodname}} installation](/getting-started/install-on-clusters/index)
 - Login access to [{{prodname}} Manager UI](/operations/cnx/access-the-manager/)
+-->
 
 **Recommended**
 

--- a/calico-cloud_versioned_docs/version-3.15/networking/configuring/bgp.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/networking/configuring/bgp.mdx
@@ -61,7 +61,8 @@ For a deeper look at common on-premises deployment models, see [Calico over IP F
 **Required**
 
 - Calico CNI
-- [calicoctl](/operations/clis/calicoctl/install) must be installed and configured
+
+<!--//TODO-CC-XREF- [calicoctl](/operations/clis/calicoctl/install) must be installed and configured-->
 
 ## How to
 
@@ -225,9 +226,11 @@ Where `<NODE_NAME>` is the resource name for one of the Calico node pods within 
 
 :::note
 
-The above command can be run from anywhere you have access to kubectl. We recommend running it as a kubectl plugin. [Follow these instructions](/operations/clis/calicoctl/install#install-calicoctl-as-a-kubectl-plugin-on-a-single-host) for how to install `calicoctl` as a kubectl plugin.
+The above command can be run from anywhere you have access to kubectl. We recommend running it as a kubectl plugin.
+<!--//TODO-CC-XREFS [Follow these instructions] (../../operations/clis/calicoctl/install.mdx#install-calicoctl-as-a-kubectl-plugin-on-a-single-host) for how to install `calicoctl` as a kubectl plugin.-->
 
 :::
+
 If you install the binary as a kubectl plugin using the above instructions, you can then run the command as follows:
 
 ```

--- a/calico-cloud_versioned_docs/version-3.15/networking/configuring/custom-bgp-config.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/networking/configuring/custom-bgp-config.mdx
@@ -34,7 +34,7 @@ for the BGP configuration using these resources:
 
 - [BGP Configuration](../../reference/resources/bgpconfig.mdx)
 - [BGP Peer](../../reference/resources/bgppeer.mdx)
-- [calicoctl](/reference/clis/calicoctl/index)
+<!-- //TODO-CC-XREFS - [calicoctl](/reference/clis/calicoctl/index)-->
 
 ### Apply BGP Customizations
 

--- a/calico-cloud_versioned_docs/version-3.15/networking/configuring/dual-tor.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/networking/configuring/dual-tor.mdx
@@ -601,8 +601,9 @@ at two examples: with OpenShift, and when adding Calico to an existing Kubernete
 
 **OpenShift**
 
-With OpenShift, follow [our documentation](/getting-started/install-on-clusters/openshift/index) as
-far as the option to [provide additional configuration](/getting-started/install-on-clusters/openshift/installation/).
+With OpenShift, follow our documentation as
+far as the option to provide additional configuration.
+<!--TODO-XREFS-CC -->
 Then use `kubectl create configmap ...`, as that documentation says, to combine the
 prepared BGPPeer, BGPConfiguration and IPPool resources into a `calico-resources`
 ConfigMap. Place the generated file in the manifests directory for the OpenShift install.
@@ -614,7 +615,9 @@ resources into the datastore as early as possible.
 
 **Adding to an existing Kubernetes cluster**
 
-Follow [our documentation](/getting-started/install-on-clusters/kubernetes/generic-install/) as
+Follow our documentation
+<!--TODO-XREFS-CC -->
+as
 far as the option for installing any custom Calico resources. Then use `calicoctl`, as
 that documentation says, to install the prepared BGPPeer, BGPConfiguration and IPPool
 resources.

--- a/calico-cloud_versioned_docs/version-3.15/networking/configuring/multiple-networks.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/networking/configuring/multiple-networks.mdx
@@ -71,7 +71,7 @@ Although the following {{prodname}} features are supported for your default {{pr
 
   :::
 
-- [Install and configure calicoctl](/operations/clis/calicoctl/index) or configure access to [Calico Enterprise Manager UI](/operations/cnx//access-the-manager/)
+<!--//TODO-CC-XREFS- [Install and configure calicoctl](/operations/clis/calicoctl/index) or configure access to [Calico Enterprise Manager UI](/operations/cnx//access-the-manager/)-->
 
 ## How to
 

--- a/calico-cloud_versioned_docs/version-3.15/networking/configuring/workloads-outside-cluster.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/networking/configuring/workloads-outside-cluster.mdx
@@ -74,7 +74,3 @@ spec:
   cidr: 10.0.0.0/8
   disabled: true
 ```
-
-## Above and beyond
-
-To learn about inbound connectivity, see [External connectivity](/networking/external-connectivity)

--- a/calico-cloud_versioned_docs/version-3.15/networking/egress/troubleshoot.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/networking/egress/troubleshoot.mdx
@@ -181,7 +181,7 @@ If the outbound connection cannot be established, the policy may be denying the 
 - From the gateway pod, egress
 - Any relevant HostEndpoints that are configured in your cluster
 
-In [Manager UI](/visibility/get-started-cem), check for dropped packets because of policy on the outbound connection path. If you are using the iptables dataplane, you can also run the following command on the client and gateway nodes to look at a lower level.
+In [Manager UI](../../tutorials/calico-cloud-features/tour.mdx), check for dropped packets because of policy on the outbound connection path. If you are using the iptables dataplane, you can also run the following command on the client and gateway nodes to look at a lower level.
 
 ```
 watch iptables-save -c | grep DROP | grep -v 0:0

--- a/calico-cloud_versioned_docs/version-3.15/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/networking/ipam/get-started-ip-addresses.mdx
@@ -66,11 +66,13 @@ The host-local IPAM plugin is primarily used by other methods of routing pod tra
 
 ### Install {{prodname}} with calico-ipam
 
-Follow one of the [getting started guides](/getting-started/index) to install {{prodname}}.
+Follow one of the getting started guides to install {{prodname}}.
+<!-- TODO-XREFS-CC -->
 
 ### Install {{prodname}} with host-local IPAM
 
-Follow one of the [getting started guides](/getting-started/index) to install {{prodname}} with flannel networking, or on GKE.
+Follow one of the getting started guides to install {{prodname}} with flannel networking, or on GKE.
+<!-- TODO-XREFS-CC -->
 
 Or, see the [reference documentation on host-local IPAM](../../reference/component-resources/configuration.mdx#using-host-local-ipam).
 
@@ -88,5 +90,6 @@ There are several other ways to leverage {{prodname}} IPAM including:
 - [Use a specific address for a pod](use-specific-ip.mdx)
 - [Migrate from one IP pool to another](migrate-pools.mdx)
 - [Restrict a pod to use an IP address in a specific range](legacy-firewalls.mdx)
-- [View IP address utilization](/reference/clis/calicoctl/ipam/show/)
 - [Change IP address block size](../../reference/resources/ippool.mdx)
+
+<!--TODO-XREFS-CC - [View IP address utilization](/reference/clis/calicoctl/ipam/show/)-->

--- a/calico-cloud_versioned_docs/version-3.15/networking/ipam/initial-ippool.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/networking/ipam/initial-ippool.mdx
@@ -38,7 +38,7 @@ resource and configures the default Calico IP pool. Note the following:
   - NodeSelector: all()
   - NATOutgoing: Enabled
 - IP pools are only used when Calico is used for pod networking, IP pools are not utilized when using other pod networking solutions.
-- To make changes to the IP pools after Tigera Operator install, you may use [calicoctl](/reference/clis/calicoctl/index) or kubectl. If you make the changes to the IP Pool in the Installation resource (Operator IPPool) after installation, the the changes are not applied.
+- To make changes to the IP pools after Tigera Operator install, you may use calicoctl or kubectl. If you make the changes to the IP Pool in the Installation resource (Operator IPPool) after installation, the the changes are not applied.
 
 ## Before you begin...
 
@@ -72,4 +72,7 @@ resource and configures the default Calico IP pool. Note the following:
 ## Above and beyond
 
 - [IP pool resource](../../reference/resources/ippool.mdx)
+
+<!--TODO-XREFS-CC
 - Use [calicoctl](/reference/clis/calicoctl/index) or `kubectl` to edit the IPPool resource.
+-->

--- a/calico-cloud_versioned_docs/version-3.15/networking/ipam/ip-autodetection.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/networking/ipam/ip-autodetection.mdx
@@ -243,4 +243,4 @@ calicoctl patch node kind-control-plane \
 - For details on autodetection methods, see the [node configuration](../../reference/component-resources/node/configuration.mdx) reference.
 - For calicoctl environment variables, see [Configuring {{nodecontainer}}](../../reference/component-resources/node/configuration.mdx)
 - [Node resource](../../reference/resources/node.mdx)
-- [Reference documentation for calicoctl patch](/reference/clis/calicoctl/patch/)
+<!--//TODO-CC-XREFS- [Reference documentation for calicoctl patch](/reference/clis/calicoctl/patch/)-->

--- a/calico-cloud_versioned_docs/version-3.15/networking/training/about-kubernetes-networking.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/networking/training/about-kubernetes-networking.mdx
@@ -57,9 +57,11 @@ There are lots of different kinds of CNI plugins, but the two main ones are:
 
 {{prodname}} provides both network and IPAM plugins, but can also integrate and work seamlessly with some other CNI
 plugins, including AWS, Azure, and Google network CNI plugins, and the host local IPAM plugin. This flexibility allows
-you to choose the best networking options for your specific needs and deployment environment. You can read more about
+you to choose the best networking options for your specific needs and deployment environment.
+<!--//TODO-CC-XREFS You can read more about
 this in the {{prodname}} [determine best networking option](/networking/determine-best-networking)
 guide.
+-->
 
 ## Kubernetes Services
 
@@ -115,8 +117,12 @@ node IP is routable). Return packets on the connection are automatically mapped 
 with the pod IP before forwarding the packet to the pod.
 
 When using {{prodname}}, depending on your environment, you can generally choose whether you prefer to run an
-overlay network, or prefer to have fully routable pod IPs. You can read more about this in the {{prodname}}
-[determine best networking option](/networking/determine-best-networking) guide. {{prodname}} also
+overlay network, or prefer to have fully routable pod IPs.
+<!--TODO-XREFS-CC
+You can read more about this in the {{prodname}}
+[determine best networking option](/networking/determine-best-networking) guide.
+-->
+{{prodname}} also
 allows you to [configure outgoing NAT](../configuring/workloads-outside-cluster.mdx) for specific IP address
 ranges if more granularity is desired.
 

--- a/calico-cloud_versioned_docs/version-3.15/networking/training/about-networking.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/networking/training/about-networking.mdx
@@ -10,8 +10,8 @@ This guide provides educational material that is not specific to {{prodname}}.
 
 :::
 
-You can get up and running with {{prodname}} by following any of the {{prodname}} [install
-guides](/getting-started/index) without needing to be a networking expert. {{prodname}} hides the complexities for
+You can get up and running with {{prodname}} by following any of the {{prodname}} install
+guides without needing to be a networking expert. {{prodname}} hides the complexities for
 you. However, if you would like to learn more about networking so you can better understand what is happening under the
 covers, this guide provides a short introduction to some of the key fundamental networking concepts for anyone who is
 not already familiar with them.
@@ -117,8 +117,11 @@ the downsides of:
   are required to bridge between the overlay and the underlay network for any ingress to, or egress from, the overlay.
 
 {{prodname}} networking options are exceptionally flexible, so in general you can choose whether you prefer
-{{prodname}} to provide an overlay network, or non-overlay network. You can read more about this in the {{prodname}}
+{{prodname}} to provide an overlay network, or non-overlay network.
+<!--TODO-XREFS-CC
+You can read more about this in the {{prodname}}
 [determine best networking option](/networking/determine-best-networking) guide.
+-->
 
 ## DNS
 

--- a/calico-cloud_versioned_docs/version-3.15/operations/comms/apiserver-tls.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/operations/comms/apiserver-tls.mdx
@@ -47,6 +47,8 @@ If the {{prodname}} API server is already running, updating the secret restarts 
 
 :::
 
+<!--TODO-XREFS-CC
 ## Above and beyond
 
-Additional documentation is available for securing [{{prodname}} manager connections](crypto-auth.mdx#connections-from-calico-enterprise-components-to-kube-apiserver-kubernetes-and-openshift).
+Additional documentation is available for securing [{{prodname}} manager connections](crypto-auth.mdx).
+-->

--- a/calico-cloud_versioned_docs/version-3.15/operations/comms/certificate-management.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/operations/comms/certificate-management.mdx
@@ -22,8 +22,9 @@ If your cluster is already running {{prodname}} and you would like to enable cer
 temporarily remove [the logstorage resource](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
 before following the steps to enable certificate management and then re-apply afterwards.
 
+<!--TODO-XREFS-CC
 Currently, this feature is not supported in combination with [Multi-cluster management](/multicluster/create-a-management-cluster/).
-
+-->
 **Supported algorithms**
 
 - Private Key Pair: RSA (size: 2048, 4096, 8192), ECDSA (curve: 256, 384, 521)

--- a/calico-cloud_versioned_docs/version-3.15/operations/comms/crypto-auth.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/operations/comms/crypto-auth.mdx
@@ -22,9 +22,9 @@ For clusters installed using operator, see how to [provide TLS certificates for 
 
 For detailed reference information on TLS configuration parameters, refer to:
 
-- **Typha**: [Node-Typha TLS configuration](/reference/component-resources/typha/configuration#felix-typha-tls-configuration)
-
 - **Node**: [Node-Typha TLS configuration](../../reference/component-resources/node/felix/configuration.mdx#felix-typha-tls-configuration)
+
+<!--TODO-XREFS-CC - **Typha**: [Node-Typha TLS configuration](../../reference/component-resources/typha/configuration#felix-typha-tls-configuration)-->
 
 # {{prodname}} Manager connections
 

--- a/calico-cloud_versioned_docs/version-3.15/operations/comms/manager-tls.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/operations/comms/manager-tls.mdx
@@ -15,8 +15,11 @@ By default, the {{prodname}} manager UI uses self-signed TLS certificates on con
 ## Before you begin...
 
 - **Get the certificate and key pair for the {{prodname}} Manager UI**
-  Generate the certificate using any X.509-compatible tool or from your organization's Certificate Authority. The certificate must have Common Name or Subject Alternate Names that match the IPs or DNS names that will be used to [access the manager UI](/operations/cnx/access-the-manager/).
+  Generate the certificate using any X.509-compatible tool or from your organization's Certificate Authority.
 
+<!--TODO-XREFS-CC
+The certificate must have Common Name or Subject Alternate Names that match the IPs or DNS names that will be used to [access the manager UI](/operations/cnx/access-the-manager/).
+-->
 ## How to
 
 To provide certificates for use during deployment you must create a secret before applying the 'custom-resource.yaml' or before creating the Installation resource. To specify certificates for use in the manager, create a secret using the following command:

--- a/calico-cloud_versioned_docs/version-3.15/operations/comms/secure-metrics.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/operations/comms/secure-metrics.mdx
@@ -12,7 +12,10 @@ to limit access to {{prodname}}'s metrics endpoints.
 ## Prerequisites
 
 - {{prodname}} is installed with Prometheus metrics reporting enabled.
+
+<!--TODO-XREFS-CC
 - `calicoctl` is [installed in your PATH and configured to access the data store](/operations/clis/calicoctl/install).
+-->
 
 ## Choosing an approach
 

--- a/calico-cloud_versioned_docs/version-3.15/operations/decommissioning-a-node.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/operations/decommissioning-a-node.mdx
@@ -31,8 +31,9 @@ information.
 - Prior to removing any Node resource from the datastore the `{{nodecontainer}}`
   container should be stopped on the corresponding host and it should be
   ensured that it will not be restarted.
-- You must have [calicoctl configured](/operations/clis/calicoctl/install/) and operational to run
+- You must have calicoctl configured and operational to run
   the commands listed here.
+<!--TODO-XREFS-CC -->
 
 ## Removing a node resource
 

--- a/calico-cloud_versioned_docs/version-3.15/operations/ebpf/install.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/operations/ebpf/install.mdx
@@ -42,7 +42,8 @@ and in particular, pushing the networking capabilities of the latest Linux kerne
 
   - Ubuntu 20.04.
   - Red Hat v8.2 with Linux kernel v4.18.0-193 or above (Red Hat have backported the required features to that build).
-  - Another [supported distribution](/getting-started/install-on-clusters/requirements/) with Linux kernel v5.3 or above.
+  - Another supported distribution with Linux kernel v5.3 or above.
+<!--TODO-XREFS-CC -->
 
 - An underlying network fabric that allows VXLAN traffic between hosts. In eBPF mode, VXLAN is used to forward Kubernetes NodePort traffic.
 
@@ -55,7 +56,8 @@ and in particular, pushing the networking capabilities of the latest Linux kerne
 
 :::note
 
-eBPF supports AKS with Calico CNI and {{prodname}} network policy. However, with [AKS with Azure CNI and {{prodname}} network policy](/getting-started/install-on-clusters/aks/#install-with-azure-cni-networking), kube-proxy cannot be disabled so the performance benefits of eBPF are lost. However, there are other reasons to use eBPF other than performance gains, as described in [eBPF use cases](use-cases-ebpf.mdx).
+eBPF supports AKS with Calico CNI and {{prodname}} network policy. However, with AKS with Azure CNI and {{prodname}} network policy, kube-proxy cannot be disabled so the performance benefits of eBPF are lost. However, there are other reasons to use eBPF other than performance gains, as described in [eBPF use cases](use-cases-ebpf.mdx).
+<!--TODO-XREFS-CC -->
 
 :::
 

--- a/calico-cloud_versioned_docs/version-3.15/operations/fips.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/operations/fips.mdx
@@ -52,7 +52,8 @@ agencies and government contractors. {{prodname}} FIPS mode is enabled during in
 
 To install {{prodname}} in FIPS mode follow these steps.
 
-1. Follow [the installation steps](/getting-started/install-on-clusters/kubernetes/index) for your platform.
+1. Follow the installation steps for your platform.
+<!--TODO-XREFS-CC -->
 
    - In the step for installing custom resources, edit `custom-resources.yaml` and enable FIPS mode in the installation spec.
 
@@ -66,7 +67,7 @@ To install {{prodname}} in FIPS mode follow these steps.
    ```
 
    - For more information on configuration options available in this manifest, see [the installation reference](../reference/installation/api.mdx).
-     We strongly recommend that you [adjust log storage](/operations/logstorage/adjust-log-storage-size) according to the example.
+     <!--TODO-XREFS-CC We strongly recommend that you [adjust log storage](/operations/logstorage/adjust-log-storage-size) according to the example.-->
 
 2. Upgrade to the required Elasticsearch Platinum license to run FIPS mode.
 

--- a/calico-cloud_versioned_docs/version-3.15/reference/architecture/design/l3-interconnect-fabric.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/reference/architecture/design/l3-interconnect-fabric.mdx
@@ -29,11 +29,12 @@ fabrics.
 ## Background
 
 ### Basic {{prodname}} architecture overview
-
+<!--TODO-XREFS-CC
 A description of the {{prodname}} architecture can be found in our
 [architectural overview](/reference/architecture/overview).
 However, a brief discussion of the routing and data paths is useful for
 the discussion.
+-->
 
 In a {{prodname}} network, each compute server acts as a router for all of the
 endpoints that are hosted on that compute server. We call that function
@@ -109,7 +110,7 @@ The two methods are:
 
 1.  A BGP fabric where each of the TOR switches (and their subsidiary
     compute servers) are a unique [Autonomous
-    System (AS)](/reference/architecture/design/<https:/en.wikipedia.org/wiki/Autonomous_System_(Internet)>)
+    System (AS)](https:/en.wikipedia.org/wiki/Autonomous_System_(Internet)>)
     and they are interconnected via either an Ethernet switching plane
     provided by the spine switches in a
     [leaf/spine](http://bradhedlund.com/2012/10/24/video-a-basic-introduction-to-the-leafspine-data-center-networking-fabric-design/)

--- a/calico-cloud_versioned_docs/version-3.15/reference/faq.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/reference/faq.mdx
@@ -269,7 +269,7 @@ If a host's containers are connected to the `docker0` bridge interface, {{prodna
 would be unable to enforce security rules between workloads on the same host;
 all containers on the bridge would be able to communicate with one other.
 
-You can securely configure port mapping by following [External connectivity](/networking/external-connectivity).
+You can securely configure port mapping by following [Configure outgoing NAT](../networking/configuring/workloads-outside-cluster.mdx.
 
 ## Can {{prodname}} containers use any IP address within a pool, even subnet network/broadcast addresses?
 
@@ -293,7 +293,7 @@ center. Access to that network is via a router, which also is the default
 router for all the container hosts.
 
 If this describes your infrastructure,
-[External connectivity](/networking/external-connectivity) explains in more detail
+[Configure outgoing NAT](../networking/configuring/workloads-outside-cluster.mdx explains in more detail
 what to do. Otherwise, if you have a layer 3 (IP) fabric, then there are
 detailed datacenter networking recommendations given
 in [{{prodname}} over IP fabrics](architecture/design/l3-interconnect-fabric.mdx).

--- a/calico-cloud_versioned_docs/version-3.15/reference/public-cloud/aws.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/reference/public-cloud/aws.mdx
@@ -173,4 +173,4 @@ Install the AWS VPC CNI plugin in your Kubernetes cluster as follows.
    kubectl apply -f aws-k8s-cni.yaml
    ```
 
-1. Follow the instructions to install [{{prodname}} on AWS](/getting-started/install-on-clusters/aws/).
+1. Follow the instructions to install {{prodname}} on AWS.

--- a/calico-cloud_versioned_docs/version-3.15/reference/resources/containeradmissionpolicy.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/reference/resources/containeradmissionpolicy.mdx
@@ -1,0 +1,194 @@
+---
+description: Resource definition.
+---
+# Container admission policy
+
+A container admission policy (`ContainerAdmissionPolicy`) represents an ordered set of rules which are applied to a
+collection of containers that match a [label selector](#selector).
+
+`ContainerAdmissionPolicy` is a cluster resource. `ContainerAdmissionPolicy` can be restricted to a set of namespaces
+using a [namespace selector](#selector).
+
+## Sample YAML
+
+This sample policy allows admission requests for pod creating resources whose image is in the registry / repository
+`gcr.io/company/production-repository/*` with a scan status of either `Pass` or `Warn`, and rejects all other admission
+requests.
+
+```yaml
+apiVersion: containersecurity.tigera.io/v1beta1
+kind: ContainerAdmissionPolicy
+metadata:
+  name: reject-failed-and-non-gcr
+spec:
+  selector: all()
+  namespaceSelector: all()
+  order: 10
+  rules:
+  - action: "Reject"
+    imagePath:
+      operator: IsNoneOf
+      values:
+      - "^gcr.io/company/production-repository/.*"
+  - action: Allow
+    imageScanStatus:
+      operator: IsOneOf
+      values:
+      - Pass
+      - Warn
+  - action: Reject
+```
+
+## Container admission policy definition
+
+### Metadata
+
+| Field     | Description                                                        | Accepted Values                                     | Schema | Default   |
+|-----------|--------------------------------------------------------------------|-----------------------------------------------------|--------|-----------|
+| name      | The name of the network policy. Required.                          | Alphanumeric string with optional `.`, `_`, or `-`. | string |           |
+
+### Spec
+
+| Field             | Description                                                                                         | Accepted Values | Schema                | Default |
+|-------------------|-----------------------------------------------------------------------------------------------------|-----------------|-----------------------|---------|
+| order             | Controls the order of precedence. {{site.prodname}} applies the policy with the lowest value first. |                 | float                 |         |
+| selector          | Selects the resources to which this policy applies.                                                 |                 | [selector](#selector) | all()   |
+| namespaceSelector | Selects the namespace to which this policy applies.                                                 |                 | [selector](#selector) | all()   |
+| rules             | Ordered list of rules applied by this policy.                                                       |                 | List of [Rule](#rule) |         |
+
+### Rule
+
+A single rule matches a set of pod creating resources and applies some action to them.  Multiple rules are executed in order.
+
+| Field             | Description                                | Accepted Values                                                   | Schema                                     | Default    |
+|-------------------|---------------------------------------------------------------------|------------------------------------------|--------------------------------------------|------------|
+| action            | Action to perform when matching this rule.                    | `Allow`, `Reject`                        | string                                     |            |
+| imagePath         | Image path matching criteria.                                 |                                          | [String Values Match](#stringvaluematch)   |            |
+| imageScanStatus   | Vulnerability scan status criteria.                           |                                          | [String Values Match](#stringvaluematch)   |            |
+| imageLastScan     | Criteria for the last time the containers image was scanned.  |                                          | [Time Match](#timematch)                   |            |
+
+### Selector
+
+A label selector is an expression which either matches or does not match a resource based on its labels.
+
+{{site.prodname}} label selectors support a number of operators, which can be combined into larger expressions
+using the boolean operators and parentheses.
+
+| Expression                | Meaning                     |
+|---------------------------|-----------------------------|
+| **Logical operators**     |
+| `( <expression> )`        | Matches if and only if `<expression>` matches.  (Parentheses are used for grouping expressions.)
+| `! <expression>`          | Matches if and only if `<expression>` does not match.  **Tip:** `!` is a special character at the start of a YAML string, if you need to use `!` at the start of a YAML string, enclose the string in quotes.
+| `<expression 1> && <expression 2>` | "And": matches if and only if both `<expression 1>`, and, `<expression 2>` matches
+| <code><expression 1> &#124;&#124; <expression 2></code> | "Or": matches if and only if either `<expression 1>`, or, `<expression 2>` matches.
+| **Match operators**       |
+| `all()`                   | Match all in-scope resources.  To match _no_ resources, combine this operator with `!` to form `!all()`.
+| `global()`                | Match all non-namespaced resources.  Useful in a `namespaceSelector` to select global resources such as global network sets.
+| `k == 'v'`                | Matches resources with the label 'k' and value 'v'.
+| `k != 'v'`                | Matches resources without label 'k' or with label 'k' and value _not_ equal to `v`
+| `has(k)`                  | Matches resources with label 'k', independent of value. To match pods that do not have label `k`, combine this operator with `!` to form `!has(k)`
+| `k in { 'v1', 'v2' }`     | Matches resources with label 'k' and value in the given set
+| `k not in { 'v1', 'v2' }` | Matches resources without label 'k' or with label 'k' and value _not_ in the given set
+| `k contains 's'`          | Matches resources with label 'k' and value containing the substring 's'
+| `k starts with 's'`       | Matches resources with label 'k' and value starting with the substring 's'
+| `k ends with 's'`         | Matches resources with label 'k' and value ending with the substring 's'
+
+Operators have the following precedence:
+
+* **Highest**: all the match operators
+* Parentheses `( ... )`
+* Negation with `!`
+* Conjunction with `&&`
+* **Lowest**: Disjunction with `||`
+
+For example, the expression
+
+```
+! has(my-label) || my-label starts with 'prod' && role in {'frontend','business'}
+```
+
+Would be "bracketed" like this:
+
+```
+((!(has(my-label)) || ((my-label starts with 'prod') && (role in {'frontend','business'}))
+```
+
+It would match:
+* Any resource that did not have label "my-label".
+* Any resource that both:
+* Has a value for `my-label` that starts with "prod", and,
+* Has a role label with value either "frontend", or "business".
+
+Understanding scopes and the `all()` and `global()` operators:  selectors have a scope of resources
+that they are matched against, which depends on the context in which they are used.  For example:
+
+* The `nodeSelector` in an `IPPool` selects over `Node` resources.
+
+* The top-level selector in a `NetworkPolicy` selects over the workloads _in the same namespace_ as the
+`NetworkPolicy`.
+
+* The top-level selector in a `GlobalNetworkPolicy` doesn't have the same restriction, it selects over all endpoints
+including namespaced `WorkloadEndpoint`s and non-namespaced `HostEndpoint`s.
+
+* The `namespaceSelector` in a `NetworkPolicy` (or `GlobalNetworkPolicy`) _rule_ selects over the labels on namespaces
+rather than workloads.
+
+* The `namespaceSelector` determines the scope of the accompanying `selector` in the entity rule.  If no `namespaceSelector`
+is present then the rule's `selector` matches the default scope for that type of policy.  (This is the same namespace
+for `NetworkPolicy` and all endpoints/network sets for `GlobalNetworkPolicy`)
+
+* The `global()` operator can be used (only) in a `namespaceSelector` to change the scope of the main `selector` to
+include non-namespaced resources such as [GlobalNetworkSet]({{ site.baseurl }}/reference/resources/globalnetworkset).
+This allows namespaced `NetworkPolicy` resources to refer to global non-namespaced resources, which would otherwise
+be impossible.
+
+
+### StringValueMatch
+A string values match does a match or negative match on a target against a set of values.
+
+| Field     | Description                                       | Accepted Values       | Schema            | Default    |
+|-----------|---------------------------------------------------|-----------------------|-------------------|------------|
+| operator  | Match operator to use against the list of values  | `IsOneOf`, `IsNoneOf` | string            |            |
+| values    | List of values to match against.                  |                       | list of strings   |            |
+
+### TimeMatch
+A time match does a match or negative match against a time or duration.
+
+Duration is the length of time into the past from the current time to match against. As an example,
+
+```yaml
+  operator: "gt"
+  duration:
+    days: 3
+```
+
+is false for 4 days prior to the current date time, and true for 2 days prior to current date time.
+
+Time is the absolute time to match a given time against. As an example,
+
+```yaml
+  operator: "gt"
+  time: "2022-01-02T0:00:00Z"
+```
+
+is false for "2022-01-01T0:00:00Z", and true for "2022-01-03T0:00:00Z".
+
+| Field     | Description                                           | Accepted Values       | Schema                                            | Default    |
+|-----------|-------------------------------------------------------|-----------------------|---------------------------------------------------|------------|
+| operator  | Match operator to use against the duration or time.   | `gt`, `lt`    | string                                            |            |
+| duration  | The duration that this operator matches within.       |               | [Duration](#duration)                             |            |
+| time      | List of values to match against.                      |               | String of the format "2006-01-02T15:04:05Z07:00"  |            |
+
+### Duration
+
+| Field     | Description                                   | Accepted Values   | Schema    | Default    |
+|-----------|-----------------------------------------------|-------------------|-----------|------------|
+| days      | Number of days past from the current time.    |                   | integer   |            |
+| months    | Number of months past from the current time.  |                   | integer   |            |
+| years     | Number of years past from the current time.   |                   | integer   |            |
+
+## Supported operations
+
+| Datastore type           | Create/Delete | Update | Get/List | Notes
+|--------------------------|---------------|--------|----------|------
+| Kubernetes API datastore | Yes           | Yes    | Yes      |

--- a/calico-cloud_versioned_docs/version-3.15/reference/resources/felixconfig.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/reference/resources/felixconfig.mdx
@@ -4,7 +4,7 @@ description: API for this Calico Enterprise resource.
 
 # Felix configuration
 
-A [Felix](/reference/architecture/overview#felix) configuration resource (`FelixConfiguration`) represents Felix configuration options for the cluster.
+A Felix configuration resource (`FelixConfiguration`) represents Felix configuration options for the cluster.
 
 For `kubectl` commands, the following case-insensitive aliases may be used to specify the resource type on the CLI: `felixconfiguration.projectcalico.org`, `felixconfigurations.projectcalico.org` as well as abbreviations such as `felixconfiguration.p` and `felixconfigurations.p`.
 
@@ -31,7 +31,8 @@ spec:
 | ----- | --------------------------------------------------------- | --------------------------------------------------- | ------ |
 | name  | Unique name to describe this resource instance. Required. | Alphanumeric string with optional `.`, `_`, or `-`. | string |
 
-- {{prodname}} automatically creates a resource named `default` containing the global default configuration settings for Felix. You can use [calicoctl](/reference/clis/calicoctl/overview/) to view and edit these settings
+- {{prodname}} automatically creates a resource named `default` containing the global default configuration settings for Felix.
+<!--TODO-XREF-CC You can use [calicoctl](/reference/clis/calicoctl/overview/) to view and edit these settings-->
 - The resources with the name `node.<nodename>` contain the node-specific overrides, and will be applied to the node `<nodename>`. When deleting a node the FelixConfiguration resource associated with the node will also be deleted.
 
 ### Spec

--- a/calico-cloud_versioned_docs/version-3.15/reference/resources/globalnetworkpolicy.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/reference/resources/globalnetworkpolicy.mdx
@@ -29,8 +29,10 @@ Select a namespace in a `GlobalNetworkPolicy` in the standard selector by using
 value to compare against, e.g., `projectcalico.org/namespace == "default"`.
 See [network policy resource](networkpolicy.mdx) for namespaced network policy.
 
-`GlobalNetworkPolicy` resources can be used to define network connectivity rules between groups of {{prodname}} endpoints and host endpoints, and
-take precedence over [Profile resources](/reference/resources/profile) if any are defined.
+`GlobalNetworkPolicy` resources can be used to define network connectivity rules between groups of {{prodname}} endpoints and host endpoints.
+<!--TODO-XREF-CC
+and take precedence over [Profile resources](/reference/resources/profile) if any are defined.
+-->
 
 GlobalNetworkPolicies are organized into [tiers](tier.mdx), which provide an additional layer of ordering—in particular, note that the `Pass` action skips to the
 next [tier](tier.mdx), to enable hierarchical security policy.

--- a/calico-cloud_versioned_docs/version-3.15/reference/resources/kubecontrollersconfig.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/reference/resources/kubecontrollersconfig.mdx
@@ -34,7 +34,8 @@ spec:
 | ----- | --------------------------------------------------------- | ----------------- | ------ |
 | name  | Unique name to describe this resource instance. Required. | Must be `default` | string |
 
-- {{prodname}} automatically creates a resource named `default` containing the configuration settings, only the name `default` is used and only one object of this type is allowed. You can use [calicoctl](/reference/clis/calicoctl/overview/) to view and edit these settings
+- {{prodname}} automatically creates a resource named `default` containing the configuration settings, only the name `default` is used and only one object of this type is allowed.
+<!--TODO-XREF-CC You can use [calicoctl](/reference/clis/calicoctl/overview/) to view and edit these settings.-->
 
 ### Spec
 

--- a/calico-cloud_versioned_docs/version-3.15/reference/resources/managedcluster.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/reference/resources/managedcluster.mdx
@@ -68,5 +68,3 @@ plane and managed plane will be reported as following:
 | ------ | ------------------------------------------------------------------------- | ------------------------- | ------ | ------------------------- |
 | type   | Type of status that is being reported                                     | -                         | string | `ManagedClusterConnected` |
 | status | Status of the connection between a Managed cluster and management cluster | `Unkown`, `True`, `False` | string | `Unknown`                 |
-
-[Multi-cluster management](/multicluster/create-a-management-cluster/)

--- a/calico-cloud_versioned_docs/version-3.15/reference/resources/networkpolicy.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/reference/resources/networkpolicy.mdx
@@ -29,8 +29,10 @@ in that namespace. Two resources are in the same namespace if the `namespace`
 value is set the same on both.
 See [global network policy resource](globalnetworkpolicy.mdx) for non-namespaced network policy.
 
-`NetworkPolicy` resources can be used to define network connectivity rules between groups of {{prodname}} endpoints and host endpoints, and
-take precedence over [profile resources](/reference/resources/profile) if any are defined.
+`NetworkPolicy` resources can be used to define network connectivity rules between groups of {{prodname}} endpoints and host endpoints.
+<!--TODO-XREF-CC
+and take precedence over [profile resources](/reference/resources/profile) if any are defined.
+-->
 
 NetworkPolicies are organized into [tiers](tier.mdx), which provide an additional layer of ordering—in particular, note that the `Pass` action skips to the
 next [tier](tier.mdx), to enable hierarchical security policy.

--- a/calico-cloud_versioned_docs/version-3.15/reference/resources/overview.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/reference/resources/overview.mdx
@@ -65,7 +65,7 @@ The following resources are supported:
 - [NetworkSet](networkset.mdx)
 - [Node](node.mdx)
 - [PacketCapture](packetcapture.mdx)
-- [Profile](/reference/resources/profile)
+<!--TODO-XREF-CC- [Profile](/reference/resources/profile)-->
 - [RemoteClusterConfiguration](remoteclusterconfiguration.mdx)
 - [StagedGlobalNetworkPolicy](stagedglobalnetworkpolicy.mdx)
 - [StagedKubernetesNetworkPolicy](stagedkubernetesnetworkpolicy.mdx)

--- a/calico-cloud_versioned_docs/version-3.15/reference/resources/remoteclusterconfiguration.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/reference/resources/remoteclusterconfiguration.mdx
@@ -14,14 +14,14 @@ A remote cluster configuration causes Typha and `calicoq` to retrieve the follow
 
 - [Workload endpoints](workloadendpoint.mdx)
 - [Host endpoints](hostendpoint.mdx)
-- [Profiles](/reference/resources/profile) (rules are not retrieved from remote profiles, only the `LabelsToApply` field is used)
+<!--TODO-XREF-CC- [Profiles](/reference/resources/profile) (rules are not retrieved from remote profiles, only the `LabelsToApply` field is used)-->
 
 When using the Kubernetes API datastore with RBAC enabled on the remote cluster, the RBAC rules must be configured to
 allow access to these resources.
 
 For more details on the federation feature refer to the [Overview](../../multicluster/overview.mdx).
 
-For the meaning of the fields matches the configuration used for configuring `calicoctl`, see [Kubernetes datastore](/operations/clis/calicoctl/configure/datastore) instructions for more details.
+<!--TODO-XREF-CC For the meaning of the fields matches the configuration used for configuring `calicoctl`, see [Kubernetes datastore](/operations/clis/calicoctl/configure/datastore) instructions for more details.-->
 
 This resource is not supported in `kubectl`.
 

--- a/calico-cloud_versioned_docs/version-3.15/reference/resources/stagedglobalnetworkpolicy.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/reference/resources/stagedglobalnetworkpolicy.mdx
@@ -28,8 +28,10 @@ Select a namespace in a `StagedGlobalNetworkPolicy` in the standard selector by 
 value to compare against, e.g., `projectcalico.org/namespace == "default"`.
 See [staged network policy resource](stagednetworkpolicy.mdx) for staged namespaced network policy.
 
-`StagedGlobalNetworkPolicy` resources can be used to define network connectivity rules between groups of {{prodname}} endpoints and host endpoints, and
-take precedence over [Profile resources](/reference/resources/profile) if any are defined.
+`StagedGlobalNetworkPolicy` resources can be used to define network connectivity rules between groups of {{prodname}} endpoints and host endpoints.
+<!--TODO-XREF-CC
+and take precedence over [Profile resources](/reference/resources/profile) if any are defined.
+-->
 
 StagedGlobalNetworkPolicies are organized into [tiers](tier.mdx), which provide an additional layer of ordering—in particular, note that the `Pass` action skips to the
 next [tier](tier.mdx), to enable hierarchical security policy.

--- a/calico-cloud_versioned_docs/version-3.15/reference/resources/stagednetworkpolicy.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/reference/resources/stagednetworkpolicy.mdx
@@ -28,8 +28,10 @@ in that namespace. Two resources are in the same namespace if the `namespace`
 value is set the same on both.
 See [staged global network policy resource](stagedglobalnetworkpolicy.mdx) for staged non-namespaced network policy.
 
-`StagedNetworkPolicy` resources can be used to define network connectivity rules between groups of {{prodname}} endpoints and host endpoints, and
-take precedence over [profile resources](/reference/resources/profile) if any are defined.
+`StagedNetworkPolicy` resources can be used to define network connectivity rules between groups of {{prodname}} endpoints and host endpoints.
+<!--TODO-XREF-CC
+and take precedence over [profile resources](/reference/resources/profile) if any are defined.
+-->
 
 StagedNetworkPolicies are organized into [tiers](tier.mdx), which provide an additional layer of ordering—in particular, note that the `Pass` action skips to the
 next [tier](tier.mdx), to enable hierarchical security policy.

--- a/calico-cloud_versioned_docs/version-3.15/reference/resources/tier.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/reference/resources/tier.mdx
@@ -29,8 +29,9 @@ Policies in each Tier are then processed in order.
 - If a [NetworkPolicy](networkpolicy.mdx) or [GlobalNetworkPolicy](globalnetworkpolicy.mdx) in the Tier `Pass`es the packet, the next Tier containing a Policy that applies to the endpoint processes the packet.
 
 If the Tier applies to the endpoint, but takes no action on the packet the packet is dropped.
-
+<!--TODO-XREF-CC
 If the last Tier applying to the endpoint `Pass`es the packet, that endpoint's [Profiles](/reference/resources/profile) are evaluated.
+-->
 
 ## Sample YAML
 

--- a/calico-cloud_versioned_docs/version-3.15/release-notes/index.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/release-notes/index.mdx
@@ -137,7 +137,7 @@ Calico Cloud uses eBPF-based monitoring to log file hashes of programs running i
 If there's a match to known malware from our threat intelligence library, you receive an alert.
 You can view your alerts on the _Alerts_ page on Manager UI.
 
-To get started see, [Malware Detection](/threat/malware-detection)
+To get started see, [Malware Detection](../threat/container-threat-detection.mdx)
 
 ## July 27, 2022
 

--- a/calico-cloud_versioned_docs/version-3.15/threat/security-anomalies.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/threat/security-anomalies.mdx
@@ -96,10 +96,12 @@ For a list of anomalies that are enabled by default, see [Anomaly detection refe
 
 - To use L7/HTTP anomaly detectors, you must enable [L7 logs](../visibility/elastic/l7/configure.mdx) on the cluster
 
+<!--TODO-XREFS-CC
 **Optional**
 
 By default models created from anomaly detection's training cycle are stored in ephemeral storage.
 To persist storage for the training models [configure a storage class](/threat/anomaly-detection/storage)
+-->
 
 ## How To
 

--- a/calico-cloud_versioned_docs/version-3.15/threat/suspicious-external-ips.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/threat/suspicious-external-ips.mdx
@@ -136,7 +136,7 @@ the directions based on your orchestrator.
 
 **Prerequisites**:
 
-- [{{prodname}} installed](/getting-started/index)
+<!--TODO-XREFS-CC - [{{prodname}} installed](/getting-started/index)-->
 
 Ingress flow log correlation requires the Policy Sync API to be enabled on Felix. To do this cluster-wide, modify the `default`
 FelixConfiguration to set the field `policySyncPathPrefix` to `/var/run/nodeagent`.

--- a/calico-cloud_versioned_docs/version-3.15/tutorials/about-calico-enterprise.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/tutorials/about-calico-enterprise.mdx
@@ -98,7 +98,7 @@ Connectivity issues between microservices are difficult to troubleshoot. Trouble
 
 **Documentation**
 
-- [Flow visualizer](/visibility/get-started-cem)
+<!--TODO-XREFS-CC - [Flow visualizer](/visibility/get-started-cem)-->
 - [Flow logs in Kibana](../visibility/elastic/index.mdx)
 - [Alerts](../visibility/alerts.mdx)
 - [Packet capture](../visibility/packetcapture.mdx)
@@ -181,7 +181,7 @@ When deploying a new microservice to a secure cluster, it needs to be deployed a
 - [Tiered network policy](../network-policy/policy-tiers/tiered-policy.mdx)
 - [RBAC for tiered network policy](../network-policy/policy-tiers/rbac-tiered-policies.mdx)
 - [Policy recommendations](../network-policy/generate-policy-recommendation.mdx)
-- [Policy impact preview](/network-policy/policy-impact-preview)
+<!--TODO-XREFS-CC - [Policy impact preview](/network-policy/policy-impact-preview)-->
 - [Staged network policies](../network-policy/staged-network-policies.mdx)
 
 ## Microsegmentation
@@ -203,7 +203,7 @@ Every cloud and hosting environment has a unique approach to segmentation, which
 
 **Documentation**
 
-- [Install Calico Enterprise on non-cluster hosts](/getting-started/bare-metal/index)
+<!--TODO-XREFS-CC - [Install Calico Enterprise on non-cluster hosts](/getting-started/bare-metal/index)-->
 
 ## Intrusion detection
 

--- a/calico-cloud_versioned_docs/version-3.15/tutorials/kubernetes-tutorials/kubernetes-demo.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/tutorials/kubernetes-tutorials/kubernetes-demo.mdx
@@ -7,10 +7,12 @@ description: An interactive demo that visually shows how applying Kubernetes pol
 The included demo sets up a frontend and backend service, as well as a client service, all
 running on Kubernetes. It then configures network policy on each service.
 
+<!--TODO-XREFS-CC
 ## Prerequisites
 
 To create a Kubernetes cluster which supports the Kubernetes network policy API, follow
 one of our [getting started guides](/getting-started/index).
+-->
 
 ## Running the stars example
 

--- a/calico-cloud_versioned_docs/version-3.15/tutorials/kubernetes-tutorials/kubernetes-policy-basic.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/tutorials/kubernetes-tutorials/kubernetes-policy-basic.mdx
@@ -6,7 +6,9 @@ description: Learn how to use basic Kubernetes network policy to securely restri
 
 This guide provides a simple way to try out Kubernetes `NetworkPolicy` with {{prodname}}. It requires a Kubernetes cluster configured with {{prodname}} networking, and expects that you have `kubectl` configured to interact with the cluster.
 
+<!--TODO-XREFS-CC
 You can quickly and easily deploy such a cluster by following one of the [installation guides](/getting-started/install-on-clusters/kubernetes/index).
+-->
 
 ## Configure namespaces
 

--- a/calico-cloud_versioned_docs/version-3.15/tutorials/training/about-kubernetes-egress.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/tutorials/training/about-kubernetes-egress.mdx
@@ -45,7 +45,7 @@ traffic.
 One limitation when using Kubernetes Network Policy to restrict access to specific external resources, is that the external
 resources need to be specified as IP addresses (or IP address ranges) within the policy rules. If the IP addresses
 associated with an external resource change, then every policy that referenced those IP addresses needs to be updated with
-the new IP addresses. This limitation can be circumvented using {{prodname}} [Use external IPs or networks rules in policy](/network-policy/beginners/external-ips-policy/), or [DNS policy](/network-policy/beginners/domain-based-policy/) in policy rules.
+the new IP addresses. This limitation can be circumvented using {{prodname}} [Use external IPs or networks rules in policy](../../network-policy/beginners/policy-rules/external-ips-policy.mdx), or [DNS policy](../../network-policy/domain-based-policy.mdx) in policy rules.
 
 In addition to using network policy, service meshes typically allow you to configure which external services each pod
 can access. In the case of Istio, {{prodname}} can be integrated to enforce network policy at the service mesh
@@ -101,7 +101,7 @@ deployments. In these scenarios, using egress gateways is likely to be a better 
 
 ## Above and beyond
 
-- [Use external IPs or networks rules in policy](/network-policy/beginners/external-ips-policy/)
+- [Use external IPs or networks rules in policy](../../network-policy/beginners/policy-rules/external-ips-policy.mdx)
 - [Restrict a pod to use an IP address in a specific range](../../networking/ipam/legacy-firewalls.mdx)
 - [Assign IP addresses based on topology](../../networking/ipam/assign-ip-addresses-topology.mdx)
 - [Egress gateways](../../networking/egress/index.mdx)

--- a/calico-cloud_versioned_docs/version-3.15/tutorials/training/about-network-policy.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/tutorials/training/about-network-policy.mdx
@@ -87,8 +87,10 @@ network plugins implement the mainline elements of Kubernetes network policies, 
 of the specification. ({{prodname}} does implement every feature, and was the original reference implementation of Kubernetes
 network policies.)
 
+<!--TODO-XREFS-CC
 To learn more about Kubernetes network policies, read the [Get started with Kubernetes network
 policy](/tutorials/training/tutorials/kubernetes-network-policy/) guide.
+-->
 
 ## {{prodname}} network policy
 

--- a/calico-cloud_versioned_docs/version-3.15/visibility/alerts.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/visibility/alerts.mdx
@@ -230,7 +230,7 @@ kubectl delete globalalert <global-alert-name>
 - [GlobalAlert and templates](../reference/resources/globalalert.mdx)
 - Alerts for [honeypods](../threat/honeypod/index.mdx)
 - Alerts for [Deep packet inspection](../threat/deeppacketinspection.mdx)
-- Alerts for [anomaly detection](/threat/anomaly-detection/index)
+- Alerts for [anomaly detection](../threat/security-anomalies.mdx)
 - Alerts for [suspicious IPs](../threat/suspicious-ips.mdx)
 - Alerts for [suspicious domains](../threat/suspicious-domains.mdx)
 - Alerts for [Web Application Firewall](../threat/web-application-firewall.mdx)

--- a/calico-cloud_versioned_docs/version-3.15/visibility/elastic/flow/aggregation.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/visibility/elastic/flow/aggregation.mdx
@@ -487,4 +487,3 @@ If you turn off aggregation, your log storage may be overwhelmed. Be sure to pro
 ## Above and beyond
 
 - [Archive logs to storage](../archive-storage.mdx)
-- [Configure data retention](/visibility/elastic/retention)

--- a/calico-cloud_versioned_docs/version-3.15/visibility/elastic/l7/configure.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/visibility/elastic/l7/configure.mdx
@@ -48,11 +48,9 @@ L7 logs are visible in the Manager UI, service graph, in the HTTP tab.
 
 **Log storage requirements**
 
-:::note
-
-L7 logs require a minimum of 1 additional GB of log storage per node, per one-day retention period. Adjust your [Log Storage](../../operations/logstorage/adjust-log-storage-size) before you start tasks in the next section.
-
-:::
+<!--TODO-XREFS-CC
+Note removed for CC
+-->
 
 ## How to
 

--- a/calico-cloud_versioned_docs/version-3.15/visibility/elastic/overview.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/visibility/elastic/overview.mdx
@@ -95,7 +95,6 @@ verbs: ['get']
 
 ## Above and beyond
 
-- [Log storage recommendations](/operations/logstorage/log-storage-recommendations)
 - [Configure flow log aggregation](flow/aggregation.mdx)
 - [Audit logs](audit-overview.mdx)
 - [BGP logs](bgp.mdx)

--- a/calico-cloud_versioned_sidebars/version-3.15-sidebars.json
+++ b/calico-cloud_versioned_sidebars/version-3.15-sidebars.json
@@ -596,6 +596,7 @@
             "reference/resources/bgppeer",
             "reference/resources/blockaffinity",
             "reference/resources/caliconodestatus",
+            "reference/resources/containeradmissionpolicy",
             {
               "type": "category",
               "label": "Compliance reports",

--- a/calico-enterprise/_includes/release-notes/_master-release-notes.mdx
+++ b/calico-enterprise/_includes/release-notes/_master-release-notes.mdx
@@ -1,0 +1,3 @@
+_Dateline_
+
+## Undefined feature X

--- a/calico-enterprise/networking/egress/egress-gateway-azure.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-azure.mdx
@@ -122,7 +122,7 @@ Azure Route Server deployment is per VNet, as such each VNet with egress gateway
 
 - [Choose route reflectors](#choose-route-reflectors)
 - [Create Azure Route Server](#create-azure-route-server)
-- [Disable the default BGP node-to-node mesh](disable-the-default-bgp-node-to-node-mesh)
+- [Disable the default BGP node-to-node mesh](#disable-the-default-bgp-node-to-node-mesh)
 - [Enable BGP](#enable-bgp)
 - [Provision an egress IP pool](#provision-an-egress-ip-pool)
 - [(Optional) Limit number of route advertisement](#limit-number-of-route-advertisement)

--- a/calico-enterprise/reference/faq.mdx
+++ b/calico-enterprise/reference/faq.mdx
@@ -291,7 +291,7 @@ center. Access to that network is via a router, which also is the default
 router for all the container hosts.
 
 If this describes your infrastructure,
-[External connectivity](/networking/external-connectivity) explains in more detail
+[Configure outgoing NAT](../networking/configuring/workloads-outside-cluster.mdx explains in more detail
 what to do. Otherwise, if you have a layer 3 (IP) fabric, then there are
 detailed datacenter networking recommendations given
 in [{{prodname}} over IP fabrics](architecture/design/l3-interconnect-fabric.mdx).

--- a/calico-enterprise/visibility/elastic/l7/configure.mdx
+++ b/calico-enterprise/visibility/elastic/l7/configure.mdx
@@ -50,12 +50,11 @@ L7 logs are visible in the Manager UI, service graph, in the HTTP tab.
 
 :::note
 
-L7 logs require a minimum of 1 additional GB of log storage per node, per one-day retention period. Adjust your [Log Storage](../../operations/logstorage/adjust-log-storage-size) before you start tasks in the next section.
+L7 logs require a minimum of 1 additional GB of log storage per node, per one-day retention period. Adjust your [Log Storage](../../../operations/logstorage/adjust-log-storage-size.mdx) before you start tasks in the next section.
 
 :::
 
 ## How to
-
 - [Configure Felix for log data collection](#configure-felix-for-log-data-collection)
 - [Configure L7 logs](#configure-l7-logs)
 - [View L7 logs in Manager UI](#view-l7-logs-in-manager-ui)

--- a/calico-enterprise_versioned_docs/version-3.14/reference/faq.mdx
+++ b/calico-enterprise_versioned_docs/version-3.14/reference/faq.mdx
@@ -291,7 +291,7 @@ center. Access to that network is via a router, which also is the default
 router for all the container hosts.
 
 If this describes your infrastructure,
-[External connectivity](/networking/external-connectivity) explains in more detail
+[Configure outgoing NAT](../networking/configuring/workloads-outside-cluster.mdx explains in more detail
 what to do. Otherwise, if you have a layer 3 (IP) fabric, then there are
 detailed datacenter networking recommendations given
 in [{{prodname}} over IP fabrics](architecture/design/l3-interconnect-fabric.mdx).

--- a/calico-enterprise_versioned_docs/version-3.14/visibility/elastic/l7/configure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.14/visibility/elastic/l7/configure.mdx
@@ -51,7 +51,7 @@ L7 logs are visible in the Manager UI, service graph, in the HTTP tab.
 
 :::note
 
-L7 logs require a minimum of 1 additional GB of log storage per node, per one day retention period. Adjust your [Log Storage](../../operations/logstorage/adjust-log-storage-size) now.
+L7 logs require a minimum of 1 additional GB of log storage per node, per one-day retention period. Adjust your [Log Storage](../../../operations/logstorage/adjust-log-storage-size.mdx) before you start tasks in the next section.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.15/networking/configuring/workloads-outside-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/networking/configuring/workloads-outside-cluster.mdx
@@ -74,7 +74,3 @@ spec:
   cidr: 10.0.0.0/8
   disabled: true
 ```
-
-## Above and beyond
-
-To learn about inbound connectivity, see [External connectivity](/networking/external-connectivity)

--- a/calico-enterprise_versioned_docs/version-3.15/reference/faq.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/reference/faq.mdx
@@ -269,7 +269,7 @@ If a host's containers are connected to the `docker0` bridge interface, {{prodna
 would be unable to enforce security rules between workloads on the same host;
 all containers on the bridge would be able to communicate with one other.
 
-You can securely configure port mapping by following [External connectivity](/networking/external-connectivity).
+You can securely configure port mapping by following [Configure outgoing NAT](../networking/configuring/workloads-outside-cluster.mdx.
 
 ## Can {{prodname}} containers use any IP address within a pool, even subnet network/broadcast addresses?
 
@@ -293,7 +293,7 @@ center. Access to that network is via a router, which also is the default
 router for all the container hosts.
 
 If this describes your infrastructure,
-[External connectivity](/networking/external-connectivity) explains in more detail
+[Configure outgoing NAT](../networking/configuring/workloads-outside-cluster.mdx explains in more detail
 what to do. Otherwise, if you have a layer 3 (IP) fabric, then there are
 detailed datacenter networking recommendations given
 in [{{prodname}} over IP fabrics](architecture/design/l3-interconnect-fabric.mdx).

--- a/calico-enterprise_versioned_docs/version-3.15/visibility/elastic/l7/configure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/visibility/elastic/l7/configure.mdx
@@ -50,7 +50,7 @@ L7 logs are visible in the Manager UI, service graph, in the HTTP tab.
 
 :::note
 
-L7 logs require a minimum of 1 additional GB of log storage per node, per one-day retention period. Adjust your [Log Storage](../../operations/logstorage/adjust-log-storage-size) before you start tasks in the next section.
+L7 logs require a minimum of 1 additional GB of log storage per node, per one-day retention period. Adjust your [Log Storage](../../../operations/logstorage/adjust-log-storage-size.mdx) before you start tasks in the next section.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.16/networking/egress/egress-gateway-azure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/networking/egress/egress-gateway-azure.mdx
@@ -122,7 +122,7 @@ Azure Route Server deployment is per VNet, as such each VNet with egress gateway
 
 - [Choose route reflectors](#choose-route-reflectors)
 - [Create Azure Route Server](#create-azure-route-server)
-- [Disable the default BGP node-to-node mesh](disable-the-default-bgp-node-to-node-mesh)
+- [Disable the default BGP node-to-node mesh](#disable-the-default-bgp-node-to-node-mesh)
 - [Enable BGP](#enable-bgp)
 - [Provision an egress IP pool](#provision-an-egress-ip-pool)
 - [(Optional) Limit number of route advertisement](#limit-number-of-route-advertisement)

--- a/calico-enterprise_versioned_docs/version-3.16/reference/faq.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/reference/faq.mdx
@@ -291,7 +291,7 @@ center. Access to that network is via a router, which also is the default
 router for all the container hosts.
 
 If this describes your infrastructure,
-[External connectivity](/networking/external-connectivity) explains in more detail
+[Configure outgoing NAT](../networking/configuring/workloads-outside-cluster.mdx explains in more detail
 what to do. Otherwise, if you have a layer 3 (IP) fabric, then there are
 detailed datacenter networking recommendations given
 in [{{prodname}} over IP fabrics](architecture/design/l3-interconnect-fabric.mdx).

--- a/calico-enterprise_versioned_docs/version-3.16/visibility/elastic/l7/configure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/visibility/elastic/l7/configure.mdx
@@ -50,7 +50,7 @@ L7 logs are visible in the Manager UI, service graph, in the HTTP tab.
 
 :::note
 
-L7 logs require a minimum of 1 additional GB of log storage per node, per one-day retention period. Adjust your [Log Storage](../../operations/logstorage/adjust-log-storage-size) before you start tasks in the next section.
+L7 logs require a minimum of 1 additional GB of log storage per node, per one-day retention period. Adjust your [Log Storage](../../../operations/logstorage/adjust-log-storage-size.mdx) before you start tasks in the next section.
 
 :::
 

--- a/calico/_includes/release-notes/_master-release-notes.mdx
+++ b/calico/_includes/release-notes/_master-release-notes.mdx
@@ -1,0 +1,3 @@
+_Dateline_
+
+## Undefined feature X

--- a/calico/reference/faq.mdx
+++ b/calico/reference/faq.mdx
@@ -301,7 +301,7 @@ center. Access to that network is via a router, which also is the default
 router for all the container hosts.
 
 If this describes your infrastructure,
-[External connectivity](/networking/external-connectivity) explains in more detail
+[Configure outgoing NAT](../networking/configuring/workloads-outside-cluster.mdx explains in more detail
 what to do. Otherwise, if you have a layer 3 (IP) fabric, then there are
 detailed datacenter networking recommendations given
 in [{{prodname}} over IP fabrics](architecture/design/l3-interconnect-fabric.mdx).

--- a/calico_versioned_docs/version-3.24/reference/faq.mdx
+++ b/calico_versioned_docs/version-3.24/reference/faq.mdx
@@ -301,7 +301,7 @@ center. Access to that network is via a router, which also is the default
 router for all the container hosts.
 
 If this describes your infrastructure,
-[External connectivity](/networking/external-connectivity) explains in more detail
+[Configure outgoing NAT](../networking/configuring/workloads-outside-cluster.mdx explains in more detail
 what to do. Otherwise, if you have a layer 3 (IP) fabric, then there are
 detailed datacenter networking recommendations given
 in [{{prodname}} over IP fabrics](architecture/design/l3-interconnect-fabric.mdx).

--- a/calico_versioned_docs/version-3.25/reference/faq.mdx
+++ b/calico_versioned_docs/version-3.25/reference/faq.mdx
@@ -301,7 +301,7 @@ center. Access to that network is via a router, which also is the default
 router for all the container hosts.
 
 If this describes your infrastructure,
-[External connectivity](/networking/external-connectivity) explains in more detail
+[Configure outgoing NAT](../networking/configuring/workloads-outside-cluster.mdx explains in more detail
 what to do. Otherwise, if you have a layer 3 (IP) fabric, then there are
 detailed datacenter networking recommendations given
 in [{{prodname}} over IP fabrics](architecture/design/l3-interconnect-fabric.mdx).

--- a/sidebars-calico-cloud.js
+++ b/sidebars-calico-cloud.js
@@ -457,6 +457,7 @@ module.exports = {
             'reference/resources/bgpfilter',
             'reference/resources/blockaffinity',
             'reference/resources/caliconodestatus',
+            'reference/resources/containeradmissionpolicy',
             {
               type: 'category',
               label: 'Compliance reports',


### PR DESCRIPTION
https://tigera.atlassian.net/browse/DOCS-724

Removes broken cross references from the docs. 

By and large, these were caused by moving CE 3.15 docs into CC. Some links were to files not present in CC.
