### PR TITLE
Fix EE install-calico-windows.ps1 scripts

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/windows-calico/quickstart.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/windows-calico/quickstart.mdx
@@ -97,9 +97,9 @@ The following steps install a Kubernetes cluster on a single Windows node with a
    mkdir c:\k
    ```
 
-1. Copy the Kubernetes kubeconfig file from the master node (default, Location $HOME/.kube/config), to **c:\k\config**.
+1. Copy the Kubernetes kubeconfig file from the control-plane node (default, Location $HOME/.kube/config), to **c:\k\config**.
 
-1. Copy the installation zip file to **c:\tigera-calico-windows.zip**.
+1. Copy the {{prodnameWindows}} installation zip file to **c:\tigera-calico-windows.zip**.
 
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 
@@ -188,7 +188,9 @@ The following steps install a Kubernetes cluster on a single Windows node with a
    mkdir c:\k
    ```
 
-1. Copy the Kubernetes kubeconfig file from the master node (default, Location $HOME/.kube/config), to **c:\k\config**.
+1. Copy the Kubernetes kubeconfig file from the control-plane node (default, Location $HOME/.kube/config), to **c:\k\config**.
+
+1. Copy the {{prodnameWindows}} installation zip file to **c:\tigera-calico-windows.zip**.
 
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 
@@ -262,6 +264,8 @@ The following steps install a Kubernetes cluster on a single Windows node with a
    ```
 
 1. [Install kubectl](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html#windows) and move the kubectl binary to **c:\k**.
+
+1. Copy the {{prodnameWindows}} installation zip file to **c:\tigera-calico-windows.zip**.
 
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 

--- a/calico-enterprise_versioned_docs/version-3.14/getting-started/install-on-clusters/windows-calico/quickstart.mdx
+++ b/calico-enterprise_versioned_docs/version-3.14/getting-started/install-on-clusters/windows-calico/quickstart.mdx
@@ -111,9 +111,9 @@ Note: if {{prodname}} is installed in kube-system, update the `namespace` in the
    mkdir c:\k
    ```
 
-1. Copy the Kubernetes kubeconfig file from the master node (default, Location $HOME/.kube/config), to **c:\k\config**.
+1. Copy the Kubernetes kubeconfig file from the control-plane node (default, Location $HOME/.kube/config), to **c:\k\config**.
 
-1. Copy the installation zip file to **c:\tigera-calico-windows.zip**.
+1. Copy the {{prodnameWindows}} installation zip file to **c:\tigera-calico-windows.zip**.
 
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 
@@ -202,7 +202,9 @@ Note: if {{prodname}} is installed in kube-system, update the `namespace` in the
    mkdir c:\k
    ```
 
-1. Copy the Kubernetes kubeconfig file from the master node (default, Location $HOME/.kube/config), to **c:\k\config**.
+1. Copy the Kubernetes kubeconfig file from the control-plane node (default, Location $HOME/.kube/config), to **c:\k\config**.
+
+1. Copy the {{prodnameWindows}} installation zip file to **c:\tigera-calico-windows.zip**.
 
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 
@@ -276,6 +278,8 @@ Note: if {{prodname}} is installed in kube-system, update the `namespace` in the
    ```
 
 1. [Install kubectl](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html#windows) and move the kubectl binary to **c:\k**.
+
+1. Copy the {{prodnameWindows}} installation zip file to **c:\tigera-calico-windows.zip**.
 
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 

--- a/calico-enterprise_versioned_docs/version-3.15/getting-started/install-on-clusters/windows-calico/quickstart.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/getting-started/install-on-clusters/windows-calico/quickstart.mdx
@@ -97,9 +97,9 @@ The following steps install a Kubernetes cluster on a single Windows node with a
    mkdir c:\k
    ```
 
-1. Copy the Kubernetes kubeconfig file from the master node (default, Location $HOME/.kube/config), to **c:\k\config**.
+1. Copy the Kubernetes kubeconfig file from the control-plane node (default, Location $HOME/.kube/config), to **c:\k\config**.
 
-1. Copy the installation zip file to **c:\tigera-calico-windows.zip**.
+1. Copy the {{prodnameWindows}} installation zip file to **c:\tigera-calico-windows.zip**.
 
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 
@@ -188,7 +188,9 @@ The following steps install a Kubernetes cluster on a single Windows node with a
    mkdir c:\k
    ```
 
-1. Copy the Kubernetes kubeconfig file from the master node (default, Location $HOME/.kube/config), to **c:\k\config**.
+1. Copy the Kubernetes kubeconfig file from the control-plane node (default, Location $HOME/.kube/config), to **c:\k\config**.
+
+1. Copy the {{prodnameWindows}} installation zip file to **c:\tigera-calico-windows.zip**.
 
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 
@@ -262,6 +264,8 @@ The following steps install a Kubernetes cluster on a single Windows node with a
    ```
 
 1. [Install kubectl](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html#windows) and move the kubectl binary to **c:\k**.
+
+1. Copy the {{prodnameWindows}} installation zip file to **c:\tigera-calico-windows.zip**.
 
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 

--- a/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/windows-calico/quickstart.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/windows-calico/quickstart.mdx
@@ -97,9 +97,9 @@ The following steps install a Kubernetes cluster on a single Windows node with a
    mkdir c:\k
    ```
 
-1. Copy the Kubernetes kubeconfig file from the master node (default, Location $HOME/.kube/config), to **c:\k\config**.
+1. Copy the Kubernetes kubeconfig file from the control-plane node (default, Location $HOME/.kube/config), to **c:\k\config**.
 
-1. Copy the installation zip file to **c:\tigera-calico-windows.zip**.
+1. Copy the {{prodnameWindows}} installation zip file to **c:\tigera-calico-windows.zip**.
 
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 
@@ -188,7 +188,9 @@ The following steps install a Kubernetes cluster on a single Windows node with a
    mkdir c:\k
    ```
 
-1. Copy the Kubernetes kubeconfig file from the master node (default, Location $HOME/.kube/config), to **c:\k\config**.
+1. Copy the Kubernetes kubeconfig file from the control-plane node (default, Location $HOME/.kube/config), to **c:\k\config**.
+
+1. Copy the {{prodnameWindows}} installation zip file to **c:\tigera-calico-windows.zip**.
 
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 
@@ -262,6 +264,8 @@ The following steps install a Kubernetes cluster on a single Windows node with a
    ```
 
 1. [Install kubectl](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html#windows) and move the kubectl binary to **c:\k**.
+
+1. Copy the {{prodnameWindows}} installation zip file to **c:\tigera-calico-windows.zip**.
 
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 

--- a/calico/getting-started/kubernetes/windows-calico/quickstart.mdx
+++ b/calico/getting-started/kubernetes/windows-calico/quickstart.mdx
@@ -101,7 +101,7 @@ The following steps install a Kubernetes cluster on a single Windows node with a
    mkdir c:\k
    ```
 
-1. Copy the Kubernetes kubeconfig file from the master node (default, Location $HOME/.kube/config), to **c:\k\config**.
+1. Copy the Kubernetes kubeconfig file from the control-plane node (default, Location $HOME/.kube/config), to **c:\k\config**.
 
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 
@@ -199,7 +199,7 @@ The following steps install a Kubernetes cluster on a single Windows node with a
    mkdir c:\k
    ```
 
-1. Copy the Kubernetes kubeconfig file from the master node (default, Location $HOME/.kube/config), to **c:\k\config**.
+1. Copy the Kubernetes kubeconfig file from the control-plane node (default, Location $HOME/.kube/config), to **c:\k\config**.
 
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 

--- a/calico_versioned_docs/version-3.24/getting-started/kubernetes/windows-calico/quickstart.mdx
+++ b/calico_versioned_docs/version-3.24/getting-started/kubernetes/windows-calico/quickstart.mdx
@@ -101,7 +101,7 @@ The following steps install a Kubernetes cluster on a single Windows node with a
    mkdir c:\k
    ```
 
-1. Copy the Kubernetes kubeconfig file from the master node (default, Location $HOME/.kube/config), to **c:\k\config**.
+1. Copy the Kubernetes kubeconfig file from the control-plane node (default, Location $HOME/.kube/config), to **c:\k\config**.
 
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 
@@ -199,7 +199,7 @@ The following steps install a Kubernetes cluster on a single Windows node with a
    mkdir c:\k
    ```
 
-1. Copy the Kubernetes kubeconfig file from the master node (default, Location $HOME/.kube/config), to **c:\k\config**.
+1. Copy the Kubernetes kubeconfig file from the control-plane node (default, Location $HOME/.kube/config), to **c:\k\config**.
 
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 

--- a/calico_versioned_docs/version-3.25/getting-started/kubernetes/windows-calico/quickstart.mdx
+++ b/calico_versioned_docs/version-3.25/getting-started/kubernetes/windows-calico/quickstart.mdx
@@ -101,7 +101,7 @@ The following steps install a Kubernetes cluster on a single Windows node with a
    mkdir c:\k
    ```
 
-1. Copy the Kubernetes kubeconfig file from the master node (default, Location $HOME/.kube/config), to **c:\k\config**.
+1. Copy the Kubernetes kubeconfig file from the control-plane node (default, Location $HOME/.kube/config), to **c:\k\config**.
 
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 
@@ -199,7 +199,7 @@ The following steps install a Kubernetes cluster on a single Windows node with a
    mkdir c:\k
    ```
 
-1. Copy the Kubernetes kubeconfig file from the master node (default, Location $HOME/.kube/config), to **c:\k\config**.
+1. Copy the Kubernetes kubeconfig file from the control-plane node (default, Location $HOME/.kube/config), to **c:\k\config**.
 
 1. Download the PowerShell script, **install-calico-windows.ps1**.
 

--- a/static/calico-enterprise/3.14/scripts/install-calico-windows.ps1
+++ b/static/calico-enterprise/3.14/scripts/install-calico-windows.ps1
@@ -1,6 +1,3 @@
----
-layout: null
----
 # Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +13,7 @@ layout: null
 # limitations under the License.
 <#
 .DESCRIPTION
-    This script installs and starts {{site.prodname}} services on a Windows node.
+    This script installs and starts Calico Enterprise services on a Windows node.
 
     Note: EKS requires downloading kubectl.exe to c:\k before running this script: https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
 #>
@@ -24,12 +21,6 @@ layout: null
 Param(
     # Note: we don't publish a release artifact for the "master" branch. To test
     # against master, build calico-windows.zip from projectcalico/node.
-{%- if site.url contains "projectcalico" %}
-    [parameter(Mandatory = $false)] $ReleaseBaseURL="https://github.com/projectcalico/calico/releases/download/{{site.data.versions.first.components["calico/node"].version}}/",
-    [parameter(Mandatory = $false)] $ReleaseFile="calico-windows-{{site.data.versions.first.components["calico/node"].version}}.zip",
-{%- else %}
-    [parameter(Mandatory = $false)] $ReleaseBaseURL="{{site.url}}/files/windows/",
-{%- endif %}
     [parameter(Mandatory = $false)] $KubeVersion="",
     [parameter(Mandatory = $false)] $StartCalico="yes",
     [parameter(Mandatory = $false)] $Datastore="kubernetes",
@@ -162,7 +153,7 @@ function GetBackendType()
     if ($Datastore -EQ "kubernetes") {
         $encap=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.ipipEnabled}'
         if ($encap -EQ "true") {
-            throw "{{site.prodname}} on Linux has IPIP enabled. IPIP is not supported on Windows nodes."
+            throw "Calico Enterprise on Linux has IPIP enabled. IPIP is not supported on Windows nodes."
         }
 
         # Check FelixConfig first.
@@ -356,13 +347,13 @@ function SetAKSCalicoStaticRules {
 
 function InstallCalico()
 {
-    Write-Host "`nStart {{site.prodnameWindows}} install...`n"
+    Write-Host "`nStart Calico Enterprise for Windows install...`n"
 
     pushd
     cd $RootDir
     .\install-calico.ps1
     popd
-    Write-Host "`n{{site.prodnameWindows}} installed`n"
+    Write-Host "`nCalico Enterprise for Windows installed`n"
 }
 
 $ErrorActionPreference = "Stop"
@@ -396,7 +387,7 @@ ipmo -force $helperv2
 
 if (!(Test-Path $CalicoZipPath))
 {
-	throw "Cannot find {{site.prodnameWindows}} zip file $CalicoZipPath."
+	throw "Cannot find Calico Enterprise for Windows zip file $CalicoZipPath."
 }
 
 $platform=GetPlatformType
@@ -407,7 +398,7 @@ if ((Get-Service -exclude 'CalicoUpgrade' | where Name -Like 'Calico*' | where S
 }
 
 Remove-Item $RootDir -Force  -Recurse -ErrorAction SilentlyContinue
-Write-Host "Unzip {{site.prodnameWindows}} release..."
+Write-Host "Unzip Calico Enterprise for Windows release..."
 Expand-Archive -Force $CalicoZipPath c:\
 ipmo -force $RootDir\libs\calico\calico.psm1
 
@@ -416,7 +407,7 @@ if (-Not [string]::IsNullOrEmpty($KubeVersion) -and $platform -NE "eks") {
     PrepareKubernetes
 }
 
-Write-Host "Setup {{site.prodnameWindows}}..."
+Write-Host "Setup Calico Enterprise for Windows..."
 Set-ConfigParameters -var 'CALICO_DATASTORE_TYPE' -value $Datastore
 Set-ConfigParameters -var 'ETCD_ENDPOINTS' -value $EtcdEndpoints
 
@@ -431,7 +422,7 @@ Set-ConfigParameters -var 'K8S_SERVICE_CIDR' -value $ServiceCidr
 Set-ConfigParameters -var 'DNS_NAME_SERVERS' -value $DNSServerIPs
 
 if ($platform -EQ "aks") {
-    Write-Host "Setup {{site.prodnameWindows}} for AKS..."
+    Write-Host "Setup Calico Enterprise for Windows for AKS..."
     $Backend="none"
     Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "none"
     Set-ConfigParameters -var 'KUBE_NETWORK' -value "azure.*"
@@ -446,7 +437,7 @@ if ($platform -EQ "eks") {
 
     $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
     $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
-    Write-Host "Setup {{site.prodnameWindows}} for EKS, node name $awsNodeName ..."
+    Write-Host "Setup Calico Enterprise for Windows for EKS, node name $awsNodeName ..."
     $Backend = "none"
 
     Set-ConfigParameters -var 'NODENAME' -value $awsNodeName
@@ -459,7 +450,7 @@ if ($platform -EQ "eks") {
 if ($platform -EQ "ec2") {
     $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
     $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
-    Write-Host "Setup {{site.prodnameWindows}} for AWS, node name $awsNodeName ..."
+    Write-Host "Setup Calico Enterprise for Windows for AWS, node name $awsNodeName ..."
     Set-ConfigParameters -var 'NODENAME' -value $awsNodeName
 
     $calicoNs = GetCalicoNamespace
@@ -473,7 +464,7 @@ if ($platform -EQ "ec2") {
 }
 if ($platform -EQ "gce") {
     $gceNodeName = Invoke-RestMethod -UseBasicParsing -Headers @{"Metadata-Flavor"="Google"} "http://metadata.google.internal/computeMetadata/v1/instance/hostname" -ErrorAction Ignore
-    Write-Host "Setup {{site.prodnameWindows}} for GCE, node name $gceNodeName ..."
+    Write-Host "Setup Calico Enterprise for Windows for GCE, node name $gceNodeName ..."
     $gceNodeNameQuote = """$gceNodeName"""
     Set-ConfigParameters -var 'NODENAME' -value $gceNodeNameQuote
 

--- a/static/calico-enterprise/3.15/scripts/install-calico-windows.ps1
+++ b/static/calico-enterprise/3.15/scripts/install-calico-windows.ps1
@@ -1,6 +1,3 @@
----
-layout: null
----
 # Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +13,7 @@ layout: null
 # limitations under the License.
 <#
 .DESCRIPTION
-    This script installs and starts {{site.prodname}} services on a Windows node.
+    This script installs and starts Calico Enterprise services on a Windows node.
 
     Note: EKS requires downloading kubectl.exe to c:\k before running this script: https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
 #>
@@ -24,12 +21,6 @@ layout: null
 Param(
     # Note: we don't publish a release artifact for the "master" branch. To test
     # against master, build calico-windows.zip from projectcalico/node.
-{%- if site.url contains "projectcalico" %}
-    [parameter(Mandatory = $false)] $ReleaseBaseURL="https://github.com/projectcalico/calico/releases/download/{{site.data.versions.first.components["calico/node"].version}}/",
-    [parameter(Mandatory = $false)] $ReleaseFile="calico-windows-{{site.data.versions.first.components["calico/node"].version}}.zip",
-{%- else %}
-    [parameter(Mandatory = $false)] $ReleaseBaseURL="{{site.url}}/files/windows/",
-{%- endif %}
     [parameter(Mandatory = $false)] $KubeVersion="",
     [parameter(Mandatory = $false)] $StartCalico="yes",
     # As of Kubernetes version v1.24.0, service account token secrets are no longer automatically created. But this installation script uses that secret
@@ -166,7 +157,7 @@ function GetBackendType()
     if ($Datastore -EQ "kubernetes") {
         $encap=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.ipipEnabled}'
         if ($encap -EQ "true") {
-            throw "{{site.prodname}} on Linux has IPIP enabled. IPIP is not supported on Windows nodes."
+            throw "Calico Enterprise on Linux has IPIP enabled. IPIP is not supported on Windows nodes."
         }
 
         # Check FelixConfig first.
@@ -397,13 +388,13 @@ function SetAKSCalicoStaticRules {
 
 function InstallCalico()
 {
-    Write-Host "`nStart {{site.prodnameWindows}} install...`n"
+    Write-Host "`nStart Calico Enterprise for Windows install...`n"
 
     pushd
     cd $RootDir
     .\install-calico.ps1
     popd
-    Write-Host "`n{{site.prodnameWindows}} installed`n"
+    Write-Host "`nCalico Enterprise for Windows installed`n"
 }
 
 function SetConfig {
@@ -448,7 +439,7 @@ ipmo -force -DisableNameChecking $helperv2
 
 if (!(Test-Path $CalicoZipPath))
 {
-	throw "Cannot find {{site.prodnameWindows}} zip file $CalicoZipPath."
+	throw "Cannot find Calico Enterprise for Windows zip file $CalicoZipPath."
 }
 
 $platform=GetPlatformType
@@ -459,7 +450,7 @@ if ((Get-Service -exclude 'CalicoUpgrade' | where Name -Like 'Calico*' | where S
 }
 
 Remove-Item $RootDir -Force  -Recurse -ErrorAction SilentlyContinue
-Write-Host "Unzip {{site.prodnameWindows}} release..."
+Write-Host "Unzip Calico Enterprise for Windows release..."
 Expand-Archive -Force $CalicoZipPath c:\
 # This is a temporary fix to make sure nssm binary is in the correct path.
 $nssmDir = Get-ChildItem $RootDir -filter "nssm*" -Directory
@@ -472,7 +463,7 @@ if (-Not [string]::IsNullOrEmpty($KubeVersion) -and $platform -NE "eks") {
     PrepareKubernetes
 }
 
-Write-Host "Setup {{site.prodnameWindows}}..."
+Write-Host "Setup Calico Enterprise for Windows..."
 Set-ConfigParameters -var 'CALICO_DATASTORE_TYPE' -value $Datastore
 Set-ConfigParameters -var 'ETCD_ENDPOINTS' -value $EtcdEndpoints
 
@@ -487,7 +478,7 @@ Set-ConfigParameters -var 'K8S_SERVICE_CIDR' -value $ServiceCidr
 Set-ConfigParameters -var 'DNS_NAME_SERVERS' -value $DNSServerIPs
 
 if ($platform -EQ "aks") {
-    Write-Host "Setup {{site.prodnameWindows}} for AKS..."
+    Write-Host "Setup Calico Enterprise for Windows for AKS..."
     $Backend="none"
     Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "none"
     Set-ConfigParameters -var 'KUBE_NETWORK' -value "azure.*"
@@ -502,7 +493,7 @@ if ($platform -EQ "eks") {
 
     $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
     $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
-    Write-Host "Setup {{site.prodnameWindows}} for EKS, node name $awsNodeName ..."
+    Write-Host "Setup Calico Enterprise for Windows for EKS, node name $awsNodeName ..."
     $Backend = "none"
 
     Set-ConfigParameters -var 'NODENAME' -value $awsNodeName
@@ -516,7 +507,7 @@ if ($platform -EQ "eks") {
 if ($platform -EQ "ec2") {
     $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
     $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
-    Write-Host "Setup {{site.prodnameWindows}} for AWS, node name $awsNodeName ..."
+    Write-Host "Setup Calico Enterprise for Windows for AWS, node name $awsNodeName ..."
     Set-ConfigParameters -var 'NODENAME' -value $awsNodeName
 
     $calicoNs = GetCalicoNamespace
@@ -530,7 +521,7 @@ if ($platform -EQ "ec2") {
 }
 if ($platform -EQ "gce") {
     $gceNodeName = Invoke-RestMethod -UseBasicParsing -Headers @{"Metadata-Flavor"="Google"} "http://metadata.google.internal/computeMetadata/v1/instance/hostname" -ErrorAction Ignore
-    Write-Host "Setup {{site.prodnameWindows}} for GCE, node name $gceNodeName ..."
+    Write-Host "Setup Calico Enterprise for Windows for GCE, node name $gceNodeName ..."
     Set-ConfigParameters -var 'NODENAME' -value $gceNodeName
 
     $calicoNs = GetCalicoNamespace

--- a/static/calico-enterprise/3.16/scripts/install-calico-windows.ps1
+++ b/static/calico-enterprise/3.16/scripts/install-calico-windows.ps1
@@ -1,6 +1,3 @@
----
-layout: null
----
 # Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +13,7 @@ layout: null
 # limitations under the License.
 <#
 .DESCRIPTION
-    This script installs and starts {{site.prodname}} services on a Windows node.
+    This script installs and starts Calico Enterprise services on a Windows node.
 
     Note: EKS requires downloading kubectl.exe to c:\k before running this script: https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
 #>
@@ -24,12 +21,6 @@ layout: null
 Param(
     # Note: we don't publish a release artifact for the "master" branch. To test
     # against master, build calico-windows.zip from projectcalico/node.
-{%- if site.url contains "projectcalico" %}
-    [parameter(Mandatory = $false)] $ReleaseBaseURL="https://github.com/projectcalico/calico/releases/download/{{site.data.versions.first.components["calico/node"].version}}/",
-    [parameter(Mandatory = $false)] $ReleaseFile="calico-windows-{{site.data.versions.first.components["calico/node"].version}}.zip",
-{%- else %}
-    [parameter(Mandatory = $false)] $ReleaseBaseURL="{{site.url}}/files/windows/",
-{%- endif %}
     [parameter(Mandatory = $false)] $KubeVersion="",
     [parameter(Mandatory = $false)] $StartCalico="yes",
     # As of Kubernetes version v1.24.0, service account token secrets are no longer automatically created. But this installation script uses that secret
@@ -166,7 +157,7 @@ function GetBackendType()
     if ($Datastore -EQ "kubernetes") {
         $encap=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.ipipEnabled}'
         if ($encap -EQ "true") {
-            throw "{{site.prodname}} on Linux has IPIP enabled. IPIP is not supported on Windows nodes."
+            throw "Calico Enterprise on Linux has IPIP enabled. IPIP is not supported on Windows nodes."
         }
 
         # Check FelixConfig first.
@@ -397,13 +388,13 @@ function SetAKSCalicoStaticRules {
 
 function InstallCalico()
 {
-    Write-Host "`nStart {{site.prodnameWindows}} install...`n"
+    Write-Host "`nStart Calico Enterprise for Windows install...`n"
 
     pushd
     cd $RootDir
     .\install-calico.ps1
     popd
-    Write-Host "`n{{site.prodnameWindows}} installed`n"
+    Write-Host "`nCalico Enterprise for Windows installed`n"
 }
 
 function SetConfig {
@@ -448,7 +439,7 @@ ipmo -force -DisableNameChecking $helperv2
 
 if (!(Test-Path $CalicoZipPath))
 {
-	throw "Cannot find {{site.prodnameWindows}} zip file $CalicoZipPath."
+	throw "Cannot find Calico Enterprise for Windows zip file $CalicoZipPath."
 }
 
 $platform=GetPlatformType
@@ -459,7 +450,7 @@ if ((Get-Service -exclude 'CalicoUpgrade' | where Name -Like 'Calico*' | where S
 }
 
 Remove-Item $RootDir -Force  -Recurse -ErrorAction SilentlyContinue
-Write-Host "Unzip {{site.prodnameWindows}} release..."
+Write-Host "Unzip Calico Enterprise for Windows release..."
 Expand-Archive -Force $CalicoZipPath c:\
 ipmo -force $RootDir\libs\calico\calico.psm1
 
@@ -468,7 +459,7 @@ if (-Not [string]::IsNullOrEmpty($KubeVersion) -and $platform -NE "eks") {
     PrepareKubernetes
 }
 
-Write-Host "Setup {{site.prodnameWindows}}..."
+Write-Host "Setup Calico Enterprise for Windows..."
 Set-ConfigParameters -var 'CALICO_DATASTORE_TYPE' -value $Datastore
 Set-ConfigParameters -var 'ETCD_ENDPOINTS' -value $EtcdEndpoints
 
@@ -483,7 +474,7 @@ Set-ConfigParameters -var 'K8S_SERVICE_CIDR' -value $ServiceCidr
 Set-ConfigParameters -var 'DNS_NAME_SERVERS' -value $DNSServerIPs
 
 if ($platform -EQ "aks") {
-    Write-Host "Setup {{site.prodnameWindows}} for AKS..."
+    Write-Host "Setup Calico Enterprise for Windows for AKS..."
     $Backend="none"
     Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "none"
     Set-ConfigParameters -var 'KUBE_NETWORK' -value "azure.*"
@@ -498,7 +489,7 @@ if ($platform -EQ "eks") {
 
     $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
     $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
-    Write-Host "Setup {{site.prodnameWindows}} for EKS, node name $awsNodeName ..."
+    Write-Host "Setup Calico Enterprise for Windows for EKS, node name $awsNodeName ..."
     $Backend = "none"
 
     Set-ConfigParameters -var 'NODENAME' -value $awsNodeName
@@ -512,7 +503,7 @@ if ($platform -EQ "eks") {
 if ($platform -EQ "ec2") {
     $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
     $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
-    Write-Host "Setup {{site.prodnameWindows}} for AWS, node name $awsNodeName ..."
+    Write-Host "Setup Calico Enterprise for Windows for AWS, node name $awsNodeName ..."
     Set-ConfigParameters -var 'NODENAME' -value $awsNodeName
 
     $calicoNs = GetCalicoNamespace
@@ -526,7 +517,7 @@ if ($platform -EQ "ec2") {
 }
 if ($platform -EQ "gce") {
     $gceNodeName = Invoke-RestMethod -UseBasicParsing -Headers @{"Metadata-Flavor"="Google"} "http://metadata.google.internal/computeMetadata/v1/instance/hostname" -ErrorAction Ignore
-    Write-Host "Setup {{site.prodnameWindows}} for GCE, node name $gceNodeName ..."
+    Write-Host "Setup Calico Enterprise for Windows for GCE, node name $gceNodeName ..."
     Set-ConfigParameters -var 'NODENAME' -value $gceNodeName
 
     $calicoNs = GetCalicoNamespace

--- a/static/calico-enterprise/next/scripts/install-calico-windows.ps1
+++ b/static/calico-enterprise/next/scripts/install-calico-windows.ps1
@@ -1,6 +1,3 @@
----
-layout: null
----
 # Copyright (c) 2020-2022 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +13,7 @@ layout: null
 # limitations under the License.
 <#
 .DESCRIPTION
-    This script installs and starts {{site.prodname}} services on a Windows node.
+    This script installs and starts Calico Enterprise services on a Windows node.
 
     Note: EKS requires downloading kubectl.exe to c:\k before running this script: https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
 #>
@@ -24,12 +21,6 @@ layout: null
 Param(
     # Note: we don't publish a release artifact for the "master" branch. To test
     # against master, build calico-windows.zip from projectcalico/node.
-{%- if site.url contains "projectcalico" %}
-    [parameter(Mandatory = $false)] $ReleaseBaseURL="https://github.com/projectcalico/calico/releases/download/{{site.data.versions.first.components["calico/node"].version}}/",
-    [parameter(Mandatory = $false)] $ReleaseFile="calico-windows-{{site.data.versions.first.components["calico/node"].version}}.zip",
-{%- else %}
-    [parameter(Mandatory = $false)] $ReleaseBaseURL="{{site.url}}/files/windows/",
-{%- endif %}
     [parameter(Mandatory = $false)] $KubeVersion="",
     [parameter(Mandatory = $false)] $StartCalico="yes",
     # As of Kubernetes version v1.24.0, service account token secrets are no longer automatically created. But this installation script uses that secret
@@ -166,7 +157,7 @@ function GetBackendType()
     if ($Datastore -EQ "kubernetes") {
         $encap=c:\k\kubectl.exe --kubeconfig="$KubeConfigPath" get felixconfigurations.crd.projectcalico.org default -o jsonpath='{.spec.ipipEnabled}'
         if ($encap -EQ "true") {
-            throw "{{site.prodname}} on Linux has IPIP enabled. IPIP is not supported on Windows nodes."
+            throw "Calico Enterprise on Linux has IPIP enabled. IPIP is not supported on Windows nodes."
         }
 
         # Check FelixConfig first.
@@ -397,13 +388,13 @@ function SetAKSCalicoStaticRules {
 
 function InstallCalico()
 {
-    Write-Host "`nStart {{site.prodnameWindows}} install...`n"
+    Write-Host "`nStart Calico Enterprise for Windows install...`n"
 
     pushd
     cd $RootDir
     .\install-calico.ps1
     popd
-    Write-Host "`n{{site.prodnameWindows}} installed`n"
+    Write-Host "`nCalico Enterprise for Windows installed`n"
 }
 
 # kubectl errors are expected, so there are places where this is reset to "Continue" temporarily
@@ -438,7 +429,7 @@ ipmo -force -DisableNameChecking $helperv2
 
 if (!(Test-Path $CalicoZipPath))
 {
-	throw "Cannot find {{site.prodnameWindows}} zip file $CalicoZipPath."
+	throw "Cannot find Calico Enterprise for Windows zip file $CalicoZipPath."
 }
 
 $platform=GetPlatformType
@@ -449,7 +440,7 @@ if ((Get-Service -exclude 'CalicoUpgrade' | where Name -Like 'Calico*' | where S
 }
 
 Remove-Item $RootDir -Force  -Recurse -ErrorAction SilentlyContinue
-Write-Host "Unzip {{site.prodnameWindows}} release..."
+Write-Host "Unzip Calico Enterprise for Windows release..."
 Expand-Archive -Force $CalicoZipPath c:\
 ipmo -force $RootDir\libs\calico\calico.psm1
 
@@ -458,7 +449,7 @@ if (-Not [string]::IsNullOrEmpty($KubeVersion) -and $platform -NE "eks") {
     PrepareKubernetes
 }
 
-Write-Host "Setup {{site.prodnameWindows}}..."
+Write-Host "Setup Calico Enterprise for Windows..."
 Set-ConfigParameters -var 'CALICO_DATASTORE_TYPE' -value $Datastore
 Set-ConfigParameters -var 'ETCD_ENDPOINTS' -value $EtcdEndpoints
 
@@ -473,7 +464,7 @@ Set-ConfigParameters -var 'K8S_SERVICE_CIDR' -value $ServiceCidr
 Set-ConfigParameters -var 'DNS_NAME_SERVERS' -value $DNSServerIPs
 
 if ($platform -EQ "aks") {
-    Write-Host "Setup {{site.prodnameWindows}} for AKS..."
+    Write-Host "Setup Calico Enterprise for Windows for AKS..."
     $Backend="none"
     Set-ConfigParameters -var 'CALICO_NETWORKING_BACKEND' -value "none"
     Set-ConfigParameters -var 'KUBE_NETWORK' -value "azure.*"
@@ -488,7 +479,7 @@ if ($platform -EQ "eks") {
 
     $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
     $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
-    Write-Host "Setup {{site.prodnameWindows}} for EKS, node name $awsNodeName ..."
+    Write-Host "Setup Calico Enterprise for Windows for EKS, node name $awsNodeName ..."
     $Backend = "none"
 
     Set-ConfigParameters -var 'NODENAME' -value $awsNodeName
@@ -501,7 +492,7 @@ if ($platform -EQ "eks") {
 if ($platform -EQ "ec2") {
     $token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -Method PUT -Uri http://169.254.169.254/latest/api/token -ErrorAction Ignore
     $awsNodeName = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/local-hostname -ErrorAction Ignore
-    Write-Host "Setup {{site.prodnameWindows}} for AWS, node name $awsNodeName ..."
+    Write-Host "Setup Calico Enterprise for Windows for AWS, node name $awsNodeName ..."
     Set-ConfigParameters -var 'NODENAME' -value $awsNodeName
 
     $calicoNs = GetCalicoNamespace
@@ -515,7 +506,7 @@ if ($platform -EQ "ec2") {
 }
 if ($platform -EQ "gce") {
     $gceNodeName = Invoke-RestMethod -UseBasicParsing -Headers @{"Metadata-Flavor"="Google"} "http://metadata.google.internal/computeMetadata/v1/instance/hostname" -ErrorAction Ignore
-    Write-Host "Setup {{site.prodnameWindows}} for GCE, node name $gceNodeName ..."
+    Write-Host "Setup Calico Enterprise for Windows for GCE, node name $gceNodeName ..."
     Set-ConfigParameters -var 'NODENAME' -value $gceNodeName
 
     $calicoNs = GetCalicoNamespace


### PR DESCRIPTION
The `install-calico-windows.ps1` script had this `layout: null` docs metadata in it which was preventing it from running properly.

Additionally, jekyll liquid markup was not correctly being substituted for the correct values.

Finally, there was a step missing in the Calico for Windows EE quickstart guides for some configuration options.