### PR TITLE
Remove alert forwarding not supported note

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ This website is built using [Docusaurus 2](https://docusaurus.io/), a modern sta
 * Install / use Node.js v16.14.2+. Use the outstanding [nvm tool](https://github.com/nvm-sh/nvm) to manage
   your node versions.
 * Install yarn `npm install -g yarn`
-* Fork and clone our docs repo https://github.com/tigera/docs
+* Fork and clone our docs repo <https://github.com/tigera/docs>
 
 ## Install Dependencies
 
 ```bash
-$ yarn install
+yarn install
 ```
 
 This installs all the package dependencies, such as docusaurus.
@@ -25,7 +25,7 @@ This installs all the package dependencies, such as docusaurus.
 ## Local Development
 
 ```bash
-$ yarn start
+yarn start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without
@@ -34,8 +34,8 @@ having to restart the server. This build is faster, but does not produce all the
 ## Full Build & Serve
 
 ```bash
-$ yarn build
-$ yarn serve
+yarn build
+yarn serve
 ```
 
 This command generates static content into the `build` directory and can be served using any static content hosting
@@ -44,4 +44,4 @@ warning and error output. If you are trying to reproduce an error on Netlify, th
 
 ## Other Resources
 
-Netlify site: https://app.netlify.com/sites/calico-tigera-docs/overview
+Netlify site: <https://app.netlify.com/sites/calico-tigera-docs/overview>

--- a/calico-cloud/visibility/alerts.mdx
+++ b/calico-cloud/visibility/alerts.mdx
@@ -20,10 +20,6 @@ for common tasks that you can rename and edit to suit your own needs.
 
 ## Before you begin
 
-**Not supported**
-
-- Sending {{prodname}} alerts to other tools to operationalize alerts, or to a SIEM for logging and event correlation
-
 **Recommended**
 
 We recommend turning down the aggregation level for flow logs to ensure that you see pod-specific results. {{prodname}} aggregates flow logs over the external IPs for allowed traffic, and alert events will not provide pod-specific results (unless the traffic is denied by policy). 

--- a/calico-cloud_versioned_docs/version-3.15/visibility/alerts.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/visibility/alerts.mdx
@@ -20,10 +20,6 @@ for common tasks that you can rename and edit to suit your own needs.
 
 ## Before you begin
 
-**Not supported**
-
-- Sending {{prodname}} alerts to other tools to operationalize alerts, or to a SIEM for logging and event correlation
-
 **Recommended**
 
 We recommend turning down the aggregation level for flow logs to ensure that you see pod-specific results. {{prodname}} aggregates flow logs over the external IPs for allowed traffic, and alert events will not provide pod-specific results (unless the traffic is denied by policy). 

--- a/calico-enterprise/visibility/alerts.mdx
+++ b/calico-enterprise/visibility/alerts.mdx
@@ -20,10 +20,6 @@ for common tasks that you can rename and edit to suit your own needs.
 
 ## Before you begin
 
-**Not supported**
-
-- Sending {{prodname}} alerts to other tools to operationalize alerts, or to a SIEM for logging and event correlation
-
 **Recommended**
 
 We recommend turning down the aggregation level for flow logs to ensure that you see pod-specific results. {{prodname}} aggregates flow logs over the external IPs for allowed traffic, and alert events will not provide pod-specific results (unless the traffic is denied by policy).

--- a/calico-enterprise_versioned_docs/version-3.15/visibility/alerts.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/visibility/alerts.mdx
@@ -20,10 +20,6 @@ for common tasks that you can rename and edit to suit your own needs.
 
 ## Before you begin
 
-**Not supported**
-
-- Sending {{prodname}} alerts to other tools to operationalize alerts, or to a SIEM for logging and event correlation
-
 **Recommended**
 
 We recommend turning down the aggregation level for flow logs to ensure that you see pod-specific results. {{prodname}} aggregates flow logs over the external IPs for allowed traffic, and alert events will not provide pod-specific results (unless the traffic is denied by policy).

--- a/calico-enterprise_versioned_docs/version-3.16/visibility/alerts.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/visibility/alerts.mdx
@@ -20,10 +20,6 @@ for common tasks that you can rename and edit to suit your own needs.
 
 ## Before you begin
 
-**Not supported**
-
-- Sending {{prodname}} alerts to other tools to operationalize alerts, or to a SIEM for logging and event correlation
-
 **Recommended**
 
 We recommend turning down the aggregation level for flow logs to ensure that you see pod-specific results. {{prodname}} aggregates flow logs over the external IPs for allowed traffic, and alert events will not provide pod-specific results (unless the traffic is denied by policy).


### PR DESCRIPTION
This changeset removes alerts forwarding not supported notes in Calico Enterprise and Cloud v3.15, v3.16, and root level docs. Calico Enterprise do support alert forwarding. It also reformats `README.md` codeblocks.

Fix applies to CC docs 3.15 and 3.16