### PR TITLE
Add Tigera operator PSP step in docs

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/kubernetes/quickstart.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/kubernetes/quickstart.mdx
@@ -87,6 +87,12 @@ A Linux host that meets the following requirements.
 
 1. [Configure a storage class for {{prodname}}.](../../../operations/logstorage/create-storage.mdx)
 
+1. In a v1.24 or earlier cluster, if the [PodSecurityPolicy admission controller](https://v1-24.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy) is enabled, install the required Tigera operator Pod Security Policy.
+
+   ```batch
+   kubectl create -f {{filesUrl}}/manifests/psp-tigera-operator.yaml
+   ```
+
 1. Install the Tigera operator and custom resource definitions.
 
    ```batch

--- a/calico-enterprise/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/rancher.mdx
@@ -53,6 +53,12 @@ The geeky details of what you get:
 
 1. [Configure a storage class for {{prodname}}.](../../operations/logstorage/create-storage.mdx).
 
+1. In a v1.24 or earlier cluster, if the [PodSecurityPolicy admission controller](https://v1-24.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy) is enabled, install the required Tigera operator Pod Security Policy.
+
+   ```batch
+   kubectl create -f {{filesUrl}}/manifests/psp-tigera-operator.yaml
+   ```
+
 1. Install the Tigera operator and custom resource definitions.
 
    ```batch

--- a/calico-enterprise/getting-started/install-on-clusters/rke2.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/rke2.mdx
@@ -52,7 +52,7 @@ The geeky details of what you get:
 
 1. [Configure a storage class for {{prodname}}.](../../operations/logstorage/create-storage.mdx).
 
-1. If you are using RKE2 [CIS hardened clusters](https://docs.rke2.io/security/hardening_guide) with v1.24 or earlier, install the required Tigera operator PSP.
+1. In a v1.24 or earlier cluster, if the [PodSecurityPolicy admission controller](https://v1-24.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy) is enabled or it is a [CIS hardened cluster](https://docs.rke2.io/security/hardening_guide), install the required Tigera operator Pod Security Policy.
 
    ```batch
    kubectl create -f {{filesUrl}}/manifests/psp-tigera-operator.yaml

--- a/calico-enterprise_versioned_docs/version-3.15/getting-started/install-on-clusters/kubernetes/quickstart.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/getting-started/install-on-clusters/kubernetes/quickstart.mdx
@@ -87,6 +87,12 @@ A Linux host that meets the following requirements.
 
 1. [Configure a storage class for {{prodname}}.](../../../operations/logstorage/create-storage.mdx)
 
+1. In a v1.24 or earlier cluster, if the [PodSecurityPolicy admission controller](https://v1-24.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy) is enabled, install the required Tigera operator Pod Security Policy.
+
+   ```batch
+   kubectl create -f {{filesUrl}}/manifests/psp-tigera-operator.yaml
+   ```
+
 1. Install the Tigera operator and custom resource definitions.
 
    ```batch

--- a/calico-enterprise_versioned_docs/version-3.15/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/getting-started/install-on-clusters/rancher.mdx
@@ -53,6 +53,12 @@ The geeky details of what you get:
 
 1. [Configure a storage class for {{prodname}}.](../../operations/logstorage/create-storage.mdx).
 
+1. In a v1.24 or earlier cluster, if the [PodSecurityPolicy admission controller](https://v1-24.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy) is enabled, install the required Tigera operator Pod Security Policy.
+
+   ```batch
+   kubectl create -f {{filesUrl}}/manifests/psp-tigera-operator.yaml
+   ```
+
 1. Install the Tigera operator and custom resource definitions.
 
    ```batch

--- a/calico-enterprise_versioned_docs/version-3.15/getting-started/install-on-clusters/rke2.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/getting-started/install-on-clusters/rke2.mdx
@@ -52,7 +52,7 @@ The geeky details of what you get:
 
 1. [Configure a storage class for {{prodname}}.](../../operations/logstorage/create-storage.mdx).
 
-1. For RKE2 [CIS hardened clusters](https://docs.rke2.io/security/hardening_guide) with v1.24 or earlier, if the Tigera operator PSP is not installed, add it now.
+1. In a v1.24 or earlier cluster, if the [PodSecurityPolicy admission controller](https://v1-24.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy) is enabled or it is a [CIS hardened cluster](https://docs.rke2.io/security/hardening_guide), install the required Tigera operator Pod Security Policy.
 
    ```batch
    kubectl create -f {{filesUrl}}/manifests/psp-tigera-operator.yaml

--- a/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/kubernetes/quickstart.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/kubernetes/quickstart.mdx
@@ -87,6 +87,12 @@ A Linux host that meets the following requirements.
 
 1. [Configure a storage class for {{prodname}}.](../../../operations/logstorage/create-storage.mdx)
 
+1. In a v1.24 or earlier cluster, if the [PodSecurityPolicy admission controller](https://v1-24.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy) is enabled, install the required Tigera operator Pod Security Policy.
+
+   ```batch
+   kubectl create -f {{filesUrl}}/manifests/psp-tigera-operator.yaml
+   ```
+
 1. Install the Tigera operator and custom resource definitions.
 
    ```batch

--- a/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/rancher.mdx
@@ -53,6 +53,12 @@ The geeky details of what you get:
 
 1. [Configure a storage class for {{prodname}}.](../../operations/logstorage/create-storage.mdx).
 
+1. In a v1.24 or earlier cluster, if the [PodSecurityPolicy admission controller](https://v1-24.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy) is enabled, install the required Tigera operator Pod Security Policy.
+
+   ```batch
+   kubectl create -f {{filesUrl}}/manifests/psp-tigera-operator.yaml
+   ```
+
 1. Install the Tigera operator and custom resource definitions.
 
    ```batch

--- a/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/rke2.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/rke2.mdx
@@ -52,7 +52,7 @@ The geeky details of what you get:
 
 1. [Configure a storage class for {{prodname}}.](../../operations/logstorage/create-storage.mdx).
 
-1. If you are using RKE2 [CIS hardened clusters](https://docs.rke2.io/security/hardening_guide) with v1.24 or earlier, install the required Tigera operator PSP.
+1. In a v1.24 or earlier cluster, if the [PodSecurityPolicy admission controller](https://v1-24.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy) is enabled or it is a [CIS hardened cluster](https://docs.rke2.io/security/hardening_guide), install the required Tigera operator Pod Security Policy.
 
    ```batch
    kubectl create -f {{filesUrl}}/manifests/psp-tigera-operator.yaml


### PR DESCRIPTION
When Calico Enterprise v3.15+ is installed on a cluster with k8s <= v1.24 and psp admission controller is enabled, we need this additional step to apply Tigera Operator PSP before applying the Tigera Operator manifest.