### PR TITLE
Fix wrong use of deny when describing allow policy in secure metrics

### DIFF
--- a/calico-cloud/operations/comms/secure-metrics.mdx
+++ b/calico-cloud/operations/comms/secure-metrics.mdx
@@ -401,7 +401,7 @@ The basic process is as follows:
              - 9091
    ```
 
-   This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress deny rule.
+   This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress allow rule.
    The ingress rule allows traffic to port 9091 from any source with the label `calico-prometheus-access: true`, meaning
    all {{prodname}} workload endpoints, host endpoints, and global network sets that have the label will be allowed access.
 
@@ -469,7 +469,7 @@ spec:
           - 9093
 ```
 
-This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress deny rule.
+This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress allow rule.
 The ingress rule allows traffic to port 9093 from any source with the label `calico-prometheus-access: true`, meaning
 all {{prodname}} workload endpoints, host endpoints, and global network sets that have the label will be allowed access.
 

--- a/calico-cloud_versioned_docs/version-3.15/operations/comms/secure-metrics.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/operations/comms/secure-metrics.mdx
@@ -402,7 +402,7 @@ The basic process is as follows:
              - 9091
    ```
 
-   This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress deny rule.
+   This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress allow rule.
    The ingress rule allows traffic to port 9091 from any source with the label `calico-prometheus-access: true`, meaning
    all {{prodname}} workload endpoints, host endpoints, and global network sets that have the label will be allowed access.
 
@@ -470,7 +470,7 @@ spec:
           - 9093
 ```
 
-This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress deny rule.
+This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress allow rule.
 The ingress rule allows traffic to port 9093 from any source with the label `calico-prometheus-access: true`, meaning
 all {{prodname}} workload endpoints, host endpoints, and global network sets that have the label will be allowed access.
 

--- a/calico-enterprise/operations/comms/secure-metrics.mdx
+++ b/calico-enterprise/operations/comms/secure-metrics.mdx
@@ -399,7 +399,7 @@ The basic process is as follows:
              - 9091
    ```
 
-   This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress deny rule.
+   This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress allow rule.
    The ingress rule allows traffic to port 9091 from any source with the label `calico-prometheus-access: true`, meaning
    all {{prodname}} workload endpoints, host endpoints, and global network sets that have the label will be allowed access.
 
@@ -467,7 +467,7 @@ spec:
           - 9093
 ```
 
-This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress deny rule.
+This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress allow rule.
 The ingress rule allows traffic to port 9093 from any source with the label `calico-prometheus-access: true`, meaning
 all {{prodname}} workload endpoints, host endpoints, and global network sets that have the label will be allowed access.
 

--- a/calico-enterprise_versioned_docs/version-3.14/operations/comms/secure-metrics.mdx
+++ b/calico-enterprise_versioned_docs/version-3.14/operations/comms/secure-metrics.mdx
@@ -399,7 +399,7 @@ The basic process is as follows:
              - 9091
    ```
 
-   This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress deny rule.
+   This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress allow rule.
    The ingress rule alows traffic to port 9091 from any source with the label `calico-prometheus-access: true`, meaning
    all {{prodname}} workload endpoints, host endpoints, and global network sets that have the label will be allowed access.
 
@@ -467,7 +467,7 @@ spec:
           - 9093
 ```
 
-This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress deny rule.
+This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress allow rule.
 The ingress rule alows traffic to port 9093 from any source with the label `calico-prometheus-access: true`, meaning
 all {{prodname}} workload endpoints, host endpoints, and global network sets that have the label will be allowed access.
 

--- a/calico-enterprise_versioned_docs/version-3.15/operations/comms/secure-metrics.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/operations/comms/secure-metrics.mdx
@@ -399,7 +399,7 @@ The basic process is as follows:
              - 9091
    ```
 
-   This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress deny rule.
+   This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress allow rule.
    The ingress rule allows traffic to port 9091 from any source with the label `calico-prometheus-access: true`, meaning
    all {{prodname}} workload endpoints, host endpoints, and global network sets that have the label will be allowed access.
 
@@ -467,7 +467,7 @@ spec:
           - 9093
 ```
 
-This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress deny rule.
+This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress allow rule.
 The ingress rule allows traffic to port 9093 from any source with the label `calico-prometheus-access: true`, meaning
 all {{prodname}} workload endpoints, host endpoints, and global network sets that have the label will be allowed access.
 

--- a/calico-enterprise_versioned_docs/version-3.16/operations/comms/secure-metrics.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/operations/comms/secure-metrics.mdx
@@ -399,7 +399,7 @@ The basic process is as follows:
              - 9091
    ```
 
-   This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress deny rule.
+   This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress allow rule.
    The ingress rule allows traffic to port 9091 from any source with the label `calico-prometheus-access: true`, meaning
    all {{prodname}} workload endpoints, host endpoints, and global network sets that have the label will be allowed access.
 
@@ -467,7 +467,7 @@ spec:
           - 9093
 ```
 
-This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress deny rule.
+This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress allow rule.
 The ingress rule allows traffic to port 9093 from any source with the label `calico-prometheus-access: true`, meaning
 all {{prodname}} workload endpoints, host endpoints, and global network sets that have the label will be allowed access.
 

--- a/calico/network-policy/comms/secure-metrics.mdx
+++ b/calico/network-policy/comms/secure-metrics.mdx
@@ -399,7 +399,7 @@ The basic process is as follows:
              - 9091
    ```
 
-   This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress deny rule.
+   This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress allow rule.
    The ingress rule allows traffic to port 9091 from any source with the label `calico-prometheus-access: true`, meaning
    all {{prodname}} workload endpoints, host endpoints, and global network sets that have the label will be allowed access.
 
@@ -467,7 +467,7 @@ spec:
           - 9093
 ```
 
-This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress deny rule.
+This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress allow rule.
 The ingress rule allows traffic to port 9093 from any source with the label `calico-prometheus-access: true`, meaning
 all {{prodname}} workload endpoints, host endpoints, and global network sets that have the label will be allowed access.
 

--- a/calico_versioned_docs/version-3.24/network-policy/comms/secure-metrics.mdx
+++ b/calico_versioned_docs/version-3.24/network-policy/comms/secure-metrics.mdx
@@ -399,7 +399,7 @@ The basic process is as follows:
              - 9091
    ```
 
-   This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress deny rule.
+   This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress allow rule.
    The ingress rule allows traffic to port 9091 from any source with the label `calico-prometheus-access: true`, meaning
    all {{prodname}} workload endpoints, host endpoints, and global network sets that have the label will be allowed access.
 
@@ -467,7 +467,7 @@ spec:
           - 9093
 ```
 
-This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress deny rule.
+This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress allow rule.
 The ingress rule allows traffic to port 9093 from any source with the label `calico-prometheus-access: true`, meaning
 all {{prodname}} workload endpoints, host endpoints, and global network sets that have the label will be allowed access.
 

--- a/calico_versioned_docs/version-3.25/network-policy/comms/secure-metrics.mdx
+++ b/calico_versioned_docs/version-3.25/network-policy/comms/secure-metrics.mdx
@@ -399,7 +399,7 @@ The basic process is as follows:
              - 9091
    ```
 
-   This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress deny rule.
+   This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress allow rule.
    The ingress rule allows traffic to port 9091 from any source with the label `calico-prometheus-access: true`, meaning
    all {{prodname}} workload endpoints, host endpoints, and global network sets that have the label will be allowed access.
 
@@ -467,7 +467,7 @@ spec:
           - 9093
 ```
 
-This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress deny rule.
+This policy selects all endpoints that have the label `running-calico: true`, and enforces a single ingress allow rule.
 The ingress rule allows traffic to port 9093 from any source with the label `calico-prometheus-access: true`, meaning
 all {{prodname}} workload endpoints, host endpoints, and global network sets that have the label will be allowed access.
 


### PR DESCRIPTION
The secure metrics documents  describe all Allow rules as deny.

This pull request fixes them.