### PR TITLE
Use kubectl to configure route reflector.

### DIFF
--- a/calico-cloud/networking/configuring/bgp.mdx
+++ b/calico-cloud/networking/configuring/bgp.mdx
@@ -124,13 +124,13 @@ spec:
 
 To configure a node to be a route reflector with cluster ID 244.0.0.1, run the following command.
 
-```
-calicoctl patch node my-node -p '{"spec": {"bgp": {"routeReflectorClusterID": "244.0.0.1"}}}'
+```bash
+kubectl annotate node my-node projectcalico.org/RouteReflectorClusterID=244.0.0.1
 ```
 
 Typically, you will want to label this node to indicate that it is a route reflector, allowing it to be easily selected by a BGPPeer resource. You can do this with kubectl. For example:
 
-```
+```bash
 kubectl label node my-node route-reflector=true
 ```
 
@@ -162,7 +162,7 @@ The default **node-to-node BGP mesh** may be turned off to enable other BGP topo
 
 Run the following command to disable the BGP full-mesh:
 
-```
+```bash
 calicoctl patch bgpconfiguration default -p '{"spec": {"nodeToNodeMeshEnabled": false}}'
 ```
 
@@ -221,7 +221,7 @@ You can use `calicoctl` to view the BGP information for all peers of a particula
 
 Run the following command from anywhere you have access to `kubectl`:
 
-```
+```bash
 calicoctl bgp peers <NODE_NAME>
 ```
 
@@ -236,7 +236,7 @@ The above command can be run from anywhere you have access to kubectl. We recomm
 
 If you install the binary as a kubectl plugin using the above instructions, you can then run the command as follows:
 
-```
+```bash
 kubectl calico bgp peers <NODE_NAME>
 ```
 
@@ -244,7 +244,7 @@ kubectl calico bgp peers <NODE_NAME>
 
 By default, all Calico nodes use the 64512 autonomous system, unless a per-node AS has been specified for the node. You can change the global default for all nodes by modifying the default **BGPConfiguration** resource. The following example command sets the global default AS number to **64513**.
 
-```
+```bash
 kubectl patch bgpconfiguration default -p '{"spec": {"asNumber": "64513"}}'
 ```
 
@@ -258,7 +258,7 @@ If the default BGP configuration resource does not exist, you need to create it 
 
 You can configure an AS for a particular node by modifying the node object using `calicoctl`. For example, the following command changes the node named **node-1** to belong to **AS 64514**.
 
-```
+```bash
 calicoctl patch node node-1 -p '{"spec": {"bgp": {"asNumber": "64514"}}}'
 ```
 

--- a/calico-enterprise/networking/configuring/bgp.mdx
+++ b/calico-enterprise/networking/configuring/bgp.mdx
@@ -123,13 +123,13 @@ spec:
 
 To configure a node to be a route reflector with cluster ID 244.0.0.1, run the following command.
 
-```
-calicoctl patch node my-node -p '{"spec": {"bgp": {"routeReflectorClusterID": "244.0.0.1"}}}'
+```bash
+kubectl annotate node my-node projectcalico.org/RouteReflectorClusterID=244.0.0.1
 ```
 
 Typically, you will want to label this node to indicate that it is a route reflector, allowing it to be easily selected by a BGPPeer resource. You can do this with kubectl. For example:
 
-```
+```bash
 kubectl label node my-node route-reflector=true
 ```
 
@@ -161,7 +161,7 @@ The default **node-to-node BGP mesh** may be turned off to enable other BGP topo
 
 Run the following command to disable the BGP full-mesh:
 
-```
+```bash
 calicoctl patch bgpconfiguration default -p '{"spec": {"nodeToNodeMeshEnabled": false}}'
 ```
 
@@ -220,7 +220,7 @@ You can use `calicoctl` to view the BGP information for all peers of a particula
 
 Run the following command from anywhere you have access to `kubectl`:
 
-```
+```bash
 calicoctl bgp peers <NODE_NAME>
 ```
 
@@ -233,7 +233,7 @@ The above command can be run from anywhere you have access to kubectl. We recomm
 :::
 If you install the binary as a kubectl plugin using the above instructions, you can then run the command as follows:
 
-```
+```bash
 kubectl calico bgp peers <NODE_NAME>
 ```
 
@@ -241,7 +241,7 @@ kubectl calico bgp peers <NODE_NAME>
 
 By default, all Calico nodes use the 64512 autonomous system, unless a per-node AS has been specified for the node. You can change the global default for all nodes by modifying the default **BGPConfiguration** resource. The following example command sets the global default AS number to **64513**.
 
-```
+```bash
 kubectl patch bgpconfiguration default -p '{"spec": {"asNumber": "64513"}}'
 ```
 
@@ -255,7 +255,7 @@ If the default BGP configuration resource does not exist, you need to create it 
 
 You can configure an AS for a particular node by modifying the node object using `calicoctl`. For example, the following command changes the node named **node-1** to belong to **AS 64514**.
 
-```
+```bash
 calicoctl patch node node-1 -p '{"spec": {"bgp": {"asNumber": "64514"}}}'
 ```
 

--- a/calico-enterprise_versioned_docs/version-3.16/networking/configuring/bgp.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/networking/configuring/bgp.mdx
@@ -123,13 +123,13 @@ spec:
 
 To configure a node to be a route reflector with cluster ID 244.0.0.1, run the following command.
 
-```
-calicoctl patch node my-node -p '{"spec": {"bgp": {"routeReflectorClusterID": "244.0.0.1"}}}'
+```bash
+kubectl annotate node my-node projectcalico.org/RouteReflectorClusterID=244.0.0.1
 ```
 
 Typically, you will want to label this node to indicate that it is a route reflector, allowing it to be easily selected by a BGPPeer resource. You can do this with kubectl. For example:
 
-```
+```bash
 kubectl label node my-node route-reflector=true
 ```
 
@@ -161,7 +161,7 @@ The default **node-to-node BGP mesh** may be turned off to enable other BGP topo
 
 Run the following command to disable the BGP full-mesh:
 
-```
+```bash
 calicoctl patch bgpconfiguration default -p '{"spec": {"nodeToNodeMeshEnabled": false}}'
 ```
 
@@ -220,7 +220,7 @@ You can use `calicoctl` to view the BGP information for all peers of a particula
 
 Run the following command from anywhere you have access to `kubectl`:
 
-```
+```bash
 calicoctl bgp peers <NODE_NAME>
 ```
 
@@ -233,7 +233,7 @@ The above command can be run from anywhere you have access to kubectl. We recomm
 :::
 If you install the binary as a kubectl plugin using the above instructions, you can then run the command as follows:
 
-```
+```bash
 kubectl calico bgp peers <NODE_NAME>
 ```
 
@@ -241,7 +241,7 @@ kubectl calico bgp peers <NODE_NAME>
 
 By default, all Calico nodes use the 64512 autonomous system, unless a per-node AS has been specified for the node. You can change the global default for all nodes by modifying the default **BGPConfiguration** resource. The following example command sets the global default AS number to **64513**.
 
-```
+```bash
 kubectl patch bgpconfiguration default -p '{"spec": {"asNumber": "64513"}}'
 ```
 
@@ -255,7 +255,7 @@ If the default BGP configuration resource does not exist, you need to create it 
 
 You can configure an AS for a particular node by modifying the node object using `calicoctl`. For example, the following command changes the node named **node-1** to belong to **AS 64514**.
 
-```
+```bash
 calicoctl patch node node-1 -p '{"spec": {"bgp": {"asNumber": "64514"}}}'
 ```
 

--- a/calico/networking/configuring/bgp.mdx
+++ b/calico/networking/configuring/bgp.mdx
@@ -4,6 +4,9 @@ description: Configure BGP peering with full mesh, node-specific peering, ToR, a
 
 # Configure BGP peering
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Big picture
 
 Configure BGP (Border Gateway Protocol) between Calico nodes or peering with network infrastructure to distribute routing information.
@@ -119,13 +122,26 @@ spec:
 
 To configure a node to be a route reflector with cluster ID 244.0.0.1, run the following command.
 
+<Tabs>
+<TabItem label="Kubernetes API datastore" value="kubernetes-api-datastore" default>
+
+```bash
+kubectl annotate node my-node projectcalico.org/RouteReflectorClusterID=244.0.0.1
 ```
+
+</TabItem>
+<TabItem label="etcd datastore" value="etcd-datastore">
+
+```bash
 calicoctl patch node my-node -p '{"spec": {"bgp": {"routeReflectorClusterID": "244.0.0.1"}}}'
 ```
 
+</TabItem>
+</Tabs>
+
 Typically, you will want to label this node to indicate that it is a route reflector, allowing it to be easily selected by a BGPPeer resource. You can do this with kubectl. For example:
 
-```
+```bash
 kubectl label node my-node route-reflector=true
 ```
 
@@ -157,7 +173,7 @@ The default **node-to-node BGP mesh** may be turned off to enable other BGP topo
 
 Run the following command to disable the BGP full-mesh:
 
-```
+```bash
 calicoctl patch bgpconfiguration default -p '{"spec": {"nodeToNodeMeshEnabled": false}}'
 ```
 
@@ -214,7 +230,7 @@ This command communicates with the local {{prodname}} agent, so you must execute
 
 By default, all Calico nodes use the 64512 autonomous system, unless a per-node AS has been specified for the node. You can change the global default for all nodes by modifying the default **BGPConfiguration** resource. The following example command sets the global default AS number to **64513**.
 
-```
+```bash
 calicoctl patch bgpconfiguration default -p '{"spec": {"asNumber": "64513"}}'
 ```
 
@@ -228,7 +244,7 @@ If the default BGP configuration resource does not exist, you need to create it 
 
 You can configure an AS for a particular node by modifying the node object using `calicoctl`. For example, the following command changes the node named **node-1** to belong to **AS 64514**.
 
-```
+```bash
 calicoctl patch node node-1 -p '{"spec": {"bgp": {"asNumber": "64514"}}}'
 ```
 

--- a/calico_versioned_docs/version-3.24/networking/configuring/bgp.mdx
+++ b/calico_versioned_docs/version-3.24/networking/configuring/bgp.mdx
@@ -4,6 +4,9 @@ description: Configure BGP peering with full mesh, node-specific peering, ToR, a
 
 # Configure BGP peering
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Big picture
 
 Configure BGP (Border Gateway Protocol) between Calico nodes or peering with network infrastructure to distribute routing information.
@@ -116,13 +119,26 @@ spec:
 
 To configure a node to be a route reflector with cluster ID 244.0.0.1, run the following command.
 
+<Tabs>
+<TabItem label="Kubernetes API datastore" value="kubernetes-api-datastore" default>
+
+```bash
+kubectl annotate node my-node projectcalico.org/RouteReflectorClusterID=244.0.0.1
 ```
+
+</TabItem>
+<TabItem label="etcd datastore" value="etcd-datastore">
+
+```bash
 calicoctl patch node my-node -p '{"spec": {"bgp": {"routeReflectorClusterID": "244.0.0.1"}}}'
 ```
 
+</TabItem>
+</Tabs>
+
 Typically, you will want to label this node to indicate that it is a route reflector, allowing it to be easily selected by a BGPPeer resource. You can do this with kubectl. For example:
 
-```
+```bash
 kubectl label node my-node route-reflector=true
 ```
 
@@ -154,7 +170,7 @@ The default **node-to-node BGP mesh** may be turned off to enable other BGP topo
 
 Run the following command to disable the BGP full-mesh:
 
-```
+```bash
 calicoctl patch bgpconfiguration default -p '{"spec": {"nodeToNodeMeshEnabled": false}}'
 ```
 
@@ -211,7 +227,7 @@ This command communicates with the local {{prodname}} agent, so you must execute
 
 By default, all Calico nodes use the 64512 autonomous system, unless a per-node AS has been specified for the node. You can change the global default for all nodes by modifying the default **BGPConfiguration** resource. The following example command sets the global default AS number to **64513**.
 
-```
+```bash
 calicoctl patch bgpconfiguration default -p '{"spec": {"asNumber": "64513"}}'
 ```
 
@@ -225,7 +241,7 @@ If the default BGP configuration resource does not exist, you need to create it 
 
 You can configure an AS for a particular node by modifying the node object using `calicoctl`. For example, the following command changes the node named **node-1** to belong to **AS 64514**.
 
-```
+```bash
 calicoctl patch node node-1 -p '{"spec": {"bgp": {"asNumber": "64514"}}}'
 ```
 

--- a/calico_versioned_docs/version-3.25/networking/configuring/bgp.mdx
+++ b/calico_versioned_docs/version-3.25/networking/configuring/bgp.mdx
@@ -4,6 +4,9 @@ description: Configure BGP peering with full mesh, node-specific peering, ToR, a
 
 # Configure BGP peering
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Big picture
 
 Configure BGP (Border Gateway Protocol) between Calico nodes or peering with network infrastructure to distribute routing information.
@@ -116,13 +119,26 @@ spec:
 
 To configure a node to be a route reflector with cluster ID 244.0.0.1, run the following command.
 
+<Tabs>
+<TabItem label="Kubernetes API datastore" value="kubernetes-api-datastore" default>
+
+```bash
+kubectl annotate node my-node projectcalico.org/RouteReflectorClusterID=244.0.0.1
 ```
+
+</TabItem>
+<TabItem label="etcd datastore" value="etcd-datastore">
+
+```bash
 calicoctl patch node my-node -p '{"spec": {"bgp": {"routeReflectorClusterID": "244.0.0.1"}}}'
 ```
 
+</TabItem>
+</Tabs>
+
 Typically, you will want to label this node to indicate that it is a route reflector, allowing it to be easily selected by a BGPPeer resource. You can do this with kubectl. For example:
 
-```
+```bash
 kubectl label node my-node route-reflector=true
 ```
 
@@ -154,7 +170,7 @@ The default **node-to-node BGP mesh** may be turned off to enable other BGP topo
 
 Run the following command to disable the BGP full-mesh:
 
-```
+```bash
 calicoctl patch bgpconfiguration default -p '{"spec": {"nodeToNodeMeshEnabled": false}}'
 ```
 
@@ -211,7 +227,7 @@ This command communicates with the local {{prodname}} agent, so you must execute
 
 By default, all Calico nodes use the 64512 autonomous system, unless a per-node AS has been specified for the node. You can change the global default for all nodes by modifying the default **BGPConfiguration** resource. The following example command sets the global default AS number to **64513**.
 
-```
+```bash
 calicoctl patch bgpconfiguration default -p '{"spec": {"asNumber": "64513"}}'
 ```
 
@@ -225,7 +241,7 @@ If the default BGP configuration resource does not exist, you need to create it 
 
 You can configure an AS for a particular node by modifying the node object using `calicoctl`. For example, the following command changes the node named **node-1** to belong to **AS 64514**.
 
-```
+```bash
 calicoctl patch node node-1 -p '{"spec": {"bgp": {"asNumber": "64514"}}}'
 ```
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,9 @@
 # all contexts unless otherwise overridden by more specific contexts.
 [build]
 publish = "build/"
-command = "make all"
+
+# Default build command.
+command = "make clean && make build"
 
 [[plugins]]
 # Installs the Lighthouse Build Plugin for all deploy contexts


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

At present we are using calicoctl to configure route reflectors. Going forward we need to use kubectl as appropriate validations are added to the annotations. 

- For CC and CE, 3.16 
- For OSS, 3.25, 3.24

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->