### PR TITLE
DOCS-1357: Restores SysReq prerequisite to RKE install procedure

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/gke.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/gke.mdx
@@ -45,7 +45,7 @@ The geeky details of what you get:
 
   :::
 
-- Cluster meets [system requirements](requirements.mdx#network-requirements)
+- Cluster meets [system requirements](requirements.mdx)
 
 - A [Tigera license key and credentials](calico-enterprise.mdx#get-private-registry-credentials-and-license-key)
 

--- a/calico-enterprise/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/rancher.mdx
@@ -37,6 +37,8 @@ The geeky details of what you get:
 
   :::
 
+- Cluster meets [system requirements](requirements.mdx)
+
 - A [Tigera license key and credentials](calico-enterprise.mdx).
 
 - A `kubectl` environment with access to your cluster

--- a/calico-enterprise_versioned_docs/version-3.14/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.14/getting-started/install-on-clusters/rancher.mdx
@@ -33,7 +33,7 @@ The geeky details of what you get:
 
   - Configure your cluster with a [Cluster Config File](https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/#cluster-config-file) and specify [no network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) by setting `plugin: none` under `network` in your configuration file.
 
-- RKE cluster meets the [{{prodname}} requirements](requirements.mdx)
+- Cluster meets [system requirements](requirements.mdx)
 
 - [Credentials for the Tigera private registry and a license key](calico-enterprise.mdx).
 

--- a/calico-enterprise_versioned_docs/version-3.15/getting-started/install-on-clusters/gke.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/getting-started/install-on-clusters/gke.mdx
@@ -45,7 +45,7 @@ The geeky details of what you get:
 
   :::
 
-- Cluster meets [system requirements](requirements.mdx#network-requirements)
+- Cluster meets [system requirements](requirements.mdx)
 
 - A [Tigera license key and credentials](calico-enterprise.mdx#get-private-registry-credentials-and-license-key)
 

--- a/calico-enterprise_versioned_docs/version-3.15/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/getting-started/install-on-clusters/rancher.mdx
@@ -37,6 +37,8 @@ The geeky details of what you get:
 
   :::
 
+- Cluster meets [system requirements](requirements.mdx)
+
 - A [Tigera license key and credentials](calico-enterprise.mdx).
 
 - A `kubectl` environment with access to your cluster

--- a/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/gke.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/gke.mdx
@@ -45,7 +45,7 @@ The geeky details of what you get:
 
   :::
 
-- Cluster meets [system requirements](requirements.mdx#network-requirements)
+- Cluster meets [system requirements](requirements.mdx)
 
 - A [Tigera license key and credentials](calico-enterprise.mdx#get-private-registry-credentials-and-license-key)
 

--- a/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/rancher.mdx
@@ -37,6 +37,8 @@ The geeky details of what you get:
 
   :::
 
+- Cluster meets [system requirements](requirements.mdx)
+
 - A [Tigera license key and credentials](calico-enterprise.mdx).
 
 - A `kubectl` environment with access to your cluster


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
https://tigera.atlassian.net/browse/DOCS-1357

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->