### PR TITLE
Fix a redirect

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -505,6 +505,8 @@
 /v1.6/* https://docs.tigera.io/archive/v1.6/:splat 301
 /v1.5/* https://docs.tigera.io/archive/v1.5/:splat 301
 
+/calico-enterprise/  https://docs.tigera.io/calico-enterprise/latest/about-calico-enterprise 301
+
 # Keeping felix alive and well for all the old READMEs.
 /images/felix.png /images/felix.png 200
 


### PR DESCRIPTION
Doug's request on docops channel.

this URL is broken - can we fix the redirect for this?  https://docs.tigera.io/calico/latest/calico-enterprise/  (it is coming from this origin:  https://docs.projectcalico.org/calico-enterprise/ )