### PR TITLE
Mention ordering with Kubernetes NetworkPolicies

### DIFF
--- a/calico_versioned_docs/version-3.25/network-policy/get-started/calico-policy/calico-network-policy.mdx
+++ b/calico_versioned_docs/version-3.25/network-policy/get-started/calico-policy/calico-network-policy.mdx
@@ -217,7 +217,7 @@ spec:
 
 ### Apply network policies in specific order
 
-To control the order/sequence of applying network policies, you can use the **order** field (with precedence from the lowest value to highest). Defining policy **order** is important when you include both **action: allow** and **action: deny** rules that may apply to the same endpoint.
+To control the order/sequence of applying network policies, you can use the **order** field (with precedence from the lowest value to highest). Defining policy **order** is important when you include both **action: allow** and **action: deny** rules that may apply to the same endpoint. Because Kubernetes NetworkPolicy don't have an explicit order field, they are treated as though they had an implicit order of 1000.
 
 In the following example, the policy **allow-cluster-internal-ingress** (order: 10) will be applied before the **policy drop-other-ingress** (order: 20).
 

--- a/calico_versioned_docs/version-3.25/network-policy/get-started/calico-policy/calico-network-policy.mdx
+++ b/calico_versioned_docs/version-3.25/network-policy/get-started/calico-policy/calico-network-policy.mdx
@@ -217,7 +217,7 @@ spec:
 
 ### Apply network policies in specific order
 
-To control the order/sequence of applying network policies, you can use the **order** field (with precedence from the lowest value to highest). Defining policy **order** is important when you include both **action: allow** and **action: deny** rules that may apply to the same endpoint. Because Kubernetes NetworkPolicy don't have an explicit order field, they are treated as though they had an implicit order of 1000.
+To control the order/sequence of applying network policies, you can use the **order** field (with precedence from the lowest value to highest). Defining policy **order** is important when you include both **action: allow** and **action: deny** rules that may apply to the same endpoint. Because Kubernetes NetworkPolicies don't have an explicit order field, they are treated as though they had an implicit order of 1000.
 
 In the following example, the policy **allow-cluster-internal-ingress** (order: 10) will be applied before the **policy drop-other-ingress** (order: 20).
 

--- a/calico_versioned_docs/version-3.25/network-policy/get-started/calico-policy/calico-network-policy.mdx
+++ b/calico_versioned_docs/version-3.25/network-policy/get-started/calico-policy/calico-network-policy.mdx
@@ -217,7 +217,7 @@ spec:
 
 ### Apply network policies in specific order
 
-To control the order/sequence of applying network policies, you can use the **order** field (with precedence from the lowest value to highest). Defining policy **order** is important when you include both **action: allow** and **action: deny** rules that may apply to the same endpoint. Because Kubernetes NetworkPolicies don't have an explicit order field, they are treated as though they had an implicit order of 1000.
+To control the order/sequence of applying network policies, you can use the **order** field (with precedence from the lowest value to highest). Defining policy **order** is important when you include both **action: allow** and **action: deny** rules that may apply to the same endpoint. Because Kubernetes network policies don't have an explicit order field, they are treated as though they had an implicit order of 1000.
 
 In the following example, the policy **allow-cluster-internal-ingress** (order: 10) will be applied before the **policy drop-other-ingress** (order: 20).
 


### PR DESCRIPTION
Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:

The documentation for NetworkPolicies mention the `order` field and give example of its use, but doesn't say how those policies are ordered relative to Kubernetes NetworkPolicies. I was able to find that information on StackOverflow, but I believe it should definitely be mentioned in your documentation.

Source: https://stackoverflow.com/a/68134768/711380

<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->