### PR TITLE
doc: VXLAN in IPv6 is only supported for kernel versions >=4.19.1 or redhat kernel version >= 4.18.0

### DIFF
--- a/calico/networking/configuring/vxlan-ipip.mdx
+++ b/calico/networking/configuring/vxlan-ipip.mdx
@@ -49,7 +49,7 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 **Limitations**
 
 - IP in IP supports only IPv4 addresses
-- VXLAN in IPv6 is only supported for kernel versions >= 3.12
+- VXLAN in IPv6 is only supported for kernel versions >=4.19.1 or redhat kernel version >= 4.18.0
 
 ## How to
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue: https://github.com/projectcalico/calico/issues/7251 https://github.com/projectcalico/calico/issues/6273 https://github.com/projectcalico/calico/issues/6877 
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->