### PR TITLE
Restores latest helm chart URL

### DIFF
--- a/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -137,7 +137,7 @@ Before you get started, make sure you have downloaded and configured the [necess
 1. Add {{prodname}} into your Helm repository.
 
     ```batch
-    helm repo add projectcalico https://docs.projectcalico.org/charts
+    helm repo add projectcalico https://docs.tigera.io/calico/charts
     ```
 
 1. If {{prodname}} is already added, update it to get the latest released version.

--- a/calico_versioned_docs/version-3.24/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico_versioned_docs/version-3.24/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -127,7 +127,7 @@ Before you get started, make sure you have downloaded and configured the [necess
 1. Add {{prodname}} into your Helm repository.
 
     ```batch
-    helm repo add projectcalico https://docs.projectcalico.org/charts
+    helm repo add projectcalico https://docs.tigera.io/calico/charts
     ```
 
 1. If {{prodname}} is already added, update it to get the latest released version.

--- a/calico_versioned_docs/version-3.25/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico_versioned_docs/version-3.25/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -137,7 +137,7 @@ Before you get started, make sure you have downloaded and configured the [necess
 1. Add {{prodname}} into your Helm repository.
 
     ```batch
-    helm repo add projectcalico https://docs.projectcalico.org/charts
+    helm repo add projectcalico https://docs.tigera.io/calico/charts
     ```
 
 1. If {{prodname}} is already added, update it to get the latest released version.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
https://github.com/tigera/docs/pull/454 introduced the old helm chart location, which functions, but isn't consistent with our other helm documentation. This PR restores the correct URL.
<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->