### PR TITLE
Correct EKS getting started docs

### DIFF
--- a/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -70,10 +70,16 @@ Before you get started, make sure you have downloaded and configured the [necess
    eksctl create cluster --name my-calico-cluster --without-nodegroup
    ```
 
-1. Since this cluster will use {{prodname}} for networking, you must delete the `aws-node` daemon set to disable AWS VPC networking for pods.
+1. Since this cluster will use {{prodname}} for networking, you must delete the `aws-node` daemonset to prevent it from writing conflicting CNI config to your nodes.
 
    ```bash
    kubectl delete daemonset -n kube-system aws-node
+   ```
+
+1. Now that the aws-node daemonset is gone, you can add nodes to the cluster.
+
+   ```batch
+   eksctl create nodegroup --cluster my-calico-cluster --node-type t3.medium --max-pods-per-node 100
    ```
 
 1. Now that you have a cluster configured, you can install {{prodname}}.
@@ -104,12 +110,6 @@ Before you get started, make sure you have downloaded and configured the [necess
    EOF
    ```
 
-1. Finally, add nodes to the cluster.
-
-   ```batch
-   eksctl create nodegroup --cluster my-calico-cluster --node-type t3.medium --max-pods-per-node 100
-   ```
-
 </TabItem>
 <TabItem label="Manifest" value="Manifest-1">
 
@@ -123,12 +123,6 @@ Before you get started, make sure you have downloaded and configured the [necess
 
    ```bash
    kubectl -n kube-system set env daemonset/calico-node FELIX_AWSSRCDSTCHECK=Disable
-   ```
-
-1. Finally, add nodes to the cluster.
-
-   ```bash
-   eksctl create nodegroup --cluster my-calico-cluster --node-type t3.medium --max-pods-per-node 100
    ```
 
 </TabItem>
@@ -146,16 +140,15 @@ Before you get started, make sure you have downloaded and configured the [necess
     helm repo update
     ```
 
+1. Create the tigera-operator namespace.
+    ```batch
+    kubectl create namespace tigera-operator
+    ```
+
 1. Install version {{releaseTitle}} of the {{prodname}} operator and custom resource definitions.
 
     ```batch
-    helm install calico projectcalico/tigera-operator --version {{releaseTitle}}
-    ```
-
-1. Finally, add nodes to the cluster.
-
-    ```batch
-    eksctl create nodegroup --cluster my-calico-cluster --node-type t3.medium --max-pods-per-node 100
+    helm install calico projectcalico/tigera-operator --namespace tigera-operator --version {{releaseTitle}}
     ```
 
 </TabItem>

--- a/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -70,15 +70,15 @@ Before you get started, make sure you have downloaded and configured the [necess
    eksctl create cluster --name my-calico-cluster --without-nodegroup
    ```
 
-1. Since this cluster will use {{prodname}} for networking, you must delete the `aws-node` daemonset to prevent it from writing conflicting CNI config to your nodes.
+1. Since this cluster will use {{prodname}} for networking, you must delete the `aws-node` daemonset to prevent it from writing a conflicting CNI config to your nodes.
 
    ```bash
    kubectl delete daemonset -n kube-system aws-node
    ```
 
-1. Now that the aws-node daemonset is gone, you can add nodes to the cluster.
+1. Now that the `aws-node` daemonset is gone, you can add nodes to the cluster.
 
-   ```batch
+   ```bash
    eksctl create nodegroup --cluster my-calico-cluster --node-type t3.medium --max-pods-per-node 100
    ```
 
@@ -145,7 +145,7 @@ Before you get started, make sure you have downloaded and configured the [necess
     kubectl create namespace tigera-operator
     ```
 
-1. Install version {{releaseTitle}} of the {{prodname}} operator and custom resource definitions.
+1. Install version {{releaseTitle}} of the tigera-operator and custom resource definitions.
 
     ```batch
     helm install calico projectcalico/tigera-operator --namespace tigera-operator --version {{releaseTitle}}

--- a/calico_versioned_docs/version-3.24/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico_versioned_docs/version-3.24/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -60,10 +60,16 @@ Before you get started, make sure you have downloaded and configured the [necess
    eksctl create cluster --name my-calico-cluster --without-nodegroup
    ```
 
-1. Since this cluster will use {{prodname}} for networking, you must delete the `aws-node` daemon set to disable AWS VPC networking for pods.
+1. Since this cluster will use {{prodname}} for networking, you must delete the `aws-node` daemonset to prevent it from writing conflicting CNI config to your nodes.
 
    ```bash
    kubectl delete daemonset -n kube-system aws-node
+   ```
+
+1. Now that the aws-node daemonset is gone, you can add nodes to the cluster.
+
+   ```batch
+   eksctl create nodegroup --cluster my-calico-cluster --node-type t3.medium --max-pods-per-node 100
    ```
 
 1. Now that you have a cluster configured, you can install {{prodname}}.
@@ -94,12 +100,6 @@ Before you get started, make sure you have downloaded and configured the [necess
    EOF
    ```
 
-1. Finally, add nodes to the cluster.
-
-   ```batch
-   eksctl create nodegroup --cluster my-calico-cluster --node-type t3.medium --max-pods-per-node 100
-   ```
-
 </TabItem>
 <TabItem label="Manifest" value="Manifest-1">
 
@@ -113,12 +113,6 @@ Before you get started, make sure you have downloaded and configured the [necess
 
    ```bash
    kubectl -n kube-system set env daemonset/calico-node FELIX_AWSSRCDSTCHECK=Disable
-   ```
-
-1. Finally, add nodes to the cluster.
-
-   ```bash
-   eksctl create nodegroup --cluster my-calico-cluster --node-type t3.medium --max-pods-per-node 100
    ```
 
 </TabItem>
@@ -136,16 +130,15 @@ Before you get started, make sure you have downloaded and configured the [necess
     helm repo update
     ```
 
+1. Create the tigera-operator namespace.
+    ```batch
+    kubectl create namespace tigera-operator
+    ```
+
 1. Install version {{releaseTitle}} of the {{prodname}} operator and custom resource definitions.
 
     ```batch
-    helm install calico projectcalico/tigera-operator --version {{releaseTitle}}
-    ```
-
-1. Finally, add nodes to the cluster.
-
-    ```batch
-    eksctl create nodegroup --cluster my-calico-cluster --node-type t3.medium --max-pods-per-node 100
+    helm install calico projectcalico/tigera-operator --namespace tigera-operator --version {{releaseTitle}}
     ```
 
 </TabItem>

--- a/calico_versioned_docs/version-3.24/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico_versioned_docs/version-3.24/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -68,7 +68,7 @@ Before you get started, make sure you have downloaded and configured the [necess
 
 1. Now that the aws-node daemonset is gone, you can add nodes to the cluster.
 
-   ```batch
+   ```bash
    eksctl create nodegroup --cluster my-calico-cluster --node-type t3.medium --max-pods-per-node 100
    ```
 

--- a/calico_versioned_docs/version-3.25/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico_versioned_docs/version-3.25/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -78,7 +78,7 @@ Before you get started, make sure you have downloaded and configured the [necess
 
 1. Now that the aws-node daemonset is gone, you can add nodes to the cluster.
 
-   ```batch
+   ```bash
    eksctl create nodegroup --cluster my-calico-cluster --node-type t3.medium --max-pods-per-node 100
    ```
 

--- a/calico_versioned_docs/version-3.25/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico_versioned_docs/version-3.25/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -70,10 +70,16 @@ Before you get started, make sure you have downloaded and configured the [necess
    eksctl create cluster --name my-calico-cluster --without-nodegroup
    ```
 
-1. Since this cluster will use {{prodname}} for networking, you must delete the `aws-node` daemon set to disable AWS VPC networking for pods.
+1. Since this cluster will use {{prodname}} for networking, you must delete the `aws-node` daemonset to prevent it from writing conflicting CNI config to your nodes.
 
    ```bash
    kubectl delete daemonset -n kube-system aws-node
+   ```
+
+1. Now that the aws-node daemonset is gone, you can add nodes to the cluster.
+
+   ```batch
+   eksctl create nodegroup --cluster my-calico-cluster --node-type t3.medium --max-pods-per-node 100
    ```
 
 1. Now that you have a cluster configured, you can install {{prodname}}.
@@ -104,12 +110,6 @@ Before you get started, make sure you have downloaded and configured the [necess
    EOF
    ```
 
-1. Finally, add nodes to the cluster.
-
-   ```batch
-   eksctl create nodegroup --cluster my-calico-cluster --node-type t3.medium --max-pods-per-node 100
-   ```
-
 </TabItem>
 <TabItem label="Manifest" value="Manifest-1">
 
@@ -123,12 +123,6 @@ Before you get started, make sure you have downloaded and configured the [necess
 
    ```bash
    kubectl -n kube-system set env daemonset/calico-node FELIX_AWSSRCDSTCHECK=Disable
-   ```
-
-1. Finally, add nodes to the cluster.
-
-   ```bash
-   eksctl create nodegroup --cluster my-calico-cluster --node-type t3.medium --max-pods-per-node 100
    ```
 
 </TabItem>
@@ -146,16 +140,15 @@ Before you get started, make sure you have downloaded and configured the [necess
     helm repo update
     ```
 
+1. Create the tigera-operator namespace.
+    ```batch
+    kubectl create namespace tigera-operator
+    ```
+
 1. Install version {{releaseTitle}} of the {{prodname}} operator and custom resource definitions.
 
     ```batch
-    helm install calico projectcalico/tigera-operator --version {{releaseTitle}}
-    ```
-
-1. Finally, add nodes to the cluster.
-
-    ```batch
-    eksctl create nodegroup --cluster my-calico-cluster --node-type t3.medium --max-pods-per-node 100
+    helm install calico projectcalico/tigera-operator --namespace tigera-operator --version {{releaseTitle}}
     ```
 
 </TabItem>


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
EKS getting started docs are wrong:
- the Helm install doesn't mention needing to create and specify a namespace
- nodegroup can be added once aws-node daemonset is deleted, and this means the Helm instructions won't fail at the `helm install` step.

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->
Calico v3.24 upwards.

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->
Raised by CU Byron Mansfield in slack thread: https://calicousers.slack.com/archives/CPTH1KS00/p1680705961183599

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->