### PR TITLE
Add a step to install honeypod PSP when needed

### DIFF
--- a/calico-cloud/threat/honeypod/honeypods.mdx
+++ b/calico-cloud/threat/honeypod/honeypods.mdx
@@ -40,10 +40,16 @@ Honeypods can be configured on a per-cluster basis using "template" honeypod man
 
 ### Configure namespace and RBAC for honeypods
 
+In a v1.24 or earlier cluster, if the [PodSecurityPolicy admission controller](https://v1-24.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy) is enabled, install the required Honeypod Pod Security Policy:
+
+```bash
+kubectl create -f {{filesUrl_CE}}/manifests/threatdef/honeypod/psp-honeypod.yaml
+```
+
 Apply the following manifest to create a namespace and RBAC for the honeypods:
 
 ```bash
-kubectl apply -f {{filesUrl_CE}}/manifests/threatdef/honeypod/common.yaml
+kubectl create -f {{filesUrl_CE}}/manifests/threatdef/honeypod/common.yaml
 ```
 
 Add `tigera-pull-secret` into the namespace `tigera-internal`:

--- a/calico-enterprise/threat/honeypod/honeypods.mdx
+++ b/calico-enterprise/threat/honeypod/honeypods.mdx
@@ -40,10 +40,16 @@ Honeypods can be configured on a per-cluster basis using "template" honeypod man
 
 ### Configure namespace and RBAC for honeypods
 
+In a v1.24 or earlier cluster, if the [PodSecurityPolicy admission controller](https://v1-24.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy) is enabled, install the required Honeypod Pod Security Policy:
+
+```bash
+kubectl create -f {{filesUrl}}/manifests/threatdef/honeypod/psp-honeypod.yaml
+```
+
 Apply the following manifest to create a namespace and RBAC for the honeypods:
 
 ```bash
-kubectl apply -f {{filesUrl}}/manifests/threatdef/honeypod/common.yaml
+kubectl create -f {{filesUrl}}/manifests/threatdef/honeypod/common.yaml
 ```
 
 Add `tigera-pull-secret` into the namespace `tigera-internal`:


### PR DESCRIPTION
Add a step in Honeypod configure page to apply a PSP manifest first when needed. This line is borrowed from our quickstart guide.

Here is a screenshot of the change:

![Screenshot from 2023-04-06 10-12-46](https://user-images.githubusercontent.com/7075046/230449385-25b169b6-3a4f-4b31-80f3-fa6b2b2a990c.png)


Product Version(s):

Proposed for CE v3.17.0 and CC.

Issue:

DOCS-1399

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->