### PR TITLE
Doc change for EV-2287 - mtls changes for kube controller metrics

### DIFF
--- a/calico-enterprise/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-enterprise/operations/monitor/prometheus/byo-prometheus.mdx
@@ -173,7 +173,29 @@ The .yamls have no namespace defined so when you apply `kubectl`, it is applied 
 </TabItem>
 <TabItem label="kube-controllers" value="kube-controllers-3">
 
-Note that kube-controllers metrics are not TLS enabled, so configuration is not required.
+**Configure TLS certificates**
+
+1. Copy the required secret and configmap to your namespace.
+2. Save the manifest of the required TLS secret and CA configmap.
+
+   ```bash
+   kubectl get secret calico-node-prometheus-client-tls -n tigera-prometheus -o yaml >  calico-node-prometheus-client-tls.yaml
+   ```
+
+   ```bash
+   kubectl get configmap -n tigera-prometheus tigera-ca-bundle -o yaml > tigera-ca-bundle.yaml
+   ```
+
+3. Edit `calico-node-prometheus-client-tls.yaml` and `tigera-ca-bundle.yaml` by changing the namespace to the namespace where your prometheus instance is running.
+4. Apply the manifests to your cluster.
+
+   ```bash
+   kubectl apply -f calico-node-prometheus-client-tls.yaml
+   ```
+
+   ```bash
+   kubectl apply -f tigera-ca-bundle.yaml
+   ```
 
 **Create the service monitor**
 


### PR DESCRIPTION
For CE only

https://tigera.atlassian.net/browse/EV-2287

Added mtls change to secure kube controller metrics endpoints.

Calico-private changes:
https://github.com/tigera/calico-private/pull/5576

Operator changes -
PR - https://github.com/tigera/operator/pull/2387

Testing:
![image](https://user-images.githubusercontent.com/102720382/232898385-5b02d21e-dce8-4365-a827-3a4b1d13ae2f.png)
