### PR TITLE
Global threat updates to CC 3.16 and next versions

### DIFF
--- a/calico-cloud/threat/suspicious-domains.mdx
+++ b/calico-cloud/threat/suspicious-domains.mdx
@@ -20,9 +20,7 @@ This how-to guide uses the following {{prodname}} features:
 
 ## Concepts
 
-### Pull or push threat feeds?
-
-{{prodname}} supports both push and pull methods for updating threat feeds. Use the **pull method** for fully automated threat feed updates without user intervention. Use the **push method** to schedule your own updates or if your threat feed is not available over HTTP(S).
+{{prodname}} supports pull methods for updating threat feeds. Use this method for fully automated threat feed updates without user intervention. 
 
 ### Domain name threat feeds
 
@@ -44,10 +42,8 @@ We recommend that you turn down the aggregation of DNS logs sent to Elasticsearc
 
 ## How to
 
-This section describes how to pull or push threat feeds to {{prodname}}.
+This section describes how to pull threat feeds to {{prodname}}.
 
-- [Pull threat feed updates](#pull-threat-feed-updates)
-- [Push threat feed updates](#push-threat-feed-updates)
 
 ### Pull threat feed updates
 
@@ -63,7 +59,7 @@ To add threat feeds to {{prodname}} for automatic updates (default is once a day
    - **Content type**: DomainNameSet
    - **Labels**: Choose a label from the list.
 3. Click **Save Changes**.
-   <br />
+   
    From the **Action** menu, you can view or edit the details that you entered and can download the manifest file.
 
 > Go to the Alerts page to view events that are generated when an endpoint in the cluster queries a name on the list. For more information, see [Manage alerts](../visibility/alerts.mdx).
@@ -95,45 +91,6 @@ To add threat feeds to {{prodname}} for automatic updates (default is once a day
    ```
 
 > Go to the Alerts page to view events that are generated when an endpoint in the cluster queries a name on the list. For more information, see [Manage alerts](../visibility/alerts.mdx).
-
-### Push threat feed updates
-
-Use the push method if your threat feeds that are not in newline-delimited format, not available over HTTP, or if you prefer to push updates as they become available.
-
-1. Create the GlobalThreatFeed YAML and save it to file.
-   Replace the **name** field with your own name. The name is important in the later steps so make note of it.
-
-   ```yaml
-   apiVersion: projectcalico.org/v3
-   kind: GlobalThreatFeed
-   metadata:
-     name: my-threat-feed
-   spec:
-     content: DomainNameSet
-     mode: Enabled
-     description: 'This is my threat feed'
-     feedType: Custom
-   ```
-
-2. Add the global threat feed to the cluster.
-
-   ```shell
-   kubectl apply -f <your_threatfeed_filename>
-   ```
-
-3. Configure or program your threat feed to write updates to Elasticsearch. This Elasticsearch document is in the index **.tigera.domainnameset.\<cluster_name\>** and must have the ID set to the name of the global threat feed object. The doc should have a single field called **domains**, containing a list of domain names. For example:
-
-   ```
-   PUT .tigera.domainnameset.cluster/_doc/my-threat-feed
-   {
-       "domains" : ["malicious.badstuff", "hacks.r.us"]
-   }
-   ```
-
-   Note that in order to push data to ES, you'll need to configure a policy that allows that information to reach the ES cluster.
-   See the Elasticsearch document APIs for how to create and update documents in Elasticsearch.
-
-4. In {{prodname}} Manager, go the “Alerts” page to view events that are generated when an endpoint in the cluster queries a name on the list.
 
 ## Above and beyond
 

--- a/calico-cloud/threat/suspicious-ips.mdx
+++ b/calico-cloud/threat/suspicious-ips.mdx
@@ -21,9 +21,7 @@ This how-to guide uses the following {{prodname}} features:
 
 ## Concepts
 
-### Pull or push threat feeds?
-
-{{prodname}} supports both push and pull methods for updating threat feeds. Use the **pull method** for fully automated threat feed updates without user intervention. Use the **push method** to schedule your own updates or if your threat feed is not available over HTTP(S).
+{{prodname}} supports pull methods for updating threat feeds. Use this method for fully automated threat feed updates without user intervention.
 
 ### Suspicious IPs: test before you block
 
@@ -37,7 +35,7 @@ Privileges to manage GlobalThreatFeed and GlobalNetworkPolicy.
 
 ### Recommended
 
-We recommend that you turn down the aggregation of flow logs sent to Elasticsearch for configuring threat feeds. If you do not adjust flow logs, Calico Enterprise aggregates over the external IPs for allowed traffic, and threat feed searches will not provide useful results (unless the traffic is denied by policy). Go to: [FelixConfiguration](../reference/resources/felixconfig.mdx) and set the field, **flowLogsFileAggregationKindForAllowed** to **1**.
+We recommend that you turn down the aggregation of flow logs sent to Elasticsearch for configuring threat feeds. If you do not adjust flow logs, {{prodname}} aggregates over the external IPs for allowed traffic, and threat feed searches will not provide useful results (unless the traffic is denied by policy). Go to: [FelixConfiguration](../reference/resources/felixconfig.mdx) and set the field, **flowLogsFileAggregationKindForAllowed** to **1**.
 
 You can adjust the flow logs by running the following command:
 
@@ -47,10 +45,9 @@ kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"flowLogsFi
 
 ## How to
 
-This section describes how to pull or push threat feeds to {{prodname}}, and block traffic to a cluster for a suspicious IP.
+This section describes how to pull threat feeds to {{prodname}}, and block traffic to a cluster for a suspicious IP.
 
 - [Pull threat feed updates](#pull-threat-feed-updates)
-- [Push threat feed updates](#push-threat-feed-updates)
 - [Block traffic to a cluster](#block-traffic-to-a-cluster)
 
 ### Pull threat feed updates
@@ -67,7 +64,7 @@ To add threat feeds to {{prodname}} for automatic updates (default is once a day
    - **Content type**: IPSet
    - **Labels**: Choose a label from the list.
 3. Click **Save Changes**.
-   <br />
+   
    From the **Action** menu, you can view or edit the details that you entered and can download the manifest file.
 
 > Go to the Alerts page to view events that are generated when an IP is displayed on the threat feed list. For more information, see [Manage alerts](../visibility/alerts.mdx). When you create a global threat feed in Manager UI, network traffic is not automatically blocked. If you find suspicious IPs on the Alerts page, you need to create a network policy to block the traffic. For help with policy, see [Block traffic to a cluster](#block-traffic-to-a-cluster).
@@ -99,45 +96,6 @@ To add threat feeds to {{prodname}} for automatic updates (default is once a day
    ```
 
 > Go to the Alerts page to view events that are generated when an IP is displayed on the threat feed list. For more information, see [Manage alerts](../visibility/alerts.mdx).
-
-
-### Push threat feed updates
-
-Use the push method if your threat feeds that are not in newline-delimited format, not available over HTTP, or if you prefer to push updates as they become available.
-
-1. Create the GlobalThreatFeed YAML and save it to file.
-   Replace the **name** field with your own name. The name is important in the later steps so make note of it.
-
-   ```yaml
-   apiVersion: projectcalico.org/v3
-   kind: GlobalThreatFeed
-   metadata:
-     name: my-threat-feed
-   spec:
-     content: IPSet
-     mode: Enabled
-     description: 'This is my threat feed'
-     feedType: Custom
-   ```
-
-2. Add the global threat feed to the cluster.
-
-   ```bash
-   kubectl apply -f <your_threatfeed_filename>
-   ```
-
-3. Configure or program your threat feed to write updates to Elasticsearch. This Elasticsearch document is in the index **.tigera.ipset.\<cluster_name\>** and must have the ID set to the name of the global threat feed object. The doc should have a single field called **ips**, containing a list of IP prefixes. For example:
-
-   ```
-   PUT .tigera.ipset.cluster/_doc/my-threat-feed
-   {
-       "ips" : ["99.99.99.99/32", "100.100.100.0/24"]
-   }
-   ```
-
-   See the Elasticsearch document APIs for how to create and update documents in Elasticsearch.
-
-4. In {{prodname}} Manager, go the “Alerts" page to view events that are generated when an IP is displayed on the threat feed list.
 
 ### Block traffic to a cluster
 

--- a/calico-cloud_versioned_docs/version-3.15/threat/suspicious-ips.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/threat/suspicious-ips.mdx
@@ -35,7 +35,7 @@ Privileges to manage GlobalThreatFeed and GlobalNetworkPolicy.
 
 ### Recommended
 
-We recommend that you turn down the aggregation of flow logs sent to Elasticsearch for configuring threat feeds. If you do not adjust flow logs, Calico Enterprise aggregates over the external IPs for allowed traffic, and threat feed searches will not provide useful results (unless the traffic is denied by policy). Go to: [FelixConfiguration](../reference/resources/felixconfig.mdx) and set the field, **flowLogsFileAggregationKindForAllowed** to **1**.
+We recommend that you turn down the aggregation of flow logs sent to Elasticsearch for configuring threat feeds. If you do not adjust flow logs, {{prodname}} aggregates over the external IPs for allowed traffic, and threat feed searches will not provide useful results (unless the traffic is denied by policy). Go to: [FelixConfiguration](../reference/resources/felixconfig.mdx) and set the field, **flowLogsFileAggregationKindForAllowed** to **1**.
 
 You can adjust the flow logs by running the following command:
 

--- a/calico-cloud_versioned_docs/version-3.16/threat/suspicious-domains.mdx
+++ b/calico-cloud_versioned_docs/version-3.16/threat/suspicious-domains.mdx
@@ -20,9 +20,7 @@ This how-to guide uses the following {{prodname}} features:
 
 ## Concepts
 
-### Pull or push threat feeds?
-
-{{prodname}} supports both push and pull methods for updating threat feeds. Use the **pull method** for fully automated threat feed updates without user intervention. Use the **push method** to schedule your own updates or if your threat feed is not available over HTTP(S).
+{{prodname}} supports pull methods for updating threat feeds. Use this method for fully automated threat feed updates without user intervention. 
 
 ### Domain name threat feeds
 
@@ -44,10 +42,8 @@ We recommend that you turn down the aggregation of DNS logs sent to Elasticsearc
 
 ## How to
 
-This section describes how to pull or push threat feeds to {{prodname}}.
+This section describes how to pull threat feeds to {{prodname}}.
 
-- [Pull threat feed updates](#pull-threat-feed-updates)
-- [Push threat feed updates](#push-threat-feed-updates)
 
 ### Pull threat feed updates
 
@@ -63,7 +59,7 @@ To add threat feeds to {{prodname}} for automatic updates (default is once a day
    - **Content type**: DomainNameSet
    - **Labels**: Choose a label from the list.
 3. Click **Save Changes**.
-   <br />
+   
    From the **Action** menu, you can view or edit the details that you entered and can download the manifest file.
 
 > Go to the Alerts page to view events that are generated when an endpoint in the cluster queries a name on the list. For more information, see [Manage alerts](../visibility/alerts.mdx).
@@ -95,45 +91,6 @@ To add threat feeds to {{prodname}} for automatic updates (default is once a day
    ```
 
 > Go to the Alerts page to view events that are generated when an endpoint in the cluster queries a name on the list. For more information, see [Manage alerts](../visibility/alerts.mdx).
-
-### Push threat feed updates
-
-Use the push method if your threat feeds that are not in newline-delimited format, not available over HTTP, or if you prefer to push updates as they become available.
-
-1. Create the GlobalThreatFeed YAML and save it to file.
-   Replace the **name** field with your own name. The name is important in the later steps so make note of it.
-
-   ```yaml
-   apiVersion: projectcalico.org/v3
-   kind: GlobalThreatFeed
-   metadata:
-     name: my-threat-feed
-   spec:
-     content: DomainNameSet
-     mode: Enabled
-     description: 'This is my threat feed'
-     feedType: Custom
-   ```
-
-2. Add the global threat feed to the cluster.
-
-   ```shell
-   kubectl apply -f <your_threatfeed_filename>
-   ```
-
-3. Configure or program your threat feed to write updates to Elasticsearch. This Elasticsearch document is in the index **.tigera.domainnameset.\<cluster_name\>** and must have the ID set to the name of the global threat feed object. The doc should have a single field called **domains**, containing a list of domain names. For example:
-
-   ```
-   PUT .tigera.domainnameset.cluster/_doc/my-threat-feed
-   {
-       "domains" : ["malicious.badstuff", "hacks.r.us"]
-   }
-   ```
-
-   Note that in order to push data to ES, you'll need to configure a policy that allows that information to reach the ES cluster.
-   See the Elasticsearch document APIs for how to create and update documents in Elasticsearch.
-
-4. In {{prodname}} Manager, go the “Alerts” page to view events that are generated when an endpoint in the cluster queries a name on the list.
 
 ## Above and beyond
 

--- a/calico-cloud_versioned_docs/version-3.16/threat/suspicious-ips.mdx
+++ b/calico-cloud_versioned_docs/version-3.16/threat/suspicious-ips.mdx
@@ -21,9 +21,7 @@ This how-to guide uses the following {{prodname}} features:
 
 ## Concepts
 
-### Pull or push threat feeds?
-
-{{prodname}} supports both push and pull methods for updating threat feeds. Use the **pull method** for fully automated threat feed updates without user intervention. Use the **push method** to schedule your own updates or if your threat feed is not available over HTTP(S).
+{{prodname}} supports pull methods for updating threat feeds. Use this method for fully automated threat feed updates without user intervention.
 
 ### Suspicious IPs: test before you block
 
@@ -47,10 +45,9 @@ kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"flowLogsFi
 
 ## How to
 
-This section describes how to pull or push threat feeds to {{prodname}}, and block traffic to a cluster for a suspicious IP.
+This section describes how to pull threat feeds to {{prodname}}, and block traffic to a cluster for a suspicious IP.
 
 - [Pull threat feed updates](#pull-threat-feed-updates)
-- [Push threat feed updates](#push-threat-feed-updates)
 - [Block traffic to a cluster](#block-traffic-to-a-cluster)
 
 ### Pull threat feed updates
@@ -67,7 +64,7 @@ To add threat feeds to {{prodname}} for automatic updates (default is once a day
    - **Content type**: IPSet
    - **Labels**: Choose a label from the list.
 3. Click **Save Changes**.
-   <br />
+   
    From the **Action** menu, you can view or edit the details that you entered and can download the manifest file.
 
 > Go to the Alerts page to view events that are generated when an IP is displayed on the threat feed list. For more information, see [Manage alerts](../visibility/alerts.mdx). When you create a global threat feed in Manager UI, network traffic is not automatically blocked. If you find suspicious IPs on the Alerts page, you need to create a network policy to block the traffic. For help with policy, see [Block traffic to a cluster](#block-traffic-to-a-cluster).
@@ -99,45 +96,6 @@ To add threat feeds to {{prodname}} for automatic updates (default is once a day
    ```
 
 > Go to the Alerts page to view events that are generated when an IP is displayed on the threat feed list. For more information, see [Manage alerts](../visibility/alerts.mdx).
-
-
-### Push threat feed updates
-
-Use the push method if your threat feeds that are not in newline-delimited format, not available over HTTP, or if you prefer to push updates as they become available.
-
-1. Create the GlobalThreatFeed YAML and save it to file.
-   Replace the **name** field with your own name. The name is important in the later steps so make note of it.
-
-   ```yaml
-   apiVersion: projectcalico.org/v3
-   kind: GlobalThreatFeed
-   metadata:
-     name: my-threat-feed
-   spec:
-     content: IPSet
-     mode: Enabled
-     description: 'This is my threat feed'
-     feedType: Custom
-   ```
-
-2. Add the global threat feed to the cluster.
-
-   ```bash
-   kubectl apply -f <your_threatfeed_filename>
-   ```
-
-3. Configure or program your threat feed to write updates to Elasticsearch. This Elasticsearch document is in the index **.tigera.ipset.\<cluster_name\>** and must have the ID set to the name of the global threat feed object. The doc should have a single field called **ips**, containing a list of IP prefixes. For example:
-
-   ```
-   PUT .tigera.ipset.cluster/_doc/my-threat-feed
-   {
-       "ips" : ["99.99.99.99/32", "100.100.100.0/24"]
-   }
-   ```
-
-   See the Elasticsearch document APIs for how to create and update documents in Elasticsearch.
-
-4. In {{prodname}} Manager, go the “Alerts" page to view events that are generated when an IP is displayed on the threat feed list.
 
 ### Block traffic to a cluster
 


### PR DESCRIPTION
The global threat updates only made it to 3.15 version. This PR is to push the changes to CC 3.16 and next versions.

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->