### PR TITLE
DOCS-1372: Add support for Windows Server 2022

### DIFF
--- a/calico/getting-started/kubernetes/windows-calico/kubernetes/requirements.mdx
+++ b/calico/getting-started/kubernetes/windows-calico/kubernetes/requirements.mdx
@@ -76,7 +76,7 @@ For operator-managed Linux {{prodname}} clusters, three Linux worker nodes are r
 - Windows versions:
 
   - Windows Server 1809 (build Build 17763.1432 or greater)
-  - Windows Server 20H2 (build 19042)
+  - Windows Server 2022
 
   :::note
 


### PR DESCRIPTION
This PR is to 

Product Version(s):
Calico OSS 3.26

Check with @coutinhop if the support to be extended to OSS 3.25 as well.

Issue:
https://tigera.atlassian.net/browse/DOCS-1372

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->