### PR TITLE
Fix: Stricter regex pattern 

### DIFF
--- a/src/utils/getVariableByFilePath.js
+++ b/src/utils/getVariableByFilePath.js
@@ -22,7 +22,7 @@ const rootDir = path.posix.resolve('src', '..');
 
 function getContextVariables(file) {
   const posixFriendlyPath = convertToPosixFriendlyPath(file.path);
-  const pathToVersionedDocsRoot = posixFriendlyPath.match(/calico.*_versioned_docs\/version-.*?\//g);
+  const pathToVersionedDocsRoot = posixFriendlyPath.match(/calico(-(enterprise|cloud))?_versioned_docs\/version-.*?\//g);
 
   if (pathToVersionedDocsRoot) {
     return require(path.resolve(`${pathToVersionedDocsRoot[0]}variables.js`));


### PR DESCRIPTION
This PR updates the lazy match pattern used in `getContextVariables`.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->
Build will fail in cases where docs are copied in a path that includes `calico`.
for example:
```
/home/calico/docs/
```
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->