### PR TITLE
Docs-#258-fixes

### DIFF
--- a/calico-cloud_versioned_docs/version-3.15/visibility/elastic/overview.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/visibility/elastic/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Summary of the out-of-box features for Calico Enterprise logs.
+description: Summary of the out-of-box features for Calico Cloud logs.
 ---
 
 # Overview
@@ -95,7 +95,6 @@ verbs: ['get']
 
 ## Above and beyond
 
-- [Log storage recommendations](/operations/logstorage/log-storage-recommendations)
 - [Configure flow log aggregation](flow/aggregation.mdx)
 - [Audit logs](audit-overview.mdx)
 - [BGP logs](bgp.mdx)

--- a/calico-cloud_versioned_docs/version-3.16/visibility/elastic/overview.mdx
+++ b/calico-cloud_versioned_docs/version-3.16/visibility/elastic/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Summary of the out-of-box features for Calico Enterprise logs.
+description: Summary of the out-of-box features for Calico Cloud logs.
 ---
 
 # Overview

--- a/calico/about/kubernetes-training/about-network-policy.mdx
+++ b/calico/about/kubernetes-training/about-network-policy.mdx
@@ -227,7 +227,7 @@ spec:
 
 ### Hierarchical policy
 
-[Calico Enterprise](https://docs.tigera.io/calico-enterprise/latest/network-policy/policy-tiers/tiered-policyd-policy.mdx) supports hierarchical network policy using policy tiers. RBAC
+[Calico Enterprise](/calico-enterprise/latest/network-policy/policy-tiers/tiered-policy) supports hierarchical network policy using policy tiers. RBAC
 for each tier can be defined to restrict who can interact with each tier. This can be used to delegate trust across
 multiple teams.
 

--- a/calico/about/kubernetes-training/kubernetes-policy-basic.mdx
+++ b/calico/about/kubernetes-training/kubernetes-policy-basic.mdx
@@ -202,6 +202,6 @@ kubectl delete ns policy-demo
 ```
 
 This was just a simple example of the Kubernetes NetworkPolicy API and how Calico can secure your Kubernetes cluster. For more
-information on network policy in Kubernetes, see the [Kubernetes user-guide](http://kubernetes.io/docs/user-guide/networkpolicies/).
+information on network policy in Kubernetes, see the [Kubernetes user-guide](https://kubernetes.io/docs/concepts/services-networking/network-policies/).
 
 For a slightly more detailed demonstration of policy, check out the [Kubernetes policy demo](kubernetes-demo.mdx).


### PR DESCRIPTION
- Fixed dead links in prod build
- Fixed files that were committed in error in 258 

LINK-CHECK REPORT
Summary: ignored: 5784, skipped: 108, invalid: 26, errors: 0, dead: 0, alive: 1225, total: 1359

Product Version(s):

Issue:
Based on issues in: https://github.com/tigera/docs/pull/285

Link to docs preview:
https://deploy-preview-609--tigera.netlify.app/calico/next/about/kubernetes-training/about-network-policy
https://deploy-preview-609--tigera.netlify.app/calico-cloud/visibility/elastic/ (Fixed in 3.15 as well, even though that folder is unused)


SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->