### PR TITLE
temporary fix for calico-cloud search page issue

### DIFF
--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -37,6 +37,12 @@ function ResultsFooter({ state, onClose, productId }) {
   if (productId) {
     version = localStorage.getItem(`docs-preferred-version-${productId}`) || 'current';
   }
+  if(productId === 'calico-cloud'){
+    //TODO: figure this out
+    //current search is disabled for calico-cloud
+    // see docusaurus.config.js
+    version = '3.16'
+  }
 
   const to = `/search?q=${encodeURIComponent(state.query)}&p=${productId || ''}&v=${version}`;
 
@@ -97,6 +103,7 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
       ...props.searchParameters,
       facetFilters: productId ? filterFacetFiltersByProduct(facetFilters, productId) : facetFilters,
     });
+    console.log('searchParameters',searchParameters)
   }, [productId]);
   const [footer, setFooter] = useState();
   const { withBaseUrl } = useBaseUrlUtils();

--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -216,12 +216,25 @@ function SearchPageContent() {
     algoliaHelper.addDisjunctiveFacetRefinement('docusaurus_tag', 'default');
     algoliaHelper.addDisjunctiveFacetRefinement('language', currentLocale);
     if (productId) {
-      algoliaHelper.addDisjunctiveFacetRefinement('docusaurus_tag', `docs-${productId}-${version}`);
+      //TODO: figure this out
+      //current search is disabled for calico-cloud
+      // see docusaurus.config.js
+      if(productId === 'calico-cloud'){
+        algoliaHelper.addDisjunctiveFacetRefinement('docusaurus_tag', `docs-calico-cloud-3.16`); 
+      }else{
+        algoliaHelper.addDisjunctiveFacetRefinement('docusaurus_tag', `docs-${productId}-${version}`);
+      }
     } else {
       Object.entries(docsSearchVersionsHelpers.searchVersions).forEach(([pluginId]) => {
         const searchVersion = localStorage.getItem(`docs-preferred-version-${pluginId}`) || 'current';
         algoliaHelper.addDisjunctiveFacetRefinement('docusaurus_tag', `docs-${pluginId}-${searchVersion}`);
       });
+     
+      //TODO: figure this out
+      //current search is disabled for calico-cloud
+      // see docusaurus.config.js
+      algoliaHelper.addDisjunctiveFacetRefinement('docusaurus_tag', `docs-calico-cloud-3.16`);
+
     }
     algoliaHelper.setQuery(searchQuery).setPage(page).search();
   });


### PR DESCRIPTION
The issue stems from  docusaurus.config.js line   399  onlyIncludeVersions: [/*'current',*/'3.16'/*,'3.15'*/],
Only 3.16 is included for calico cloud, changing this to current does not add any of the revelant results to search so minor adjustments were made in the search behavior as to acomodate and address this issue while the proper way of fixing this is assessed.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->