### PR TITLE
[EV-3673] Add binding to cluster admin to calico-cni-plugin

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/docker-enterprise.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/docker-enterprise.mdx
@@ -47,11 +47,13 @@ The geeky details of what you get:
 
 1. [Configure a storage class for {{prodname}}](../../operations/logstorage/create-storage.mdx).
 
-1. Configure Tigera operator role bindings for Docker EE.
+1. Configure Tigera operator and Calico CNI plugin role bindings for Docker EE.
 
    ```bash
    kubectl create clusterrolebinding tigera-operator-cluster-admin -n tigera-operator \
     --clusterrole cluster-admin --serviceaccount tigera-operator:tigera-operator
+   kubectl create clusterrolebinding calico-cni-plugin-cluster-admin -n calico-system \
+    --clusterrole cluster-admin --serviceaccount calico-system:calico-cni-plugin
    ```
 
 1. Install the Tigera operator and custom resource definitions.


### PR DESCRIPTION
[DOCS#EV-3673]: Add binding to cluster admin to calico-cni-plugin

Product Version(s):
Calico Enterprise 3.17 only

Issue:
https://tigera.atlassian.net/browse/EV-3683
https://tigera.atlassian.net/browse/EV-3673

Link to docs preview:
/next/getting-started/install-on-clusters/docker-enterprise

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->