### PR TITLE
Fix two broken links

### DIFF
--- a/calico-cloud/tutorials/training/about-network-policy.mdx
+++ b/calico-cloud/tutorials/training/about-network-policy.mdx
@@ -73,7 +73,7 @@ more tightly with Kubernetes. However, this does not remove the need or value of
 
 ## Kubernetes network policy
 
-Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#networkpolicy-v1-networking-k8s-io) resource.
+Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/kubernetes-api/policy-resources/network-policy-v1/) resource.
 
 The main features of Kubernetes network policies are:
 

--- a/calico-cloud_versioned_docs/version-3.15/tutorials/training/about-network-policy.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/tutorials/training/about-network-policy.mdx
@@ -73,7 +73,7 @@ more tightly with Kubernetes. However, this does not remove the need or value of
 
 ## Kubernetes network policy
 
-Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#networkpolicy-v1-networking-k8s-io) resource.
+Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/kubernetes-api/policy-resources/network-policy-v1/) resource.
 
 The main features of Kubernetes network policies are:
 

--- a/calico-cloud_versioned_docs/version-3.16/tutorials/training/about-network-policy.mdx
+++ b/calico-cloud_versioned_docs/version-3.16/tutorials/training/about-network-policy.mdx
@@ -73,7 +73,7 @@ more tightly with Kubernetes. However, this does not remove the need or value of
 
 ## Kubernetes network policy
 
-Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#networkpolicy-v1-networking-k8s-io) resource.
+Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/kubernetes-api/policy-resources/network-policy-v1/) resource.
 
 The main features of Kubernetes network policies are:
 

--- a/calico-enterprise/_includes/components/InstallEKS.js
+++ b/calico-enterprise/_includes/components/InstallEKS.js
@@ -144,7 +144,7 @@ spec:
         of EKS's custom networking support, not specific to {prodname}.) As a workaround, trusted pods that require
         control plane nodes to connect to them, such as those implementing admission controller webhooks, can include{' '}
         <code>hostNetwork:true</code> in their pod spec. See the Kuberentes API{' '}
-        <Link href='https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#podspec-v1-core'>
+        <Link href='https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec'>
           pod spec
         </Link>{' '}
         definition for more information on this setting.

--- a/calico-enterprise/network-policy/get-started/about-network-policy.mdx
+++ b/calico-enterprise/network-policy/get-started/about-network-policy.mdx
@@ -73,7 +73,7 @@ more tightly with Kubernetes. However, this does not remove the need or value of
 
 ## Kubernetes network policy
 
-Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#networkpolicy-v1-networking-k8s-io) resource.
+Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/kubernetes-api/policy-resources/network-policy-v1/) resource.
 
 The main features of Kubernetes network policies are:
 

--- a/calico-enterprise_versioned_docs/version-3.14/_includes/components/InstallEKS.js
+++ b/calico-enterprise_versioned_docs/version-3.14/_includes/components/InstallEKS.js
@@ -186,7 +186,7 @@ spec:
         of EKS's custom networking support, not specific to {prodname}.) As a workaround, trusted pods that require
         control plane nodes to connect to them, such as those implementing admission controller webhooks, can include{' '}
         <code>hostNetwork:true</code> in their pod spec. See the Kuberentes API{' '}
-        <Link href='https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#podspec-v1-core'>
+        <Link href='https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec'>
           pod spec
         </Link>{' '}
         definition for more information on this setting.

--- a/calico-enterprise_versioned_docs/version-3.14/network-policy/get-started/about-network-policy.mdx
+++ b/calico-enterprise_versioned_docs/version-3.14/network-policy/get-started/about-network-policy.mdx
@@ -73,7 +73,7 @@ more tightly with Kubernetes. However, this does not remove the need or value of
 
 ## Kubernetes network policy
 
-Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#networkpolicy-v1-networking-k8s-io) resource.
+Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/kubernetes-api/policy-resources/network-policy-v1/) resource.
 
 The main features of Kubernetes network policies are:
 

--- a/calico-enterprise_versioned_docs/version-3.15/_includes/components/InstallEKS.js
+++ b/calico-enterprise_versioned_docs/version-3.15/_includes/components/InstallEKS.js
@@ -144,7 +144,7 @@ spec:
         of EKS's custom networking support, not specific to {prodname}.) As a workaround, trusted pods that require
         control plane nodes to connect to them, such as those implementing admission controller webhooks, can include{' '}
         <code>hostNetwork:true</code> in their pod spec. See the Kuberentes API{' '}
-        <Link href='https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#podspec-v1-core'>
+        <Link href='https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec'>
           pod spec
         </Link>{' '}
         definition for more information on this setting.

--- a/calico-enterprise_versioned_docs/version-3.15/network-policy/get-started/about-network-policy.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/network-policy/get-started/about-network-policy.mdx
@@ -73,7 +73,7 @@ more tightly with Kubernetes. However, this does not remove the need or value of
 
 ## Kubernetes network policy
 
-Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#networkpolicy-v1-networking-k8s-io) resource.
+Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/kubernetes-api/policy-resources/network-policy-v1/) resource.
 
 The main features of Kubernetes network policies are:
 

--- a/calico-enterprise_versioned_docs/version-3.16/_includes/components/InstallEKS.js
+++ b/calico-enterprise_versioned_docs/version-3.16/_includes/components/InstallEKS.js
@@ -144,7 +144,7 @@ spec:
         of EKS's custom networking support, not specific to {prodname}.) As a workaround, trusted pods that require
         control plane nodes to connect to them, such as those implementing admission controller webhooks, can include{' '}
         <code>hostNetwork:true</code> in their pod spec. See the Kuberentes API{' '}
-        <Link href='https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#podspec-v1-core'>
+        <Link href='https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec'>
           pod spec
         </Link>{' '}
         definition for more information on this setting.

--- a/calico-enterprise_versioned_docs/version-3.16/network-policy/get-started/about-network-policy.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/network-policy/get-started/about-network-policy.mdx
@@ -73,7 +73,7 @@ more tightly with Kubernetes. However, this does not remove the need or value of
 
 ## Kubernetes network policy
 
-Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#networkpolicy-v1-networking-k8s-io) resource.
+Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/kubernetes-api/policy-resources/network-policy-v1/) resource.
 
 The main features of Kubernetes network policies are:
 

--- a/calico/about/kubernetes-training/about-network-policy.mdx
+++ b/calico/about/kubernetes-training/about-network-policy.mdx
@@ -73,7 +73,7 @@ more tightly with Kubernetes. However, this does not remove the need or value of
 
 ## Kubernetes network policy
 
-Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#networkpolicy-v1-networking-k8s-io) resource.
+Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/kubernetes-api/policy-resources/network-policy-v1/) resource.
 
 The main features of Kubernetes network policies are:
 

--- a/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -55,7 +55,7 @@ The geeky details of what you get:
 will not be able to initiate network connections to {{prodname}} pods. (This is a general limitation of EKS's custom networking support,
 not specific to {{prodname}}.) As a workaround, trusted pods that require control plane nodes to connect to them, such as those implementing
 admission controller webhooks, can include `hostNetwork:true` in their pod spec. See the Kubernetes API
-[pod spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#podspec-v1-core)
+[pod spec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)
 definition for more information on this setting.
 
 :::

--- a/calico_versioned_docs/version-3.24/about/about-network-policy.mdx
+++ b/calico_versioned_docs/version-3.24/about/about-network-policy.mdx
@@ -74,7 +74,7 @@ more tightly with Kubernetes. However, this does not remove the need or value of
 
 ## Kubernetes network policy
 
-Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#networkpolicy-v1-networking-k8s-io) resource.
+Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/kubernetes-api/policy-resources/network-policy-v1/) resource.
 
 The main features of Kubernetes network policies are:
 

--- a/calico_versioned_docs/version-3.24/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico_versioned_docs/version-3.24/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -45,7 +45,7 @@ The geeky details of what you get:
 will not be able to initiate network connections to {{prodname}} pods. (This is a general limitation of EKS's custom networking support,
 not specific to {{prodname}}.) As a workaround, trusted pods that require control plane nodes to connect to them, such as those implementing
 admission controller webhooks, can include `hostNetwork:true` in their pod spec. See the Kubernetes API
-[pod spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#podspec-v1-core)
+[pod spec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)
 definition for more information on this setting.
 
 :::

--- a/calico_versioned_docs/version-3.25/about/about-network-policy.mdx
+++ b/calico_versioned_docs/version-3.25/about/about-network-policy.mdx
@@ -74,7 +74,7 @@ more tightly with Kubernetes. However, this does not remove the need or value of
 
 ## Kubernetes network policy
 
-Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#networkpolicy-v1-networking-k8s-io) resource.
+Kubernetes network policies are defined using the Kubernetes [NetworkPolicy](https://kubernetes.io/docs/reference/kubernetes-api/policy-resources/network-policy-v1/) resource.
 
 The main features of Kubernetes network policies are:
 

--- a/calico_versioned_docs/version-3.25/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico_versioned_docs/version-3.25/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -55,7 +55,7 @@ The geeky details of what you get:
 will not be able to initiate network connections to {{prodname}} pods. (This is a general limitation of EKS's custom networking support,
 not specific to {{prodname}}.) As a workaround, trusted pods that require control plane nodes to connect to them, such as those implementing
 admission controller webhooks, can include `hostNetwork:true` in their pod spec. See the Kubernetes API
-[pod spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#podspec-v1-core)
+[pod spec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)
 definition for more information on this setting.
 
 :::


### PR DESCRIPTION

[WARN] LINK-CHECK found the following 2 dead link(s):
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#networkpolicy-v1-networking-k8s-io is dead (404)
==>Origin: http://localhost:4242/calico-cloud/tutorials/training/about-network-policy

https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#podspec-v1-core is dead (404)
==>Origin: http://localhost:4242/calico-enterprise/3.14/getting-started/install-on-clusters/eks

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->