### PR TITLE
DOCS-1438-Add archive link

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.16/_includes/components/ReleaseNotes.js
+++ b/calico-enterprise_versioned_docs/version-3.16/_includes/components/ReleaseNotes.js
@@ -43,14 +43,14 @@ export default function ReleaseNotes() {
             Calico Enterprise {release.title}
           </Heading>
           {release.title !== 'master' && (
-            <p> {/*
+            <p> 
               <Link
                 href={`${downloadsurl}/ee/archives/release-${release.title}-${release['tigera-operator'].version}.tgz`}
               >
                 Release archive
               </Link>{' '}
               with Kubernetes manifests. Based on Calico {releases[0].calico.minor_version}.
-            */}</p>
+            </p>
           )}
           {release.note}
           <Heading


### PR DESCRIPTION
Add archive link back in after temporary removal. 

Product Version(s):
3.16.1

Issue:
https://deploy-preview-661--tigera.netlify.app/calico-enterprise/latest/release-notes/

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review: Dan Fox approved
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->