### PR TITLE
Standardize VXLAN and IPIP limitations across docs for all Calico versions

### DIFF
--- a/calico-cloud/networking/configuring/vxlan-ipip.mdx
+++ b/calico-cloud/networking/configuring/vxlan-ipip.mdx
@@ -43,6 +43,15 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 - Calico CNI
 
+**Not supported**
+
+- OpenStack
+
+**Limitations**
+
+- IP in IP supports only IPv4 addresses
+- VXLAN in IPv6 is only supported for kernel versions >=4.19.1 or redhat kernel version >= 4.18.0
+
 ## How to
 
 - [Configure default IP pools at install time](#configure-default-ip-pools-at-install-time)

--- a/calico-cloud_versioned_docs/version-3.15/networking/configuring/vxlan-ipip.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/networking/configuring/vxlan-ipip.mdx
@@ -43,6 +43,15 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 - Calico CNI
 
+**Not supported**
+
+- OpenStack
+
+**Limitations**
+
+- IP in IP supports only IPv4 addresses
+- VXLAN in IPv6 is only supported for kernel versions >=4.19.1 or redhat kernel version >= 4.18.0
+
 ## How to
 
 - [Configure default IP pools at install time](#configure-default-ip-pools-at-install-time)

--- a/calico-enterprise/networking/configuring/vxlan-ipip.mdx
+++ b/calico-enterprise/networking/configuring/vxlan-ipip.mdx
@@ -43,6 +43,15 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 - Calico CNI
 
+**Not supported**
+
+- OpenStack
+
+**Limitations**
+
+- IP in IP supports only IPv4 addresses
+- VXLAN in IPv6 is only supported for kernel versions >=4.19.1 or redhat kernel version >= 4.18.0
+
 ## How to
 
 - [Configure default IP pools at install time](#configure-default-ip-pools-at-install-time)

--- a/calico-enterprise_versioned_docs/version-3.14/networking/configuring/vxlan-ipip.mdx
+++ b/calico-enterprise_versioned_docs/version-3.14/networking/configuring/vxlan-ipip.mdx
@@ -47,7 +47,8 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 ### IPv4/6 address support
 
-IP in IP supports only IPv4 addresses.
+- IP in IP supports only IPv4 addresses.
+- VXLAN in IPv6 is only supported for kernel versions >=4.19.1 or redhat kernel version >= 4.18.0
 
 ### Best practice
 

--- a/calico-enterprise_versioned_docs/version-3.15/networking/configuring/vxlan-ipip.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/networking/configuring/vxlan-ipip.mdx
@@ -43,6 +43,15 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 - Calico CNI
 
+**Not supported**
+
+- OpenStack
+
+**Limitations**
+
+- IP in IP supports only IPv4 addresses
+- VXLAN in IPv6 is only supported for kernel versions >=4.19.1 or redhat kernel version >= 4.18.0
+
 ## How to
 
 - [Configure default IP pools at install time](#configure-default-ip-pools-at-install-time)

--- a/calico-enterprise_versioned_docs/version-3.16/networking/configuring/vxlan-ipip.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/networking/configuring/vxlan-ipip.mdx
@@ -43,6 +43,15 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 - Calico CNI
 
+**Not supported**
+
+- OpenStack
+
+**Limitations**
+
+- IP in IP supports only IPv4 addresses
+- VXLAN in IPv6 is only supported for kernel versions >=4.19.1 or redhat kernel version >= 4.18.0
+
 ## How to
 
 - [Configure default IP pools at install time](#configure-default-ip-pools-at-install-time)

--- a/calico_versioned_docs/version-3.24/networking/configuring/vxlan-ipip.mdx
+++ b/calico_versioned_docs/version-3.24/networking/configuring/vxlan-ipip.mdx
@@ -50,7 +50,8 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 ### IPv4/6 address support
 
-IP in IP supports only IPv4 addresses.
+- IP in IP supports only IPv4 addresses.
+- VXLAN in IPv6 is only supported for kernel versions >=4.19.1 or redhat kernel version >= 4.18.0
 
 ### Best practice
 

--- a/calico_versioned_docs/version-3.25/networking/configuring/vxlan-ipip.mdx
+++ b/calico_versioned_docs/version-3.25/networking/configuring/vxlan-ipip.mdx
@@ -49,6 +49,7 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 **Limitations**
 
 - IP in IP supports only IPv4 addresses
+- VXLAN in IPv6 is only supported for kernel versions >=4.19.1 or redhat kernel version >= 4.18.0
 
 ## How to
 


### PR DESCRIPTION
Update all Calico versions with new information from https://github.com/tigera/docs/pull/515 (which just updates latest OSS Calico).

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->