### PR TITLE
Fix dead links

### DIFF
--- a/calico-cloud/network-policy/policy-firewalls/aws-integration/get-started.mdx
+++ b/calico-cloud/network-policy/policy-firewalls/aws-integration/get-started.mdx
@@ -56,7 +56,7 @@ The high-level implementation steps are:
 | 2 - Enable {{prodname}} AWS security group integration | Create a custom resource definition (CRD) with VPC security group information.                                                                            |
 | 3 - Control pod access to/from VPC resources           | Use {{prodname}} tiered network policy and annotations to allow and deny access.                                                                          |
 
-To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/)
+To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://ncarb.github.io/eks-workshop/beginner/120_network-policies/tigera/tsce-sg-integration/)
 
 ## Next steps
 

--- a/calico-cloud_versioned_docs/version-3.15/network-policy/policy-firewalls/aws-integration/get-started.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/network-policy/policy-firewalls/aws-integration/get-started.mdx
@@ -56,7 +56,7 @@ The high-level implementation steps are:
 | 2 - Enable {{prodname}} AWS security group integration | Create a custom resource definition (CRD) with VPC security group information.                                                                            |
 | 3 - Control pod access to/from VPC resources           | Use {{prodname}} tiered network policy and annotations to allow and deny access.                                                                          |
 
-To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/)
+To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://ncarb.github.io/eks-workshop/beginner/120_network-policies/tigera/tsce-sg-integration/)
 
 ## Next steps
 

--- a/calico-cloud_versioned_docs/version-3.16/network-policy/policy-firewalls/aws-integration/get-started.mdx
+++ b/calico-cloud_versioned_docs/version-3.16/network-policy/policy-firewalls/aws-integration/get-started.mdx
@@ -56,7 +56,7 @@ The high-level implementation steps are:
 | 2 - Enable {{prodname}} AWS security group integration | Create a custom resource definition (CRD) with VPC security group information.                                                                            |
 | 3 - Control pod access to/from VPC resources           | Use {{prodname}} tiered network policy and annotations to allow and deny access.                                                                          |
 
-To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/)
+To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://ncarb.github.io/eks-workshop/beginner/120_network-policies/tigera/tsce-sg-integration/)
 
 ## Next steps
 

--- a/calico-enterprise/network-policy/policy-firewalls/aws-integration/get-started.mdx
+++ b/calico-enterprise/network-policy/policy-firewalls/aws-integration/get-started.mdx
@@ -56,7 +56,7 @@ The high-level implementation steps are:
 | 2 - Enable {{prodname}} AWS security group integration | Create a custom resource definition (CRD) with VPC security group information.                                                                            |
 | 3 - Control pod access to/from VPC resources           | Use {{prodname}} tiered network policy and annotations to allow and deny access.                                                                          |
 
-To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/)
+To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://ncarb.github.io/eks-workshop/beginner/120_network-policies/tigera/tsce-sg-integration/)
 
 ## Next steps
 

--- a/calico-enterprise_versioned_docs/version-3.14/network-policy/policy-firewalls/aws-integration/get-started.mdx
+++ b/calico-enterprise_versioned_docs/version-3.14/network-policy/policy-firewalls/aws-integration/get-started.mdx
@@ -56,7 +56,7 @@ The high-level implementation steps are:
 | 2 - Enable {{prodname}} AWS security group integration | Create a custom resource definition (CRD) with VPC security group information.                                                                            |
 | 3 - Control pod access to/from VPC resources           | Use {{prodname}} tiered network policy and annotations to allow and deny access.                                                                          |
 
-To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/)
+To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://ncarb.github.io/eks-workshop/beginner/120_network-policies/tigera/tsce-sg-integration/)
 
 ## Next steps
 

--- a/calico-enterprise_versioned_docs/version-3.15/network-policy/policy-firewalls/aws-integration/get-started.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/network-policy/policy-firewalls/aws-integration/get-started.mdx
@@ -56,7 +56,7 @@ The high-level implementation steps are:
 | 2 - Enable {{prodname}} AWS security group integration | Create a custom resource definition (CRD) with VPC security group information.                                                                            |
 | 3 - Control pod access to/from VPC resources           | Use {{prodname}} tiered network policy and annotations to allow and deny access.                                                                          |
 
-To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/)
+To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://ncarb.github.io/eks-workshop/beginner/120_network-policies/tigera/tsce-sg-integration/)
 
 ## Next steps
 

--- a/calico-enterprise_versioned_docs/version-3.16/network-policy/policy-firewalls/aws-integration/get-started.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/network-policy/policy-firewalls/aws-integration/get-started.mdx
@@ -56,7 +56,7 @@ The high-level implementation steps are:
 | 2 - Enable {{prodname}} AWS security group integration | Create a custom resource definition (CRD) with VPC security group information.                                                                            |
 | 3 - Control pod access to/from VPC resources           | Use {{prodname}} tiered network policy and annotations to allow and deny access.                                                                          |
 
-To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/)
+To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://ncarb.github.io/eks-workshop/beginner/120_network-policies/tigera/tsce-sg-integration/)
 
 ## Next steps
 

--- a/calico-enterprise_versioned_docs/version-3.17/network-policy/policy-firewalls/aws-integration/get-started.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/network-policy/policy-firewalls/aws-integration/get-started.mdx
@@ -56,7 +56,7 @@ The high-level implementation steps are:
 | 2 - Enable {{prodname}} AWS security group integration | Create a custom resource definition (CRD) with VPC security group information.                                                                            |
 | 3 - Control pod access to/from VPC resources           | Use {{prodname}} tiered network policy and annotations to allow and deny access.                                                                          |
 
-To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/)
+To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://ncarb.github.io/eks-workshop/beginner/120_network-policies/tigera/tsce-sg-integration/)
 
 ## Next steps
 


### PR DESCRIPTION
`8:32:41 PM: https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/ (0) error: message: 'certificate has expired', errno: undefined, code: CERT_HAS_EXPIRED
8:32:41 PM: ==>Origin: http://localhost:4242/calico-cloud/network-policy/policy-firewalls/aws-integration/get-started`

Product Version(s):
Calico 3.26

Issue:
github.com/tigera/docs/pull/671

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->