### PR TITLE
Add allow PSA update step in rancher manager doc

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/rancher-ui.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/rancher-ui.mdx
@@ -60,6 +60,35 @@ The geeky details of what you get:
    ```bash
    kubectl patch installation default --type='json' -p='[{"op": "remove", "path": "/spec/imagePath"},{"op": "remove", "path": "/spec/imagePrefix"}]'
    ```
+7. Create ClusterRole and ClusterRoleBinding to allow Tigera Operator to update Pod Security Admission.
+   ```bash
+   kubectl create -f - <<EOF
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRole
+   metadata:
+     name: tigera-operator-psa
+   rules:
+   - apiGroups:
+     - management.cattle.io
+     resources:
+     - projects
+     verbs:
+     - updatepsa
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRoleBinding
+   metadata:
+     name: tigera-operator-psa
+   roleRef:
+     apiGroup: rbac.authorization.k8s.io
+     kind: ClusterRole
+     name: tigera-operator-psa
+   subjects:
+   - kind: ServiceAccount
+     name: tigera-operator
+     namespace: tigera-operator
+   EOF
+   ```
 
 ### Upgrade to {{prodname}}
 

--- a/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/rancher-ui.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/rancher-ui.mdx
@@ -60,6 +60,35 @@ The geeky details of what you get:
    ```bash
    kubectl patch installation default --type='json' -p='[{"op": "remove", "path": "/spec/imagePath"},{"op": "remove", "path": "/spec/imagePrefix"}]'
    ```
+7. Create ClusterRole and ClusterRoleBinding to allow Tigera Operator to update Pod Security Admission.
+   ```bash
+   kubectl create -f - <<EOF
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRole
+   metadata:
+     name: tigera-operator-psa
+   rules:
+   - apiGroups:
+     - management.cattle.io
+     resources:
+     - projects
+     verbs:
+     - updatepsa
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRoleBinding
+   metadata:
+     name: tigera-operator-psa
+   roleRef:
+     apiGroup: rbac.authorization.k8s.io
+     kind: ClusterRole
+     name: tigera-operator-psa
+   subjects:
+   - kind: ServiceAccount
+     name: tigera-operator
+     namespace: tigera-operator
+   EOF
+   ```
 
 ### Upgrade to {{prodname}}
 

--- a/calico-enterprise_versioned_docs/version-3.17/getting-started/install-on-clusters/rancher-ui.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/getting-started/install-on-clusters/rancher-ui.mdx
@@ -60,6 +60,35 @@ The geeky details of what you get:
    ```bash
    kubectl patch installation default --type='json' -p='[{"op": "remove", "path": "/spec/imagePath"},{"op": "remove", "path": "/spec/imagePrefix"}]'
    ```
+7. Create ClusterRole and ClusterRoleBinding to allow Tigera Operator to update Pod Security Admission.
+   ```bash
+   kubectl create -f - <<EOF
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRole
+   metadata:
+     name: tigera-operator-psa
+   rules:
+   - apiGroups:
+     - management.cattle.io
+     resources:
+     - projects
+     verbs:
+     - updatepsa
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRoleBinding
+   metadata:
+     name: tigera-operator-psa
+   roleRef:
+     apiGroup: rbac.authorization.k8s.io
+     kind: ClusterRole
+     name: tigera-operator-psa
+   subjects:
+   - kind: ServiceAccount
+     name: tigera-operator
+     namespace: tigera-operator
+   EOF
+   ```
 
 ### Upgrade to {{prodname}}
 


### PR DESCRIPTION
Add a step in rancher manager doc to allow Tigera Operator update PSA. This step is reported necessary for Calico Enterprise installation from rancher v2.7.2. More details are in the vendor issue:  https://github.com/rancher/rancher/issues/41191.

Product Version(s):

Calico Enterprise from v3.16 to next.

Issue:

https://github.com/rancher/rancher/issues/41191

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->