### PR TITLE
Update Openshift doc to update networkType for 4.12+

### DIFF
--- a/calico-enterprise/_includes/components/InstallOpenShift.js
+++ b/calico-enterprise/_includes/components/InstallOpenShift.js
@@ -56,7 +56,7 @@ export default function InstallOpenShift(props) {
         <Link href={`${baseUrl}/getting-started/install-on-clusters/openshift/requirements`}>system requirements</Link>:
       </p>
       <CodeBlock language='bash'>
-        sed -i 's/OpenShiftSDN/Calico/' install-config.yaml{'\n'}
+        sed -i 's/\(OpenShiftSDN\|OVNKubernetes\)/Calico/' install-config.yaml{'\n'}
         sed -i 's/platform: {}/platform:\n{'\t'}aws:\n{'\t'}type: m4.xlarge/g' install-config.yaml
       </CodeBlock>
 

--- a/calico-enterprise_versioned_docs/version-3.16/_includes/components/InstallOpenShift.js
+++ b/calico-enterprise_versioned_docs/version-3.16/_includes/components/InstallOpenShift.js
@@ -56,7 +56,7 @@ export default function InstallOpenShift(props) {
         <Link href={`${baseUrl}/getting-started/install-on-clusters/openshift/requirements`}>system requirements</Link>:
       </p>
       <CodeBlock language='bash'>
-        sed -i 's/OpenShiftSDN/Calico/' install-config.yaml{'\n'}
+        sed -i 's/\(OpenShiftSDN\|OVNKubernetes\)/Calico/' install-config.yaml{'\n'}
         sed -i 's/platform: {}/platform:\n{'\t'}aws:\n{'\t'}type: m4.xlarge/g' install-config.yaml
       </CodeBlock>
 

--- a/calico-enterprise_versioned_docs/version-3.17/_includes/components/InstallOpenShift.js
+++ b/calico-enterprise_versioned_docs/version-3.17/_includes/components/InstallOpenShift.js
@@ -56,7 +56,7 @@ export default function InstallOpenShift(props) {
         <Link href={`${baseUrl}/getting-started/install-on-clusters/openshift/requirements`}>system requirements</Link>:
       </p>
       <CodeBlock language='bash'>
-        sed -i 's/OpenShiftSDN/Calico/' install-config.yaml{'\n'}
+        sed -i 's/\(OpenShiftSDN\|OVNKubernetes\)/Calico/' install-config.yaml{'\n'}
         sed -i 's/platform: {}/platform:\n{'\t'}aws:\n{'\t'}type: m4.xlarge/g' install-config.yaml
       </CodeBlock>
 

--- a/calico/getting-started/kubernetes/openshift/installation.mdx
+++ b/calico/getting-started/kubernetes/openshift/installation.mdx
@@ -57,7 +57,7 @@ Once the installer has finished, your staging directory will contain the configu
 Override the OpenShift networking to use Calico and update the AWS instance types to meet the [system requirements](requirements.mdx):
 
 ```bash
-sed -i 's/OpenShiftSDN/Calico/' install-config.yaml
+sed -i 's/\(OpenShiftSDN\|OVNKubernetes\)/Calico/' install-config.yaml
 ```
 
 ### Generate the install manifests

--- a/calico/getting-started/kubernetes/windows-calico/openshift-installation.mdx
+++ b/calico/getting-started/kubernetes/windows-calico/openshift-installation.mdx
@@ -61,7 +61,7 @@ Once the installer has finished, your staging directory will contain the configu
 Override the OpenShift networking to use Calico and update the AWS instance types to meet the [system requirements](../openshift/requirements.mdx):
 
 ```bash
-sed -i 's/OpenShiftSDN/Calico/' install-config.yaml
+sed -i 's/\(OpenShiftSDN\|OVNKubernetes\)/Calico/' install-config.yaml
 ```
 
 ### Generate the install manifests

--- a/calico_versioned_docs/version-3.25/getting-started/kubernetes/openshift/installation.mdx
+++ b/calico_versioned_docs/version-3.25/getting-started/kubernetes/openshift/installation.mdx
@@ -57,7 +57,7 @@ Once the installer has finished, your staging directory will contain the configu
 Override the OpenShift networking to use Calico and update the AWS instance types to meet the [system requirements](requirements.mdx):
 
 ```bash
-sed -i 's/OpenShiftSDN/Calico/' install-config.yaml
+sed -i 's/\(OpenShiftSDN\|OVNKubernetes\)/Calico/' install-config.yaml
 ```
 
 ### Generate the install manifests

--- a/calico_versioned_docs/version-3.25/getting-started/kubernetes/windows-calico/openshift-installation.mdx
+++ b/calico_versioned_docs/version-3.25/getting-started/kubernetes/windows-calico/openshift-installation.mdx
@@ -61,7 +61,7 @@ Once the installer has finished, your staging directory will contain the configu
 Override the OpenShift networking to use Calico and update the AWS instance types to meet the [system requirements](../openshift/requirements.mdx):
 
 ```bash
-sed -i 's/OpenShiftSDN/Calico/' install-config.yaml
+sed -i 's/\(OpenShiftSDN\|OVNKubernetes\)/Calico/' install-config.yaml
 ```
 
 ### Generate the install manifests


### PR DESCRIPTION
From Openshift 4.12+, the default `networkType` is `OVNKubernetes` instead of `OpenShiftSDN`. This changeset updates the `sed` match pattern in both Calico OSS and Enterprise doc.

Product Version(s):

* Calico OSS v3.25+.
* Calico Enterprise v3.16+.

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->