### PR TITLE
Add a step to install honeypod PSP when needed for v3.16 docs

### DIFF
--- a/calico-cloud_versioned_docs/version-3.16/threat/honeypod/honeypods.mdx
+++ b/calico-cloud_versioned_docs/version-3.16/threat/honeypod/honeypods.mdx
@@ -40,16 +40,10 @@ Honeypods can be configured on a per-cluster basis using "template" honeypod man
 
 ### Configure namespace and RBAC for honeypods
 
-In a v1.24 or earlier cluster, if the [PodSecurityPolicy admission controller](https://v1-24.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy) is enabled, install the required Honeypod Pod Security Policy:
-
-```bash
-kubectl create -f {{filesUrl_CE}}/manifests/threatdef/honeypod/psp-honeypod.yaml
-```
-
 Apply the following manifest to create a namespace and RBAC for the honeypods:
 
 ```bash
-kubectl create -f {{filesUrl_CE}}/manifests/threatdef/honeypod/common.yaml
+kubectl apply -f {{filesUrl_CE}}/manifests/threatdef/honeypod/common.yaml
 ```
 
 Add `tigera-pull-secret` into the namespace `tigera-internal`:

--- a/calico-cloud_versioned_docs/version-3.16/threat/honeypod/honeypods.mdx
+++ b/calico-cloud_versioned_docs/version-3.16/threat/honeypod/honeypods.mdx
@@ -40,10 +40,16 @@ Honeypods can be configured on a per-cluster basis using "template" honeypod man
 
 ### Configure namespace and RBAC for honeypods
 
+In a v1.24 or earlier cluster, if the [PodSecurityPolicy admission controller](https://v1-24.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy) is enabled, install the required Honeypod Pod Security Policy:
+
+```bash
+kubectl create -f {{filesUrl_CE}}/manifests/threatdef/honeypod/psp-honeypod.yaml
+```
+
 Apply the following manifest to create a namespace and RBAC for the honeypods:
 
 ```bash
-kubectl apply -f {{filesUrl_CE}}/manifests/threatdef/honeypod/common.yaml
+kubectl create -f {{filesUrl_CE}}/manifests/threatdef/honeypod/common.yaml
 ```
 
 Add `tigera-pull-secret` into the namespace `tigera-internal`:

--- a/calico-enterprise_versioned_docs/version-3.16/threat/honeypod/honeypods.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/threat/honeypod/honeypods.mdx
@@ -40,10 +40,16 @@ Honeypods can be configured on a per-cluster basis using "template" honeypod man
 
 ### Configure namespace and RBAC for honeypods
 
+In a v1.24 or earlier cluster, if the [PodSecurityPolicy admission controller](https://v1-24.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy) is enabled, install the required Honeypod Pod Security Policy:
+
+```bash
+kubectl create -f {{filesUrl}}/manifests/threatdef/honeypod/psp-honeypod.yaml
+```
+
 Apply the following manifest to create a namespace and RBAC for the honeypods:
 
 ```bash
-kubectl apply -f {{filesUrl}}/manifests/threatdef/honeypod/common.yaml
+kubectl create -f {{filesUrl}}/manifests/threatdef/honeypod/common.yaml
 ```
 
 Add `tigera-pull-secret` into the namespace `tigera-internal`:


### PR DESCRIPTION
Add a step in Honeypod configure page to apply a PSP manifest first when needed. This line is borrowed from our quickstart guide.

Pick https://github.com/tigera/docs/pull/549 to Calico Enterprise and Cloud v3.16 release docs.

Product Version(s):

Calico Enterprise and Calico Cloud v3.16+ (v3.17 and next have this change already).

Issue:

Pick https://github.com/tigera/docs/pull/549 to v3.16 release docs.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->