### PR TITLE
DOCS-missing-users-content

### DIFF
--- a/calico-cloud_versioned_docs/version-3.16/users/index.mdx
+++ b/calico-cloud_versioned_docs/version-3.16/users/index.mdx
@@ -1,0 +1,8 @@
+---
+title: Users
+hide_table_of_contents: true
+---
+import DocCardList from '@theme/DocCardList';
+import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
+
+<DocCardList items={useCurrentSidebarCategory().items}/>

--- a/calico-cloud_versioned_docs/version-3.17/users/index.mdx
+++ b/calico-cloud_versioned_docs/version-3.17/users/index.mdx
@@ -1,0 +1,8 @@
+---
+title: Users
+hide_table_of_contents: true
+---
+import DocCardList from '@theme/DocCardList';
+import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
+
+<DocCardList items={useCurrentSidebarCategory().items}/>

--- a/calico-cloud_versioned_sidebars/version-3.16-sidebars.json
+++ b/calico-cloud_versioned_sidebars/version-3.16-sidebars.json
@@ -54,6 +54,18 @@
     },
     {
       "type": "category",
+      "label": "Users",
+      "link": {
+        "type": "doc",
+        "id": "users/index"
+      },
+      "items": [
+        "users/user-management",
+        "users/create-and-assign-custom-roles"
+      ]
+    },
+    {
+      "type": "category",
       "label": "Tutorials",
       "link": {
         "type": "doc",

--- a/calico-cloud_versioned_sidebars/version-3.17-sidebars.json
+++ b/calico-cloud_versioned_sidebars/version-3.17-sidebars.json
@@ -54,6 +54,18 @@
     },
     {
       "type": "category",
+      "label": "Users",
+      "link": {
+        "type": "doc",
+        "id": "users/index"
+      },
+      "items": [
+        "users/user-management",
+        "users/create-and-assign-custom-roles"
+      ]
+    },
+    {
+      "type": "category",
       "label": "Tutorials",
       "link": {
         "type": "doc",


### PR DESCRIPTION
Users tab is missing from CC sidebar/TOC.

Product Version(s):
CC 3.16, 3.17

Issue:
n/a

Link to docs preview:
https://deploy-preview-687--tigera.netlify.app/calico-cloud/about

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->