### PR TITLE
WAF changes for namespaces-name combination

### DIFF
--- a/calico-cloud/threat/web-application-firewall.mdx
+++ b/calico-cloud/threat/web-application-firewall.mdx
@@ -54,11 +54,16 @@ You simply enable WAF in Manager UI, and determine the services that you want to
 
 :::caution
 
-Enabling WAF for certain system services may result in an undesired cluster state. Do not enable WAF for system service with the following prefixes:
+Enabling WAF for certain system services may result in an undesired cluster state.
+- Do not enable WAF for system service with the following prefixes:
 
-- `tigera-*`
-- `calico-*`
-- `kube-system`
+  - `tigera-*`
+  - `calico-*`
+  - `kube-system`
+
+- Do not enable WAF for system services with the following combination of name and namespaces:
+  - name: `kubernetes`, namespace: `default`
+  - name: `gatekeeper-webhook-service`, namespace: `gatekeeper-system`
 
 :::
 

--- a/calico-cloud_versioned_docs/version-3.16/threat/web-application-firewall.mdx
+++ b/calico-cloud_versioned_docs/version-3.16/threat/web-application-firewall.mdx
@@ -54,11 +54,16 @@ You simply enable WAF in Manager UI, and determine the services that you want to
 
 :::caution
 
-Enabling WAF for certain system services may result in an undesired cluster state. Do not enable WAF for system service with the following prefixes:
+Enabling WAF for certain system services may result in an undesired cluster state.
+- Do not enable WAF for system service with the following prefixes:
 
-- `tigera-*`
-- `calico-*`
-- `kube-system`
+  - `tigera-*`
+  - `calico-*`
+  - `kube-system`
+
+- Do not enable WAF for system services with the following combination of name and namespaces:
+  - name: `kubernetes`, namespace: `default`
+  - name: `gatekeeper-webhook-service`, namespace: `gatekeeper-system`
 
 :::
 

--- a/calico-cloud_versioned_docs/version-3.17/threat/web-application-firewall.mdx
+++ b/calico-cloud_versioned_docs/version-3.17/threat/web-application-firewall.mdx
@@ -54,11 +54,16 @@ You simply enable WAF in Manager UI, and determine the services that you want to
 
 :::caution
 
-Enabling WAF for certain system services may result in an undesired cluster state. Do not enable WAF for system service with the following prefixes:
+Enabling WAF for certain system services may result in an undesired cluster state.
+- Do not enable WAF for system service with the following prefixes:
 
-- `tigera-*`
-- `calico-*`
-- `kube-system`
+  - `tigera-*`
+  - `calico-*`
+  - `kube-system`
+
+- Do not enable WAF for system services with the following combination of name and namespaces:
+  - name: `kubernetes`, namespace: `default`
+  - name: `gatekeeper-webhook-service`, namespace: `gatekeeper-system`
 
 :::
 

--- a/calico-enterprise/threat/web-application-firewall.mdx
+++ b/calico-enterprise/threat/web-application-firewall.mdx
@@ -54,12 +54,18 @@ You simply enable WAF in Manager UI, and determine the services that you want to
 
 :::caution
 
-Enabling WAF for certain system services may result in an undesired cluster state. Do not enable WAF for system service with the following prefixes:
+Enabling WAF for certain system services may result in an undesired cluster state.
+- Do not enable WAF for system service with the following prefixes:
 
-- `tigera-*`
-- `calico-*`
-- `kube-system`
-- `openshift-*`
+  - `tigera-*`
+  - `calico-*`
+  - `kube-system`
+  - `openshift-*`
+
+- Do not enable WAF for system services with the following combination of name and namespaces:
+  - name: `kubernetes`, namespace: `default`
+  - name: `openshift`, namespace: `default`
+  - name: `gatekeeper-webhook-service`, namespace: `gatekeeper-system`
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.15/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/threat/web-application-firewall.mdx
@@ -55,12 +55,19 @@ With {{prodname}} WAF, you gain visibility into internal east/west traffic at th
 
 :::caution
 
-Enabling WAF for certain system services may result in an undesired cluster state. Do not enable WAF for system service with the following prefixes:
+Enabling WAF for certain system services may result in an undesired cluster state.
+- Do not enable WAF for system service with the following prefixes:
 
-- `tigera-*`
-- `calico-*`
-- `kube-system`
-- `openshift-*`
+  - `tigera-*`
+  - `calico-*`
+  - `kube-system`
+  - `openshift-*`
+
+- Do not enable WAF for system services with the following combination of name and namespaces:
+  - name: `kubernetes`, namespace: `default`
+  - name: `openshift`, namespace: `default`
+  - name: `gatekeeper-webhook-service`, namespace: `gatekeeper-system`
+
 :::
 
 **Required**

--- a/calico-enterprise_versioned_docs/version-3.16/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/threat/web-application-firewall.mdx
@@ -54,12 +54,18 @@ You simply enable WAF in Manager UI, and determine the services that you want to
 
 :::caution
 
-Enabling WAF for certain system services may result in an undesired cluster state. Do not enable WAF for system service with the following prefixes:
+Enabling WAF for certain system services may result in an undesired cluster state.
+- Do not enable WAF for system service with the following prefixes:
 
-- `tigera-*`
-- `calico-*`
-- `kube-system`
-- `openshift-*`
+  - `tigera-*`
+  - `calico-*`
+  - `kube-system`
+  - `openshift-*`
+
+- Do not enable WAF for system services with the following combination of name and namespaces:
+  - name: `kubernetes`, namespace: `default`
+  - name: `openshift`, namespace: `default`
+  - name: `gatekeeper-webhook-service`, namespace: `gatekeeper-system`
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.17/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/threat/web-application-firewall.mdx
@@ -54,12 +54,18 @@ You simply enable WAF in Manager UI, and determine the services that you want to
 
 :::caution
 
-Enabling WAF for certain system services may result in an undesired cluster state. Do not enable WAF for system service with the following prefixes:
+Enabling WAF for certain system services may result in an undesired cluster state.
+- Do not enable WAF for system service with the following prefixes:
 
-- `tigera-*`
-- `calico-*`
-- `kube-system`
-- `openshift-*`
+  - `tigera-*`
+  - `calico-*`
+  - `kube-system`
+  - `openshift-*`
+
+- Do not enable WAF for system services with the following combination of name and namespaces:
+  - name: `kubernetes`, namespace: `default`
+  - name: `openshift`, namespace: `default`
+  - name: `gatekeeper-webhook-service`, namespace: `gatekeeper-system`
 
 :::
 


### PR DESCRIPTION
Enabling WAF for certain system services may result in an undesired cluster state. Do not enable WAF for system services with the following namespace prefixes:
tigera-*
calico-*
kube-system
openshift-*
In addition to that the following combination of name and namespaces:
name: 'kubernetes', namespace: 'default'
name: 'openshift', namespace: 'default'
name: 'gatekeeper-webhook-service', namespace: 'gatekeeper-system'

Product Version(s):
Calico Enterprise and Calico Cloud 

Issue:
(https://tigera.atlassian.net/browse/DOCS-1443)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->