### PR TITLE
DOCS-1423: Replace absolute URLs with relative paths

### DIFF
--- a/calico-cloud/operations/disconnect.mdx
+++ b/calico-cloud/operations/disconnect.mdx
@@ -35,4 +35,4 @@ To remove policies from tiers, you have these options:
 
 ## Next steps
 
-Continue using your cluster with open-source [Project Calico](https://docs.tigera.io/calico/latest/about).
+Continue using your cluster with open-source [Project Calico](/calico/latest/about).

--- a/calico-cloud_versioned_docs/version-3.15/operations/disconnect.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/operations/disconnect.mdx
@@ -41,4 +41,4 @@ To remove policies from tiers, you have these options:
 
 ## Next steps
 
-Continue using your cluster with open-source [Project Calico](https://docs.tigera.io/calico/latest/about).
+Continue using your cluster with open-source [Project Calico](/calico/latest/about).

--- a/calico-cloud_versioned_docs/version-3.15/threat/web-application-firewall.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/threat/web-application-firewall.mdx
@@ -75,7 +75,7 @@ kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"policySync
 
 #### Step 1: Configure ApplicationLayer CRD
 
-Create or update the [ApplicationLayer](https://docs.tigera.io/reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the webApplicationFirewall section of the file. Ensure value of the field is set to Enabled.
+Create or update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the webApplicationFirewall section of the file. Ensure value of the field is set to Enabled.
 
 Example:
 

--- a/calico-cloud_versioned_docs/version-3.16/operations/disconnect.mdx
+++ b/calico-cloud_versioned_docs/version-3.16/operations/disconnect.mdx
@@ -35,4 +35,4 @@ To remove policies from tiers, you have these options:
 
 ## Next steps
 
-Continue using your cluster with open-source [Project Calico](https://docs.tigera.io/calico/latest/about).
+Continue using your cluster with open-source [Project Calico](/calico/latest/about).

--- a/calico-cloud_versioned_docs/version-3.16/threat/web-application-firewall.mdx
+++ b/calico-cloud_versioned_docs/version-3.16/threat/web-application-firewall.mdx
@@ -146,7 +146,7 @@ In Service Graph, go to the service and click the HTTP tab. You will see the fol
 
 To view WAF events In Kibana:
 
-1. Create the `tigera_secure_ee_waf*` index pattern. For help with index patterns, see [Kibana index pattern](https://docs.tigera.io/calico-cloud/visibility/kibana).
+1. Create the `tigera_secure_ee_waf*` index pattern. For help with index patterns, see [Kibana index pattern](/calico-cloud/visibility/kibana).
 2. Select the `tigera_secure_ee_waf*` index pattern. 
 
 You should see the relevant WAF assessment from your request.

--- a/calico-cloud_versioned_docs/version-3.17/operations/disconnect.mdx
+++ b/calico-cloud_versioned_docs/version-3.17/operations/disconnect.mdx
@@ -35,4 +35,4 @@ To remove policies from tiers, you have these options:
 
 ## Next steps
 
-Continue using your cluster with open-source [Project Calico](https://docs.tigera.io/calico/latest/about).
+Continue using your cluster with open-source [Project Calico](/calico/latest/about).

--- a/calico-enterprise/getting-started/manifest-archive.mdx
+++ b/calico-enterprise/getting-started/manifest-archive.mdx
@@ -35,7 +35,7 @@ This feature is:
 
    ```bash
    tar xzvf release-x.y.z.tgz
-   ```
+      ```
 
 <Tabs>
 <TabItem label="Kubernetes" value="Kubernetes-0">

--- a/calico-enterprise/threat/web-application-firewall.mdx
+++ b/calico-enterprise/threat/web-application-firewall.mdx
@@ -136,7 +136,7 @@ In Service Graph, go to the service and click the HTTP tab. You will see the fol
 
 To view WAF events In Kibana:
 
-1. Create the `tigera_secure_ee_waf*` index pattern. For help with index patterns, see [Kibana index pattern](https://docs.tigera.io/calico-cloud/visibility/kibana).
+1. Create the `tigera_secure_ee_waf*` index pattern. For help with index patterns, see [Kibana index pattern](/calico-cloud/visibility/kibana).
 2. Select the `tigera_secure_ee_waf*` index pattern. 
 
 You should see the relevant WAF assessment from your request.
@@ -284,7 +284,7 @@ kubectl replace -f ../my-ruleset.yaml
 
 ### Enable WAF using CLIs
 
-1. Create or update the [ApplicationLayer](https://docs.tigera.io/reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the `webApplicationFirewall` field, and ensure it is set to `Enabled`.
+1. Create or update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the `webApplicationFirewall` field, and ensure it is set to `Enabled`.
 
 ```yaml
 apiVersion: operator.tigera.io/v1
@@ -316,7 +316,7 @@ kubectl annotate svc <service-name> -n <service-namespace> projectcalico.org/l7-
 
 #### Disable WAF feature
 
-To disable WAF, update the [ApplicationLayer](https://docs.tigera.io/reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the `webApplicationFirewall` field, and ensure it is set to `Disabled`.
+To disable WAF, update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the `webApplicationFirewall` field, and ensure it is set to `Disabled`.
 
 Example:
 

--- a/calico-enterprise_versioned_docs/version-3.14/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.14/threat/web-application-firewall.mdx
@@ -75,7 +75,7 @@ kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"policySync
 
 #### Step 1: Configure ApplicationLayer CRD
 
-Create or update the [ApplicationLayer](https://docs.tigera.io/reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the webApplicationFirewall section of the file. Ensure value of the field is set to Enabled.
+Create or update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the webApplicationFirewall section of the file. Ensure value of the field is set to Enabled.
 
 Example:
 

--- a/calico-enterprise_versioned_docs/version-3.15/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/threat/web-application-firewall.mdx
@@ -92,7 +92,7 @@ kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"policySync
 
 #### Step 1: Configure ApplicationLayer CRD
 
-Create or update the [ApplicationLayer](https://docs.tigera.io/reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the webApplicationFirewall section of the file. Ensure value of the field is set to Enabled.
+Create or update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the webApplicationFirewall section of the file. Ensure value of the field is set to Enabled.
 
 Example:
 

--- a/calico-enterprise_versioned_docs/version-3.16/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/threat/web-application-firewall.mdx
@@ -148,7 +148,7 @@ In Service Graph, go to the service and click the HTTP tab. You will see the fol
 
 To view WAF events In Kibana:
 
-1. Create the `tigera_secure_ee_waf*` index pattern. For help with index patterns, see [Kibana index pattern](https://docs.tigera.io/calico-cloud/visibility/kibana).
+1. Create the `tigera_secure_ee_waf*` index pattern. For help with index patterns, see [Kibana index pattern](/calico-cloud/visibility/kibana).
 2. Select the `tigera_secure_ee_waf*` index pattern. 
 
 You should see the relevant WAF assessment from your request.
@@ -288,7 +288,7 @@ kubectl replace -f ../my-ruleset.yaml
 
 ### Enable WAF using CLIs
 
-1. Create or update the [ApplicationLayer](https://docs.tigera.io/reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the `webApplicationFirewall` field, and ensure it is set to `Enabled`.
+1. Create or update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the `webApplicationFirewall` field, and ensure it is set to `Enabled`.
 
 ```yaml
 apiVersion: operator.tigera.io/v1
@@ -320,7 +320,7 @@ kubectl annotate svc <service-name> -n <service-namespace> projectcalico.org/l7-
 
 #### Disable WAF feature
 
-To disable WAF, update the [ApplicationLayer](https://docs.tigera.io/reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the `webApplicationFirewall` field, and ensure it is set to `Disabled`.
+To disable WAF, update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the `webApplicationFirewall` field, and ensure it is set to `Disabled`.
 
 Example:
 

--- a/calico-enterprise_versioned_docs/version-3.17/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/threat/web-application-firewall.mdx
@@ -136,7 +136,7 @@ In Service Graph, go to the service and click the HTTP tab. You will see the fol
 
 To view WAF events In Kibana:
 
-1. Create the `tigera_secure_ee_waf*` index pattern. For help with index patterns, see [Kibana index pattern](https://docs.tigera.io/calico-cloud/visibility/kibana).
+1. Create the `tigera_secure_ee_waf*` index pattern. For help with index patterns, see [Kibana index pattern](/calico-cloud/visibility/kibana).
 2. Select the `tigera_secure_ee_waf*` index pattern. 
 
 You should see the relevant WAF assessment from your request.
@@ -284,7 +284,7 @@ kubectl replace -f ../my-ruleset.yaml
 
 ### Enable WAF using CLIs
 
-1. Create or update the [ApplicationLayer](https://docs.tigera.io/reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the `webApplicationFirewall` field, and ensure it is set to `Enabled`.
+1. Create or update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the `webApplicationFirewall` field, and ensure it is set to `Enabled`.
 
 ```yaml
 apiVersion: operator.tigera.io/v1
@@ -316,7 +316,7 @@ kubectl annotate svc <service-name> -n <service-namespace> projectcalico.org/l7-
 
 #### Disable WAF feature
 
-To disable WAF, update the [ApplicationLayer](https://docs.tigera.io/reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the `webApplicationFirewall` field, and ensure it is set to `Disabled`.
+To disable WAF, update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the `webApplicationFirewall` field, and ensure it is set to `Disabled`.
 
 Example:
 

--- a/calico/about/kubernetes-training/about-kubernetes-egress.mdx
+++ b/calico/about/kubernetes-training/about-kubernetes-egress.mdx
@@ -100,4 +100,4 @@ deployments. In these scenarios, using egress gateways is likely to be a better 
 - [Use external IPs or networks rules in policy](/network-policy/policy-rules/external-ips-policy.mdx)
 - [Restrict a pod to use an IP address in a specific range](../../networking/ipam/legacy-firewalls.mdx)
 - [Assign IP addresses based on topology](../../networking/ipam/assign-ip-addresses-topology.mdx)
-- [Egress gateways for Calico Enterprise](https://docs.tigera.io/calico-enterprise/latest/networking/egress/)
+- [Egress gateways for Calico Enterprise](/calico-enterprise/latest/networking/egress/)

--- a/calico_versioned_docs/version-3.24/about/about-network-policy.mdx
+++ b/calico_versioned_docs/version-3.24/about/about-network-policy.mdx
@@ -237,7 +237,7 @@ spec:
 
 ### Hierarchical policy
 
-[Calico Enterprise](https://docs.tigera.io/v3.11/security/tiered-policy) supports hierarchical network policy using policy tiers. RBAC
+[Calico Enterprise](/calico-enterprise/latest/network-policy/policy-tiers/tiered-policy) supports hierarchical network policy using policy tiers. RBAC
 for each tier can be defined to restrict who can interact with each tier. This can be used to delegate trust across
 multiple teams.
 

--- a/calico_versioned_docs/version-3.25/about/about-network-policy.mdx
+++ b/calico_versioned_docs/version-3.25/about/about-network-policy.mdx
@@ -237,7 +237,7 @@ spec:
 
 ### Hierarchical policy
 
-[Calico Enterprise](https://docs.tigera.io/v3.11/security/tiered-policy) supports hierarchical network policy using policy tiers. RBAC
+[Calico Enterprise](/calico-enterprise/latest/network-policy/policy-tiers/tiered-policy) supports hierarchical network policy using policy tiers. RBAC
 for each tier can be defined to restrict who can interact with each tier. This can be used to delegate trust across
 multiple teams.
 

--- a/calico_versioned_docs/version-3.26/about/kubernetes-training/about-kubernetes-egress.mdx
+++ b/calico_versioned_docs/version-3.26/about/kubernetes-training/about-kubernetes-egress.mdx
@@ -100,4 +100,4 @@ deployments. In these scenarios, using egress gateways is likely to be a better 
 - [Use external IPs or networks rules in policy](/network-policy/policy-rules/external-ips-policy.mdx)
 - [Restrict a pod to use an IP address in a specific range](../../networking/ipam/legacy-firewalls.mdx)
 - [Assign IP addresses based on topology](../../networking/ipam/assign-ip-addresses-topology.mdx)
-- [Egress gateways for Calico Enterprise](https://docs.tigera.io/calico-enterprise/latest/networking/egress/)
+- [Egress gateways for Calico Enterprise](/calico-enterprise/latest/networking/egress/)


### PR DESCRIPTION
Exceptions:

- In commands such as this:
 ```bash
- `helm repo add projectcalico https://docs.tigera.io/calico/charts`
 ```
 
- In the API source files.
  `_api.mdx`
 
- In source files that are no longer used (EOL):
  `Pod-security-policy.mdx`

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<https://tigera.atlassian.net/browse/DOCS-1423>

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->