### PR TITLE
DOCS-1544: Fixes backport omission for OVNKubernetes/Calico swap command

### DIFF
--- a/calico_versioned_docs/version-3.26/getting-started/kubernetes/openshift/installation.mdx
+++ b/calico_versioned_docs/version-3.26/getting-started/kubernetes/openshift/installation.mdx
@@ -57,7 +57,7 @@ Once the installer has finished, your staging directory will contain the configu
 Override the OpenShift networking to use Calico and update the AWS instance types to meet the [system requirements](requirements.mdx):
 
 ```bash
-sed -i 's/OpenShiftSDN/Calico/' install-config.yaml
+sed -i 's/\(OpenShiftSDN\|OVNKubernetes\)/Calico/' install-config.yaml
 ```
 
 ### Generate the install manifests

--- a/calico_versioned_docs/version-3.26/getting-started/kubernetes/windows-calico/openshift-installation.mdx
+++ b/calico_versioned_docs/version-3.26/getting-started/kubernetes/windows-calico/openshift-installation.mdx
@@ -61,7 +61,7 @@ Once the installer has finished, your staging directory will contain the configu
 Override the OpenShift networking to use Calico and update the AWS instance types to meet the [system requirements](../openshift/requirements.mdx):
 
 ```bash
-sed -i 's/OpenShiftSDN/Calico/' install-config.yaml
+sed -i 's/\(OpenShiftSDN\|OVNKubernetes\)/Calico/' install-config.yaml
 ```
 
 ### Generate the install manifests


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
[An earlier PR](https://github.com/tigera/docs/pull/681/files) omitted changes to OSS 3.26. 

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->
OSS 3.26

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->
https://tigera.atlassian.net/browse/DOCS-1544

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->