### PR TITLE
[Docs] Replace `calicoctl` typos

### DIFF
--- a/calico_versioned_docs/version-3.26/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.26/operations/ebpf/enabling-ebpf.mdx
@@ -296,7 +296,7 @@ kubectl patch networks.operator.openshift.io cluster --type merge -p '{"spec":{"
 If you cannot disable `kube-proxy` (for example, because it is managed by your Kubernetes distribution), then you _must_ change Felix configuration parameter `BPFKubeProxyIptablesCleanupEnabled` to `false`. This can be done with `kubectl` as follows:
 
 ```
-kubectl patch felixconfiguration.p default --patch='{"spec": {"bpfKubeProxyIptablesCleanupEnabled": false}}'
+calicoctl patch felixconfiguration default --patch='{"spec": {"bpfKubeProxyIptablesCleanupEnabled": false}}'
 ```
 
 If both `kube-proxy` and `BPFKubeProxyIptablesCleanupEnabled` is enabled then `kube-proxy` will write its iptables rules and Felix will try to clean them up resulting in iptables flapping between the two.

--- a/calico_versioned_docs/version-3.26/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.26/operations/ebpf/enabling-ebpf.mdx
@@ -296,7 +296,10 @@ kubectl patch networks.operator.openshift.io cluster --type merge -p '{"spec":{"
 If you cannot disable `kube-proxy` (for example, because it is managed by your Kubernetes distribution), then you _must_ change Felix configuration parameter `BPFKubeProxyIptablesCleanupEnabled` to `false`. This can be done with `kubectl` as follows:
 
 ```
-calicoctl patch felixconfiguration default --patch='{"spec": {"bpfKubeProxyIptablesCleanupEnabled": false}}'
+kubectl patch felixconfiguration default --patch='{"spec": {"bpfKubeProxyIptablesCleanupEnabled": false}}'
+
+
+
 ```
 
 If both `kube-proxy` and `BPFKubeProxyIptablesCleanupEnabled` is enabled then `kube-proxy` will write its iptables rules and Felix will try to clean them up resulting in iptables flapping between the two.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->
```
# calicoctl version
Client Version:    v3.23.3
Git commit:        3a3559be1
Cluster Version:   v3.23.3
Cluster Type:      kubespray,bgp,kubeadm,kdd
```

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->
```
# kubectl get felixconfiguration.p default
error: the server doesn't have a resource type "felixconfiguration"
```

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->