### PR TITLE
DOCS-1472: Remove EOL product links from the docs and from the skip list

### DIFF
--- a/__tests__/crawler.test.js
+++ b/__tests__/crawler.test.js
@@ -50,6 +50,7 @@ test("Crawl the docs and execute tests", async () => {
     'http://localhost:4242/calico/3.26/reference/legal/projectcalico',
     'http://localhost:4242/calico/latest/reference/legal/projectcalico',
     'http://localhost:4242/calico/next/reference/legal/projectcalico',
+    'http://localhost:4242/calico/3.25/reference/legal/node',
   ];
   const skipList = [
     /^https?:\/\/([\w-]+\.)?example\.com/,
@@ -122,7 +123,7 @@ test("Crawl the docs and execute tests", async () => {
     'https://tools.ietf.org/html/rfc1123',
     'http://cr.yp.to/libtai/tai64.html#tai64n',
     'https://thenewstack.io/faster-troubleshooting-with-dynamic-packet-capture/', //==>Origin: http://localhost:4242/calico-cloud/visibility/packetcapture
-    'https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/', //This is a temporary fix. A ticket created to fix the docs
+  
   ];
 
   const lc = linkChecker();

--- a/calico-cloud/network-policy/policy-firewalls/aws-integration/get-started.mdx
+++ b/calico-cloud/network-policy/policy-firewalls/aws-integration/get-started.mdx
@@ -56,8 +56,6 @@ The high-level implementation steps are:
 | 2 - Enable {{prodname}} AWS security group integration | Create a custom resource definition (CRD) with VPC security group information.                                                                            |
 | 3 - Control pod access to/from VPC resources           | Use {{prodname}} tiered network policy and annotations to allow and deny access.                                                                          |
 
-To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/)
-
 ## Next steps
 
 - [Configure {{prodname}} AWS security groups integration](aws-security-group-integration.mdx)

--- a/calico-cloud_versioned_docs/version-3.15/network-policy/policy-firewalls/aws-integration/get-started.mdx
+++ b/calico-cloud_versioned_docs/version-3.15/network-policy/policy-firewalls/aws-integration/get-started.mdx
@@ -56,8 +56,6 @@ The high-level implementation steps are:
 | 2 - Enable {{prodname}} AWS security group integration | Create a custom resource definition (CRD) with VPC security group information.                                                                            |
 | 3 - Control pod access to/from VPC resources           | Use {{prodname}} tiered network policy and annotations to allow and deny access.                                                                          |
 
-To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/)
-
 ## Next steps
 
 - [Configure {{prodname}} AWS security groups integration](aws-security-group-integration.mdx)

--- a/calico-cloud_versioned_docs/version-3.16/network-policy/policy-firewalls/aws-integration/get-started.mdx
+++ b/calico-cloud_versioned_docs/version-3.16/network-policy/policy-firewalls/aws-integration/get-started.mdx
@@ -56,8 +56,6 @@ The high-level implementation steps are:
 | 2 - Enable {{prodname}} AWS security group integration | Create a custom resource definition (CRD) with VPC security group information.                                                                            |
 | 3 - Control pod access to/from VPC resources           | Use {{prodname}} tiered network policy and annotations to allow and deny access.                                                                          |
 
-To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/)
-
 ## Next steps
 
 - [Configure {{prodname}} AWS security groups integration](aws-security-group-integration.mdx)

--- a/calico-cloud_versioned_docs/version-3.17/network-policy/policy-firewalls/aws-integration/get-started.mdx
+++ b/calico-cloud_versioned_docs/version-3.17/network-policy/policy-firewalls/aws-integration/get-started.mdx
@@ -56,8 +56,6 @@ The high-level implementation steps are:
 | 2 - Enable {{prodname}} AWS security group integration | Create a custom resource definition (CRD) with VPC security group information.                                                                            |
 | 3 - Control pod access to/from VPC resources           | Use {{prodname}} tiered network policy and annotations to allow and deny access.                                                                          |
 
-To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/)
-
 ## Next steps
 
 - [Configure {{prodname}} AWS security groups integration](aws-security-group-integration.mdx)

--- a/calico-enterprise/network-policy/policy-firewalls/aws-integration/get-started.mdx
+++ b/calico-enterprise/network-policy/policy-firewalls/aws-integration/get-started.mdx
@@ -56,8 +56,6 @@ The high-level implementation steps are:
 | 2 - Enable {{prodname}} AWS security group integration | Create a custom resource definition (CRD) with VPC security group information.                                                                            |
 | 3 - Control pod access to/from VPC resources           | Use {{prodname}} tiered network policy and annotations to allow and deny access.                                                                          |
 
-To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/)
-
 ## Next steps
 
 - [Configure {{prodname}} AWS security groups integration](aws-security-group-integration.mdx)

--- a/calico-enterprise_versioned_docs/version-3.14/network-policy/policy-firewalls/aws-integration/get-started.mdx
+++ b/calico-enterprise_versioned_docs/version-3.14/network-policy/policy-firewalls/aws-integration/get-started.mdx
@@ -56,8 +56,6 @@ The high-level implementation steps are:
 | 2 - Enable {{prodname}} AWS security group integration | Create a custom resource definition (CRD) with VPC security group information.                                                                            |
 | 3 - Control pod access to/from VPC resources           | Use {{prodname}} tiered network policy and annotations to allow and deny access.                                                                          |
 
-To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/)
-
 ## Next steps
 
 - [Configure {{prodname}} AWS security groups integration](aws-security-group-integration.mdx)

--- a/calico-enterprise_versioned_docs/version-3.15/network-policy/policy-firewalls/aws-integration/get-started.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/network-policy/policy-firewalls/aws-integration/get-started.mdx
@@ -56,8 +56,6 @@ The high-level implementation steps are:
 | 2 - Enable {{prodname}} AWS security group integration | Create a custom resource definition (CRD) with VPC security group information.                                                                            |
 | 3 - Control pod access to/from VPC resources           | Use {{prodname}} tiered network policy and annotations to allow and deny access.                                                                          |
 
-To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/)
-
 ## Next steps
 
 - [Configure {{prodname}} AWS security groups integration](aws-security-group-integration.mdx)

--- a/calico-enterprise_versioned_docs/version-3.16/network-policy/policy-firewalls/aws-integration/get-started.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/network-policy/policy-firewalls/aws-integration/get-started.mdx
@@ -56,8 +56,6 @@ The high-level implementation steps are:
 | 2 - Enable {{prodname}} AWS security group integration | Create a custom resource definition (CRD) with VPC security group information.                                                                            |
 | 3 - Control pod access to/from VPC resources           | Use {{prodname}} tiered network policy and annotations to allow and deny access.                                                                          |
 
-To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/)
-
 ## Next steps
 
 - [Configure {{prodname}} AWS security groups integration](aws-security-group-integration.mdx)

--- a/calico-enterprise_versioned_docs/version-3.17/network-policy/policy-firewalls/aws-integration/get-started.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/network-policy/policy-firewalls/aws-integration/get-started.mdx
@@ -56,8 +56,6 @@ The high-level implementation steps are:
 | 2 - Enable {{prodname}} AWS security group integration | Create a custom resource definition (CRD) with VPC security group information.                                                                            |
 | 3 - Control pod access to/from VPC resources           | Use {{prodname}} tiered network policy and annotations to allow and deny access.                                                                          |
 
-To see an EKS workshop on AWS security groups and Tigera Secure Cloud Edition, see [Integrating VPC security groups and Kubernetes network policy with TSCE](https://www.eksworkshop.com/beginner/120_network-policies/tigera/tsce-sg-integration/)
-
 ## Next steps
 
 - [Configure {{prodname}} AWS security groups integration](aws-security-group-integration.mdx)


### PR DESCRIPTION
Tigera Cloud Secure Edition (TCSE) is a product that does not exist anymore (Doug confirmed). We have references of that product in our docs at multiple places. The link related to that product was breaking, and it was added to the skip list. Since the links are removed from the docs, I’m removing the link from the skip list as well. 

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
(https://tigera.atlassian.net/browse/DOCS-1472)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->