### PR TITLE
[DOCS-1571] Add CNI type patch with 'Calico' for Helm install on EKS

### DIFF
--- a/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -152,6 +152,12 @@ Before you get started, make sure you have downloaded and configured the [necess
     helm install calico projectcalico/tigera-operator --version {{releaseTitle}}
     ```
 
+1. Patch the CNI type with value `Calico`.
+
+    ```batch
+    kubectl patch installation default --type='json' -p='[{"op": "replace", "path": "/spec/cni/type", "value": "Calico"}]'
+    ```
+
 1. Finally, add nodes to the cluster.
 
     ```batch

--- a/calico_versioned_docs/version-3.24/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico_versioned_docs/version-3.24/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -142,6 +142,12 @@ Before you get started, make sure you have downloaded and configured the [necess
     helm install calico projectcalico/tigera-operator --version {{releaseTitle}}
     ```
 
+1. Patch the CNI type with value `Calico`.
+
+    ```batch
+    kubectl patch installation default --type='json' -p='[{"op": "replace", "path": "/spec/cni/type", "value": "Calico"}]'
+    ```
+
 1. Finally, add nodes to the cluster.
 
     ```batch

--- a/calico_versioned_docs/version-3.25/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico_versioned_docs/version-3.25/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -152,6 +152,12 @@ Before you get started, make sure you have downloaded and configured the [necess
     helm install calico projectcalico/tigera-operator --version {{releaseTitle}}
     ```
 
+1. Patch the CNI type with value `Calico`.
+
+    ```batch
+    kubectl patch installation default --type='json' -p='[{"op": "replace", "path": "/spec/cni/type", "value": "Calico"}]'
+    ```
+
 1. Finally, add nodes to the cluster.
 
     ```batch


### PR DESCRIPTION
When following the EKS installation docs https://docs.tigera.io/calico/latest/getting-started/kubernetes/managed-public-cloud/eks for Helm, and after executing step 3, we need to patch the `spec/cni/type` value of the `default` `Installation` resource with the `Calico` value. Otherwise, executing step 4 fails with:

```
Error: failed to create nodegroups for cluster
```

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->
Calico

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->
https://tigera.atlassian.net/browse/DOCS-1571

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->