### PR TITLE
Update k8s versions in system-requirements.mdx

### DIFF
--- a/calico-cloud_versioned_docs/version-3.16/get-started/connect/requirements/system-requirements.mdx
+++ b/calico-cloud_versioned_docs/version-3.16/get-started/connect/requirements/system-requirements.mdx
@@ -17,7 +17,7 @@ Verify that your cluster meets these requirements.
 | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Platforms**               | All of the open-source [Kubernetes deployments](https://docs.projectcalico.org/getting-started/kubernetes/), except: <br/><br/>- IBM Cloud Kubernetes Service (IKS)<br/>- K3s <br />- Clusters with Windows nodes |
 | **Architecture**            | Only AMD64                                                                                                                                                                                                        |
-| **Kubernetes version**      | - Minimum: v1.23<br/>- Maximum: v1.25<br /><br />If you have a later version than the maximum, contact [Support](https://support.tigera.io/).                                                                     |
+| **Kubernetes version**      | - Minimum: v1.24<br/>- Maximum: v1.26<br /><br />If you have a later version than the maximum, contact [Support](https://support.tigera.io/).                                                                     |
 | **CNIs**                    | - Calico CNI v3.15 to v3.24<br />- Amazon VPC CNI<br/>- Azure CNI<br/>- GKE CNI                                                                                                                                                 |
 | **Browsers for Manager UI** | {{prodname}} supports the latest version and "latest minus one" versions of the following browsers:<br/><br/>- Chrome<br/>- Firefox<br/>- Safari                                                                  |
 


### PR DESCRIPTION
k8s versions should be aligned the Enterprise release that Cloud is currently based on. The current window is 1.24-1.26

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->