### PR TITLE
Fix the vppbranch var in v3.24, v3.25 and v3.26 branches

### DIFF
--- a/calico_versioned_docs/version-3.24/variables.js
+++ b/calico_versioned_docs/version-3.24/variables.js
@@ -18,7 +18,7 @@ const variables = {
   manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.24.6',
   releases,
   registry: '',
-  vppbranch: 'v3.24.0',
+  vppbranch: 'v3.24.1',
   tigeraOperator: releases[0]['tigera-operator'],
   tigeraOperatorVersionShort: releases[0]['tigera-operator'].version.split('.').slice(0, 2).join('.'),
   imageNames: {

--- a/calico_versioned_docs/version-3.25/variables.js
+++ b/calico_versioned_docs/version-3.25/variables.js
@@ -18,7 +18,7 @@ const variables = {
   manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.25.1',
   releases,
   registry: '',
-  vppbranch: 'master',
+  vppbranch: 'v3.25.1',
   tigeraOperator: releases[0]['tigera-operator'],
   tigeraOperatorVersionShort: releases[0]['tigera-operator'].version.split('.').slice(0, 2).join('.'),
   imageNames: {

--- a/calico_versioned_docs/version-3.26/variables.js
+++ b/calico_versioned_docs/version-3.26/variables.js
@@ -18,7 +18,7 @@ const variables = {
   manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.26.1',
   releases,
   registry: '',
-  vppbranch: 'master',
+  vppbranch: 'v3.26.0',
   tigeraOperator: releases[0]['tigera-operator'],
   tigeraOperatorVersionShort: releases[0]['tigera-operator'].version.split('.').slice(0, 2).join('.'),
   imageNames: {


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
The docs were moved to the dedicated `docs` repo and as such the `vppbranch` var that was updated in https://github.com/projectcalico/calico/blob/v3.25.1/calico/_config.yml seems to be failing to do its job. This fix will hopefully do the trick.


Product Version(s): v3.24, v3.25, v3.26
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->