### PR TITLE
DOCS-update-unsupported-platforms

### DIFF
--- a/calico-cloud/get-started/connect/requirements/system-requirements.mdx
+++ b/calico-cloud/get-started/connect/requirements/system-requirements.mdx
@@ -13,13 +13,14 @@ redirect_from:
 
 Verify that your cluster meets these requirements.
 
-| Required                    | Supported                                                                                                                                                                                                         |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Platforms**               | All of the open-source [Kubernetes deployments](https://docs.projectcalico.org/getting-started/kubernetes/), except: <br/><br/>- IBM Cloud Kubernetes Service (IKS)<br/>- K3s <br />- Clusters with Windows nodes |
-| **Architecture**            | Only AMD64                                                                                                                                                                                                        |
-| **Kubernetes version**      | - Minimum: v1.23<br/>- Maximum: v1.25<br /><br />If you have a later version than the maximum, contact [Support](https://support.tigera.io/).                                                                     |
-| **CNIs**                    | - Calico CNI v3.15 to v3.24<br />- Amazon VPC CNI<br/>- Azure CNI<br/>- GKE CNI                                                                                                                                                 |
-| **Browsers for Manager UI** | {{prodname}} supports the latest version and "latest minus one" versions of the following browsers:<br/><br/>- Chrome<br/>- Firefox<br/>- Safari                                                                  |
+| Required                    | Supported                                                    |
+| --------------------------- | ------------------------------------------------------------ |
+| **Platforms**               | All of the Calico Open Source [Kubernetes deployments](https://docs.projectcalico.org/getting-started/kubernetes/), except: <br/><br/>- OpenShift<br />- IBM Cloud Kubernetes Service (IKS)<br/>- K3s <br />- Clusters with Windows nodes<br />- RKE |
+| **Architecture**            | Only AMD64                                                   |
+| **Kubernetes version**      | - Minimum: v1.23<br/>- Maximum: v1.26<br /><br />If you have a later version than the maximum, contact [Support](https://support.tigera.io/). |
+| **CNIs**                    | - Calico CNI v3.15 to v3.26<br />- Amazon VPC CNI<br/>- Azure CNI<br/>- GKE CNI |
+| **Browsers for Manager UI** | {{prodname}} supports the latest version and "latest minus one" versions of the following browsers:<br/><br/>- Chrome<br/>- Firefox<br/>- Safari |
+
 
 ### Step 2: Verify cluster is not managed by a Kubernetes reconciler
 

--- a/calico-cloud_versioned_docs/version-3.16/get-started/connect/requirements/system-requirements.mdx
+++ b/calico-cloud_versioned_docs/version-3.16/get-started/connect/requirements/system-requirements.mdx
@@ -13,13 +13,14 @@ redirect_from:
 
 Verify that your cluster meets these requirements.
 
-| Required                    | Supported                                                                                                                                                                                                         |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Platforms**               | All of the open-source [Kubernetes deployments](https://docs.projectcalico.org/getting-started/kubernetes/), except: <br/><br/>- IBM Cloud Kubernetes Service (IKS)<br/>- K3s <br />- Clusters with Windows nodes |
-| **Architecture**            | Only AMD64                                                                                                                                                                                                        |
-| **Kubernetes version**      | - Minimum: v1.24<br/>- Maximum: v1.26<br /><br />If you have a later version than the maximum, contact [Support](https://support.tigera.io/).                                                                     |
-| **CNIs**                    | - Calico CNI v3.15 to v3.24<br />- Amazon VPC CNI<br/>- Azure CNI<br/>- GKE CNI                                                                                                                                                 |
-| **Browsers for Manager UI** | {{prodname}} supports the latest version and "latest minus one" versions of the following browsers:<br/><br/>- Chrome<br/>- Firefox<br/>- Safari                                                                  |
+| Required                    | Supported                                                    |
+| --------------------------- | ------------------------------------------------------------ |
+| **Platforms**               | All of the Calico Open Source [Kubernetes deployments](https://docs.projectcalico.org/getting-started/kubernetes/), except: <br/><br/>- OpenShift<br />- IBM Cloud Kubernetes Service (IKS)<br/>- K3s <br />- Clusters with Windows nodes<br />- RKE |
+| **Architecture**            | Only AMD64                                                   |
+| **Kubernetes version**      | - Minimum: v1.23<br/>- Maximum: v1.25<br /><br />If you have a later version than the maximum, contact [Support](https://support.tigera.io/). |
+| **CNIs**                    | - Calico CNI v3.15 to v3.25<br />- Amazon VPC CNI<br/>- Azure CNI<br/>- GKE CNI |
+| **Browsers for Manager UI** | {{prodname}} supports the latest version and "latest minus one" versions of the following browsers:<br/><br/>- Chrome<br/>- Firefox<br/>- Safari |
+
 
 ### Step 2: Verify cluster is not managed by a Kubernetes reconciler
 

--- a/calico-cloud_versioned_docs/version-3.17/get-started/connect/requirements/system-requirements.mdx
+++ b/calico-cloud_versioned_docs/version-3.17/get-started/connect/requirements/system-requirements.mdx
@@ -13,13 +13,14 @@ redirect_from:
 
 Verify that your cluster meets these requirements.
 
-| Required                    | Supported                                                                                                                                                                                                         |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Platforms**               | All of the open-source [Kubernetes deployments](https://docs.projectcalico.org/getting-started/kubernetes/), except: <br/><br/>- IBM Cloud Kubernetes Service (IKS)<br/>- K3s <br />- Clusters with Windows nodes |
-| **Architecture**            | Only AMD64                                                                                                                                                                                                        |
-| **Kubernetes version**      | - Minimum: v1.23<br/>- Maximum: v1.25<br /><br />If you have a later version than the maximum, contact [Support](https://support.tigera.io/).                                                                     |
-| **CNIs**                    | - Calico CNI v3.15 to v3.24<br />- Amazon VPC CNI<br/>- Azure CNI<br/>- GKE CNI                                                                                                                                                 |
-| **Browsers for Manager UI** | {{prodname}} supports the latest version and "latest minus one" versions of the following browsers:<br/><br/>- Chrome<br/>- Firefox<br/>- Safari                                                                  |
+| Required                    | Supported                                                    |
+| --------------------------- | ------------------------------------------------------------ |
+| **Platforms**               | All of the Calico Open Source [Kubernetes deployments](https://docs.projectcalico.org/getting-started/kubernetes/), except: <br/><br/>- OpenShift<br />- IBM Cloud Kubernetes Service (IKS)<br/>- K3s <br />- Clusters with Windows nodes<br />- RKE |
+| **Architecture**            | Only AMD64                                                   |
+| **Kubernetes version**      | - Minimum: v1.23<br/>- Maximum: v1.26<br /><br />If you have a later version than the maximum, contact [Support](https://support.tigera.io/). |
+| **CNIs**                    | - Calico CNI v3.15 to v3.26<br />- Amazon VPC CNI<br/>- Azure CNI<br/>- GKE CNI |
+| **Browsers for Manager UI** | {{prodname}} supports the latest version and "latest minus one" versions of the following browsers:<br/><br/>- Chrome<br/>- Firefox<br/>- Safari |
+
 
 ### Step 2: Verify cluster is not managed by a Kubernetes reconciler
 


### PR DESCRIPTION
Add RKE and OCP as unsupported platforms. Note that RKE2 is not supported a supported platform for OSS. 

Product Version(s):
CC 3.16, 3.17, 3.18

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->