### PR TITLE
Simplify kubectl command in WAF doc

### DIFF
--- a/calico-enterprise/threat/web-application-firewall.mdx
+++ b/calico-enterprise/threat/web-application-firewall.mdx
@@ -128,7 +128,7 @@ If WAF is already enabled in your cluster, you do not see this page.
 In the ApplicationLayer custom resource, named `tigera-secure`, set the `webApplicationFirewall` field to `Enabled`.
 
 ```bash
-cat << EOF | kubectl apply -f -
+kubectl apply -f - <<EOF
 apiVersion: operator.tigera.io/v1
 kind: ApplicationLayer
 metadata:
@@ -137,6 +137,7 @@ spec:
   webApplicationFirewall: Enabled
 EOF
 ```
+
 ## Apply WAF
 
 Now that your cluster is enabled for WAF, you can apply WAF to your services and make sure that your


### PR DESCRIPTION
This change aligns `kubectl` here-doc usage with other occurrences in our doc.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):

main/next docs only.

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->