### PR TITLE
Restore WAF Global Alerts documentation for 3.17

### DIFF
--- a/calico-cloud_versioned_docs/version-3.16/threat/web-application-firewall.mdx
+++ b/calico-cloud_versioned_docs/version-3.16/threat/web-application-firewall.mdx
@@ -315,7 +315,7 @@ spec:
 
   ```bash
      kubectl annotate svc <service-name> -n <service-namespace> projectcalico.org/l7-logging-
-  ``
+  ```
 
 #### Disable WAF for a service
 

--- a/calico-cloud_versioned_docs/version-3.17/threat/web-application-firewall.mdx
+++ b/calico-cloud_versioned_docs/version-3.17/threat/web-application-firewall.mdx
@@ -301,7 +301,7 @@ spec:
 
   ```bash
      kubectl annotate svc <service-name> -n <service-namespace> projectcalico.org/l7-logging-
-  ``
+  ```
 
 #### Disable WAF for a service
 

--- a/calico-enterprise_versioned_docs/version-3.16/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/threat/web-application-firewall.mdx
@@ -315,7 +315,7 @@ spec:
 
   ```bash
      kubectl annotate svc <service-name> -n <service-namespace> projectcalico.org/l7-logging-
-  ``
+  ```
 
 #### Disable WAF for a service
 

--- a/calico-enterprise_versioned_docs/version-3.17/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/threat/web-application-firewall.mdx
@@ -100,6 +100,7 @@ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/microserv
 - [Enable WAF on your cluster](#enable-waf-on-your-cluster)
 - [Apply WAF to your services](#apply-waf)
 - [View WAF events](#view-waf-events)
+- [Create global alerts](#create-global-alerts)
 - [Disable WAF feature from your cluster](#disable-waf-in-your-cluster)
 
 ### Enable WAF on your cluster
@@ -270,6 +271,33 @@ To view WAF events In Kibana:
 2. Select the `tigera_secure_ee_waf*` index pattern. 
 
 You should see the relevant WAF assessment from your request.
+
+### Create global alerts
+
+To get notifications on WAF events, create Global Alerts.
+
+The following example creates a Global Alert for a SQL Injection attack. Specifically, for Rule ID 942100 [Core Rule Set file](https://raw.githubusercontent.com/coreruleset/coreruleset/v3.3/dev/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf)
+that will "deny" all traffic instead of "block" traffic.
+
+```yaml
+apiVersion: projectcalico.org/v3
+kind: GlobalAlert
+metadata:
+  name: waf-new-alert-rule-info
+spec:
+  summary: 'WAF new waf-alert-942100'
+  description: 'Test WAF Global Alert'
+  severity: 1
+  dataSet: waf
+  period: 1m
+  lookback: 1h
+  query: '"rule_info" IN {"*942100*"}'
+  threshold: 0
+  condition: gt
+```
+Apply the YAML to your cluster using: `kubectl apply -f test-demo-alert.yaml`
+
+Now if a SQL Injection attack is detected for rule ID 942100, you will see the global alert in Manager UI, Activity, Alerts.
 
 #### Disable WAF for a service
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Global Alerts are only automatically generated for WAF in 3.18

Product Version(s):
Calico Enterprise 3.17
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->