### PR TITLE
Update kubernetes-network-policy.mdx

### DIFF
--- a/calico_versioned_docs/version-3.26/network-policy/get-started/kubernetes-policy/kubernetes-network-policy.mdx
+++ b/calico_versioned_docs/version-3.26/network-policy/get-started/kubernetes-policy/kubernetes-network-policy.mdx
@@ -94,7 +94,7 @@ In the following example, incoming traffic is allowed only if they come from a p
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  name: allow-same-namespace
+  name: allow-different-namespace
   namespace: default
 spec:
   podSelector:


### PR DESCRIPTION
Changing the np name for different namespace. This networkpolicy is for "Allow ingress traffic from pods in a different namespace" ,current name is in-consistent with it's purpose.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->