### PR TITLE
Add limitation for enabling UI for RS with k8s v1.27

### DIFF
--- a/calico-cloud/threat/container-threat-detection.mdx
+++ b/calico-cloud/threat/container-threat-detection.mdx
@@ -37,6 +37,9 @@ Our threat detection engine also monitors activity within the containers running
 
 ## Before you begin...
 
+**Not supported:**
+- Enabling Container threat detection through the UI, if you are running Kubernetes v1.27. You can still enable the feature using kubectl. 
+
 ### Required
 
 {{prodname}} Container threat detection uses eBPF to monitor container activity, and it runs on Linux-based

--- a/calico-cloud_versioned_docs/version-3.17/release-notes/index.mdx
+++ b/calico-cloud_versioned_docs/version-3.17/release-notes/index.mdx
@@ -43,6 +43,10 @@ For more information, see [Security event management](../threat/security-event-m
 * Runtime Security alerts now correctly show the generated_time as the time the alert was generated. Previously they incorrectly showed the time when the underlying event which caused the alert was generated.
 * Runtime Security alerts now correctly show the associated Mitre information.
 
+### Known issues
+
+* Enabling WAF and Container Threat Detection through the UI is not possible for clusters running Kubernetes v1.27+. Both features can be enabled using kubectl. 
+
 ### Security updates
 
 * Runtime security upgraded to [golang 1.20.7](https://go.dev/doc/devel/release#go1.20.7), which includes security updates.

--- a/calico-cloud_versioned_docs/version-3.17/threat/container-threat-detection.mdx
+++ b/calico-cloud_versioned_docs/version-3.17/threat/container-threat-detection.mdx
@@ -37,6 +37,9 @@ Our threat detection engine also monitors activity within the containers running
 
 ## Before you begin...
 
+**Not supported:**
+- Enabling Container threat detection through the UI, if you are running Kubernetes v1.27. You can still enable the feature using kubectl. 
+
 ### Required
 
 {{prodname}} Container threat detection uses eBPF to monitor container activity, and it runs on Linux-based


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Add a Not Supported section to the Container Threat Detection docs to highlight that enabling the feature through the UI is not possible with k8s v1.27. This limitation will be removed in the next CC release taking any future version of Calico Enterprise. 

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->