### PR TITLE
DOCS-1576: Updates for federated VXLAN and cluster mesh

### DIFF
--- a/calico-cloud/multicluster/aws.mdx
+++ b/calico-cloud/multicluster/aws.mdx
@@ -2,11 +2,11 @@
 description: A sample configuration of Calico Enterprise federated endpoint identity and federated services for an AWS cluster.
 ---
 
-# Federation example for an AWS cluster
+# Cluster mesh example for clusters in AWS
 
 ## Big picture
 
-A sample configuration for federated endpoint identity and federated services using AWS clusters.
+A sample configuration for cluster mesh using AWS clusters.
 
 ## Tutorial
 

--- a/calico-cloud/multicluster/index.mdx
+++ b/calico-cloud/multicluster/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico Cloud features for scaling to production.
+description: Steps to configure cluster mesh.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud/multicluster/index.mdx
+++ b/calico-cloud/multicluster/index.mdx
@@ -3,7 +3,7 @@ description: Calico Cloud features for scaling to production.
 hide_table_of_contents: true
 ---
 
-# Multi-cluster management and federation
+# Federation and multi-cluster networking
 
 import DocCardList from '@theme/DocCardList';
 import { useCurrentSidebarCategory } from '@docusaurus/theme-common';

--- a/calico-cloud/multicluster/kubeconfig.mdx
+++ b/calico-cloud/multicluster/kubeconfig.mdx
@@ -2,15 +2,15 @@
 description: Configure a local cluster to pull endpoint data from a remote cluster.
 ---
 
-# Configure federated endpoint identity
+# Configure federated endpoint identity and multi-cluster networking
 
 ## Big picture
 
-Configure a local cluster to pull endpoint data from a remote cluster.
+Configure a cluster to federate endpoint identities and establish cross-cluster connectivity.
 
 ## Value
 
-Federating endpoints allows teams to write policies in a local cluster that references/selects endpoints in remote clusters. This expands efficiency and self-service.
+Secure cross-cluster traffic with identity-aware policy, and leverage {{prodname}} to establish the required cross-cluster networking.
 
 ## Features
 
@@ -22,42 +22,27 @@ This how to guide uses the following {{prodname}} features:
 
 ### Local and remote clusters
 
-Each cluster in the federation acts as both a local and remote cluster.
+Each cluster in the cluster mesh can act as both a local and remote cluster.
 
-- Local clusters retrieve endpoint data from remote clusters
-- Remote clusters allow local clusters to retrieve endpoint data
+- Local clusters are configured to retrieve endpoint and routing data from remote clusters (via RemoteClusterConfiguration)
+- Remote clusters authorize local clusters to retrieve endpoint and routing data
 
-### Configure access to remote clusters
+### Remote endpoint identity and policy
 
-To allow a local cluster to access resources on a remote cluster, you create a **RemoteClusterConfiguration**. This configuration contains the information required for the local cluster to establish connection to the remote cluster. The connection in a remote cluster configuration is one-way: information flows only from the remote cluster to the local cluster. If you want to share information from a local cluster to a remote cluster, you must create a remote cluster configuration resource on the remote cluster.
+Typically, policy can only reference the endpoint identity (e.g. pod labels) of local endpoints. Federated endpoint identity enables local policy rules to reference remote endpoint identities.
 
-In the following example, we federate three clusters with each other: `cluster-a`, `cluster-b`, and `cluster-c`:
+### RemoteClusterConfiguration
+RemoteClusterConfiguration is the resource that configures a local cluster to sync resources from a remote cluster. It primarily describes how a local cluster establishes that connection to the remote cluster through which resources are synced.
 
-- **cluster a**
+The resources synced through this connection enable the local cluster to reference remote endpoint identity and establish cross-cluster overlay routes.
 
-  Create two RemoteClusterConfiguration resources: 1 for cluster-b, 1 for cluster-c
+RemoteClusterConfiguration creates this connection in one direction. If you want identity-aware policy on both sides (i.e. both clusters) of a connection, or you want {{prodname}} to establish cross-cluster overlay networking, you need to create a RemoteClusterConfiguration for both directions.
 
-- **cluster b**
+### kubeconfig files
+Each cluster in the cluster mesh should have a dedicated kubeconfig file used by other clusters in the mesh to connect and authenticate.
 
-  Create two RemoteClusterConfiguration resources: 1 for cluster-a, 1 for cluster-c
-
-- **cluster c**
-
-  Create two RemoteClusterConfiguration resources: 1 for cluster-a, 1 for cluster-b
-
-:::note
-
-Although this example applies remote cluster configurations symmetrically across clusters, this is not required; add RemoteClusterConfiguration resources only where needed.
-
-:::
 
 ## Before you begin
-
-**Supported networking**
-
-- {{prodname}} with BGP
-- AKS/Azure, EKS/AWS, and GKE with VPC
-
 <!--//TODO-CC-XREFS
 **Required**
 
@@ -66,163 +51,56 @@ Although this example applies remote cluster configurations symmetrically across
 -->
 
 ## How to
-
 - [Create kubeconfig files](#create-kubeconfig-files)
-- [Create secrets](#create-secrets)
-- [Create access to secrets for clusters](#create-access-to-secrets-for-clusters)
-- [Add remote cluster configurations](#add-remote-cluster-configurations)
+- [Create RemoteClusterConfiguration](#create-remoteclusterconfigurations)
+- [Validate federation and multi-cluster networking](#validate-federation-and-multi-cluster-networking)
+- [Create remote-identity-aware network policy](#create-remote-identity-aware-network-policy)
+- [Troubleshoot](#troubleshoot)
 - [Configure IP pool resources](#configure-ip-pool-resources)
-- [Use policy to reference pods on a remote cluster](#use-policy-to-reference-pods-on-a-remote-cluster)
-- [Troubleshoot remote clusters](#troubleshoot-remote-clusters)
+
+
+### Ensure pod IP routability
+Federation of workload endpoint identities requires [Pod IP routability](./overview#pod-ip-routability) between clusters. If your clusters are using a supported overlay networking mode, {{prodname}} can automatically meet this requirement when clusters are connected.
+
+#### {{prodname}} multi-cluster networking
+{{prodname}} can automatically extend the overlay networking in your clusters to establish pod IP routes across clusters and thus meet the requirement for Pod IP routability. Only VXLAN overlay is supported at this time.
+
+Ensure the following requirements are met:
+- All nodes in the cluster mesh can establish connections to each other via their private IP.
+- VXLAN must be enabled on participating IP pools in all clusters and their IP pool CIDRs must not overlap.
+- `routeSource` and `vxlan*` FelixConfiguration options must be aligned across clusters, and traffic on the `vxlanPort` must be allowed between nodes in the cluster mesh.
+- RemoteClusterConfigurations must be established in both directions for cluster pairs in the cluster mesh.
+- CNI must be Calico.
+
+With these requirements met, multi-cluster networking will be automatically established when RemoteClusterConfigurations are created.
+
+#### Other networking configurations
+Alternatively, you can meet the requirement for Pod IP routability by configuring {{prodname}} with BGP or with VPC routing to establish unencapsulated Pod IP routes in your environment.
+
 
 ### Create kubeconfig files
 
-For each cluster in the federation, we will create a kubeconfig. This kubeconfig will be used by other clusters in the federation to establish remote cluster connections to the cluster specified in the kubeconfig. To create the required kubeconfigs, follow these steps for each cluster in the federation.
+Create a kubeconfig file, for each cluster, that will be used by other clusters to connect and authenticate themselves.
 
-1. Access the cluster using a `kubeconfig` with administrative privileges.
+**For each** cluster in the cluster mesh, utilizing an existing kubeconfig with administrative privileges, follow these steps:
 
-1. If RBAC is enabled, apply this manifest.
-
-   ```bash
-   kubectl apply -f \
-   {{filesUrl_CE}}/manifests/federation-rem-rbac-kdd.yaml
-   ```
-
-1. Apply the following manifest to create a service account called `tigera-federation-remote-cluster`.
+1. Create the ServiceAccount used by remote clusters for authentication:
 
    ```bash
-   kubectl apply -f \
-   {{filesUrl_CE}}/manifests/federation-remote-sa.yaml
+   kubectl apply -f {{filesUrl}}/manifests/federation-remote-sa.yaml
    ```
 
-1. Create a secret for service Account manually.
-
-   :::note
-
-   This step is needed if your k8s version is 1.24 or above. From K8s 1.24, K8s won’t generate Secrets automatically for ServiceAccounts and need be created manually.
-
-   :::
+1. If RBAC is enabled, create the ClusterRole and ClusterRoleBinding used by remote clusters for authorization:
 
    ```bash
-   kubectl apply -f - <<EOF
-   apiVersion: v1
-   kind: Secret
-   type: kubernetes.io/service-account-token
-   metadata:
-     name: tigera-federation-remote-cluster
-     namespace: kube-system
-     annotations:
-       kubernetes.io/service-account.name: "tigera-federation-remote-cluster"
-   EOF
+   kubectl apply -f {{filesUrl}}/manifests/federation-rem-rbac-kdd.yaml
    ```
 
-   Use the following command to retrieve the token of the service account.
+1. Create the kubeconfig file:
 
-   ```bash
-   kubectl describe secret tigera-federation-remote-cluster -n kube-system
-   ```
+    Open a file in your favorite editor. Consider establishing a naming scheme unique to each cluster, e.g. `kubeconfig-app-a`.
 
-1. Use the following command to retrieve the name of the secret containing the token associated
-   with the `tigera-federation-remote-cluster` service account.
-
-   :::note
-
-   This step is applicable only if your k8s version is less than 1.24.
-
-   :::
-
-   ```bash
-   kubectl describe serviceaccounts tigera-federation-remote-cluster -n kube-system
-   ```
-
-   It should return something like the following.
-
-   ```bash
-   Name:         tigera-federation-remote-cluster
-   Namespace:    kube-system
-   Labels:       <none>
-   Annotations:  kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"v1","kind":"ServiceAccount","metadata":{"annotations":{},"name":"remote-cluster","namespace":"kube-system"}}
-
-   Image pull secrets:  <none>
-   Mountable secrets:   tigera-federation-remote-cluster-token-wzdgp
-   Tokens:              tigera-federation-remote-cluster-wzdgp
-   Events:              <none>
-   ```
-
-   The value of `Tokens` is the name of the secret containing the service account's token.
-
-   Use the following command to retrieve the token of the service account.
-
-   ```bash
-   kubectl describe secrets tigera-federation-remote-cluster-token-wzdgp -n kube-system
-   ```
-
-   It should return something like the following.
-
-   ```bash
-   Name:         tigera-federation-remote-cluster-token-wzdgp
-   Namespace:    kube-system
-   Labels:       <none>
-   Annotations:  kubernetes.io/service-account.name=tigera-federation-remote-cluster
-                 kubernetes.io/service-account.uid=b3044d23-96b5-11e8-ac9b-42010a80000e
-
-   Type:  kubernetes.io/service-account-token
-
-   Data
-   ====
-   ca.crt:     1025 bytes
-   namespace:  11 bytes
-   token:      eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJrdWJlLXN5c3RlbSIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJyZW1vdGUtY2x1c3Rlci10b2tlbi13emRncCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJyZW1vdGUtY2x1c3RlciIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6ImIzMDQ0ZDIzLTk2YjUtMTFlOC1hYzliLTQyMDEwYTgwMDAwZSIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDprdWJlLXN5c3RlbTpyZW1vdGUtY2x1c3RlciJ9.h8ngEwzjzHLMnaRANiXoqrSAWGxycVqq7cO54RM56qyyy_KlAbLpjbhHiaQBNAqJ_LTvjSZ23r2vZn-ZUbTDcoHninD4N2GXKygyVxoBeBzBJinbHWTPp6BYnLvM1pifnj5QNrQanqb0Nwy_p9T1CBMr7NmTsJ5HvRHASCMImjLToCC251kL5oIVM6MWdty_dKGvCzO1rUQhCqcwQyq4Bg6cTFNCLejFpgH0p7XdVcqSsd2uYUpPeS85q5paEKza630Dxg8jdwa5VhYAb_LZfklPOVwHAgNx9OT-z_ZRLYfWoBVlkgazXiiEz9kDweK8hESGLQdW7996C0vdeVx21A
-   ```
-
-1. Save the `token` value for later steps.
-
-1. Use the following command to retrieve the certificate authority and server data.
-
-   ```bash
-   kubectl config view --flatten --minify
-   ```
-
-   It should return something like the following.
-
-   ```bash
-   apiVersion: v1
-   clusters:
-   - cluster:
-       certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRFNE1EY3lOVEUyTURjek4xb1hEVEk0TURjeU1qRTJNRGN6TjFvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTU9FCjc1ZWtxbmdMdjZKZW9IaGhFLy9iVU0rdnNRMyt3cUZ1eHp5NDlReFk1cmtZaGJ4WWt1TFl0c3ZBVTgycjVnNlYKbUVwbDRlOHJMQjRnTnFpRnVDcVplcmMwWWxqZDVQNllKcW5PN3A1b1J3SG5BWXA3dnZwczJRZjFTemNsTVNjSAo3Qk9XbkF4aEFFZTUzKytPSkhaVmZzL2tlTWtlK3F4b01IZ0R1eGxUb2xXU2dDV0YvbCt3eFk3ZTcyNmozYWZnClRXL0lxSk9GNTN6YTVHR05MMGRIQndFR0gzSU5CVllXa1V5TjEycXZJYlh3RzJReElCU1hEbTcvV1dvNUphMHkKeVNSWkx4L3FZSHBld1hsOU5Od3ZYaXNOZ2xvVVVsZFJ4OGtSWmJOdmViZkpad2FqQVBlRytNRkYwYVJVNHF0Zgo5NVYzdHZ5RHYxaHNJdytGQiswQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFFaFJBNmEzUUNBRGVGalNOeFM1Qi9NZVo4dTIKenNvV2F0c21pdm81YUREUUIwUnRUUWFLTUEwU2ZlaGNLd3ZUdTJjVW5CaVJHZlZMSnJ3REwvUzUvRHBhemdBbgozVlZuWERlbGRzcjVKa3dpTElhQUZCSzg5K3BaLzVybXpuZmZpMldKS0JvY2t3N015REplb05FdklkSjVtb2t0ClMxL0pKYlcvbExZU054RjYxOXJxOE9LVVZ2YStwTmczZ2JEbGlFSUZNUmpobWdtU01tUEthRnMvaE1GcDlzdVMKV3VDd1czY2lQVXlUZXV6bnRYbzY5K3NpUGYyLzFxYUFmRWtmSHp3NS9QeG8xM1dOWnEzSzI0dDNoNXh1QjFvRwpwaXRDbEZPSGFLSnNLZ0g1UkFOSWt3dkNIOXgySG9oTzR2M3ZoOXd1KzlOMEt1K3FLVWJIODRENkVpMD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-       server: https://10.128.0.14:6443
-     name: kubernetes
-   contexts:
-   - context:
-       cluster: kubernetes
-       user: kubernetes-admin
-     name: kubernetes-admin@kubernetes
-   current-context: kubernetes-admin@kubernetes
-   kind: Config
-   preferences: {}
-   users:
-   - name: kubernetes-admin
-     user:
-       client-certificate-data: ...
-       client-key-data: ...
-   ```
-
-1. Save the `certificate-authority-data` and the `server` values for the next step.
-
-1. Open a new file in your favorite editor.
-
-   :::tip
-
-   We recommend coming up with a naming scheme for your clusters that makes sense for your
-   specific use case. For example, if you have four remote clusters that are similar except that they
-   are serving web pages in different languages, you can name the files `kubeconfig-rem-cluster-en`,
-   `kubeconfig-rem-cluster-es`, `kubeconfig-rem-cluster-ja`, and `kubeconfig-rem-cluster-sw`. This will
-   make the installation procedure easier to follow.
-
-   :::
-
-1. Paste the following into your new file.
-
+    Paste the following into the file - we will replace the templated values with data retrieved in following steps.
    ```yaml
    apiVersion: v1
    kind: Config
@@ -243,85 +121,202 @@ For each cluster in the federation, we will create a kubeconfig. This kubeconfig
    current-context: tigera-federation-remote-cluster-ctx
    ```
 
-1. Replace `<YOUR-SERVICE-ACCOUNT-TOKEN>`, `<YOUR-CERTIFICATE-AUTHORITY-DATA>`,
-   and `<YOUR-SERVER-ADDRESS>` with the values obtained in the previous steps.
+1. Retrieve the ServiceAccount token:
 
-1. Verify that the `kubeconfig` file works by issuing the following command.
-
+   #### If using Kubernetes >= 1.24
+   - Create the ServiceAccount token:
    ```bash
-   kubectl --kubeconfig=kubeconfig-rem-cluster-n get services
+   kubectl apply -f - <<EOF
+   apiVersion: v1
+   kind: Secret
+   type: kubernetes.io/service-account-token
+   metadata:
+     name: tigera-federation-remote-cluster
+     namespace: kube-system
+     annotations:
+       kubernetes.io/service-account.name: "tigera-federation-remote-cluster"
+   EOF
+   ```
+   - Retrieve the ServiceAccount token value and replace `<YOUR-SERVICE-ACCOUNT-TOKEN>` with it's value:
+   ```bash
+   kubectl describe secret tigera-federation-remote-cluster -n kube-system
    ```
 
-   You should see your cluster listed.
+   #### If using Kubernetes < 1.24
+   - Retrieve the ServiceAccount token value and replace `<YOUR-SERVICE-ACCOUNT-TOKEN>` with it's value:
+   ```bash
+   kubectl describe secret -n kube-system $(kubectl get serviceaccounts tigera-federation-remote-cluster -n kube-system -o jsonpath='{.secrets[0].name}')
+   ```
 
-### Create secrets
+1. Retrieve and save the certificate authority and server data:
 
-We'll now create secrets in each local cluster that contain the created kubeconfig for a given remote cluster that we wish to connect to. The simplest method to create a secret for a remote cluster is to use the `kubectl` command because it correctly encodes the data and formats the file.
+   Run the following command:
+   ```bash
+   kubectl config view --flatten --minify
+   ```
+   Replace `<YOUR-CERTIFICATE-AUTHORITY-DATA>` and `<YOUR-SERVER-ADDRESS>` with `certificate-authority-data` and `server` values respectively.
 
-Within a local cluster, create a secret for a remote cluster with a command like the following.
+1. Verify that the `kubeconfig` file works:
 
+   Issue a command like the following to validate the kubeconfig file can be used to connect to the current cluster and access resources:
+   ```bash
+   kubectl --kubeconfig=kubeconfig-app-a get nodes
+   ```
+
+### Create RemoteClusterConfigurations
+We'll now create the RemoteClusterConfigurations that establish synchronization between clusters. This enables remote-identity aware policy, federated services, and can establish multi-cluster networking.
+
+**For each pair** of clusters in the cluster mesh (e.g. cluster A and cluster B):
+
+1. In cluster A, create a secret that contains the kubeconfig for cluster B:
+
+   Determine the namespace (`<namespace>`) for the secret to replace in all steps.
+   The simplest method to create a secret for a remote cluster is to use the `kubectl` command because it correctly encodes the data and formats the file.
+   ```bash
+   kubectl create secret generic remote-cluster-secret-name -n <namespace> \
+      --from-literal=datastoreType=kubernetes \
+      --from-file=kubeconfig=<kubeconfig file>
+   ```
+
+1. If RBAC is enabled in cluster A, create a Role and RoleBinding that {{prodname}} will use to access the secret that contains the kubeconfig for cluster B:
+   ```bash
+   kubectl create -f - <<EOF
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: Role
+   metadata:
+     name: remote-cluster-secret-access
+     namespace: <namespace>
+   rules:
+   - apiGroups: [""]
+     resources: ["secrets"]
+     verbs: ["watch", "list", "get"]
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: RoleBinding
+   metadata:
+     name: remote-cluster-secret-access
+     namespace: <namespace>
+   roleRef:
+     apiGroup: rbac.authorization.k8s.io
+     kind: Role
+     name: remote-cluster-secret-access
+   subjects:
+   - kind: ServiceAccount
+     name: calico-typha
+     namespace: calico-system
+   EOF
+   ```
+
+1. Create the RemoteClusterConfiguration in cluster A:
+
+   Within the RemoteClusterConfiguration, we specify the secret used to access cluster B, and the overlay routing mode which toggles the establishment of cross-cluster overlay routes.
+   ```yaml
+   kubectl create -f - <<EOF
+   apiVersion: projectcalico.org/v3
+   kind: RemoteClusterConfiguration
+   metadata:
+     name: cluster-b
+   spec:
+     clusterAccessSecret:
+       name: remote-cluster-secret-name
+       namespace: <namespace>
+       kind: Secret
+     syncOptions:
+       overlayRoutingMode: Enabled
+   EOF
+   ```
+
+1. If you have IPPools in cluster A with NAT-outgoing enabled, you must [configure IP pool resources](#configure-ip-pool-resources).
+
+1. [Validate](#validate-federation-and-multi-cluster-networking) that the remote cluster connection can be established.
+
+1. Repeat the above steps, switching cluster A and cluster B.
+
+
+After completing the above steps for all cluster pairs in the cluster mesh, your clusters should now be ready to utilize remote-identity-aware policy and federated services, along with multi-cluster networking if requirements were met.
+
+:::note
+ This tutorial sets up RemoteClusterConfigurations in both directions. This is required for {{prodname}} to manage multi-cluster networking, and also ensures you can write identity-aware policy on both sides of a cross-cluster connection. Unidirectional connections can be made at your own discretion.
+:::
+
+### Validate federation and multi-cluster networking
+#### RemoteClusterConfiguration & federated endpoint identity
+calicoq can be used to ensure that a local cluster has connected to it's configured remote clusters. Use the following command:
 ```bash
-kubectl create secret generic remote-cluster-secret-name -n <namespace> \
-    --from-literal=datastoreType=kubernetes \
-    --from-file=kubeconfig=<kubeconfig file>
+calicoq eval "all()"
+```
+If all remote clusters are accessible, calicoq returns something like the following. Note the remote cluster prefixes: there should be endpoints prefixed with the name of each RemoteClusterConfiguration in the local cluster.
+```
+Endpoints matching selector all():
+  Workload endpoint remote-cluster-1/host-1/k8s/kube-system.kube-dns-5fbcb4d67b-h6686/eth0
+  Workload endpoint remote-cluster-1/host-2/k8s/kube-system.cnx-manager-66c4dbc5b7-6d9xv/eth0
+  Workload endpoint host-a/k8s/kube-system.kube-dns-5fbcb4d67b-7wbhv/eth0
+  Workload endpoint host-b/k8s/kube-system.cnx-manager-66c4dbc5b7-6ghsm/eth0
 ```
 
-Additional arguments:
+You can also view the Prometheus metrics for Typha to check the remote cluster connection status.
 
-- `--from-literal=<key>=<value>` to add literal values
-- `--from-file=<key>=<file>` to add values with file contents
+If either output contains unexpected results, proceed to the troubleshooting section.
 
-### Create access to secrets for clusters
+#### Multi-cluster networking
+If all requirements were met for {{prodname}} to establish multi-cluster networking, you can test the functionality by establishing a connection from a pod in a local cluster to the IP of a pod in a remote cluster. Ensure that there is no policy in either cluster that may block this connection.
 
-{{prodname}} does not generally have access to all secrets in a cluster so it is necessary to create a Role and RoleBinding for each namespace where the secrets for RemoteClusterConfigurations are created. You can reduce the number of Role and RoleBindings needed by putting the remote cluster Secrets in a dedicated namespace.
+If the connection fails, proceed to the [troubleshooting](#troubleshoot) section.
 
-```bash
-kubectl create -f - <<EOF
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: remote-cluster-secret-access
-  namespace: <namespace>
-rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["watch", "list", "get"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: remote-cluster-secret-access
-  namespace: <namespace>
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: remote-cluster-secret-access
-subjects:
-- kind: ServiceAccount
-  name: calico-typha
-  namespace: calico-system
-EOF
-```
+### Create remote-identity-aware network policy
+With federated endpoint identity and routing between clusters established, you can now use labels to reference endpoints on a remote cluster in local policy rules, rather than referencing them by IP address.
 
-### Add remote cluster configurations
+The main policy selector still refers only to local endpoints; and that selector chooses which local endpoints to apply the policy.
+However, rule selectors can now refer to both local and remote endpoints.
 
-Add remote cluster configuration where needed. Each instance of the [Remote Cluster Configuration](../reference/resources/remoteclusterconfiguration.mdx)
-resource represents a single remote cluster from which the local cluster can retrieve endpoint information. We reference the kubeconfig secret created above to specify how to connect to this remote cluster.
-
+In the following example, cluster A (an application cluster) has a network policy that governs outbound connections to cluster B (a database cluster).
 ```yaml
-apiVersion: projectcalico.org/v3
-kind: RemoteClusterConfiguration
+apiversion: projectcalico.org/v3
+kind: NetworkPolicy
 metadata:
-  name: cluster-n
+    name: default.app-to-db
+    namespace: myapp
 spec:
-  clusterAccessSecret:
-    name: remote-cluster-secret-name
-    namespace: <namespace>
-    kind: Secret
+    # The main policy selector selects endpoints from the local cluster only.
+    selector: app == 'backend-app'
+    tier: default
+    egress:
+    - destination:
+        # Rule selectors can select endpoints from local AND remote clusters.
+        selector: app == 'postgres'
+      protocol: TCP
+      ports: [5432]
+      action: Allow
 ```
+
+### Troubleshoot
+#### RemoteClusterConfiguration & federated endpoint identity
+For each impacted remote cluster pair (between cluster A and cluster B):
+1. Retrieve the kubeconfig from the secret stored in cluster A. Manually verify that it can be used to connect to Cluster B.
+   ```bash
+   kubectl get secret -n <namespace> remote-cluster-secret-name -o=jsonpath="{.data.kubeconfig}" | base64 -d > verify_kubeconfig_b
+   kubectl --kubeconfig=verify_kubeconfig_b get nodes
+   ```
+2. Validate that the Typha service account in Cluster A is authorized to retrieve the kubeconfig secret for Cluster B.
+   ```bash
+    kubectl auth can-i list secrets --namespace <namespace> --as=system:serviceaccount:calico-system:calico-typha
+   ```
+3. Repeat the above, switching cluster A to cluster B.
+
+The output from [calicoq](#remoteclusterconfiguration--federated-endpoint-identity) may also provide insight into where issues may be occurring.
+
+If the above steps provide no useful information, consider looking at the `typha` and `calico-node` logs for any relevant errors or warnings.
+
+
+#### Multi-cluster networking
+First, ensure that RemoteClusterConfiguration and federated endpoint identity are [functioning correctly](#remoteclusterconfiguration--federated-endpoint-identity-1).
+
+Next, carefully validate that **all** [requirements](#calico-enterprise-multi-cluster-networking) for multi-cluster networking have been met. If all requirements are satisfied, consider:
+* Validating that no network policy or firewall is causing packets to be dropped.
+* Checking the `typha` and `calico-node` logs for any relevant errors or warnings.
+
 
 ### Configure IP pool resources
-
 For local clusters with `NATOutgoing` configured on your IP pools, verify the following:
 
 - Configure additional IP pools to cover the IP ranges of your remote clusters. This ensures that outgoing NAT is not performed on packets bound for the remote clusters.
@@ -338,59 +333,6 @@ metadata:
 spec:
   cidr: 192.168.0.0/18
   disabled: true
-```
-
-Congratulations! You have completed configuration of federated endpoint identity.
-
-### Use policy to reference pods on a remote cluster
-
-For federated clusters, use labels to reference pods on a remote cluster in the local policy rules, rather than referencing them by IP address. The main policy selector still refers only to local endpoints; and that selector chooses which local endpoints to apply the policy.
-
-For policy rule selectors on the local cluster to correctly reference endpoints across all of the clusters, you must align the following between clusters.
-
-- Namespace names
-- Host endpoint label names and values
-- Pod label names and values within the namespace
-- Service accounts (if you configure {{prodname}} federated services)
-
-### Troubleshoot remote clusters
-
-To verify that remote clusters are accessible, use the following command.
-
-```bash
-$ calicoq eval "all()"
-```
-
-If all remote clusters are accessible, `calicoq` returns something like the following. In this example, the `remote-cluster-1` prefix indicates the remote cluster endpoints (as configured in the RemoteClusterConfiguration resource).
-
-```
-Endpoints matching selector all():
-  Workload endpoint remote-cluster-1/host-1/k8s/kube-system.kube-dns-5fbcb4d67b-h6686/eth0
-  Workload endpoint remote-cluster-1/host-2/k8s/kube-system.cnx-manager-66c4dbc5b7-6d9xv/eth0
-  Workload endpoint host-a/k8s/kube-system.kube-dns-5fbcb4d67b-7wbhv/eth0
-  Workload endpoint host-b/k8s/kube-system.cnx-manager-66c4dbc5b7-6ghsm/eth0
-```
-
-If a remote cluster is inaccessible, (network failure or a misconfiguration), the `calicoq` output includes details about the error.
-
-**Example**: Remote-cluster-secret is not accessible
-
-```
-E0615 12:24:04.895079   30873 reflector.go:153] github.com/projectcalico/libcalico-go/lib/backend/syncersv1/remotecluster/secret_watcher.go:111: Failed to list *v1.Secret: secrets "remote-cluster-secret" is forbidden: User "system:serviceaccount:policy-demo:limited-sa" cannot list resource "secrets" in API group "" in the namespace "remote-cluster-ns"
-Endpoints matching selector all():
-  Workload endpoint host-a/k8s/kube-system.kube-dns-5fbcb4d67b-7wbhv/eth0
-  Workload endpoint host-b/k8s/kube-system.cnx-manager-66c4dbc5b7-6ghsm/eth0
-```
-
-**Example**: Incorrect connection information in the Remote Cluster Configuration
-
-```
-Endpoints matching selector all():
-  Workload endpoint host-a/k8s/kube-system.kube-dns-5fbcb4d67b-7wbhv/eth0
-  Workload endpoint host-b/k8s/kube-system.cnx-manager-66c4dbc5b7-6ghsm/eth0
-The following problems were encountered connecting to the remote clusters
-which may have resulted in incomplete data:
--  RemoteClusterConfiguration(remote-cluster-1): connection to remote cluster failed: Get https://192.168.0.55:6443/api/v1/pods: dial tcp 192.168.0.55:6443: i/o timeout
 ```
 
 ## Next steps

--- a/calico-cloud/multicluster/overview.mdx
+++ b/calico-cloud/multicluster/overview.mdx
@@ -1,51 +1,57 @@
 ---
-description: Configure local clusters for cross-cluster workload and host endpoints sharing, and cross-cluster service discovery.
+description: Configure a cluster mesh for cross-cluster endpoints sharing, cross-cluster connectivity, and cross-cluster service discovery.
 ---
 
 # Overview
 
 ## Big picture
 
-Configure local clusters for cross-cluster workload and host endpoints sharing, and cross-cluster service discovery.
+Secure cross-cluster connections with identity-aware network policy, and federate services for cross-cluster service discovery.
+
+Utilize {{prodname}} to establish cross-cluster connectivity.
+
 
 ## Value
 
-At some point in your Kubernetes journey, you may have multiple teams (development, QA, and others) that need to work in parallel across multiple clusters, without negative impacts on each other. By default, deployed Kubernetes pods can only see pods within their cluster. Using network policy and services, you can grant access to other clusters and the applications they are running. {{prodname}} provides these federation features:
+At some point in your Kubernetes journey, you may have applications that need to access services and workloads running in another cluster.
 
+By default, pods can only communicate with pods within the same cluster. Additionally, services and network policy only select pods from within the same cluster. {{prodname}} can help overcome these barriers by forming a cluster mesh the following features:
 - **Federated endpoint identity**
 
-  Allow a local Kubernetes cluster to include the workload endpoints (pods) and host endpoints of a remote cluster in the calculation of local policies applied on each node of the local cluster.
+  Allow a local Kubernetes cluster to include the workload endpoints (pods) and host endpoints of a remote cluster in the calculation of local network policies applied on each node of the local cluster.
 
 - **Federated services**
 
-  Provides cross-cluster service discovery for a local cluster.
+  Enable a local Kubernetes Service to populate with Endpoints selected from both local cluster and remote cluster Services.
+
+- **Multi-cluster networking**
+
+  Establish an overlay network between clusters to provide cross-cluster connectivity with {{prodname}}.
+
 
 ## Concepts
 
-### Federation: network layer features
+### Pod IP routability
 
-{{prodname}} federated endpoint identity and federated services are implemented in Kubernetes at the network layer. To apply fine-grained network policy between multiple clusters, the pod source and destination IPs must be preserved. So these features are valuable only if your clusters are designed with common networking across clusters with no encapsulation (for example, BGP routing or VPC routing). (Although there are ways to achieve a common networking equivalent across clusters using overlays, this is outside the realm of this article.)
+{{prodname}} cluster mesh is implemented at Kubernetes at the network layer, based on pod IPs.
+
+Taking advantage of federated workload endpoint identity and federated services requires that pod IPs are routable between clusters. This is because identity-aware network policy requires source and destination pod IPs to be preserved in order to establish pod identity. Additionally, the Endpoint IPs of pods selected by a federated Service must be routable in order for that Service to be of value.
+
+You can utilize {{prodname}} multi-cluster networking to establish pod IP routability between clusters via overlay. Alternatively, you can manually set up pod IP routability between clusters without encapsulation (e.g. VPC routing, BGP routing).
+
 
 ### Federated endpoint identity
 
-A simple example of implementing policy across multiple clusters is:
-
-"Cluster A's network policy allows **web** to talk to **db**, but all of the **web** is in cluster A, and all of the **db** is in cluster B."
-
-Federated endpoint identity solves this by allowing a local Kubernetes cluster to include the workload endpoints (pods) and host endpoints of a remote cluster in the calculation of the local policies for each node.
-
-:::note
+Federated endpoint identity in a cluster mesh allows a local Kubernetes cluster to include the workload endpoints (pods) and host endpoints of a remote cluster in the calculation of the local policies for each node, e.g. Cluster A network policy allows its application pods to talk to database pods in Cluster B.
 
 This feature does not _federate network policies_; policies from a remote cluster are not applied to the endpoints on the local cluster, and the policy from the local cluster is rendered only locally and applied to the local endpoints.
 
-:::
-
 ### Federated services
 
-Federated services works with federated endpoint identity, providing cross-cluster service discovery for a local cluster. If you have an existing service discovery mechanism, this feature is optional.
+Federated services in a cluster mesh works with federated endpoint identity, providing cross-cluster service discovery for a local cluster. If you have an existing service discovery mechanism, this feature is optional.
 
 Federated services use the Tigera Federated Services Controller to federate all [Kubernetes endpoints](https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#endpoints-v1-core) (workload and host endpoints) across all of the clusters. The Federated Services Controller accesses service and endpoints data in the remote clusters directly through the Kubernetes API.
 
 ## Next steps
 
-[Configure federated endpoint identity ](kubeconfig.mdx)
+[Configure remote-aware policy and multi-cluster networking](kubeconfig.mdx)

--- a/calico-cloud/multicluster/services-controller.mdx
+++ b/calico-cloud/multicluster/services-controller.mdx
@@ -10,7 +10,7 @@ Configure local clusters to discover services across multiple clusters.
 
 ## Value
 
-Use federate services discovery along with federated endpoint identity to extend and automate endpoints sharing. (Optional if you have your own service discovery mechanism.)
+Use cluster mesh and federated services discovery along with federated endpoint identity to extend and automate endpoints sharing. (Optional if you have your own service discovery mechanism.)
 
 ## Features
 
@@ -23,7 +23,7 @@ This how to guide uses the following {{prodname}} features:
 
 ### Federated services
 
-A federated service (also called a backing service), is a set of services with consolidated endpoints. {{prodname}} discovers services across all clusters (both local cluster and remote clusters) and creates a "federated service" on the local cluster that encompasses all of the individual services.
+A federated service (also called a backing service), is a set of services with consolidated endpoints. {{prodname}} discovers services across a cluster mesh (both local cluster and remote clusters) and creates a "federated service" on the local cluster that encompasses all of the individual services.
 
 Federated services are managed by the Tigera Federated Service Controller, which monitors and maintains endpoints for each locally-federated service. The controller does not change configuration on remote clusters.
 
@@ -84,7 +84,7 @@ You can also match services using a label. The label is implicitly added to each
 
 ### Create service resources
 
-On each cluster that is providing a particular service, create your service resources as you normal would with the following requirements:
+On each cluster in the mesh that is providing a particular service, create your service resources as you normal would with the following requirements:
 
 - Services must all be in the same namespace.
 - Configure each service with a common label key and value to identify the common set of services across your clusters (for example, `run=my-app`).
@@ -165,7 +165,7 @@ spec:
 
 The `spec.selector` is not specified so it will not be managed by Kubernetes. Instead, we use a `federation.tigera.io/selector` annotation, indicating that this is a federated service managed by the Federated Services Controller.
 
-The controller matches the `my-app` services (matching the run label) on both the local and remote clusters, consolidates endpoints from the `my-app-ui` TCP port for both of those services. Because the federated service does not specify the `my-app-console` port, the controller does not include these endpoints in the federated service.
+The controller matches the `my-app` services (matching the run label) on both the local and remote clusters, and consolidates endpoints from the `my-app-ui` TCP port for both of those services. Because the federated service does not specify the `my-app-console` port, the controller does not include these endpoints in the federated service.
 
 The endpoints data for the federated service is similar to the following. Note that the name of the remote cluster is included in `targetRef.name`.
 
@@ -212,5 +212,5 @@ subsets:
 
 ## Additional resources
 
-- [Federated identity and services example for AWS](aws.mdx)
+- [Cluster mesh example for AWS](aws.mdx)
 - [Federated service controller](../reference/component-resources/kube-controllers/configuration.mdx)

--- a/calico-enterprise/multicluster/federation/aws.mdx
+++ b/calico-enterprise/multicluster/federation/aws.mdx
@@ -2,11 +2,11 @@
 description: A sample configuration of Calico Enterprise federated endpoint identity and federated services for an AWS cluster.
 ---
 
-# Federation example for an AWS cluster
+# Cluster mesh example for clusters in AWS
 
 ## Big picture
 
-A sample configuration for federated endpoint identity and federated services using AWS clusters.
+A sample configuration for cluster mesh using AWS clusters.
 
 ## Tutorial
 

--- a/calico-enterprise/multicluster/federation/index.mdx
+++ b/calico-enterprise/multicluster/federation/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to configure federation for clusters and cross-cluster service discovery.
+description: Steps to configure cluster mesh.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/multicluster/federation/index.mdx
+++ b/calico-enterprise/multicluster/federation/index.mdx
@@ -3,7 +3,7 @@ description: Steps to configure federation for clusters and cross-cluster servic
 hide_table_of_contents: true
 ---
 
-# Federated endpoint identity and services
+# Federation and multi-cluster networking
 
 import DocCardList from '@theme/DocCardList';
 import { useCurrentSidebarCategory } from '@docusaurus/theme-common';

--- a/calico-enterprise/multicluster/federation/kubeconfig.mdx
+++ b/calico-enterprise/multicluster/federation/kubeconfig.mdx
@@ -6,7 +6,7 @@ description: Configure a local cluster to pull endpoint data from a remote clust
 
 ## Big picture
 
-Create RemoteClusterConfiguration to federate endpoint identities and establish cross-cluster connectivity.
+Configure a cluster to federate endpoint identities and establish cross-cluster connectivity.
 
 ## Value
 
@@ -24,12 +24,12 @@ This how to guide uses the following {{prodname}} features:
 
 Each cluster in the cluster mesh can act as both a local and remote cluster.
 
-- Local clusters are configured (via RemoteClusterConfiguration) to retrieve endpoint and routing data from remote clusters
+- Local clusters are configured to retrieve endpoint and routing data from remote clusters (via RemoteClusterConfiguration)
 - Remote clusters authorize local clusters to retrieve endpoint and routing data
 
 ### Remote endpoint identity and policy
 
-Policy can typically only reference the endpoint identity (e.g. pod labels) of local endpoints. Federated endpoint identity enables local policy rules to reference remote endpoint identities.
+Typically, policy can only reference the endpoint identity (e.g. pod labels) of local endpoints. Federated endpoint identity enables local policy rules to reference remote endpoint identities.
 
 ### RemoteClusterConfiguration
 RemoteClusterConfiguration is the resource that configures a local cluster to sync resources from a remote cluster. It primarily describes how a local cluster establishes that connection to the remote cluster through which resources are synced.
@@ -39,7 +39,7 @@ The resources synced through this connection enable the local cluster to referen
 RemoteClusterConfiguration creates this connection in one direction. If you want identity-aware policy on both sides (i.e. both clusters) of a connection, or you want {{prodname}} to establish cross-cluster overlay networking, you need to create a RemoteClusterConfiguration for both directions.
 
 ### kubeconfig files
-Each cluster in the cluster mesh should have a dedicated kubeconfig file used by other clusters in the mesh connect and authenticate.
+Each cluster in the cluster mesh should have a dedicated kubeconfig file used by other clusters in the mesh to connect and authenticate.
 
 
 ## Before you begin
@@ -57,7 +57,7 @@ Each cluster in the cluster mesh should have a dedicated kubeconfig file used by
 
 
 ### Ensure pod IP routability
-Federation of workload endpoint identities only has utility when [Pod IP routability](./overview#pod-ip-routability) is established between clusters. If your clusters are using a supported overlay networking mode, {{prodname}} can automatically meet this requirement when clusters are connected.
+Federation of workload endpoint identities requires [Pod IP routability](./overview#pod-ip-routability) between clusters. If your clusters are using a supported overlay networking mode, {{prodname}} can automatically meet this requirement when clusters are connected.
 
 #### {{prodname}} multi-cluster networking
 {{prodname}} can automatically extend the overlay networking in your clusters to establish pod IP routes across clusters and thus meet the requirement for Pod IP routability. Only VXLAN overlay is supported at this time.
@@ -167,7 +167,7 @@ We'll now create the RemoteClusterConfigurations that establish synchronization 
 
 1. In cluster A, create a secret that contains the kubeconfig for cluster B:
 
-   Determine the namespace you will create the secret in - this will be the value of `<namespace>` to replace in all steps.
+   Determine the namespace (`<namespace>`) for the secret to replace in all steps.
    The simplest method to create a secret for a remote cluster is to use the `kubectl` command because it correctly encodes the data and formats the file.
    ```bash
    kubectl create secret generic remote-cluster-secret-name -n <namespace> \

--- a/calico-enterprise/multicluster/federation/kubeconfig.mdx
+++ b/calico-enterprise/multicluster/federation/kubeconfig.mdx
@@ -2,15 +2,15 @@
 description: Configure a local cluster to pull endpoint data from a remote cluster.
 ---
 
-# Configure federated endpoint identity
+# Configure federated endpoint identity and multi-cluster networking
 
 ## Big picture
 
-Configure a local cluster to pull endpoint data from a remote cluster.
+Create RemoteClusterConfiguration to federate endpoint identities and establish cross-cluster connectivity.
 
 ## Value
 
-Federating endpoints allows teams to write policies in a local cluster that references/selects endpoints in remote clusters. This expands efficiency and self-service.
+Secure cross-cluster traffic with identity-aware policy, and leverage {{prodname}} to establish the required cross-cluster networking.
 
 ## Features
 
@@ -22,205 +22,82 @@ This how to guide uses the following {{prodname}} features:
 
 ### Local and remote clusters
 
-Each cluster in the federation acts as both a local and remote cluster.
+Each cluster in a federation can act as both a local and remote cluster.
 
-- Local clusters retrieve endpoint data from remote clusters
-- Remote clusters allow local clusters to retrieve endpoint data
+- Local clusters are configured (via RemoteClusterConfiguration) to retrieve endpoint and routing data from remote clusters
+- Remote clusters authorize local clusters to retrieve endpoint and routing data
 
-### Configure access to remote clusters
+### Remote endpoint identity and policy
 
-To allow a local cluster to access resources on a remote cluster, you create a **RemoteClusterConfiguration**. This configuration contains the information required for the local cluster to establish connection to the remote cluster. The connection in a remote cluster configuration is one-way: information flows only from the remote cluster to the local cluster. If you want to share information from a local cluster to a remote cluster, you must create a remote cluster configuration resource on the remote cluster.
+Policy can typically only reference the endpoint identity (e.g. pod labels) of local endpoints. Federated endpoint identity enables local policy rules to reference remote endpoint identities.
 
-In the following example, we federate three clusters with each other: `cluster-a`, `cluster-b`, and `cluster-c`:
+### RemoteClusterConfiguration
+RemoteClusterConfiguration is the resource that configures a local cluster to sync resources from a remote cluster. It primarily describes how a local cluster establishes that connection to the remote cluster through which resources are synced.
 
-- **cluster a**
+The resources synced through this connection enable the local cluster to reference remote endpoint identity and establish cross-cluster overlay routes.
 
-  Create two RemoteClusterConfiguration resources: 1 for cluster-b, 1 for cluster-c
+RemoteClusterConfiguration creates this connection in one direction. If you want identity-aware policy on both sides (i.e. both clusters) of a connection, or you want {{prodname}} to establish cross-cluster overlay networking, you need to create a RemoteClusterConfiguration for both directions.
 
-- **cluster b**
+### kubeconfig files
+Each cluster in the federation should have a dedicated kubeconfig file used to connect and authenticate to other clusters in the federation.
 
-  Create two RemoteClusterConfiguration resources: 1 for cluster-a, 1 for cluster-c
-
-- **cluster c**
-
-  Create two RemoteClusterConfiguration resources: 1 for cluster-a, 1 for cluster-b
-
-:::note
-
-Although this example applies remote cluster configurations symmetrically across clusters, this is not required; add RemoteClusterConfiguration resources only where needed.
-
-:::
 
 ## Before you begin
-
-**Supported networking**
-
-- {{prodname}} with BGP
-- AKS/Azure, EKS/AWS, and GKE with VPC
-
 **Required**
-
 - [Install {{prodname}}](../../getting-started/install-on-clusters/kubernetes/index.mdx)
-- [Install and configure calicoq](../../operations/clis/calicoq/installing.mdx)
+- [Ensure pod IP routability](#ensure-pod-ip-routability)
 
 ## How to
-
 - [Create kubeconfig files](#create-kubeconfig-files)
-- [Create secrets](#create-secrets)
-- [Create access to secrets for clusters](#create-access-to-secrets-for-clusters)
-- [Add remote cluster configurations](#add-remote-cluster-configurations)
+- [Create RemoteClusterConfiguration](#create-remoteclusterconfigurations)
+- [Validate federation and multi-cluster networking](#validate-federation-and-multi-cluster-networking)
+- [Create remote-identity-aware network policy](#create-remote-identity-aware-network-policy)
+- [Troubleshoot](#troubleshoot)
 - [Configure IP pool resources](#configure-ip-pool-resources)
-- [Use policy to reference pods on a remote cluster](#use-policy-to-reference-pods-on-a-remote-cluster)
-- [Troubleshoot remote clusters](#troubleshoot-remote-clusters)
+
+
+### Ensure pod IP routability
+Federation of workload endpoint identities only has utility when [Pod IP routability](./overview#pod-ip-routability) is established between clusters. If your clusters are using a supported overlay networking mode, {{prodname}} can automatically meet this requirement when clusters are connected.
+
+#### {{prodname}} multi-cluster networking
+{{prodname}} can automatically extend the overlay networking in your clusters to establish pod IP routes across clusters and thus meet the requirement for Pod IP routability. Only VXLAN overlay is supported at this time.
+
+Ensure the following requirements are met:
+- All nodes in the federation can establish connections to each other via their private IP.
+- VXLAN must be enabled on participating IP pools in all clusters and their IP pool CIDRs must not overlap.
+- `routeSource` and `vxlan*` FelixConfiguration options must be aligned across clusters, and traffic on the `vxlanPort` must be allowed between nodes in the federation.
+- RemoteClusterConfigurations must be established in both directions for cluster pairs in the federation.
+- CNI must be Calico.
+
+With these requirements met, multi-cluster networking will be automatically established when RemoteClusterConfigurations are created.
+
+#### Other networking configurations
+Alternatively, you can meet the requirement for Pod IP routability by configuring {{prodname}} with BGP or with VPC routing to establish unencapsulated Pod IP routes in your environment.
+
 
 ### Create kubeconfig files
 
-For each cluster in the federation, we will create a kubeconfig. This kubeconfig will be used by other clusters in the federation to establish remote cluster connections to the cluster specified in the kubeconfig. To create the required kubeconfigs, follow these steps for each cluster in the federation.
+Create a kubeconfig file, for each cluster, that will be used by other clusters to connect and authenticate themselves.
 
-1. Access the cluster using a `kubeconfig` with administrative privileges.
+**For each** cluster in the federation, utilizing an existing kubeconfig with administrative privileges, follow these steps:
 
-1. If RBAC is enabled, apply this manifest.
-
-   ```bash
-   kubectl apply -f \
-   {{filesUrl}}/manifests/federation-rem-rbac-kdd.yaml
-   ```
-
-1. Apply the following manifest to create a service account called `tigera-federation-remote-cluster`.
+1. Create the ServiceAccount used by remote clusters for authentication:
 
    ```bash
-   kubectl apply -f \
-   {{filesUrl}}/manifests/federation-remote-sa.yaml
+   kubectl apply -f {{filesUrl}}/manifests/federation-remote-sa.yaml
    ```
 
-1. Create a secret for service Account manually.
-
-   :::note
-
-   This step is needed if your k8s version is 1.24 or above. From K8s 1.24, K8s won’t generate Secrets automatically for ServiceAccounts and need be created manually.
-
-   :::
+1. If RBAC is enabled, create the ClusterRole and ClusterRoleBinding used by remote clusters for authorization:
 
    ```bash
-   kubectl apply -f - <<EOF
-   apiVersion: v1
-   kind: Secret
-   type: kubernetes.io/service-account-token
-   metadata:
-     name: tigera-federation-remote-cluster
-     namespace: kube-system
-     annotations:
-       kubernetes.io/service-account.name: "tigera-federation-remote-cluster"
-   EOF
+   kubectl apply -f {{filesUrl}}/manifests/federation-rem-rbac-kdd.yaml
    ```
 
-   Use the following command to retrieve the token of the service account.
+1. Create the kubeconfig file:
 
-   ```bash
-   kubectl describe secret tigera-federation-remote-cluster -n kube-system
-   ```
+    Open a file in your favorite editor. Consider establishing a naming scheme unique to each cluster, e.g. `kubeconfig-app-a`.
 
-1. Use the following command to retrieve the name of the secret containing the token associated
-   with the `tigera-federation-remote-cluster` service account.
-
-   :::note
-
-   This step is applicable only if your k8s version is less than 1.24.
-
-   :::
-
-   ```bash
-   kubectl describe serviceaccounts tigera-federation-remote-cluster -n kube-system
-   ```
-
-   It should return something like the following.
-
-   ```bash
-   Name:         tigera-federation-remote-cluster
-   Namespace:    kube-system
-   Labels:       <none>
-   Annotations:  kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"v1","kind":"ServiceAccount","metadata":{"annotations":{},"name":"remote-cluster","namespace":"kube-system"}}
-
-   Image pull secrets:  <none>
-   Mountable secrets:   tigera-federation-remote-cluster-token-wzdgp
-   Tokens:              tigera-federation-remote-cluster-wzdgp
-   Events:              <none>
-   ```
-
-   The value of `Tokens` is the name of the secret containing the service account's token.
-
-   Use the following command to retrieve the token of the service account.
-
-   ```bash
-   kubectl describe secrets tigera-federation-remote-cluster-token-wzdgp -n kube-system
-   ```
-
-   It should return something like the following.
-
-   ```bash
-   Name:         tigera-federation-remote-cluster-token-wzdgp
-   Namespace:    kube-system
-   Labels:       <none>
-   Annotations:  kubernetes.io/service-account.name=tigera-federation-remote-cluster
-                 kubernetes.io/service-account.uid=b3044d23-96b5-11e8-ac9b-42010a80000e
-
-   Type:  kubernetes.io/service-account-token
-
-   Data
-   ====
-   ca.crt:     1025 bytes
-   namespace:  11 bytes
-   token:      eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJrdWJlLXN5c3RlbSIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJyZW1vdGUtY2x1c3Rlci10b2tlbi13emRncCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50Lm5hbWUiOiJyZW1vdGUtY2x1c3RlciIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6ImIzMDQ0ZDIzLTk2YjUtMTFlOC1hYzliLTQyMDEwYTgwMDAwZSIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDprdWJlLXN5c3RlbTpyZW1vdGUtY2x1c3RlciJ9.h8ngEwzjzHLMnaRANiXoqrSAWGxycVqq7cO54RM56qyyy_KlAbLpjbhHiaQBNAqJ_LTvjSZ23r2vZn-ZUbTDcoHninD4N2GXKygyVxoBeBzBJinbHWTPp6BYnLvM1pifnj5QNrQanqb0Nwy_p9T1CBMr7NmTsJ5HvRHASCMImjLToCC251kL5oIVM6MWdty_dKGvCzO1rUQhCqcwQyq4Bg6cTFNCLejFpgH0p7XdVcqSsd2uYUpPeS85q5paEKza630Dxg8jdwa5VhYAb_LZfklPOVwHAgNx9OT-z_ZRLYfWoBVlkgazXiiEz9kDweK8hESGLQdW7996C0vdeVx21A
-   ```
-
-1. Save the `token` value for later steps.
-
-1. Use the following command to retrieve the certificate authority and server data.
-
-   ```bash
-   kubectl config view --flatten --minify
-   ```
-
-   It should return something like the following.
-
-   ```bash
-   apiVersion: v1
-   clusters:
-   - cluster:
-       certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRFNE1EY3lOVEUyTURjek4xb1hEVEk0TURjeU1qRTJNRGN6TjFvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTU9FCjc1ZWtxbmdMdjZKZW9IaGhFLy9iVU0rdnNRMyt3cUZ1eHp5NDlReFk1cmtZaGJ4WWt1TFl0c3ZBVTgycjVnNlYKbUVwbDRlOHJMQjRnTnFpRnVDcVplcmMwWWxqZDVQNllKcW5PN3A1b1J3SG5BWXA3dnZwczJRZjFTemNsTVNjSAo3Qk9XbkF4aEFFZTUzKytPSkhaVmZzL2tlTWtlK3F4b01IZ0R1eGxUb2xXU2dDV0YvbCt3eFk3ZTcyNmozYWZnClRXL0lxSk9GNTN6YTVHR05MMGRIQndFR0gzSU5CVllXa1V5TjEycXZJYlh3RzJReElCU1hEbTcvV1dvNUphMHkKeVNSWkx4L3FZSHBld1hsOU5Od3ZYaXNOZ2xvVVVsZFJ4OGtSWmJOdmViZkpad2FqQVBlRytNRkYwYVJVNHF0Zgo5NVYzdHZ5RHYxaHNJdytGQiswQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFFaFJBNmEzUUNBRGVGalNOeFM1Qi9NZVo4dTIKenNvV2F0c21pdm81YUREUUIwUnRUUWFLTUEwU2ZlaGNLd3ZUdTJjVW5CaVJHZlZMSnJ3REwvUzUvRHBhemdBbgozVlZuWERlbGRzcjVKa3dpTElhQUZCSzg5K3BaLzVybXpuZmZpMldKS0JvY2t3N015REplb05FdklkSjVtb2t0ClMxL0pKYlcvbExZU054RjYxOXJxOE9LVVZ2YStwTmczZ2JEbGlFSUZNUmpobWdtU01tUEthRnMvaE1GcDlzdVMKV3VDd1czY2lQVXlUZXV6bnRYbzY5K3NpUGYyLzFxYUFmRWtmSHp3NS9QeG8xM1dOWnEzSzI0dDNoNXh1QjFvRwpwaXRDbEZPSGFLSnNLZ0g1UkFOSWt3dkNIOXgySG9oTzR2M3ZoOXd1KzlOMEt1K3FLVWJIODRENkVpMD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-       server: https://10.128.0.14:6443
-     name: kubernetes
-   contexts:
-   - context:
-       cluster: kubernetes
-       user: kubernetes-admin
-     name: kubernetes-admin@kubernetes
-   current-context: kubernetes-admin@kubernetes
-   kind: Config
-   preferences: {}
-   users:
-   - name: kubernetes-admin
-     user:
-       client-certificate-data: ...
-       client-key-data: ...
-   ```
-
-1. Save the `certificate-authority-data` and the `server` values for the next step.
-
-1. Open a new file in your favorite editor.
-
-   :::tip
-
-   We recommend coming up with a naming scheme for your clusters that makes sense for your
-   specific use case. For example, if you have four remote clusters that are similar except that they
-   are serving web pages in different languages, you can name the files `kubeconfig-rem-cluster-en`,
-   `kubeconfig-rem-cluster-es`, `kubeconfig-rem-cluster-ja`, and `kubeconfig-rem-cluster-sw`. This will
-   make the installation procedure easier to follow.
-
-   :::
-
-1. Paste the following into your new file.
-
+    Paste the following into the file - we will replace the templated values with data retrieved in following steps.
    ```yaml
    apiVersion: v1
    kind: Config
@@ -241,85 +118,202 @@ For each cluster in the federation, we will create a kubeconfig. This kubeconfig
    current-context: tigera-federation-remote-cluster-ctx
    ```
 
-1. Replace `<YOUR-SERVICE-ACCOUNT-TOKEN>`, `<YOUR-CERTIFICATE-AUTHORITY-DATA>`,
-   and `<YOUR-SERVER-ADDRESS>` with the values obtained in the previous steps.
+1. Retrieve the ServiceAccount token:
 
-1. Verify that the `kubeconfig` file works by issuing the following command.
-
+   #### If using Kubernetes >= 1.24
+   - Create the ServiceAccount token:
    ```bash
-   kubectl --kubeconfig=kubeconfig-rem-cluster-n get services
+   kubectl apply -f - <<EOF
+   apiVersion: v1
+   kind: Secret
+   type: kubernetes.io/service-account-token
+   metadata:
+     name: tigera-federation-remote-cluster
+     namespace: kube-system
+     annotations:
+       kubernetes.io/service-account.name: "tigera-federation-remote-cluster"
+   EOF
+   ```
+   - Retrieve the ServiceAccount token value and replace `<YOUR-SERVICE-ACCOUNT-TOKEN>` with it's value:
+   ```bash
+   kubectl describe secret tigera-federation-remote-cluster -n kube-system
    ```
 
-   You should see your cluster listed.
+   #### If using Kubernetes < 1.24
+   - Retrieve the ServiceAccount token value and replace `<YOUR-SERVICE-ACCOUNT-TOKEN>` with it's value:
+   ```bash
+   kubectl describe secret -n kube-system $(kubectl get serviceaccounts tigera-federation-remote-cluster -n kube-system -o jsonpath='{.secrets[0].name}')
+   ```
 
-### Create secrets
+1. Retrieve and save the certificate authority and server data:
 
-We'll now create secrets in each local cluster that contain the created kubeconfig for a given remote cluster that we wish to connect to. The simplest method to create a secret for a remote cluster is to use the `kubectl` command because it correctly encodes the data and formats the file.
+   Run the following command:
+   ```bash
+   kubectl config view --flatten --minify
+   ```
+   Replace `<YOUR-CERTIFICATE-AUTHORITY-DATA>` and `<YOUR-SERVER-ADDRESS>` with `certificate-authority-data` and `server` values respectively.
 
-Within a local cluster, create a secret for a remote cluster with a command like the following.
+1. Verify that the `kubeconfig` file works:
 
+   Issue a command like the following to validate the kubeconfig file can be used to connect to the current cluster and access resources:
+   ```bash
+   kubectl --kubeconfig=kubeconfig-app-a get nodes
+   ```
+
+### Create RemoteClusterConfigurations
+We'll now create the RemoteClusterConfigurations that establish synchronization between clusters. This enables remote-identity aware policy, federated services, and can establish multi-cluster networking.
+
+**For each pair** of clusters in the federation (e.g. cluster A and cluster B):
+
+1. In cluster A, create a secret that contains the kubeconfig for cluster B:
+
+   Determine the namespace you will create the secret in - this will be the value of `<namespace>` to replace in all steps.
+   The simplest method to create a secret for a remote cluster is to use the `kubectl` command because it correctly encodes the data and formats the file.
+   ```bash
+   kubectl create secret generic remote-cluster-secret-name -n <namespace> \
+      --from-literal=datastoreType=kubernetes \
+      --from-file=kubeconfig=<kubeconfig file>
+   ```
+
+1. If RBAC is enabled in cluster A, create a Role and RoleBinding that {{prodname}} will use to access the secret that contains the kubeconfig for cluster B:
+   ```bash
+   kubectl create -f - <<EOF
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: Role
+   metadata:
+     name: remote-cluster-secret-access
+     namespace: <namespace>
+   rules:
+   - apiGroups: [""]
+     resources: ["secrets"]
+     verbs: ["watch", "list", "get"]
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: RoleBinding
+   metadata:
+     name: remote-cluster-secret-access
+     namespace: <namespace>
+   roleRef:
+     apiGroup: rbac.authorization.k8s.io
+     kind: Role
+     name: remote-cluster-secret-access
+   subjects:
+   - kind: ServiceAccount
+     name: calico-typha
+     namespace: calico-system
+   EOF
+   ```
+
+1. Create the RemoteClusterConfiguration in cluster A:
+
+   Within the RemoteClusterConfiguration, we specify the secret used to access cluster B, and the overlay routing mode which toggles the establishment of cross-cluster overlay routes.
+   ```yaml
+   kubectl create -f - <<EOF
+   apiVersion: projectcalico.org/v3
+   kind: RemoteClusterConfiguration
+   metadata:
+     name: cluster-b
+   spec:
+     clusterAccessSecret:
+       name: remote-cluster-secret-name
+       namespace: <namespace>
+       kind: Secret
+     syncOptions:
+       overlayRoutingMode: Enabled
+   EOF
+   ```
+
+1. If you have IPPools in cluster A with NAT-outgoing enabled, you must [configure IP pool resources](#configure-ip-pool-resources).
+
+1. Validate the that the remote cluster connection can be established using [calicoq](#validate-federation-and-multi-cluster-networking).
+
+1. Repeat the above steps, switching cluster A and cluster B.
+
+
+After completing the above steps for all cluster pairs in the federation, your clusters should now be ready to utilize remote-identity-aware policy and federated services, along with multi-cluster networking if requirements were met.
+
+:::note
+ This tutorial sets up RemoteClusterConfigurations in both directions. This is required for {{prodname}} to manage multi-cluster networking, and also ensures you can write identity-aware policy on both sides of a cross-cluster connection. Unidirectional connections can be made at your own discretion.
+:::
+
+### Validate federation and multi-cluster networking
+#### RemoteClusterConfiguration & federated endpoint identity
+[calicoq](../../operations/clis/calicoq/installing) can be used to ensure that a local cluster has connected to it's configured remote clusters. Use the following command:
 ```bash
-kubectl create secret generic remote-cluster-secret-name -n <namespace> \
-    --from-literal=datastoreType=kubernetes \
-    --from-file=kubeconfig=<kubeconfig file>
+calicoq eval "all()"
+```
+If all remote clusters are accessible, calicoq returns something like the following. Note the remote cluster prefixes: there should be endpoints prefixed with the name of each RemoteClusterConfiguration in the local cluster.
+```
+Endpoints matching selector all():
+  Workload endpoint remote-cluster-1/host-1/k8s/kube-system.kube-dns-5fbcb4d67b-h6686/eth0
+  Workload endpoint remote-cluster-1/host-2/k8s/kube-system.cnx-manager-66c4dbc5b7-6d9xv/eth0
+  Workload endpoint host-a/k8s/kube-system.kube-dns-5fbcb4d67b-7wbhv/eth0
+  Workload endpoint host-b/k8s/kube-system.cnx-manager-66c4dbc5b7-6ghsm/eth0
 ```
 
-Additional arguments:
+You can also view the [Prometheus metrics for Typha](../../reference/component-resources/typha/prometheus#metric-reference) to check the remote cluster connection status.
 
-- `--from-literal=<key>=<value>` to add literal values
-- `--from-file=<key>=<file>` to add values with file contents
+If either output contains unexpected results, proceed to the troubleshooting section.
 
-### Create access to secrets for clusters
+#### Multi-cluster networking
+If all requirements were met for {{prodname}} to establish multi-cluster networking, you can test the functionality by establishing a connection from a pod in a local cluster to the IP of a pod in a remote cluster. Ensure that there is no policy in either cluster that may block this connection.
 
-{{prodname}} does not generally have access to all secrets in a cluster so it is necessary to create a Role and RoleBinding for each namespace where the secrets for RemoteClusterConfigurations are created. You can reduce the number of Role and RoleBindings needed by putting the remote cluster Secrets in a dedicated namespace.
+If the connection fails, proceed to the [troubleshooting](#troubleshoot) section.
 
-```bash
-kubectl create -f - <<EOF
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: remote-cluster-secret-access
-  namespace: <namespace>
-rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["watch", "list", "get"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: remote-cluster-secret-access
-  namespace: <namespace>
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: remote-cluster-secret-access
-subjects:
-- kind: ServiceAccount
-  name: calico-typha
-  namespace: calico-system
-EOF
-```
+### Create remote-identity-aware network policy
+With federated endpoint identity and routing between clusters established, you can now use labels to reference endpoints on a remote cluster in local policy rules, rather than referencing them by IP address.
 
-### Add remote cluster configurations
+The main policy selector still refers only to local endpoints; and that selector chooses which local endpoints to apply the policy.
+However, rule selectors can now refer to both local and remote endpoints.
 
-Add remote cluster configuration where needed. Each instance of the [Remote Cluster Configuration](../../reference/resources/remoteclusterconfiguration.mdx)
-resource represents a single remote cluster from which the local cluster can retrieve endpoint information. We reference the kubeconfig secret created above to specify how to connect to this remote cluster.
-
+In the following example, cluster A (an application cluster) has a network policy that governs outbound connections to cluster B (a database cluster).
 ```yaml
-apiVersion: projectcalico.org/v3
-kind: RemoteClusterConfiguration
+apiversion: projectcalico.org/v3
+kind: NetworkPolicy
 metadata:
-  name: cluster-n
+    name: default.app-to-db
+    namespace: myapp
 spec:
-  clusterAccessSecret:
-    name: remote-cluster-secret-name
-    namespace: <namespace>
-    kind: Secret
+    # The main policy selector selects endpoints from the local cluster only.
+    selector: app == 'backend-app'
+    tier: default
+    egress:
+    - destination:
+        # Rule selectors can select endpoints from local AND remote clusters.
+        selector: app == 'postgres'
+      protocol: TCP
+      ports: [5432]
+      action: Allow
 ```
+
+### Troubleshoot
+#### RemoteClusterConfiguration & federated endpoint identity
+For each impacted remote cluster pair (between cluster A and cluster B):
+1. Retrieve the kubeconfig from the secret stored in cluster A. Manually verify that it can be used to connect to Cluster B.
+   ```bash
+   kubectl get secret -n <namespace> remote-cluster-secret-name -o=jsonpath="{.data.kubeconfig}" | base64 -d > verify_kubeconfig_b
+   kubectl --kubeconfig=verify_kubeconfig_b get nodes
+   ```
+2. Validate that the Typha service account in Cluster A is authorized to retrieve the kubeconfig secret for Cluster B.
+   ```bash
+    kubectl auth can-i list secrets --namespace <namespace> --as=system:serviceaccount:calico-system:calico-typha
+   ```
+3. Repeat the above, switching cluster A to cluster B.
+
+The output from [calicoq](#remoteclusterconfiguration--federated-endpoint-identity) may also provide insight into where issues may be occurring.
+
+If the above steps provide no useful information, consider looking at the `typha` and `calico-node` logs for any relevant errors or warnings.
+
+
+#### Multi-cluster networking
+First, ensure that RemoteClusterConfiguration and federated endpoint identity are [functioning correctly](#remoteclusterconfiguration--federated-endpoint-identity-1).
+
+Next, carefully validate that **all** [requirements](#calico-enterprise-multi-cluster-networking) for multi-cluster networking have been met. If all requirements are satisfied, consider:
+* Validating that no network policy or firewall is causing packets to be dropped.
+* Checking the `typha` and `calico-node` logs for any relevant errors or warnings.
+
 
 ### Configure IP pool resources
-
 For local clusters with `NATOutgoing` configured on your IP pools, verify the following:
 
 - Configure additional IP pools to cover the IP ranges of your remote clusters. This ensures that outgoing NAT is not performed on packets bound for the remote clusters.
@@ -336,59 +330,6 @@ metadata:
 spec:
   cidr: 192.168.0.0/18
   disabled: true
-```
-
-Congratulations! You have completed configuration of federated endpoint identity.
-
-### Use policy to reference pods on a remote cluster
-
-For federated clusters, use labels to reference pods on a remote cluster in the local policy rules, rather than referencing them by IP address. The main policy selector still refers only to local endpoints; and that selector chooses which local endpoints to apply the policy.
-
-For policy rule selectors on the local cluster to correctly reference endpoints across all of the clusters, you must align the following between clusters.
-
-- Namespace names
-- Host endpoint label names and values
-- Pod label names and values within the namespace
-- Service accounts (if you configure {{prodname}} federated services)
-
-### Troubleshoot remote clusters
-
-To verify that remote clusters are accessible, use the following command.
-
-```
-$ calicoq eval "all()"
-```
-
-If all remote clusters are accessible, `calicoq` returns something like the following. In this example, the `remote-cluster-1` prefix indicates the remote cluster endpoints (as configured in the RemoteClusterConfiguration resource).
-
-```
-Endpoints matching selector all():
-  Workload endpoint remote-cluster-1/host-1/k8s/kube-system.kube-dns-5fbcb4d67b-h6686/eth0
-  Workload endpoint remote-cluster-1/host-2/k8s/kube-system.cnx-manager-66c4dbc5b7-6d9xv/eth0
-  Workload endpoint host-a/k8s/kube-system.kube-dns-5fbcb4d67b-7wbhv/eth0
-  Workload endpoint host-b/k8s/kube-system.cnx-manager-66c4dbc5b7-6ghsm/eth0
-```
-
-If a remote cluster is inaccessible, (network failure or a misconfiguration), the `calicoq` output includes details about the error.
-
-**Example**: Remote-cluster-secret is not accessible
-
-```
-E0615 12:24:04.895079   30873 reflector.go:153] github.com/projectcalico/libcalico-go/lib/backend/syncersv1/remotecluster/secret_watcher.go:111: Failed to list *v1.Secret: secrets "remote-cluster-secret" is forbidden: User "system:serviceaccount:policy-demo:limited-sa" cannot list resource "secrets" in API group "" in the namespace "remote-cluster-ns"
-Endpoints matching selector all():
-  Workload endpoint host-a/k8s/kube-system.kube-dns-5fbcb4d67b-7wbhv/eth0
-  Workload endpoint host-b/k8s/kube-system.cnx-manager-66c4dbc5b7-6ghsm/eth0
-```
-
-**Example**: Incorrect connection information in the Remote Cluster Configuration
-
-```
-Endpoints matching selector all():
-  Workload endpoint host-a/k8s/kube-system.kube-dns-5fbcb4d67b-7wbhv/eth0
-  Workload endpoint host-b/k8s/kube-system.cnx-manager-66c4dbc5b7-6ghsm/eth0
-The following problems were encountered connecting to the remote clusters
-which may have resulted in incomplete data:
--  RemoteClusterConfiguration(remote-cluster-1): connection to remote cluster failed: Get https://192.168.0.55:6443/api/v1/pods: dial tcp 192.168.0.55:6443: i/o timeout
 ```
 
 ## Next steps

--- a/calico-enterprise/multicluster/federation/kubeconfig.mdx
+++ b/calico-enterprise/multicluster/federation/kubeconfig.mdx
@@ -22,7 +22,7 @@ This how to guide uses the following {{prodname}} features:
 
 ### Local and remote clusters
 
-Each cluster in a federation can act as both a local and remote cluster.
+Each cluster in the cluster mesh can act as both a local and remote cluster.
 
 - Local clusters are configured (via RemoteClusterConfiguration) to retrieve endpoint and routing data from remote clusters
 - Remote clusters authorize local clusters to retrieve endpoint and routing data
@@ -39,7 +39,7 @@ The resources synced through this connection enable the local cluster to referen
 RemoteClusterConfiguration creates this connection in one direction. If you want identity-aware policy on both sides (i.e. both clusters) of a connection, or you want {{prodname}} to establish cross-cluster overlay networking, you need to create a RemoteClusterConfiguration for both directions.
 
 ### kubeconfig files
-Each cluster in the federation should have a dedicated kubeconfig file used to connect and authenticate to other clusters in the federation.
+Each cluster in the cluster mesh should have a dedicated kubeconfig file used by other clusters in the mesh connect and authenticate.
 
 
 ## Before you begin
@@ -63,10 +63,10 @@ Federation of workload endpoint identities only has utility when [Pod IP routabi
 {{prodname}} can automatically extend the overlay networking in your clusters to establish pod IP routes across clusters and thus meet the requirement for Pod IP routability. Only VXLAN overlay is supported at this time.
 
 Ensure the following requirements are met:
-- All nodes in the federation can establish connections to each other via their private IP.
+- All nodes in the cluster mesh can establish connections to each other via their private IP.
 - VXLAN must be enabled on participating IP pools in all clusters and their IP pool CIDRs must not overlap.
-- `routeSource` and `vxlan*` FelixConfiguration options must be aligned across clusters, and traffic on the `vxlanPort` must be allowed between nodes in the federation.
-- RemoteClusterConfigurations must be established in both directions for cluster pairs in the federation.
+- `routeSource` and `vxlan*` FelixConfiguration options must be aligned across clusters, and traffic on the `vxlanPort` must be allowed between nodes in the cluster mesh.
+- RemoteClusterConfigurations must be established in both directions for cluster pairs in the cluster mesh.
 - CNI must be Calico.
 
 With these requirements met, multi-cluster networking will be automatically established when RemoteClusterConfigurations are created.
@@ -79,7 +79,7 @@ Alternatively, you can meet the requirement for Pod IP routability by configurin
 
 Create a kubeconfig file, for each cluster, that will be used by other clusters to connect and authenticate themselves.
 
-**For each** cluster in the federation, utilizing an existing kubeconfig with administrative privileges, follow these steps:
+**For each** cluster in the cluster mesh, utilizing an existing kubeconfig with administrative privileges, follow these steps:
 
 1. Create the ServiceAccount used by remote clusters for authentication:
 
@@ -163,7 +163,7 @@ Create a kubeconfig file, for each cluster, that will be used by other clusters 
 ### Create RemoteClusterConfigurations
 We'll now create the RemoteClusterConfigurations that establish synchronization between clusters. This enables remote-identity aware policy, federated services, and can establish multi-cluster networking.
 
-**For each pair** of clusters in the federation (e.g. cluster A and cluster B):
+**For each pair** of clusters in the cluster mesh (e.g. cluster A and cluster B):
 
 1. In cluster A, create a secret that contains the kubeconfig for cluster B:
 
@@ -230,7 +230,7 @@ We'll now create the RemoteClusterConfigurations that establish synchronization 
 1. Repeat the above steps, switching cluster A and cluster B.
 
 
-After completing the above steps for all cluster pairs in the federation, your clusters should now be ready to utilize remote-identity-aware policy and federated services, along with multi-cluster networking if requirements were met.
+After completing the above steps for all cluster pairs in the cluster mesh, your clusters should now be ready to utilize remote-identity-aware policy and federated services, along with multi-cluster networking if requirements were met.
 
 :::note
  This tutorial sets up RemoteClusterConfigurations in both directions. This is required for {{prodname}} to manage multi-cluster networking, and also ensures you can write identity-aware policy on both sides of a cross-cluster connection. Unidirectional connections can be made at your own discretion.

--- a/calico-enterprise/multicluster/federation/overview.mdx
+++ b/calico-enterprise/multicluster/federation/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure local clusters for cross-cluster endpoints sharing, cross-cluster connectivity, and cross-cluster service discovery.
+description: Configure a cluster mesh for cross-cluster endpoints sharing, cross-cluster connectivity, and cross-cluster service discovery.
 ---
 
 # Overview
@@ -13,9 +13,9 @@ Utilize {{prodname}} to establish cross-cluster connectivity.
 
 ## Value
 
-At some point in your Kubernetes journey, you may wish to connect workloads between environments, replicate workloads between clusters, or establish clusters that provide services to other clusters.
+At some point in your Kubernetes journey, you may have applications that need to access services and workloads running in another cluster.
 
-By default, pods can only communicate with pods within the same cluster. Additionally, services and network policy only select pods from within the same cluster. {{prodname}} can help overcome these barriers with the following features:
+By default, pods can only communicate with pods within the same cluster. Additionally, services and network policy only select pods from within the same cluster. {{prodname}} can help overcome these barriers by forming a cluster mesh the following features:
 - **Federated endpoint identity**
 
   Allow a local Kubernetes cluster to include the workload endpoints (pods) and host endpoints of a remote cluster in the calculation of local network policies applied on each node of the local cluster.
@@ -33,22 +33,22 @@ By default, pods can only communicate with pods within the same cluster. Additio
 
 ### Pod IP routability
 
-Federated workload endpoint identity and federated services are implemented in Kubernetes at the network layer, based on pod IPs.
+{{prodname}} cluster mesh is implemented at Kubernetes at the network layer, based on pod IPs.
 
-Taking advantage of these features requires that pod IPs are routable between clusters. This is because identity-aware network policy requires source and destination pod IPs to be preserved in order to establish pod identity. Additionally, the Endpoint IPs of pods selected by a federated Service must be routable in order for that Service to be of value.
+Taking advantage of federated workload endpoint identity and federated services requires that pod IPs are routable between clusters. This is because identity-aware network policy requires source and destination pod IPs to be preserved in order to establish pod identity. Additionally, the Endpoint IPs of pods selected by a federated Service must be routable in order for that Service to be of value.
 
 You can utilize {{prodname}} multi-cluster networking to establish pod IP routability between clusters via overlay. Alternatively, you can manually set up pod IP routability between clusters without encapsulation (e.g. VPC routing, BGP routing).
 
 
 ### Federated endpoint identity
 
-Federated endpoint identity allows a local Kubernetes cluster to include the workload endpoints (pods) and host endpoints of a remote cluster in the calculation of the local policies for each node, e.g. Cluster A network policy allows its application pods to talk to database pods in Cluster B.
+Federated endpoint identity in a cluster mesh allows a local Kubernetes cluster to include the workload endpoints (pods) and host endpoints of a remote cluster in the calculation of the local policies for each node, e.g. Cluster A network policy allows its application pods to talk to database pods in Cluster B.
 
 This feature does not _federate network policies_; policies from a remote cluster are not applied to the endpoints on the local cluster, and the policy from the local cluster is rendered only locally and applied to the local endpoints.
 
 ### Federated services
 
-Federated services works with federated endpoint identity, providing cross-cluster service discovery for a local cluster. If you have an existing service discovery mechanism, this feature is optional.
+Federated services in a cluster mesh works with federated endpoint identity, providing cross-cluster service discovery for a local cluster. If you have an existing service discovery mechanism, this feature is optional.
 
 Federated services use the Tigera Federated Services Controller to federate all [Kubernetes endpoints](https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#endpoints-v1-core) (workload and host endpoints) across all of the clusters. The Federated Services Controller accesses service and endpoints data in the remote clusters directly through the Kubernetes API.
 

--- a/calico-enterprise/multicluster/federation/overview.mdx
+++ b/calico-enterprise/multicluster/federation/overview.mdx
@@ -1,44 +1,50 @@
 ---
-description: Configure local clusters for cross-cluster workload and host endpoints sharing, and cross-cluster service discovery.
+description: Configure local clusters for cross-cluster endpoints sharing, cross-cluster connectivity, and cross-cluster service discovery.
 ---
 
 # Overview
 
 ## Big picture
 
-Configure local clusters for cross-cluster workload and host endpoints sharing, and cross-cluster service discovery.
+Secure cross-cluster connections with identity-aware network policy, and federate services for cross-cluster service discovery.
+
+Utilize {{prodname}} to establish cross-cluster connectivity.
+
 
 ## Value
 
-At some point in your Kubernetes journey, you may have multiple teams (development, QA, and others) that need to work in parallel across multiple clusters, without negative impacts on each other. By default, deployed Kubernetes pods can only see pods within their cluster. Using network policy and services, you can grant access to other clusters and the applications they are running. {{prodname}} provides these federation features:
+At some point in your Kubernetes journey, you may wish to connect workloads between environments, replicate workloads between clusters, or establish clusters that provide services to other clusters.
 
+By default, pods can only communicate with pods within the same cluster. Additionally, services and network policy only select pods from within the same cluster. {{prodname}} can help overcome these barriers with the following features:
 - **Federated endpoint identity**
 
-  Allow a local Kubernetes cluster to include the workload endpoints (pods) and host endpoints of a remote cluster in the calculation of local policies applied on each node of the local cluster.
+  Allow a local Kubernetes cluster to include the workload endpoints (pods) and host endpoints of a remote cluster in the calculation of local network policies applied on each node of the local cluster.
 
 - **Federated services**
 
-  Provides cross-cluster service discovery for a local cluster.
+  Enable a local Kubernetes Service to populate with Endpoints selected from both local cluster and remote cluster Services.
+
+- **Multi-cluster networking**
+
+  Establish an overlay network between clusters to provide cross-cluster connectivity with {{prodname}}.
+
 
 ## Concepts
 
-### Federation: network layer features
+### Pod IP routability
 
-{{prodname}} federated endpoint identity and federated services are implemented in Kubernetes at the network layer. To apply fine-grained network policy between multiple clusters, the pod source and destination IPs must be preserved. So these features are valuable only if your clusters are designed with common networking across clusters with no encapsulation (for example, BGP routing or VPC routing). (Although there are ways to achieve a common networking equivalent across clusters using overlays, this is outside the realm of this article.)
+Federated workload endpoint identity and federated services are implemented in Kubernetes at the network layer, based on pod IPs.
+
+Taking advantage of these features requires that pod IPs are routable between clusters. This is because identity-aware network policy requires source and destination pod IPs to be preserved in order to establish pod identity. Additionally, the Endpoint IPs of pods selected by a federated Service must be routable in order for that Service to be of value.
+
+You can utilize {{prodname}} multi-cluster networking to establish pod IP routability between clusters via overlay. Alternatively, you can manually set up pod IP routability between clusters without encapsulation (e.g. VPC routing, BGP routing).
+
 
 ### Federated endpoint identity
 
-A simple example of implementing policy across multiple clusters is:
-
-"Cluster A's network policy allows **web** to talk to **db**, but all of the **web** is in cluster A, and all of the **db** is in cluster B."
-
-Federated endpoint identity solves this by allowing a local Kubernetes cluster to include the workload endpoints (pods) and host endpoints of a remote cluster in the calculation of the local policies for each node.
-
-:::note
+Federated endpoint identity allows a local Kubernetes cluster to include the workload endpoints (pods) and host endpoints of a remote cluster in the calculation of the local policies for each node, e.g. Cluster A network policy allows its application pods to talk to database pods in Cluster B.
 
 This feature does not _federate network policies_; policies from a remote cluster are not applied to the endpoints on the local cluster, and the policy from the local cluster is rendered only locally and applied to the local endpoints.
-
-:::
 
 ### Federated services
 
@@ -48,4 +54,4 @@ Federated services use the Tigera Federated Services Controller to federate all 
 
 ## Next steps
 
-[Configure federated endpoint identity ](kubeconfig.mdx)
+[Configure remote-aware policy and multi-cluster networking](kubeconfig.mdx)

--- a/calico-enterprise/multicluster/federation/services-controller.mdx
+++ b/calico-enterprise/multicluster/federation/services-controller.mdx
@@ -10,7 +10,7 @@ Configure local clusters to discover services across multiple clusters.
 
 ## Value
 
-Use federate services discovery along with federated endpoint identity to extend and automate endpoints sharing. (Optional if you have your own service discovery mechanism.)
+Use cluster mesh and federated services discovery along with federated endpoint identity to extend and automate endpoints sharing. (Optional if you have your own service discovery mechanism.)
 
 ## Features
 
@@ -23,7 +23,7 @@ This how to guide uses the following {{prodname}} features:
 
 ### Federated services
 
-A federated service (also called a backing service), is a set of services with consolidated endpoints. {{prodname}} discovers services across all clusters (both local cluster and remote clusters) and creates a "federated service" on the local cluster that encompasses all of the individual services.
+A federated service (also called a backing service), is a set of services with consolidated endpoints. {{prodname}} discovers services across a cluster mesh (both local cluster and remote clusters) and creates a "federated service" on the local cluster that encompasses all of the individual services.
 
 Federated services are managed by the Tigera Federated Service Controller, which monitors and maintains endpoints for each locally-federated service. The controller does not change configuration on remote clusters.
 
@@ -84,7 +84,7 @@ You can also match services using a label. The label is implicitly added to each
 
 ### Create service resources
 
-On each cluster that is providing a particular service, create your service resources as you normal would with the following requirements:
+On each cluster in the mesh that is providing a particular service, create your service resources as you normal would with the following requirements:
 
 - Services must all be in the same namespace.
 - Configure each service with a common label key and value to identify the common set of services across your clusters (for example, `run=my-app`).
@@ -165,7 +165,7 @@ spec:
 
 The `spec.selector` is not specified so it will not be managed by Kubernetes. Instead, we use a `federation.tigera.io/selector` annotation, indicating that this is a federated service managed by the Federated Services Controller.
 
-The controller matches the `my-app` services (matching the run label) on both the local and remote clusters, consolidates endpoints from the `my-app-ui` TCP port for both of those services. Because the federated service does not specify the `my-app-console` port, the controller does not include these endpoints in the federated service.
+The controller matches the `my-app` services (matching the run label) on both the local and remote clusters, and consolidates endpoints from the `my-app-ui` TCP port for both of those services. Because the federated service does not specify the `my-app-console` port, the controller does not include these endpoints in the federated service.
 
 The endpoints data for the federated service is similar to the following. Note that the name of the remote cluster is included in `targetRef.name`.
 
@@ -212,5 +212,5 @@ subsets:
 
 ## Additional resources
 
-- [Federated identity and services example for AWS](aws.mdx)
+- [Cluster mesh example for AWS](aws.mdx)
 - [Federated service controller](../../reference/component-resources/kube-controllers/configuration.mdx)

--- a/sidebars-calico-cloud.js
+++ b/sidebars-calico-cloud.js
@@ -404,7 +404,7 @@ module.exports = {
     },
     {
       type: 'category',
-      label: 'Multi-cluster management',
+      label: 'Cluster mesh',
       link: {type: 'doc', id: 'multicluster/index'},
       items: [
         'multicluster/overview',

--- a/sidebars-calico-enterprise.js
+++ b/sidebars-calico-enterprise.js
@@ -415,7 +415,7 @@ module.exports = {
         'multicluster/change-cluster-type',
         {
           type: 'category',
-          label: 'Federate identity endpoints and services',
+          label: 'Federation and multi-cluster networking',
           link: {type: 'doc', id: 'multicluster/federation/index'},
           items: [
             'multicluster/federation/overview',

--- a/sidebars-calico-enterprise.js
+++ b/sidebars-calico-enterprise.js
@@ -415,7 +415,7 @@ module.exports = {
         'multicluster/change-cluster-type',
         {
           type: 'category',
-          label: 'Federation and multi-cluster networking',
+          label: 'Cluster mesh',
           link: {type: 'doc', id: 'multicluster/federation/index'},
           items: [
             'multicluster/federation/overview',


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Reworks the federation docs to include the new multi-cluster networking features, with an emphasis on improving the clarity of the solution and its configuration. 

Also includes the suggested changes to cluster mesh messaging.

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->
CE 3.19 and later.

Issues:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->
Should resolve DOCS-267 and DOCS-501.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://deploy-preview-940--tigera.netlify.app/calico-enterprise/next/multicluster/federation/overview
https://deploy-preview-940--tigera.netlify.app/calico-enterprise/next/multicluster/federation/kubeconfig

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->