### PR TITLE
[RS-1197] Get rid of tigera_secure_ee_waf* index pattern creation for 3.16+

### DIFF
--- a/calico-cloud/threat/web-application-firewall.mdx
+++ b/calico-cloud/threat/web-application-firewall.mdx
@@ -312,9 +312,7 @@ To view WAF events in a centralized security events dashboard, go to: **Threat d
 
 #### Kibana
 
-To view WAF events In Kibana:
-
-1. Select the `tigera_secure_ee_waf*` index pattern. 
+To view WAF events in Kibana, select the `tigera_secure_ee_waf*` index pattern.
 
 #### Disable WAF for a service
 

--- a/calico-cloud_versioned_docs/version-18/threat/web-application-firewall.mdx
+++ b/calico-cloud_versioned_docs/version-18/threat/web-application-firewall.mdx
@@ -312,9 +312,7 @@ To view WAF events in a centralized security events dashboard, go to: **Threat d
 
 #### Kibana
 
-To view WAF events In Kibana:
-
-1. Select the `tigera_secure_ee_waf*` index pattern. 
+To view WAF events In Kibana, select the `tigera_secure_ee_waf*` index pattern.
 
 #### Disable WAF for a service
 

--- a/calico-cloud_versioned_docs/version-3.17/threat/web-application-firewall.mdx
+++ b/calico-cloud_versioned_docs/version-3.17/threat/web-application-firewall.mdx
@@ -137,12 +137,7 @@ In Service Graph, go to the service and click the HTTP tab. You will see the fol
 
 #### Kibana
 
-To view WAF events In Kibana:
-
-1. Create the `tigera_secure_ee_waf*` index pattern. For help with index patterns, see [Kibana index pattern](../visibility/kibana).
-2. Select the `tigera_secure_ee_waf*` index pattern. 
-
-You should see the relevant WAF assessment from your request.
+To view WAF events In Kibana, select the `tigera_secure_ee_waf*` index pattern.
 
 ### Create global alerts
 

--- a/calico-enterprise/threat/web-application-firewall.mdx
+++ b/calico-enterprise/threat/web-application-firewall.mdx
@@ -30,16 +30,16 @@ This how-to-guide uses the following {{prodname}} features:
 
 ### About {{prodname}} WAF
 
-WAF is deployed in your cluster along with Envoy DaemonSet. {{prodname}} proxies selected service traffic through Envoy, checking HTTP requests using the industry-standard 
+WAF is deployed in your cluster along with Envoy DaemonSet. {{prodname}} proxies selected service traffic through Envoy, checking HTTP requests using the industry-standard
 [ModSecurity](https://owasp.org/www-project-modsecurity-core-rule-set/) with OWASP CoreRuleSet v3.3.5 modified for kubernetes workloads. To review the rules deployed with the WAF, see [Ruleset files](https://github.com/tigera/operator/tree/master/pkg/render/applicationlayer/modsec-core-ruleset).
 
-You simply enable WAF in Manager UI, and determine the services that you want to enable for WAF protection. By default WAF is set to `DetectionOnly` so no traffic will be denied until you are ready to turn on blocking mode. 
+You simply enable WAF in Manager UI, and determine the services that you want to enable for WAF protection. By default WAF is set to `DetectionOnly` so no traffic will be denied until you are ready to turn on blocking mode.
 
-Every request that WAF finds an issue with, will result in a Security Event being created for [you to review in the UI](#view-waf-events), regardless of whether the traffic was allowed or denied. This can greatly help in tuning later.  
+Every request that WAF finds an issue with, will result in a Security Event being created for [you to review in the UI](#view-waf-events), regardless of whether the traffic was allowed or denied. This can greatly help in tuning later.
 
 #### How WAF determines if a request should be allowed or denied
 
-If you configure WAF in blocking mode, WAF will use something called [anomaly scoring mode](https://coreruleset.org/docs/concepts/anomaly_scoring/) to determine if a request is allowed with `200 OK` or denied `403 Forbidden`. 
+If you configure WAF in blocking mode, WAF will use something called [anomaly scoring mode](https://coreruleset.org/docs/concepts/anomaly_scoring/) to determine if a request is allowed with `200 OK` or denied `403 Forbidden`.
 
 This works by matching a single HTTP request against all the configured WAF rules. Each rule has a score and WAF adds all the matched rule scores together, and compares it to the overall anomaly threshold score (100 by default). If the score is under the threshold the request is allowed and if the score is over the threshold the request is denied. Our WAF starts in detection mode only and with a high default scoring threshold so is safe to turn on and then [fine-tune the WAF](#fine-tuning-your-waf) for your specific needs in your cluster.
 
@@ -76,7 +76,7 @@ Enabling WAF for certain system services may result in an undesired cluster stat
   - name: `openshift`, namespace: `default`
   - name: `gatekeeper-webhook-service`, namespace: `gatekeeper-system`
 
-The rules are not overridden during upgrade, you will have to manage deploying updates to the OWASP CoreRuleSet to the cluster over time. 
+The rules are not overridden during upgrade, you will have to manage deploying updates to the OWASP CoreRuleSet to the cluster over time.
 
 If you modify the rules, it is recommended to keep your rules in git or similar source control systems.
 
@@ -137,7 +137,7 @@ On the Manager UI, click **Threat Defense**, **Web Application Firewall**, **Con
 
 ### Apply WAF to services
 
-Now that you have deployed WAF in your cluster, you can select the services you want to protect from application layer attacks. 
+Now that you have deployed WAF in your cluster, you can select the services you want to protect from application layer attacks.
 
 If you have deployed the sample application, you can apply WAF on a service associated with your app, as follows:
 ```bash
@@ -146,14 +146,14 @@ kubectl annotate svc frontend -n default --overwrite projectcalico.org/l7-loggin
 Alternatively, you can use the Manager UI to apply WAF to the `frontend` service.
 
 In this example, we applied WAF to the `frontend` service. This means that every request that goes through the `frontend` service is inspected.
-However, the traffic is not blocked because the WAF rule is set to `DetectionOnly` by default. You can adjust rules and start blocking traffic by [fine-tuning your WAF](#fine-tuning-your-waf). 
+However, the traffic is not blocked because the WAF rule is set to `DetectionOnly` by default. You can adjust rules and start blocking traffic by [fine-tuning your WAF](#fine-tuning-your-waf).
 
 In the previous example, we applied WAF to the `frontend` service of the sample application. Here, we are
 applying WAF to a service of your own application.
 
 1. On the Manager UI, click **Threat Defense**, **Web Application Firewall**.
 2. Select the services you want WAF to inspect, and then click **Confirm Selections**.
-    
+
    <img
     src='/img/calico-enterprise/waf-select-services-3.17.png'
     alt='WAF services'
@@ -167,15 +167,15 @@ applying WAF to a service of your own application.
 You have now applied WAF rule sets to your own services, and note that the traffic that goes through the selected services will be alerted but not blocked by default.
 
 #### Trigger a WAF event
-If you would like to trigger a WAF event for testing purposes, you can simulate an SQL injection attack inside your cluster by crafting a HTTP request with a query string that WAF will detect as an SQL injection attempt. 
-The query string in this example has some SQL syntax embedded in the text. This is harmless and for demo purposes, but WAF will detect this pattern and create an event for this HTTP request. 
+If you would like to trigger a WAF event for testing purposes, you can simulate an SQL injection attack inside your cluster by crafting a HTTP request with a query string that WAF will detect as an SQL injection attempt.
+The query string in this example has some SQL syntax embedded in the text. This is harmless and for demo purposes, but WAF will detect this pattern and create an event for this HTTP request.
 
 Run a simple curl command from any pod inside your cluster targeting a service you have selected for WAF protection e.g. from the demo app above we could attempt to send a simple HTTP request to the cartservice.
 ```
   curl http://cartservice/cart?artist=0+div+1+union%23foo*%2F*bar%0D%0Aselect%23foo%0D%0A1%2C2%2Ccurrent_user
 ```
 
-### Fine-tuning your WAF 
+### Fine-tuning your WAF
 
 #### Manage your rules
 The default rulesets work fine for most deployments. However, you can customize them to suit your requirements.
@@ -192,8 +192,8 @@ By default, {{prodname}} ships with CoreRuleset v3.3.5 with the following setup 
 - [crs-setup.conf](https://github.com/tigera/operator/blob/master/pkg/render/applicationlayer/modsec-core-ruleset/crs-setup.conf)
 - [Ruleset files](https://github.com/tigera/operator/tree/master/pkg/render/applicationlayer/modsec-core-ruleset)
 
-There are two ways to edit your rules. 
-1. Edit the configmap directly using kubectl. The config map combines all the rule files together, so you will need to know how to search and find the exact place in the configmap that you want to update. 
+There are two ways to edit your rules.
+1. Edit the configmap directly using kubectl. The config map combines all the rule files together, so you will need to know how to search and find the exact place in the configmap that you want to update.
 
 2. If you want to modify the rules in any meaningful way, it is recommended that you download the files locally and modify before replacing the configmap. In OWASP, it is recommended you disable rules or change configuration by modifying a set of specific metadata files and exclusion files, and not modify any of the main rule files directly. You can, of course, decide to replace the ruleset entirely with your own set of custom rules. This is completely fine once the rules are written in the same SecRule syntax understood by ModSecurity. We recommend you keep a version of your rule files safe in version control like git.
 
@@ -222,40 +222,40 @@ To download and modify the rule files:
   kubectl replace -f $HOME/my-tigera-waf-ruleset.yaml
   ```
 
-After you do these steps, the `modsecurity-ruleset` ConfigMap will be replaced in the `tigera-operator` namespace, 
-which then triggers a rolling restart of your L7 pods. This means that the HTTP connections going through L7 pods at the time of pod termination will be (RST) reset. 
+After you do these steps, the `modsecurity-ruleset` ConfigMap will be replaced in the `tigera-operator` namespace,
+which then triggers a rolling restart of your L7 pods. This means that the HTTP connections going through L7 pods at the time of pod termination will be (RST) reset.
 
 :::note
 
 It is important to adhere to [CoreRuleset documentation](https://coreruleset.org/docs) on how to edit the behaviour of
  your WAF. A good place to begin at is the [CoreRuleset Quick Start](https://coreruleset.org/docs/deployment/quick_start/).
 
-In many scenarios, the default example CRS configuration will be a good enough starting point. It is recommended to review the example configuration file before 
+In many scenarios, the default example CRS configuration will be a good enough starting point. It is recommended to review the example configuration file before
 you deploy it to make sure it’s right for your environment.
 :::
 
 
 #### Set WAF rule to block traffic
-By default WAF will not block a request even if it has matching rule violations. The rule engine is set to `DetectionOnly`. You can configure to block traffic instead with an `HTTP 403 Forbidden` response status code when the combined matched rules scores exceed a certain threshold. 
+By default WAF will not block a request even if it has matching rule violations. The rule engine is set to `DetectionOnly`. You can configure to block traffic instead with an `HTTP 403 Forbidden` response status code when the combined matched rules scores exceed a certain threshold.
 
-1. Edit the configmap: 
+1. Edit the configmap:
    ```bash
    kubectl edit cm -n tigera-operator modsecurity-ruleset
    ```
 2. Look for `SecRuleEngine DetectionOnly` and change it to `SecRuleEngine On`.
-3. Save your changes. This triggers a rolling update of the L7 pods. 
+3. Save your changes. This triggers a rolling update of the L7 pods.
 
 | Action | Description                                                                                                                                                             | Disruptive? |
 | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
 | DetectionOnly | Traffic is not denied nor dropped. {{prodname}}  will log events. | No
 | On     | Denies HTTP traffic. {{prodname}}  will log the event in Security Events. | Yes          |
-| Off    | Be cautious about using this option. Traffic is not denied, and there are no events. |No                                                                      | Yes         |                                         
+| Off    | Be cautious about using this option. Traffic is not denied, and there are no events. |No                                                                      | Yes         |
 
-#### Change anomaly scoring threshold 
+#### Change anomaly scoring threshold
 
-The default scoring threshold is set to 100, a high value that is unlikely to result in blocked requests, even if blocking mode is enabled. A critical rule violation scores 5 by default so a single HTTP request would need many rule violations to pass the default threshold of 100. You are encouraged to fine-tune and lower this threshold value iteratively until you are happy with the requests being allowed and denied for your cluster. 
+The default scoring threshold is set to 100, a high value that is unlikely to result in blocked requests, even if blocking mode is enabled. A critical rule violation scores 5 by default so a single HTTP request would need many rule violations to pass the default threshold of 100. You are encouraged to fine-tune and lower this threshold value iteratively until you are happy with the requests being allowed and denied for your cluster.
 
-1. Edit the `crs-setup.conf` file and set `tx.inbound_anomaly_score_threshold` to the value of your choice: 
+1. Edit the `crs-setup.conf` file and set `tx.inbound_anomaly_score_threshold` to the value of your choice:
    ```bash
      SecAction \
       "id:900110,\
@@ -268,18 +268,18 @@ The default scoring threshold is set to 100, a high value that is unlikely to re
    ```
 
 These are the default scoring points for each severity level, applied to each rule individually.
-The lower the overall anomaly scoring threshold value is, the more likely it is that traffic will be denied. 
+The lower the overall anomaly scoring threshold value is, the more likely it is that traffic will be denied.
 
 | Severity | Score                                                                                                                                                             | Description |
 | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
 | Critical | 5 | Mostly generated by the application attack rules (93x and 94x files)
 | Error     | 4 | Generated mostly from outbound leakage rules (95x files) |
-| Warning    | 3 | Generated mostly by malicious client rules (91x files) | 
-| Notice    | 2 | Generated mostly by the protocol rules (92x files) | 
+| Warning    | 3 | Generated mostly by malicious client rules (91x files) |
+| Notice    | 2 | Generated mostly by the protocol rules (92x files) |
 
 #### Change other default settings
 
-The CoreRuleSet has several default values and settings that you can fine-tune. Example: Rule 920420 checks the HTTP request Content-Type header against a list of allowed values. You may want to allow traffic through the WAF that has a certain Content-Type that is not allowed by default, e.g. you may have Content-Types in your micro-services workloads that are not allowed by default. 
+The CoreRuleSet has several default values and settings that you can fine-tune. Example: Rule 920420 checks the HTTP request Content-Type header against a list of allowed values. You may want to allow traffic through the WAF that has a certain Content-Type that is not allowed by default, e.g. you may have Content-Types in your micro-services workloads that are not allowed by default.
 
 1. Edit the `crs-setup.conf` file and add a new Content-Type by modifying `id:900220` and appending to the default list named `tx.allowed_request_content_type`
 
@@ -293,7 +293,7 @@ The CoreRuleSet has several default values and settings that you can fine-tune. 
       setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json| |application/grpc|'"
   ```
 
-#### Disable certain rules 
+#### Disable certain rules
 
 You may want to disable a rule entirely. For example, if you find the allowed Content-Type rule mentioned above too restrictive, you can disable it unconditionally by changing `RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf.example` and renaming that file to remove the `.example`:
 
@@ -312,9 +312,7 @@ To view WAF events in a centralized security events dashboard, go to: **Threat d
 
 #### Kibana
 
-To view WAF events In Kibana:
-
-1. Select the `tigera_secure_ee_waf*` index pattern. 
+To view WAF events In Kibana, select the `tigera_secure_ee_waf*` index pattern.
 
 #### Disable WAF for a service
 

--- a/calico-enterprise_versioned_docs/version-3.16/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/threat/web-application-firewall.mdx
@@ -151,12 +151,7 @@ In Service Graph, go to the service and click the HTTP tab. You will see the fol
 
 #### Kibana
 
-To view WAF events In Kibana:
-
-1. Create the `tigera_secure_ee_waf*` index pattern. For help with index patterns, see [Kibana index pattern](../visibility/kibana.mdx).
-2. Select the `tigera_secure_ee_waf*` index pattern. 
-
-You should see the relevant WAF assessment from your request.
+To view WAF events In Kibana, select the `tigera_secure_ee_waf*` index pattern.
 
 ### Create global alerts
 

--- a/calico-enterprise_versioned_docs/version-3.17/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/threat/web-application-firewall.mdx
@@ -262,13 +262,7 @@ In Service Graph, go to the service and click the HTTP tab. You will see the fol
 
 #### Kibana
 
-To view WAF events In Kibana:
-
-1. Create the `tigera_secure_ee_waf*` index pattern. For help with index patterns, see [Kibana index pattern](../visibility/kibana).
-
-2. Select the `tigera_secure_ee_waf*` index pattern. 
-
-You should see the relevant WAF assessment from your request.
+To view WAF events In Kibana, select the `tigera_secure_ee_waf*` index pattern.
 
 ### Create global alerts
 

--- a/calico-enterprise_versioned_docs/version-3.18/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18/threat/web-application-firewall.mdx
@@ -312,9 +312,7 @@ To view WAF events in a centralized security events dashboard, go to: **Threat d
 
 #### Kibana
 
-To view WAF events In Kibana:
-
-1. Select the `tigera_secure_ee_waf*` index pattern. 
+To view WAF events In Kibana, select the `tigera_secure_ee_waf*` index pattern.
 
 #### Disable WAF for a service
 


### PR DESCRIPTION
 Get rid of `tigera_secure_ee_waf*` index pattern creation for 3.16+ versions as this is no longer required.

Product Version(s):
CC and EE 3.16 and up.

Issue:
https://tigera.atlassian.net/browse/RS-1197

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->