### PR TITLE
waf updates to 'next' with content from calient 3.18

### DIFF
--- a/calico-enterprise/threat/web-application-firewall.mdx
+++ b/calico-enterprise/threat/web-application-firewall.mdx
@@ -16,13 +16,9 @@ Protect cloud-native applications from application layer attacks with {{prodname
 
 ## Value
 
-A web application firewall (WAF) protects web applications from a variety of application layer attacks such as [cross-site scripting (XSS)](https://www.f5.com/services/resources/glossary/cross-site-scripting-xss-or-css), [SQL injection](https://www.f5.com/services/resources/glossary/sql-injection), and [cookie poisoning](https://www.f5.com/services/resources/glossary/cookie-poisoning), among others. Given that attacks on apps are the [leading cause of breaches](https://www.f5.com/labs/articles/threat-intelligence/application-protection-report-2019--episode-2--2018-breach-trend), you need to protect the HTTP traffic that provides a gateway to valuable app data.
+Our workload-centric Web Application Firewall (WAF) protects your workloads from a variety of application layer attacks originating from within your cluster such as [SQL injection](https://owasp.org/www-community/attacks/SQL_Injection). Given that attacks on apps are the [leading cause of breaches](https://www.f5.com/labs/articles/threat-intelligence/application-protection-report-2019--episode-2--2018-breach-trend), you need to secure the HTTP traffic inside your cluster.
 
 Historically, web application firewalls (WAFs) were deployed at the edge of your cluster to filter incoming traffic. Our workload-based WAF solution takes a unique, cloud-native approach to web security by allowing you to implement zero-trust rules for workloads inside your cluster.
-
-{{prodname}} WAF allows you to selectively run service traffic within your cluster, and protect intra-cluster traffic from common HTTP-layer attacks such as SQL injection, and cross-site request forgery. To increase protection, you can use {{prodname}} network policies to enforce security controls on selected pods on the host.
-
-In addition to protecting against application layer attacks, any blocked HTTP requests are logged and available in Elasticsearch for review. You can also create global alerts based on these logs.
 
 ## Features
 
@@ -34,10 +30,18 @@ This how-to-guide uses the following {{prodname}} features:
 
 ### About {{prodname}} WAF
 
-WAF is deployed in your cluster as an Envoy DaemonSet. {{prodname}} proxies selected service traffic through Envoy, checking HTTP requests using the industry-standard 
-[ModSecurity module](https://owasp.org/www-project-modsecurity-core-rule-set/). To view the rule set that is bundled with WAF, see [rule-set](https://github.com/coreruleset/coreruleset/blob/v3.4/dev/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf).
+WAF is deployed in your cluster along with Envoy DaemonSet. {{prodname}} proxies selected service traffic through Envoy, checking HTTP requests using the industry-standard 
+[ModSecurity](https://owasp.org/www-project-modsecurity-core-rule-set/) with OWASP CoreRuleSet v3.3.5 modified for kubernetes workloads. To review the rules deployed with the WAF, see [Ruleset files](https://github.com/tigera/operator/tree/master/pkg/render/applicationlayer/modsec-core-ruleset).
 
-You simply enable WAF in Manager UI, and determine the services that you want to enable for WAF protection. You can view WAF events as HTTP logs in Service Graph and Kibana. And you can set up global alerts to get notifications on the Alerts page. 
+You simply enable WAF in Manager UI, and determine the services that you want to enable for WAF protection. By default WAF is set to `DetectionOnly` so no traffic will be denied until you are ready to turn on blocking mode. 
+
+Every request that WAF finds an issue with, will result in a Security Event being created for [you to review in the UI](#view-waf-events), regardless of whether the traffic was allowed or denied. This can greatly help in tuning later.  
+
+#### How WAF determines if a request should be allowed or denied
+
+If you configure WAF in blocking mode, WAF will use something called [anomaly scoring mode](https://coreruleset.org/docs/concepts/anomaly_scoring/) to determine if a request is allowed with `200 OK` or denied `403 Forbidden`. 
+
+This works by matching a single HTTP request against all the configured WAF rules. Each rule has a score and WAF adds all the matched rule scores together, and compares it to the overall anomaly threshold score (100 by default). If the score is under the threshold the request is allowed and if the score is over the threshold the request is denied. Our WAF starts in detection mode only and with a high default scoring threshold so is safe to turn on and then [fine-tune the WAF](#fine-tuning-your-waf) for your specific needs in your cluster.
 
 ## Before you begin
 
@@ -72,25 +76,21 @@ Enabling WAF for certain system services may result in an undesired cluster stat
   - name: `openshift`, namespace: `default`
   - name: `gatekeeper-webhook-service`, namespace: `gatekeeper-system`
 
+The rules are not overridden during upgrade, you will have to manage deploying updates to the OWASP CoreRuleSet to the cluster over time. 
+
+If you modify the rules, it is recommended to keep your rules in git or similar source control systems.
+
 :::
 
 ## How to
 
-- [Enable WAF using CLI](#enable-waf-using-cli)
-- [Enable WAF using Manager UI](#enable-waf-using-manager-ui)
-- [Apply WAF to services](#apply-waf-to-services)
+- [Enable WAF on your cluster](#enable-waf)
+- [Apply WAF to your services](#apply-waf)
 - [View WAF events](#view-waf-events)
+- [Fine-tuning your WAF](#fine-tuning-your-waf)
 - [Disable WAF feature from your cluster](#disable-waf-feature-from-your-cluster)
 
-### Enable WAF using CLI
-
-To enable WAF using the CLI rather than in Manager UI, or you have not yet
-[configured L7 logs](../visibility/elastic/l7/Configure), you must enable the Policy Sync API in Felix. To do this cluster-wide,
-modify the `default` FelixConfiguration to set the field `policySyncPathPrefix` to `/var/run/nodeagent`:
-
-```bash
-kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"policySyncPathPrefix":"/var/run/nodeagent"}}'
-```
+### Enable WAF
 
 #### (Optional) Deploy a sample application
 If you don’t have an application to test WAF with or don’t want to use it right away against your own application,
@@ -100,7 +100,17 @@ we recommend that you install the [GoogleCloudPlatform/microservices-demo app](h
 kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/release/v0.7.0/release/kubernetes-manifests.yaml
 ```
 
-#### Enable WAF using kubectl CLIs
+#### Enable WAF using the CLI
+
+##### Enable the Policy Sync API in Felix
+To enable WAF using the CLI, you must enable the Policy Sync API in Felix. To do this cluster-wide,
+modify the `default` FelixConfiguration to set the field `policySyncPathPrefix` to `/var/run/nodeagent`:
+
+```bash
+kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"policySyncPathPrefix":"/var/run/nodeagent"}}'
+```
+
+##### Enable WAF using kubectl
 
 In the ApplicationLayer custom resource, named `tigera-secure`, set the `webApplicationFirewall` field to `Enabled`.
 
@@ -115,7 +125,7 @@ spec:
 EOF
 ```
 
-### Enable WAF using Manager UI
+#### Enable WAF using the UI
 
 On the Manager UI, click **Threat Defense**, **Web Application Firewall**, **Configure Web Application Firewall**.
 
@@ -125,26 +135,18 @@ On the Manager UI, click **Threat Defense**, **Web Application Firewall**, **Con
     width='600'
   />
 
-:::note
-
-If WAF is already enabled in your cluster, you do not see this page.
-:::
-
 ### Apply WAF to services
 
-Now that your cluster is enabled for WAF, you can apply WAF to your services and make sure that your
-Web apps are protected from application layer attacks. 
+Now that you have deployed WAF in your cluster, you can select the services you want to protect from application layer attacks. 
 
 If you have deployed the sample application, you can apply WAF on a service associated with your app, as follows:
-
 ```bash
 kubectl annotate svc frontend -n default --overwrite projectcalico.org/l7-logging=true
 ```
 Alternatively, you can use the Manager UI to apply WAF to the `frontend` service.
 
 In this example, we applied WAF to the `frontend` service. This means that every request that goes through the `frontend` service is inspected.
-However, the traffic is not blocked because the WAF rule is set to `DetectionOnly` by default.  
-When you are convinced that the traffic for the service to be denied or dropped, you can [set it to block](#set-waf-rule-to-block-traffic).
+However, the traffic is not blocked because the WAF rule is set to `DetectionOnly` by default. You can then begin [fine-tuning your WAF](#fine-tuning-your-waf). 
 
 In the previous example, we applied WAF to the `frontend` service of the sample application. Here, we are
 applying WAF to a service of your own application.
@@ -164,33 +166,32 @@ applying WAF to a service of your own application.
 
 You have now applied WAF rule sets to your own services, and note that the traffic that goes through the selected services will be alerted but not blocked by default.
 
-#### Set WAF rule to block traffic
-You can change WAF rule so that the traffic is blocked.
+#### Trigger a WAF event
+If you would like to trigger a WAF event for testing purposes, you can simulate an SQL injection attack inside your cluster by crafting a HTTP request with a query string that WAF will detect as an SQL injection attempt. 
+The query string in this example has some SQL syntax embedded in the text. This is harmless and for demo purposes, but WAF will detect this pattern and create an event for this HTTP request. 
 
-1. Edit the configmap: 
-   ```bash
-   kubectl edit cm -n tigera-operator modsecurity-ruleset
-   ```
-2. Look for `SecRuleEngine DetectionOnly` and change it to `SecRuleEngine On`.
+Run a simple curl command from any pod inside your cluster targeting a service you have selected for WAF protection e.g. from the demo app above we could attempt to send a simple HTTP request to the cartservice.
+```
+  curl http://cartservice/cart?artist=0+div+1+union%23foo*%2F*bar%0D%0Aselect%23foo%0D%0A1%2C2%2Ccurrent_user
+```
 
-| Action | Description                                                                                                                                                             | Disruptive? |
-| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| DetectionOnly | Traffic is not denied nor dropped. {{prodname}}  will log events. | No
-| On     | Denies HTTP traffic. {{prodname}}  will create a security event. | Yes          |
-| Off    | Be cautious about using this option. Traffic is not denied nor alerted. |No                                                                      | Yes         |
-                                         
+### Fine-tuning your WAF 
 
-#### Manage rulesets
-
+#### Manage your rules
 The default rulesets work fine for most deployments. However, you can customize them to suit your requirements.
 
-By default, {{prodname}} ships with CoreRuleset v3.x with the following setup files pre-loaded:
+By default, {{prodname}} ships with CoreRuleset v3.3.5 with the following setup files pre-loaded:
 
 - [modsecdefault.conf](https://github.com/tigera/operator/blob/master/pkg/render/applicationlayer/modsec-core-ruleset/modsecdefault.conf)
 - [crs-setup.conf](https://github.com/tigera/operator/blob/master/pkg/render/applicationlayer/modsec-core-ruleset/crs-setup.conf)
 - [Ruleset files](https://github.com/tigera/operator/tree/master/pkg/render/applicationlayer/modsec-core-ruleset)
 
-To start creating your rules, it is recommended that you download the files (all three) and create your modifications from there, as follows:
+There are two ways to edit your rules. 
+1. Edit the configmap directly using kubectl. The config map combines all the rule files together, so you will need to know how to search and find the exact place in the configmap that you want to update. 
+
+2. If you want to modify the rules in any meaningful way, it is recommended that you download the files locally and modify before replacing the configmap. In OWASP, it is recommended you disable rules or change configuration by modifying a set of specific metadata files and exclusion files, and not modify any of the main rule files directly. You can, of course, decide to replace the ruleset entirely with your own set of custom rules. This is completely fine once the rules are written in the same SecRule syntax understood by ModSecurity. We recommend you keep a version of your rule files safe in version control like git.
+
+To download and modify the rule files:
 
 1. Clone our operator code which contains the ConfigMap source.
 
@@ -202,12 +203,13 @@ To start creating your rules, it is recommended that you download the files (all
   ```bash
   cd pkg/render/applicationlayer/modsec-core-ruleset
   ```
-3. Create a ConfigMap.
+3. Make the changes you want in the setup, conf or exclusiong files and save.
+4. Create a ConfigMap.
 
   ```bash
   kubectl create cm --dry-run=client --from-file=. -o yaml -n tigera-operator modsecurity-ruleset > $HOME/my-tigera-waf-ruleset.yaml
   ```
-4. Apply the ConfigMap to your cluster.
+5. Apply the ConfigMap to your cluster.
 
   ```bash
   kubectl replace -f $HOME/my-tigera-waf-ruleset.yaml
@@ -225,35 +227,79 @@ In many scenarios, the default example CRS configuration will be a good enough s
 you deploy it to make sure it’s right for your environment.
 :::
 
+
+#### Set WAF rule to block traffic
+By default WAF will not block a request even if it has matching rule violations. The rule engine is set to `DetectionOnly`. You can configure to block traffic instead with an `HTTP 403 Forbidden` response status code when the combined matched rules scores exceed a certain threshold. 
+
+1. Edit the configmap: 
+   ```bash
+   kubectl edit cm -n tigera-operator modsecurity-ruleset
+   ```
+2. Look for `SecRuleEngine DetectionOnly` and change it to `SecRuleEngine On`.
+3. Save your changes. This triggers a rolling update of the L7 pods. 
+
+| Action | Description                                                                                                                                                             | Disruptive? |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| DetectionOnly | Traffic is not denied nor dropped. {{prodname}}  will log events. | No
+| On     | Denies HTTP traffic. {{prodname}}  will log the event in Security Events. | Yes          |
+| Off    | Be cautious about using this option. Traffic is not denied, and there are no events. |No                                                                      | Yes         |                                         
+
+#### Change anomaly scoring threshold 
+
+The default scoring threshold is set to 100, a high value that is unlikely to result in blocked requests, even if blocking mode is enabled. A critical rule violation scores 5 by default so a single HTTP request would need many rule violations to pass the default threshold of 100. You are encouraged to fine-tune and lower this threshold value iteratively until you are happy with the requests being allowed and denied for your cluster. 
+
+1. Edit the `crs-setup.conf` file and set `tx.inbound_anomaly_score_threshold` to the value of your choice: 
+   ```bash
+     SecAction \
+      "id:900110,\
+      phase:1,\
+      nolog,\
+      pass,\
+      t:none,\
+      setvar:tx.inbound_anomaly_score_threshold=100,\
+      setvar:tx.outbound_anomaly_score_threshold=100"
+   ```
+
+These are the default scoring points for each severity level, applied to each rule individually.
+The lower the overall anomaly scoring threshold value is, the more likely it is that traffic will be denied. 
+
+| Severity | Score                                                                                                                                                             | Description |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| Critical | 5 | Mostly generated by the application attack rules (93x and 94x files)
+| Error     | 4 | Generated mostly from outbound leakage rules (95x files) |
+| Warning    | 3 | Generated mostly by malicious client rules (91x files) | 
+| Notice    | 2 | Generated mostly by the protocol rules (92x files) | 
+
+#### Change other default settings
+
+The CoreRuleSet has several default values and settings that you can fine-tune. Example: Rule 920420 checks the HTTP request Content-Type header against a list of allowed values. You may want to allow traffic through the WAF that has a certain Content-Type that is not allowed by default, e.g. you may have Content-Types in your micro-services workloads that are not allowed by default. 
+
+1. Edit the `crs-setup.conf` file and add a new Content-Type by modifying `id:900220` and appending to the default list named `tx.allowed_request_content_type`
+
+  ```bash
+    SecAction \
+     "id:900220,\
+      phase:1,\
+      nolog,\
+      pass,\
+      t:none,\
+      setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json| |application/grpc|'"
+  ```
+
+#### Disable certain rules 
+
+You may want to disable a rule entirely. For example, if you find the allowed Content-Type rule mentioned above too restrictive, you can disable it unconditionally by changing `RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf.example` and renaming that file to remove the `.example`:
+
+1. Edit `RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf.example` and add the rule ID you want to disable
+
+  ```bash
+  SecRuleRemoveById 920420
+  ```
+2. Rename `RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf.example` to `RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf` removing the *.example* in order for ModSecurity to load the file.
+
 ### View WAF events
 
-#### Service Graph
-
-To view WAF events in Service Graph,
-
-1. Select a service.
-2. Click the HTTP tab.
-
-To simulate an attack to view the default warning in Service Graph, follow these steps:
-
-1. Get the cluster/service URL.
-   - The external address of your cluster/service
-   - The cluster IP of your application's service (if testing within the cluster)
-2. Enter the following command to trigger a SQL injection attack.
-
-#### Example: SQL Injection attack
-
-```
-  curl http://my.loadbalancer.address/cart?artist=0+div+1+union%23foo*%2F*bar%0D%0Aselect%23foo%0D%0A1%2C2%2Ccurrent_user
-```
-
-In Service Graph, go to the service and click the HTTP tab. You will see the following warning:
-
-```
-  level=warning msg="WAF Process Http Request [2f435aca-4a3e-4f96-a7b2-a60c9745bd7b] URL '/test/artists.php?artist=0+div+1+union%23foo*%2F*bar%0D%0Aselect%23foo%0D%0A1%2C2%2Ccurrent_user' OWASP Warning'[2] Host:'10.224.0.38' File:'/etc/modsecurity-ruleset/REQUEST-942-APPLICATION-ATTACK-SQLI.conf' Line:'45' ID:'942100' Data:'' Severity:'0' Version:'OWASP_CRS/3.3.2' Message:'Warning. detected SQLi using libinjection.''"
-```  
-
-#### Threat defense
+#### Security Events
 
 To view WAF events in a centralized security events dashboard, go to: **Threat defense**, **Security Events**. For help, see [Security Event Management](../threat/security-event-management).
 
@@ -261,11 +307,7 @@ To view WAF events in a centralized security events dashboard, go to: **Threat d
 
 To view WAF events In Kibana:
 
-1. Create the `tigera_secure_ee_waf*` index pattern. For help with index patterns, see [Kibana index pattern](../visibility/kibana).
-
-2. Select the `tigera_secure_ee_waf*` index pattern. 
-
-You should see the relevant WAF assessment from your request.
+1. Select the `tigera_secure_ee_waf*` index pattern. 
 
 #### Disable WAF for a service
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Original PR: tigera/docs#915

> Adds a section explaining anomaly scoring and how the WAF works now.
> Also adds a detailed fine-tuning section about how a user can configure their WAF in several ways.>
> Corrects several inaccuracies such as WAF events appearing in service graph on HTTP tab.


this PR, however, copies the contents of above original PR to the 'next' section.

Product Version(s):
Calico Enterprise, Calico Cloud

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->