### PR TITLE
DOCS-Fix-heading-component-versions

### DIFF
--- a/calico-enterprise/_includes/components/ComponentVersions.js
+++ b/calico-enterprise/_includes/components/ComponentVersions.js
@@ -37,7 +37,7 @@ export default function ComponentVersions() {
             id={`component-versions-${toKebab(release.title)}`}
             data-bz-version={toKebab(release.title)}
           >
-            Component versions for {variables.prodname} {variables.releaseTitle.startsWith('v') ? variables.releaseTitle.substring(1) : variables.releaseTitle}
+            Component versions for {variables.prodname} {release.title.startsWith('v') ? release.title.substring(1) : release.title}
           </Heading>
           <p>
             {release.title !== 'master' && (

--- a/calico-enterprise_versioned_docs/version-3.18/_includes/components/ComponentVersions.js
+++ b/calico-enterprise_versioned_docs/version-3.18/_includes/components/ComponentVersions.js
@@ -37,7 +37,7 @@ export default function ComponentVersions() {
             id={`component-versions-${toKebab(release.title)}`}
             data-bz-version={toKebab(release.title)}
           >
-            Component versions for {variables.prodname} {variables.releaseTitle.startsWith('v') ? variables.releaseTitle.substring(1) : variables.releaseTitle}
+            Component versions for {variables.prodname} {release.title.startsWith('v') ? release.title.substring(1) : release.title}
           </Heading>
           <p>
             {release.title !== 'master' && (

--- a/calico/_includes/components/ComponentVersions.js
+++ b/calico/_includes/components/ComponentVersions.js
@@ -37,7 +37,7 @@ export default function ComponentVersions() {
             id={`component-versions-${toKebab(release.title)}`}
             data-bz-version={toKebab(release.title)}
           >
-            Component versions for {variables.prodname} {variables.releaseTitle.startsWith('v') ? variables.releaseTitle.substring(1) : variables.releaseTitle}
+            Component versions for {variables.prodname} {release.title.startsWith('v') ? release.title.substring(1) : release.title}
           </Heading>
           <p>
             {release.title !== 'master' && (


### PR DESCRIPTION
3.18 heading in /Reference/component versions is not displaying correct title.

Product Version(s):
CE 3.18, 3.19

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->