### PR TITLE
DOCS-1921: Adds broken component to MDXComponents.js

### DIFF
--- a/calico-enterprise/operations/clis/calicoq/installing.mdx
+++ b/calico-enterprise/operations/clis/calicoq/installing.mdx
@@ -4,8 +4,6 @@ description: Install the CLI for Calico Enterprise.
 
 # Install calicoq
 
-import MaintenanceClisCalicoqInstalling from '@site/calico-enterprise/_includes/components/MaintenanceClisCalicoqInstalling';
-
 ## About installing calicoq
 
 You can run `calicoq` on any host with network access to the

--- a/calico-enterprise_versioned_docs/version-3.15/operations/clis/calicoq/installing.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/operations/clis/calicoq/installing.mdx
@@ -4,8 +4,6 @@ description: Install the CLI for Calico Enterprise.
 
 # Install calicoq
 
-import MaintenanceClisCalicoqInstalling from '@site/calico-enterprise/_includes/components/MaintenanceClisCalicoqInstalling';
-
 ## About installing calicoq
 
 You can run `calicoq` on any host with network access to the

--- a/calico-enterprise_versioned_docs/version-3.16/operations/clis/calicoq/installing.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/operations/clis/calicoq/installing.mdx
@@ -4,8 +4,6 @@ description: Install the CLI for Calico Enterprise.
 
 # Install calicoq
 
-import MaintenanceClisCalicoqInstalling from '@site/calico-enterprise/_includes/components/MaintenanceClisCalicoqInstalling';
-
 ## About installing calicoq
 
 You can run `calicoq` on any host with network access to the

--- a/calico-enterprise_versioned_docs/version-3.17/operations/clis/calicoq/installing.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/operations/clis/calicoq/installing.mdx
@@ -4,8 +4,6 @@ description: Install the CLI for Calico Enterprise.
 
 # Install calicoq
 
-import MaintenanceClisCalicoqInstalling from '@site/calico-enterprise/_includes/components/MaintenanceClisCalicoqInstalling';
-
 ## About installing calicoq
 
 You can run `calicoq` on any host with network access to the

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -39,6 +39,7 @@ const partials = [
   'PrivateRegistryImagePath',
   'GettingStartedInstallOnClustersKubernetesHelm',
   'ComponentVersions',
+  'MaintenanceClisCalicoqInstalling',
 ];
 
 const wrappedPartials = wrapPartials(partials);
@@ -213,6 +214,9 @@ function getCalicoEnterpriseVersionedComponent(version, componentName) {
         .default;
     case 'ComponentVersions':
       return require(`../../calico-enterprise_versioned_docs/version-${version}/_includes/components/ComponentVersions`)
+        .default;
+    case 'MaintenanceClisCalicoqInstalling':
+      return require(`../../calico-enterprise_versioned_docs/version-${version}/_includes/components/MaintenanceClisCalicoqInstalling`)
         .default;
     default:
       console.error(`Versioned ${componentName} component isn't registered for Calico Enterprise`);


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Bug fix. The calicoq download URL didn't display correctly for CE 3.17+. This PR adds a component to the list of MDXComponents.js, which allows it to display correctly for different versions.


Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->