### PR TITLE
Minikube fix

### DIFF
--- a/calico/getting-started/kubernetes/minikube.mdx
+++ b/calico/getting-started/kubernetes/minikube.mdx
@@ -54,7 +54,7 @@ If `192.168.0.0/16` is already in use within your network you must select a diff
 :::
 
 ```bash
-minikube start --network-plugin=cni --extra-config=kubeadm.pod-network-cidr=192.168.0.0/16
+minikube start --cni=false --network-plugin=cni --extra-config=kubeadm.pod-network-cidr=192.168.0.0/16 --subnet=172.16.0.0/24
 ```
 
 2. Install the Tigera {{prodname}} operator and custom resource definitions.

--- a/calico_versioned_docs/version-3.24/getting-started/kubernetes/minikube.mdx
+++ b/calico_versioned_docs/version-3.24/getting-started/kubernetes/minikube.mdx
@@ -54,7 +54,7 @@ If `192.168.0.0/16` is already in use within your network you must select a diff
 :::
 
 ```bash
-minikube start --network-plugin=cni --extra-config=kubeadm.pod-network-cidr=192.168.0.0/16
+minikube start --cni=false --network-plugin=cni --extra-config=kubeadm.pod-network-cidr=192.168.0.0/16 --subnet=172.16.0.0/24
 ```
 
 2. Install the Tigera {{prodname}} operator and custom resource definitions.

--- a/calico_versioned_docs/version-3.25/getting-started/kubernetes/minikube.mdx
+++ b/calico_versioned_docs/version-3.25/getting-started/kubernetes/minikube.mdx
@@ -54,7 +54,7 @@ If `192.168.0.0/16` is already in use within your network you must select a diff
 :::
 
 ```bash
-minikube start --network-plugin=cni --extra-config=kubeadm.pod-network-cidr=192.168.0.0/16
+minikube start --cni=false --network-plugin=cni --extra-config=kubeadm.pod-network-cidr=192.168.0.0/16 --subnet=172.16.0.0/24
 ```
 
 2. Install the Tigera {{prodname}} operator and custom resource definitions.

--- a/calico_versioned_docs/version-3.26/getting-started/kubernetes/minikube.mdx
+++ b/calico_versioned_docs/version-3.26/getting-started/kubernetes/minikube.mdx
@@ -54,7 +54,7 @@ If `192.168.0.0/16` is already in use within your network you must select a diff
 :::
 
 ```bash
-minikube start --network-plugin=cni --extra-config=kubeadm.pod-network-cidr=192.168.0.0/16
+minikube start --cni=false --network-plugin=cni --extra-config=kubeadm.pod-network-cidr=192.168.0.0/16 --subnet=172.16.0.0/24
 ```
 
 2. Install the Tigera {{prodname}} operator and custom resource definitions.


### PR DESCRIPTION
This change fixes minikube pod-cidr allocation for an operator install

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->