### PR TITLE
DOCS-1919-Add-port-requirement

### DIFF
--- a/calico-cloud/_includes/components/ReqsSys.js
+++ b/calico-cloud/_includes/components/ReqsSys.js
@@ -359,6 +359,13 @@ function NetworkRequirementsEnt(props) {
             <td>Additional port required for Manager UI</td>
             <td>TCP 9449</td>
           </tr>
+          <tr className='odd'>
+            <td>
+              <strong>Egress gateway</strong>
+            </td>
+            <td>{prodname} egress gateway</td>
+            <td>UDP 4790</td>
+          </tr>
         </tbody>
       </table>
       {(props.orch === orchestrators.Kubernetes || props.orch === orchestrators.OpenShift) && (

--- a/calico-cloud/networking/egress/egress-gateway-aws.mdx
+++ b/calico-cloud/networking/egress/egress-gateway-aws.mdx
@@ -205,6 +205,7 @@ an instance (for example when scaling up the cluster).
 **Required**
 
 - Calico CNI
+- Open port UDP 4790 on the host
 
 **Not Supported**
 

--- a/calico-cloud/networking/egress/egress-gateway-azure.mdx
+++ b/calico-cloud/networking/egress/egress-gateway-azure.mdx
@@ -112,6 +112,7 @@ Azure Route Server deployment is per VNet, as such each VNet with egress gateway
 **Required**
 
 - Calico CNI
+- Open port UDP 4790 on the host
 
 **Not Supported**
 

--- a/calico-cloud/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-cloud/networking/egress/egress-gateway-on-prem.mdx
@@ -171,6 +171,7 @@ patch release.
 **Required**
 
 - Calico CNI
+- Open port UDP 4790 on the host
 
 ## How to
 

--- a/calico-cloud_versioned_docs/version-18/_includes/components/ReqsSys.js
+++ b/calico-cloud_versioned_docs/version-18/_includes/components/ReqsSys.js
@@ -359,6 +359,13 @@ function NetworkRequirementsEnt(props) {
             <td>Additional port required for Manager UI</td>
             <td>TCP 9449</td>
           </tr>
+          <tr className='odd'>
+            <td>
+              <strong>Egress gateway</strong>
+            </td>
+            <td>{prodname} egress gateway</td>
+            <td>UDP 4790</td>
+          </tr>
         </tbody>
       </table>
       {(props.orch === orchestrators.Kubernetes || props.orch === orchestrators.OpenShift) && (

--- a/calico-cloud_versioned_docs/version-18/networking/egress/egress-gateway-aws.mdx
+++ b/calico-cloud_versioned_docs/version-18/networking/egress/egress-gateway-aws.mdx
@@ -205,6 +205,7 @@ an instance (for example when scaling up the cluster).
 **Required**
 
 - Calico CNI
+- Open port UDP 4790 on the host
 
 **Not Supported**
 

--- a/calico-cloud_versioned_docs/version-18/networking/egress/egress-gateway-azure.mdx
+++ b/calico-cloud_versioned_docs/version-18/networking/egress/egress-gateway-azure.mdx
@@ -112,6 +112,7 @@ Azure Route Server deployment is per VNet, as such each VNet with egress gateway
 **Required**
 
 - Calico CNI
+- Open port UDP 4790 on the host
 
 **Not Supported**
 

--- a/calico-cloud_versioned_docs/version-18/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-cloud_versioned_docs/version-18/networking/egress/egress-gateway-on-prem.mdx
@@ -171,6 +171,7 @@ patch release.
 **Required**
 
 - Calico CNI
+- Open port UDP 4790 on the host
 
 ## How to
 

--- a/calico-enterprise/_includes/components/ReqsSys.js
+++ b/calico-enterprise/_includes/components/ReqsSys.js
@@ -378,6 +378,13 @@ function NetworkRequirementsEnt(props) {
             <td>Additional port required for Manager UI</td>
             <td>TCP 9449</td>
           </tr>
+         <tr className='odd'>
+            <td>
+              <strong>Egress gateway</strong>
+            </td>
+            <td>{prodname} egress gateway </td>
+            <td>UDP 4790 </td>
+          </tr>
         </tbody>
       </table>
       {(props.orch === orchestrators.Kubernetes || props.orch === orchestrators.OpenShift) && (

--- a/calico-enterprise/networking/egress/egress-gateway-aws.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-aws.mdx
@@ -205,6 +205,7 @@ an instance (for example when scaling up the cluster).
 **Required**
 
 - Calico CNI
+- Open port UDP 4790 on the host
 
 **Not Supported**
 

--- a/calico-enterprise/networking/egress/egress-gateway-azure.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-azure.mdx
@@ -112,6 +112,7 @@ Azure Route Server deployment is per VNet, as such each VNet with egress gateway
 **Required**
 
 - Calico CNI
+- Open port UDP 4790 on the host
 
 **Not Supported**
 

--- a/calico-enterprise/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-on-prem.mdx
@@ -171,6 +171,7 @@ patch release.
 **Required**
 
 - Calico CNI
+- Open port UDP 4790 on the host
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.15/_includes/components/ReqsSys.js
+++ b/calico-enterprise_versioned_docs/version-3.15/_includes/components/ReqsSys.js
@@ -358,6 +358,13 @@ function NetworkRequirementsEnt(props) {
             <td>Additional port required for Manager UI</td>
             <td>TCP 9449</td>
           </tr>
+          <tr className='odd'>
+            <td>
+              <strong>Egress gateway</strong>
+            </td>
+            <td>{prodname} egress gateway</td>
+            <td>UDP 4790</td>
+          </tr>
         </tbody>
       </table>
       {(props.orch === orchestrators.Kubernetes || props.orch === orchestrators.OpenShift) && (

--- a/calico-enterprise_versioned_docs/version-3.16/_includes/components/ReqsSys.js
+++ b/calico-enterprise_versioned_docs/version-3.16/_includes/components/ReqsSys.js
@@ -378,6 +378,13 @@ function NetworkRequirementsEnt(props) {
             <td>Additional port required for Manager UI</td>
             <td>TCP 9449</td>
           </tr>
+          <tr className='odd'>
+            <td>
+              <strong>Egress gateway</strong>
+            </td>
+            <td>{prodname} egress gateway</td>
+            <td>UDP 4790</td>
+          </tr>
         </tbody>
       </table>
       {(props.orch === orchestrators.Kubernetes || props.orch === orchestrators.OpenShift) && (

--- a/calico-enterprise_versioned_docs/version-3.17/_includes/components/ReqsSys.js
+++ b/calico-enterprise_versioned_docs/version-3.17/_includes/components/ReqsSys.js
@@ -378,6 +378,13 @@ function NetworkRequirementsEnt(props) {
             <td>Additional port required for Manager UI</td>
             <td>TCP 9449</td>
           </tr>
+            <tr className='odd'>
+            <td>
+              <strong>Egress gateway</strong>
+            </td>
+            <td>{prodname} egress gateway</td>
+            <td>UDP 4790</td>
+          </tr>
         </tbody>
       </table>
       {(props.orch === orchestrators.Kubernetes || props.orch === orchestrators.OpenShift) && (

--- a/calico-enterprise_versioned_docs/version-3.18/_includes/components/ReqsSys.js
+++ b/calico-enterprise_versioned_docs/version-3.18/_includes/components/ReqsSys.js
@@ -378,6 +378,13 @@ function NetworkRequirementsEnt(props) {
             <td>Additional port required for Manager UI</td>
             <td>TCP 9449</td>
           </tr>
+        <tr className='odd'>
+            <td>
+              <strong>Egress gateway</strong>
+            </td>
+            <td>{prodname} egress gateway</td>
+            <td>UDP 4790</td>
+          </tr>
         </tbody>
       </table>
       {(props.orch === orchestrators.Kubernetes || props.orch === orchestrators.OpenShift) && (


### PR DESCRIPTION
Add port to egress gateway docs and main sys req doc. 
- Verify if this port is default or changeable. 
- Verify nodes where ports are required to be opened 

Product Version(s):
CE and CC all unarchived

Issue:
https://tigera.atlassian.net/browse/DOCS-1919

Link to docs preview:
https://deploy-preview-1056--tigera.netlify.app/calico-enterprise/next/getting-started/install-on-clusters/requirements
https://deploy-preview-1056--tigera.netlify.app/calico-enterprise/next/networking/egress/egress-gateway-on-prem
https://deploy-preview-1056--tigera.netlify.app/calico-enterprise/next/networking/egress/egress-gateway-azure
https://deploy-preview-1056--tigera.netlify.app/calico-enterprise/next/networking/egress/egress-gateway-aws

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->