### PR TITLE
Regenerate generated Operator/IA API docs

### DIFF
--- a/calico-cloud/reference/installation/_api.mdx
+++ b/calico-cloud/reference/installation/_api.mdx
@@ -40,6 +40,8 @@ Resource Types:
 </li><li>
 <a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>
 </li><li>
+<a href="#operator.tigera.io/v1.Tenant">Tenant</a>
+</li><li>
 <a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>
 </li></ul>
 <h3 id="operator.tigera.io/v1.APIServer">APIServer
@@ -1333,7 +1335,21 @@ CalicoWindowsUpgradeDaemonSet
 </em>
 </td>
 <td>
-<p>CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.</p>
+<p>Deprecated. The CalicoWindowsUpgradeDaemonSet is deprecated and will be removed from the API in the future.
+CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoNodeWindowsDaemonSet</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+CalicoNodeWindowsDaemonSet
+</a>
+</em>
+</td>
+<td>
+<p>CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.</p>
 </td>
 </tr>
 <tr>
@@ -1363,6 +1379,32 @@ Logging
 <td>
 <em>(Optional)</em>
 <p>Logging Configuration for Components</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>windowsNodes</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+WindowsNodeSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Windows Configuration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceCIDRs</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Kubernetes Service CIDRs. Specifying this is required when using Calico for Windows.</p>
 </td>
 </tr>
 </table>
@@ -1453,6 +1495,20 @@ IntrusionDetectionSpec
 <em>(Optional)</em>
 <p>ComponentResources can be used to customize the resource requirements for each component.
 Only DeepPacketInspection is supported for this spec.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>anomalyDetection</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+AnomalyDetectionSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AnomalyDetection is now deprecated, and configuring it has no effect.</p>
 </td>
 </tr>
 </table>
@@ -1573,6 +1629,19 @@ CollectProcessPathOption
 <p>Configuration for enabling/disabling process path collection in flowlogs.
 If Enabled, this feature sets hostPID to true in order to read process cmdline.
 Default: Enabled</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>multiTenantManagementClusterNamespace</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>If running as a multi-tenant management cluster, the namespace in which
+the management cluster&rsquo;s tenant services are running.</p>
 </td>
 </tr>
 </table>
@@ -2171,6 +2240,89 @@ PolicyRecommendationSpec
 <em>
 <a href="#operator.tigera.io/v1.PolicyRecommendationStatus">
 PolicyRecommendationStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.Tenant">Tenant
+</h3>
+<p>Tenant is the Schema for the tenants API</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+operator.tigera.io/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>Tenant</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TenantSpec">
+TenantSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>id</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ID is the unique identifier for this tenant.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TenantStatus">
+TenantStatus
 </a>
 </em>
 </td>
@@ -2968,6 +3120,34 @@ Ready, Progressing, Degraded or other customer types.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="operator.tigera.io/v1.AnomalyDetectionSpec">AnomalyDetectionSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>storageClassName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>StorageClassName is now deprecated, and configuring it has no effect.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="operator.tigera.io/v1.ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
 (<code>string</code> alias)</h3>
 <p>
@@ -3092,7 +3272,7 @@ Ready, Progressing, Degraded or other customer types.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerSpec">ManagerSpec</a>,
+<a href="#operator.tigera.io/v1.ManagerSpec">ManagerSpec</a>, 
 <a href="#operator.tigera.io/v1.ManagerStatus">ManagerStatus</a>)
 </p>
 <p>Auth defines authentication configuration.</p>
@@ -4253,6 +4433,23 @@ Default: Iptables</p>
 </tr>
 <tr>
 <td>
+<code>windowsDataplane</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.WindowsDataplaneOption">
+WindowsDataplaneOption
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>WindowsDataplane is used to select the dataplane used for Windows nodes. In particular, it
+causes the operator to add required mounts and environment variables for the particular dataplane.
+If not specified, it is disabled and the operator will not render the Calico Windows nodes daemonset.
+Default: Disabled</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>bgp</code><br/>
 <em>
 <a href="#operator.tigera.io/v1.BGPOption">
@@ -4705,13 +4902,348 @@ CalicoNodeDaemonSetPodTemplateSpec
 </tr>
 </tbody>
 </table>
+<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+</p>
+<p>CalicoNodeWindowsDaemonSet is the configuration for the calico-node-windows DaemonSet.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the DaemonSet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">
+CalicoNodeWindowsDaemonSetSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the specification of the calico-node-windows DaemonSet.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+</p>
+<p>CalicoNodeWindowsDaemonSetContainer is a calico-node-windows DaemonSet container.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the calico-node-windows DaemonSet container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named calico-node-windows DaemonSet container&rsquo;s resources.
+If omitted, the calico-node-windows DaemonSet will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+</p>
+<p>CalicoNodeWindowsDaemonSetInitContainer is a calico-node-windows DaemonSet init container.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the calico-node-windows DaemonSet init container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named calico-node-windows DaemonSet init container&rsquo;s resources.
+If omitted, the calico-node-windows DaemonSet will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
+</p>
+<p>CalicoNodeWindowsDaemonSetPodSpec is the calico-node-windows DaemonSet&rsquo;s PodSpec.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>initContainers</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">
+[]CalicoNodeWindowsDaemonSetInitContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>InitContainers is a list of calico-node-windows init containers.
+If specified, this overrides the specified calico-node-windows DaemonSet init containers.
+If omitted, the calico-node-windows DaemonSet will use its default values for its init containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containers</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">
+[]CalicoNodeWindowsDaemonSetContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Containers is a list of calico-node-windows containers.
+If specified, this overrides the specified calico-node-windows DaemonSet containers.
+If omitted, the calico-node-windows DaemonSet will use its default values for its containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Affinity is a group of affinity scheduling rules for the calico-node-windows pods.
+If specified, this overrides any affinity that may be set on the calico-node-windows DaemonSet.
+If omitted, the calico-node-windows DaemonSet will use its default value for affinity.
+WARNING: Please note that this field will override the default calico-node-windows DaemonSet affinity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeSelector is the calico-node-windows pod&rsquo;s scheduling constraints.
+If specified, each of the key/value pairs are added to the calico-node-windows DaemonSet nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If omitted, the calico-node-windows DaemonSet will use its default value for nodeSelector.
+WARNING: Please note that this field will modify the default calico-node-windows DaemonSet nodeSelector.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations is the calico-node-windows pod&rsquo;s tolerations.
+If specified, this overrides any tolerations that may be set on the calico-node-windows DaemonSet.
+If omitted, the calico-node-windows DaemonSet will use its default value for tolerations.
+WARNING: Please note that this field will override the default calico-node-windows DaemonSet tolerations.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
+</p>
+<p>CalicoNodeWindowsDaemonSetPodTemplateSpec is the calico-node-windows DaemonSet&rsquo;s PodTemplateSpec</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
+the pod&rsquo;s metadata.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">
+CalicoNodeWindowsDaemonSetPodSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the calico-node-windows DaemonSet&rsquo;s PodSpec.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
+</p>
+<p>CalicoNodeWindowsDaemonSetSpec defines configuration for the calico-node-windows DaemonSet.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minReadySeconds</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinReadySeconds is the minimum number of seconds for which a newly created DaemonSet pod should
+be ready without any of its container crashing, for it to be considered available.
+If specified, this overrides any minReadySeconds value that may be set on the calico-node-windows DaemonSet.
+If omitted, the calico-node-windows DaemonSet will use its default value for minReadySeconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">
+CalicoNodeWindowsDaemonSetPodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Template describes the calico-node-windows DaemonSet pod that will be created.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet
 </h3>
 <p>
 (<em>Appears on:</em>
 <a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
 </p>
-<p>CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrade DaemonSet.</p>
+<p>Deprecated. The CalicoWindowsUpgradeDaemonSet is deprecated and will be removed from the API in the future.
+CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrade DaemonSet.</p>
 <table>
 <thead>
 <tr>
@@ -6309,7 +6841,7 @@ int32
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>,
+<a href="#operator.tigera.io/v1.Installation">Installation</a>, 
 <a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
 </p>
 <p>InstallationSpec defines configuration for a Calico or Calico Enterprise installation.</p>
@@ -6688,7 +7220,21 @@ CalicoWindowsUpgradeDaemonSet
 </em>
 </td>
 <td>
-<p>CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.</p>
+<p>Deprecated. The CalicoWindowsUpgradeDaemonSet is deprecated and will be removed from the API in the future.
+CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoNodeWindowsDaemonSet</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+CalicoNodeWindowsDaemonSet
+</a>
+</em>
+</td>
+<td>
+<p>CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.</p>
 </td>
 </tr>
 <tr>
@@ -6718,6 +7264,32 @@ Logging
 <td>
 <em>(Optional)</em>
 <p>Logging Configuration for Components</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>windowsNodes</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+WindowsNodeSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Windows Configuration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceCIDRs</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Kubernetes Service CIDRs. Specifying this is required when using Calico for Windows.</p>
 </td>
 </tr>
 </tbody>
@@ -6896,6 +7468,20 @@ Kubernetes core/v1.ResourceRequirements
 <em>(Optional)</em>
 <p>ComponentResources can be used to customize the resource requirements for each component.
 Only DeepPacketInspection is supported for this spec.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>anomalyDetection</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+AnomalyDetectionSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AnomalyDetection is now deprecated, and configuring it has no effect.</p>
 </td>
 </tr>
 </tbody>
@@ -7083,6 +7669,19 @@ If Enabled, this feature sets hostPID to true in order to read process cmdline.
 Default: Enabled</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>multiTenantManagementClusterNamespace</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>If running as a multi-tenant management cluster, the namespace in which
+the management cluster&rsquo;s tenant services are running.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="operator.tigera.io/v1.LogCollectorStatus">LogCollectorStatus
@@ -7132,7 +7731,7 @@ Ready, Progressing, Degraded or other customer types.</p>
 (<code>string</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNILogging">CNILogging</a>,
+<a href="#operator.tigera.io/v1.CNILogging">CNILogging</a>, 
 <a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
 </p>
 <h3 id="operator.tigera.io/v1.LogStorageComponentName">LogStorageComponentName
@@ -7631,17 +8230,19 @@ Ready, Progressing, Degraded or other customer types.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>,
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>,
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>,
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>,
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>,
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>,
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>,
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>,
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>,
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>,
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>,
+<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>, 
+<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
+<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>, 
 <a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 </p>
 <p>Metadata contains the standard Kubernetes labels and annotations fields.</p>
@@ -8112,7 +8713,7 @@ string
 (<code>string</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>,
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
 <a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
 </p>
 <p>ProductVariant represents the variant of the product.</p>
@@ -8337,7 +8938,7 @@ Allowable values are Audit, DNS, Flows and IDSEvents.
 * Audit corresponds to audit logs for both Kubernetes resources and Enterprise custom resources.
 * DNS corresponds to DNS logs generated by Calico node.
 * Flows corresponds to flow logs generated by Calico node.
-* IDSEvents corresponds to event logs for the intrusion detection system (suspicious IPs, suspicious domains and global alerts).</p>
+* IDSEvents corresponds to event logs for the intrusion detection system (anomaly detection, suspicious IPs, suspicious domains and global alerts).</p>
 <h3 id="operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec
 </h3>
 <p>
@@ -8446,6 +9047,39 @@ To reconnect existing managed clusters, change the tls.ca of the  managed cluste
 </tr>
 </tbody>
 </table>
+<h3 id="operator.tigera.io/v1.TenantSpec">TenantSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>id</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ID is the unique identifier for this tenant.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.TenantStatus">TenantStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+</p>
 <h3 id="operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition
 </h3>
 <p>
@@ -9126,4 +9760,94 @@ Default: uid</p>
 (<em>Appears on:</em>
 <a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
 </p>
+<h3 id="operator.tigera.io/v1.WindowsDataplaneOption">WindowsDataplaneOption
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+</p>
+<h3 id="operator.tigera.io/v1.WindowsNodeSpec">WindowsNodeSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>cniBinDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CNIBinDir is the path to the CNI binaries directory on Windows, it must match what is used as &lsquo;bin_dir&rsquo; under
+[plugins]
+[plugins.&ldquo;io.containerd.grpc.v1.cri&rdquo;]
+[plugins.&ldquo;io.containerd.grpc.v1.cri&rdquo;.cni]
+on the containerd &lsquo;config.toml&rsquo; file on the Windows nodes.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cniConfigDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CNIConfigDir is the path to the CNI configuration directory on Windows, it must match what is used as &lsquo;conf_dir&rsquo; under
+[plugins]
+[plugins.&ldquo;io.containerd.grpc.v1.cri&rdquo;]
+[plugins.&ldquo;io.containerd.grpc.v1.cri&rdquo;.cni]
+on the containerd &lsquo;config.toml&rsquo; file on the Windows nodes.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cniLogDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CNILogDir is the path to the Calico CNI logs directory on Windows.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>vxlanMACPrefix</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>VXLANMACPrefix is the prefix used when generating MAC addresses for virtual NICs</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>vxlanAdapter</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>VXLANAdapter is the Network Adapter used for VXLAN, leave blank for primary NIC</p>
+</td>
+</tr>
+</tbody>
+</table>
 <hr/>

--- a/calico-cloud_versioned_docs/version-3.17/reference/installation/_api.mdx
+++ b/calico-cloud_versioned_docs/version-3.17/reference/installation/_api.mdx
@@ -397,6 +397,19 @@ ApplicationLayerPolicyStatusType
 When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in workloads for traffic enforcement on the application layer.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>envoy</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.EnvoySettings">
+EnvoySettings
+</a>
+</em>
+</td>
+<td>
+<p>User-configurable settings for the Envoy proxy.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -3065,6 +3078,19 @@ ApplicationLayerPolicyStatusType
 <td>
 <p>Application Layer Policy controls whether or not ALP enforcement is enabled for the cluster.
 When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in workloads for traffic enforcement on the application layer.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>envoy</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.EnvoySettings">
+EnvoySettings
+</a>
+</em>
+</td>
+<td>
+<p>User-configurable settings for the Envoy proxy.</p>
 </td>
 </tr>
 </tbody>
@@ -5850,6 +5876,50 @@ Default: 60</p>
 </p>
 <p>EncryptionOption specifies the traffic encryption mode when connecting to a Syslog server.</p>
 <p>One of: None, TLS</p>
+<h3 id="operator.tigera.io/v1.EnvoySettings">EnvoySettings
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>xffNumTrustedHops</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The number of additional ingress proxy hops from the right side of the
+x-forwarded-for HTTP header to trust when determining the origin client’s
+IP address. 0 is permitted, but &gt;=1 is the typical setting.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>useRemoteAddress</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>If set to true, the Envoy connection manager will use the real remote address
+of the client connection when determining internal versus external origin and
+manipulating various headers.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="operator.tigera.io/v1.FIPSMode">FIPSMode
 (<code>string</code> alias)</h3>
 <p>

--- a/calico-cloud_versioned_docs/version-3.17/reference/installation/_ia-api.mdx
+++ b/calico-cloud_versioned_docs/version-3.17/reference/installation/_ia-api.mdx
@@ -9,6 +9,8 @@
 Resource Types:
 <ul><li>
 <a href="#image-assurance.operator.tigera.io/v1.ImageAssurance">ImageAssurance</a>
+</li><li>
+<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceCentral">ImageAssuranceCentral</a>
 </li></ul>
 <h3 id="image-assurance.operator.tigera.io/v1.ImageAssurance">ImageAssurance
 </h3>
@@ -76,6 +78,47 @@ string
 <p>CRISocketPath is the path to the CRI socket on the nodes. Defaults to /run/containerd/containerd.sock.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>containerdVolumeMountPath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ContainerdVolumeMountPath is the path to the root of containerd file system. Defaults to /var/lib/containerd/.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>clusterScanner</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.ClusterScannerStatusType">
+ClusterScannerStatusType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This setting enables or disables the cluster scanner.
+Allowed values are Enabled or Disabled. Defaults to Disabled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>crawdadDaemonset</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.CrawdadDaemonSet">
+CrawdadDaemonSet
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CrawdadDaemonSet is the specification of the Crawdad Daemonset.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -89,6 +132,773 @@ ImageAssuranceStatus
 </em>
 </td>
 <td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.ImageAssuranceCentral">ImageAssuranceCentral
+</h3>
+<p>ImageAssuranceCentral is the Schema for the imageassurancecentrals API.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+image-assurance.operator.tigera.io/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>ImageAssuranceCentral</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceCentralSpec">
+ImageAssuranceCentralSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>apiProxyURL</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>APIProxyURL is the url the api proxy should proxy to.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>apiProxyDeployment</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeployment">
+APIProxyDeployment
+</a>
+</em>
+</td>
+<td>
+<p>APIProxyDeployment configures the api proxy Deployment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scannerWorkerDeployment</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeployment">
+ScannerWorkerDeployment
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ScannerWorkerDeployment is the specification of the Scanner Worker Deployment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>runtimeCleanerDeployment</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeployment">
+RuntimeCleanerDeployment
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RuntimeCleanerDeployment is the specification of the Runtime Cleaner Deployment.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceCentralStatus">
+ImageAssuranceCentralStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.APIProxyDeployment">APIProxyDeployment
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceCentralSpec">ImageAssuranceCentralSpec</a>)
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+github.com/tigera/operator/api/v1.Metadata
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the Deployment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeploymentSpec">
+APIProxyDeploymentSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the specification of the api-proxy Deployment.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.APIProxyDeploymentContainer">APIProxyDeploymentContainer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeploymentPodSpec">APIProxyDeploymentPodSpec</a>)
+</p>
+<p>APIProxyDeploymentContainer is a api-proxy Deployment container.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the api-proxy Deployment container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named api-proxy Deployment container&rsquo;s resources.
+If omitted, the api-proxy Deployment will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.APIProxyDeploymentPodSpec">APIProxyDeploymentPodSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeploymentPodTemplateSpec">APIProxyDeploymentPodTemplateSpec</a>)
+</p>
+<p>APIProxyDeploymentPodSpec is the api-proxy Deployment&rsquo;s PodSpec.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>containers</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeploymentContainer">
+[]APIProxyDeploymentContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Containers is a list of api-proxy containers.
+If specified, this overrides the specified api-proxy Deployment containers.
+If omitted, the api-proxy Deployment will use its default values for its containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Affinity is a group of affinity scheduling rules for the api-proxy pods.
+If specified, this overrides any affinity that may be set on the api-proxy Deployment.
+If omitted, the api-proxy Deployment will use its default value for affinity.
+WARNING: Please note that this field will override the default api-proxy Deployment affinity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>NodeSelector is the api-proxy pod&rsquo;s scheduling constraints.
+If specified, each of the key/value pairs are added to the api-proxy Deployment nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on the api-proxy Deployment
+and each of this field&rsquo;s key/value pairs are added to the api-proxy Deployment nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If omitted, the api-proxy Deployment will use its default value for nodeSelector.
+WARNING: Please note that this field will modify the default api-proxy Deployment nodeSelector.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations is the api-proxy pod&rsquo;s tolerations.
+If specified, this overrides any tolerations that may be set on the api-proxy Deployment.
+If omitted, the api-proxy Deployment will use its default value for tolerations.
+WARNING: Please note that this field will override the default api-proxy Deployment tolerations.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.APIProxyDeploymentPodTemplateSpec">APIProxyDeploymentPodTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeploymentSpec">APIProxyDeploymentSpec</a>)
+</p>
+<p>APIProxyDeploymentPodTemplateSpec is the api-proxy Deployment&rsquo;s PodTemplateSpec</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+github.com/tigera/operator/api/v1.Metadata
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
+the pod&rsquo;s metadata.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeploymentPodSpec">
+APIProxyDeploymentPodSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the api-proxy Deployment&rsquo;s PodSpec.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.APIProxyDeploymentSpec">APIProxyDeploymentSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeployment">APIProxyDeployment</a>)
+</p>
+<p>APIProxyDeploymentSpec defines configuration for the api-proxy Deployment.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minReadySeconds</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should
+be ready without any of its container crashing, for it to be considered available.
+If specified, this overrides any minReadySeconds value that may be set on the api-proxy Deployment.
+If omitted, the api-proxy Deployment will use its default value for minReadySeconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeploymentPodTemplateSpec">
+APIProxyDeploymentPodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Template describes the api-proxy Deployment pod that will be created.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.ClusterScannerStatusType">ClusterScannerStatusType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceSpec">ImageAssuranceSpec</a>)
+</p>
+<h3 id="image-assurance.operator.tigera.io/v1.CrawdadDaemonSet">CrawdadDaemonSet
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceSpec">ImageAssuranceSpec</a>)
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+github.com/tigera/operator/api/v1.Metadata
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the DaemonSet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.CrawdadDaemonSetSpec">
+CrawdadDaemonSetSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the specification of the crawdad DaemonSet.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.CrawdadDaemonSetContainer">CrawdadDaemonSetContainer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.CrawdadDaemonSetPodSpec">CrawdadDaemonSetPodSpec</a>)
+</p>
+<p>CrawdadDaemonSetContainer is a crawdad DaemonSet container.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the crawdad DaemonSet container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named crawdad DaemonSet container&rsquo;s resources.
+If omitted, the crawdad DaemonSet will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.CrawdadDaemonSetPodSpec">CrawdadDaemonSetPodSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.CrawdadDaemonSetPodTemplateSpec">CrawdadDaemonSetPodTemplateSpec</a>)
+</p>
+<p>CrawdadDaemonSetPodSpec is the crawdad DaemonSet&rsquo;s PodSpec.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>containers</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.CrawdadDaemonSetContainer">
+[]CrawdadDaemonSetContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Containers is a list of crawdad containers.
+If specified, this overrides the specified crawdad DaemonSet cluster-scanner containers.
+If omitted, the crawdad DaemonSet will use its default values for its containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Affinity is a group of affinity scheduling rules for the crawdad pods.
+If specified, this overrides any affinity that may be set on the crawdad DaemonSet.
+If omitted, the crawdad DaemonSet will use its default value for affinity.
+WARNING: Please note that this field will override the default crawdad DaemonSet affinity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>NodeSelector is the crawdad pod&rsquo;s scheduling constraints.
+If specified, each of the key/value pairs are added to the crawdad DaemonSet nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on the crawdad DaemonSet
+and each of this field&rsquo;s key/value pairs are added to the crawdad DaemonSet nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If omitted, the crawdad DaemonSet will use its default value for nodeSelector.
+WARNING: Please note that this field will modify the default crawdad DaemonSet nodeSelector.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations is the crawdad pod&rsquo;s tolerations.
+If specified, this overrides any tolerations that may be set on the crawdad DaemonSet.
+If omitted, the crawdad DaemonSet will use its default value for tolerations.
+WARNING: Please note that this field will override the default crawdad DaemonSet tolerations.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.CrawdadDaemonSetPodTemplateSpec">CrawdadDaemonSetPodTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.CrawdadDaemonSetSpec">CrawdadDaemonSetSpec</a>)
+</p>
+<p>CrawdadDaemonSetPodTemplateSpec is the crawdad DaemonSet&rsquo;s PodTemplateSpec</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+github.com/tigera/operator/api/v1.Metadata
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
+the pod&rsquo;s metadata.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.CrawdadDaemonSetPodSpec">
+CrawdadDaemonSetPodSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the crawdad DaemonSet&rsquo;s PodSpec.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.CrawdadDaemonSetSpec">CrawdadDaemonSetSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.CrawdadDaemonSet">CrawdadDaemonSet</a>)
+</p>
+<p>CrawdadDaemonSetSpec defines configuration for the crawdad DaemonSet.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minReadySeconds</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinReadySeconds is the minimum number of seconds for which a newly created DaemonSet pod should
+be ready without any of its container crashing, for it to be considered available.
+If specified, this overrides any minReadySeconds value that may be set on the crawdad DaemonSet.
+If omitted, the crawdad DaemonSet will use its default value for minReadySeconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.CrawdadDaemonSetPodTemplateSpec">
+CrawdadDaemonSetPodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Template describes the crawdad DaemonSet pod that will be created.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.ImageAssuranceCentralSpec">ImageAssuranceCentralSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceCentral">ImageAssuranceCentral</a>)
+</p>
+<p>ImageAssuranceCentralSpec defines the desired state of ImageAssuranceCentral.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiProxyURL</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>APIProxyURL is the url the api proxy should proxy to.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>apiProxyDeployment</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeployment">
+APIProxyDeployment
+</a>
+</em>
+</td>
+<td>
+<p>APIProxyDeployment configures the api proxy Deployment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scannerWorkerDeployment</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeployment">
+ScannerWorkerDeployment
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ScannerWorkerDeployment is the specification of the Scanner Worker Deployment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>runtimeCleanerDeployment</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeployment">
+RuntimeCleanerDeployment
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RuntimeCleanerDeployment is the specification of the Runtime Cleaner Deployment.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.ImageAssuranceCentralStatus">ImageAssuranceCentralStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceCentral">ImageAssuranceCentral</a>)
+</p>
+<p>ImageAssuranceCentralStatus defines the observed state of ImageAssuranceCentral.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>state</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>State provides user-readable status.</p>
 </td>
 </tr>
 </tbody>
@@ -119,6 +929,47 @@ string
 <p>CRISocketPath is the path to the CRI socket on the nodes. Defaults to /run/containerd/containerd.sock.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>containerdVolumeMountPath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ContainerdVolumeMountPath is the path to the root of containerd file system. Defaults to /var/lib/containerd/.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>clusterScanner</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.ClusterScannerStatusType">
+ClusterScannerStatusType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This setting enables or disables the cluster scanner.
+Allowed values are Enabled or Disabled. Defaults to Disabled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>crawdadDaemonset</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.CrawdadDaemonSet">
+CrawdadDaemonSet
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CrawdadDaemonSet is the specification of the Crawdad Daemonset.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="image-assurance.operator.tigera.io/v1.ImageAssuranceStatus">ImageAssuranceStatus
@@ -128,4 +979,544 @@ string
 <a href="#image-assurance.operator.tigera.io/v1.ImageAssurance">ImageAssurance</a>)
 </p>
 <p>ImageAssuranceStatus defines the observed state of ImageAssurance</p>
+<h3 id="image-assurance.operator.tigera.io/v1.RuntimeCleanerDeployment">RuntimeCleanerDeployment
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceCentralSpec">ImageAssuranceCentralSpec</a>)
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+github.com/tigera/operator/api/v1.Metadata
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the Deployment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentSpec">
+RuntimeCleanerDeploymentSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the specification of the runtime-cleaner Deployment.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentContainer">RuntimeCleanerDeploymentContainer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentPodSpec">RuntimeCleanerDeploymentPodSpec</a>)
+</p>
+<p>RuntimeCleanerDeploymentContainer is a runtime-cleaner Deployment container.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the runtime-cleaner Deployment container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named runtime-cleaner Deployment container&rsquo;s resources.
+If omitted, the runtime-cleaner Deployment will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentPodSpec">RuntimeCleanerDeploymentPodSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentPodTemplateSpec">RuntimeCleanerDeploymentPodTemplateSpec</a>)
+</p>
+<p>RuntimeCleanerDeploymentPodSpec is the runtime-cleaner Deployment&rsquo;s PodSpec.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>containers</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentContainer">
+[]RuntimeCleanerDeploymentContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Containers is a list of runtime-cleaner containers.
+If specified, this overrides the specified runtime-cleaner Deployment containers.
+If omitted, the runtime-cleaner Deployment will use its default values for its containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Affinity is a group of affinity scheduling rules for the runtime-cleaner pods.
+If specified, this overrides any affinity that may be set on the runtime-cleaner Deployment.
+If omitted, the runtime-cleaner Deployment will use its default value for affinity.
+WARNING: Please note that this field will override the default runtime-cleaner Deployment affinity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>NodeSelector is the runtime-cleaner pod&rsquo;s scheduling constraints.
+If specified, each of the key/value pairs are added to the runtime-cleaner Deployment nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on the runtime-cleaner Deployment
+and each of this field&rsquo;s key/value pairs are added to the runtime-cleaner Deployment nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If omitted, the runtime-cleaner Deployment will use its default value for nodeSelector.
+WARNING: Please note that this field will modify the default runtime-cleaner Deployment nodeSelector.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations is the runtime-cleaner pod&rsquo;s tolerations.
+If specified, this overrides any tolerations that may be set on the runtime-cleaner Deployment.
+If omitted, the runtime-cleaner Deployment will use its default value for tolerations.
+WARNING: Please note that this field will override the default runtime-cleaner Deployment tolerations.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentPodTemplateSpec">RuntimeCleanerDeploymentPodTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentSpec">RuntimeCleanerDeploymentSpec</a>)
+</p>
+<p>RuntimeCleanerDeploymentPodTemplateSpec is the runtime-cleaner Deployment&rsquo;s PodTemplateSpec</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+github.com/tigera/operator/api/v1.Metadata
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
+the pod&rsquo;s metadata.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentPodSpec">
+RuntimeCleanerDeploymentPodSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the runtime-cleaner Deployment&rsquo;s PodSpec.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentSpec">RuntimeCleanerDeploymentSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeployment">RuntimeCleanerDeployment</a>)
+</p>
+<p>RuntimeCleanerDeploymentSpec defines configuration for the runtime-cleaner Deployment.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minReadySeconds</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should
+be ready without any of its container crashing, for it to be considered available.
+If specified, this overrides any minReadySeconds value that may be set on the runtime-cleaner Deployment.
+If omitted, the runtime-cleaner Deployment will use its default value for minReadySeconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentPodTemplateSpec">
+RuntimeCleanerDeploymentPodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Template describes the runtime-cleaner Deployment pod that will be created.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.ScannerWorkerDeployment">ScannerWorkerDeployment
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceCentralSpec">ImageAssuranceCentralSpec</a>)
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+github.com/tigera/operator/api/v1.Metadata
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the Deployment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentSpec">
+ScannerWorkerDeploymentSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the specification of the scanner worker Deployment.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentContainer">ScannerWorkerDeploymentContainer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentPodSpec">ScannerWorkerDeploymentPodSpec</a>)
+</p>
+<p>ScannerWorkerDeploymentContainer is a scanner worker Deployment container.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the scanner worker Deployment container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named scanner worker Deployment container&rsquo;s resources.
+If omitted, the scanner worker Deployment will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentPodSpec">ScannerWorkerDeploymentPodSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentPodTemplateSpec">ScannerWorkerDeploymentPodTemplateSpec</a>)
+</p>
+<p>ScannerWorkerDeploymentPodSpec is the scanner worker Deployment&rsquo;s PodSpec.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>containers</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentContainer">
+[]ScannerWorkerDeploymentContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Containers is a list of scanner worker containers.
+If specified, this overrides the specified scanner worker Deployment containers.
+If omitted, the scanner worker Deployment will use its default values for its containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Affinity is a group of affinity scheduling rules for the scanner worker pods.
+If specified, this overrides any affinity that may be set on the scanner worker Deployment.
+If omitted, the scanner worker Deployment will use its default value for affinity.
+WARNING: Please note that this field will override the default scanner worker Deployment affinity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>NodeSelector is the scanner worker pod&rsquo;s scheduling constraints.
+If specified, each of the key/value pairs are added to the scanner worker Deployment nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on the scanner worker Deployment
+and each of this field&rsquo;s key/value pairs are added to the scanner worker Deployment nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If omitted, the scanner worker Deployment will use its default value for nodeSelector.
+WARNING: Please note that this field will modify the default scanner worker Deployment nodeSelector.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations is the scanner worker pod&rsquo;s tolerations.
+If specified, this overrides any tolerations that may be set on the scanner worker Deployment.
+If omitted, the scanner worker Deployment will use its default value for tolerations.
+WARNING: Please note that this field will override the default scanner worker Deployment tolerations.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentPodTemplateSpec">ScannerWorkerDeploymentPodTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentSpec">ScannerWorkerDeploymentSpec</a>)
+</p>
+<p>ScannerWorkerDeploymentPodTemplateSpec is the scanner worker Deployment&rsquo;s PodTemplateSpec</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+github.com/tigera/operator/api/v1.Metadata
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
+the pod&rsquo;s metadata.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentPodSpec">
+ScannerWorkerDeploymentPodSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the scanner worker Deployment&rsquo;s PodSpec.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentSpec">ScannerWorkerDeploymentSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeployment">ScannerWorkerDeployment</a>)
+</p>
+<p>ScannerWorkerDeploymentSpec defines configuration for the scanner worker Deployment.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minReadySeconds</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should
+be ready without any of its container crashing, for it to be considered available.
+If specified, this overrides any minReadySeconds value that may be set on the scanner worker Deployment.
+If omitted, the scanner worker Deployment will use its default value for minReadySeconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentPodTemplateSpec">
+ScannerWorkerDeploymentPodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Template describes the scanner worker Deployment pod that will be created.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <hr/>

--- a/calico-enterprise/reference/installation/_api.mdx
+++ b/calico-enterprise/reference/installation/_api.mdx
@@ -40,6 +40,8 @@ Resource Types:
 </li><li>
 <a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>
 </li><li>
+<a href="#operator.tigera.io/v1.Tenant">Tenant</a>
+</li><li>
 <a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>
 </li></ul>
 <h3 id="operator.tigera.io/v1.APIServer">APIServer
@@ -1333,7 +1335,21 @@ CalicoWindowsUpgradeDaemonSet
 </em>
 </td>
 <td>
-<p>CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.</p>
+<p>Deprecated. The CalicoWindowsUpgradeDaemonSet is deprecated and will be removed from the API in the future.
+CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoNodeWindowsDaemonSet</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+CalicoNodeWindowsDaemonSet
+</a>
+</em>
+</td>
+<td>
+<p>CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.</p>
 </td>
 </tr>
 <tr>
@@ -1363,6 +1379,32 @@ Logging
 <td>
 <em>(Optional)</em>
 <p>Logging Configuration for Components</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>windowsNodes</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+WindowsNodeSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Windows Configuration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceCIDRs</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Kubernetes Service CIDRs. Specifying this is required when using Calico for Windows.</p>
 </td>
 </tr>
 </table>
@@ -1453,6 +1495,20 @@ IntrusionDetectionSpec
 <em>(Optional)</em>
 <p>ComponentResources can be used to customize the resource requirements for each component.
 Only DeepPacketInspection is supported for this spec.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>anomalyDetection</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+AnomalyDetectionSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AnomalyDetection is now deprecated, and configuring it has no effect.</p>
 </td>
 </tr>
 </table>
@@ -1573,6 +1629,19 @@ CollectProcessPathOption
 <p>Configuration for enabling/disabling process path collection in flowlogs.
 If Enabled, this feature sets hostPID to true in order to read process cmdline.
 Default: Enabled</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>multiTenantManagementClusterNamespace</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>If running as a multi-tenant management cluster, the namespace in which
+the management cluster&rsquo;s tenant services are running.</p>
 </td>
 </tr>
 </table>
@@ -2171,6 +2240,89 @@ PolicyRecommendationSpec
 <em>
 <a href="#operator.tigera.io/v1.PolicyRecommendationStatus">
 PolicyRecommendationStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.Tenant">Tenant
+</h3>
+<p>Tenant is the Schema for the tenants API</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+operator.tigera.io/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>Tenant</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TenantSpec">
+TenantSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>id</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ID is the unique identifier for this tenant.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TenantStatus">
+TenantStatus
 </a>
 </em>
 </td>
@@ -2968,6 +3120,34 @@ Ready, Progressing, Degraded or other customer types.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="operator.tigera.io/v1.AnomalyDetectionSpec">AnomalyDetectionSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>storageClassName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>StorageClassName is now deprecated, and configuring it has no effect.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="operator.tigera.io/v1.ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
 (<code>string</code> alias)</h3>
 <p>
@@ -3092,7 +3272,7 @@ Ready, Progressing, Degraded or other customer types.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerSpec">ManagerSpec</a>,
+<a href="#operator.tigera.io/v1.ManagerSpec">ManagerSpec</a>, 
 <a href="#operator.tigera.io/v1.ManagerStatus">ManagerStatus</a>)
 </p>
 <p>Auth defines authentication configuration.</p>
@@ -4253,6 +4433,23 @@ Default: Iptables</p>
 </tr>
 <tr>
 <td>
+<code>windowsDataplane</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.WindowsDataplaneOption">
+WindowsDataplaneOption
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>WindowsDataplane is used to select the dataplane used for Windows nodes. In particular, it
+causes the operator to add required mounts and environment variables for the particular dataplane.
+If not specified, it is disabled and the operator will not render the Calico Windows nodes daemonset.
+Default: Disabled</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>bgp</code><br/>
 <em>
 <a href="#operator.tigera.io/v1.BGPOption">
@@ -4705,13 +4902,348 @@ CalicoNodeDaemonSetPodTemplateSpec
 </tr>
 </tbody>
 </table>
+<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+</p>
+<p>CalicoNodeWindowsDaemonSet is the configuration for the calico-node-windows DaemonSet.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the DaemonSet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">
+CalicoNodeWindowsDaemonSetSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the specification of the calico-node-windows DaemonSet.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+</p>
+<p>CalicoNodeWindowsDaemonSetContainer is a calico-node-windows DaemonSet container.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the calico-node-windows DaemonSet container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named calico-node-windows DaemonSet container&rsquo;s resources.
+If omitted, the calico-node-windows DaemonSet will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+</p>
+<p>CalicoNodeWindowsDaemonSetInitContainer is a calico-node-windows DaemonSet init container.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the calico-node-windows DaemonSet init container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named calico-node-windows DaemonSet init container&rsquo;s resources.
+If omitted, the calico-node-windows DaemonSet will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
+</p>
+<p>CalicoNodeWindowsDaemonSetPodSpec is the calico-node-windows DaemonSet&rsquo;s PodSpec.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>initContainers</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">
+[]CalicoNodeWindowsDaemonSetInitContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>InitContainers is a list of calico-node-windows init containers.
+If specified, this overrides the specified calico-node-windows DaemonSet init containers.
+If omitted, the calico-node-windows DaemonSet will use its default values for its init containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containers</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">
+[]CalicoNodeWindowsDaemonSetContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Containers is a list of calico-node-windows containers.
+If specified, this overrides the specified calico-node-windows DaemonSet containers.
+If omitted, the calico-node-windows DaemonSet will use its default values for its containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Affinity is a group of affinity scheduling rules for the calico-node-windows pods.
+If specified, this overrides any affinity that may be set on the calico-node-windows DaemonSet.
+If omitted, the calico-node-windows DaemonSet will use its default value for affinity.
+WARNING: Please note that this field will override the default calico-node-windows DaemonSet affinity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeSelector is the calico-node-windows pod&rsquo;s scheduling constraints.
+If specified, each of the key/value pairs are added to the calico-node-windows DaemonSet nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If omitted, the calico-node-windows DaemonSet will use its default value for nodeSelector.
+WARNING: Please note that this field will modify the default calico-node-windows DaemonSet nodeSelector.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations is the calico-node-windows pod&rsquo;s tolerations.
+If specified, this overrides any tolerations that may be set on the calico-node-windows DaemonSet.
+If omitted, the calico-node-windows DaemonSet will use its default value for tolerations.
+WARNING: Please note that this field will override the default calico-node-windows DaemonSet tolerations.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
+</p>
+<p>CalicoNodeWindowsDaemonSetPodTemplateSpec is the calico-node-windows DaemonSet&rsquo;s PodTemplateSpec</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
+the pod&rsquo;s metadata.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">
+CalicoNodeWindowsDaemonSetPodSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the calico-node-windows DaemonSet&rsquo;s PodSpec.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
+</p>
+<p>CalicoNodeWindowsDaemonSetSpec defines configuration for the calico-node-windows DaemonSet.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minReadySeconds</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinReadySeconds is the minimum number of seconds for which a newly created DaemonSet pod should
+be ready without any of its container crashing, for it to be considered available.
+If specified, this overrides any minReadySeconds value that may be set on the calico-node-windows DaemonSet.
+If omitted, the calico-node-windows DaemonSet will use its default value for minReadySeconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">
+CalicoNodeWindowsDaemonSetPodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Template describes the calico-node-windows DaemonSet pod that will be created.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet
 </h3>
 <p>
 (<em>Appears on:</em>
 <a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
 </p>
-<p>CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrade DaemonSet.</p>
+<p>Deprecated. The CalicoWindowsUpgradeDaemonSet is deprecated and will be removed from the API in the future.
+CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrade DaemonSet.</p>
 <table>
 <thead>
 <tr>
@@ -6309,7 +6841,7 @@ int32
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>,
+<a href="#operator.tigera.io/v1.Installation">Installation</a>, 
 <a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
 </p>
 <p>InstallationSpec defines configuration for a Calico or Calico Enterprise installation.</p>
@@ -6688,7 +7220,21 @@ CalicoWindowsUpgradeDaemonSet
 </em>
 </td>
 <td>
-<p>CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.</p>
+<p>Deprecated. The CalicoWindowsUpgradeDaemonSet is deprecated and will be removed from the API in the future.
+CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoNodeWindowsDaemonSet</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+CalicoNodeWindowsDaemonSet
+</a>
+</em>
+</td>
+<td>
+<p>CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.</p>
 </td>
 </tr>
 <tr>
@@ -6718,6 +7264,32 @@ Logging
 <td>
 <em>(Optional)</em>
 <p>Logging Configuration for Components</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>windowsNodes</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+WindowsNodeSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Windows Configuration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceCIDRs</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Kubernetes Service CIDRs. Specifying this is required when using Calico for Windows.</p>
 </td>
 </tr>
 </tbody>
@@ -6896,6 +7468,20 @@ Kubernetes core/v1.ResourceRequirements
 <em>(Optional)</em>
 <p>ComponentResources can be used to customize the resource requirements for each component.
 Only DeepPacketInspection is supported for this spec.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>anomalyDetection</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+AnomalyDetectionSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AnomalyDetection is now deprecated, and configuring it has no effect.</p>
 </td>
 </tr>
 </tbody>
@@ -7083,6 +7669,19 @@ If Enabled, this feature sets hostPID to true in order to read process cmdline.
 Default: Enabled</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>multiTenantManagementClusterNamespace</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>If running as a multi-tenant management cluster, the namespace in which
+the management cluster&rsquo;s tenant services are running.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="operator.tigera.io/v1.LogCollectorStatus">LogCollectorStatus
@@ -7132,7 +7731,7 @@ Ready, Progressing, Degraded or other customer types.</p>
 (<code>string</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNILogging">CNILogging</a>,
+<a href="#operator.tigera.io/v1.CNILogging">CNILogging</a>, 
 <a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
 </p>
 <h3 id="operator.tigera.io/v1.LogStorageComponentName">LogStorageComponentName
@@ -7631,17 +8230,19 @@ Ready, Progressing, Degraded or other customer types.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>,
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>,
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>,
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>,
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>,
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>,
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>,
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>,
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>,
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>,
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>,
+<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>, 
+<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
+<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>, 
 <a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 </p>
 <p>Metadata contains the standard Kubernetes labels and annotations fields.</p>
@@ -8112,7 +8713,7 @@ string
 (<code>string</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>,
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
 <a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
 </p>
 <p>ProductVariant represents the variant of the product.</p>
@@ -8337,7 +8938,7 @@ Allowable values are Audit, DNS, Flows and IDSEvents.
 * Audit corresponds to audit logs for both Kubernetes resources and Enterprise custom resources.
 * DNS corresponds to DNS logs generated by Calico node.
 * Flows corresponds to flow logs generated by Calico node.
-* IDSEvents corresponds to event logs for the intrusion detection system (suspicious IPs, suspicious domains and global alerts).</p>
+* IDSEvents corresponds to event logs for the intrusion detection system (anomaly detection, suspicious IPs, suspicious domains and global alerts).</p>
 <h3 id="operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec
 </h3>
 <p>
@@ -8446,6 +9047,39 @@ To reconnect existing managed clusters, change the tls.ca of the  managed cluste
 </tr>
 </tbody>
 </table>
+<h3 id="operator.tigera.io/v1.TenantSpec">TenantSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>id</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ID is the unique identifier for this tenant.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.TenantStatus">TenantStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+</p>
 <h3 id="operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition
 </h3>
 <p>
@@ -9126,4 +9760,94 @@ Default: uid</p>
 (<em>Appears on:</em>
 <a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
 </p>
+<h3 id="operator.tigera.io/v1.WindowsDataplaneOption">WindowsDataplaneOption
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+</p>
+<h3 id="operator.tigera.io/v1.WindowsNodeSpec">WindowsNodeSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>cniBinDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CNIBinDir is the path to the CNI binaries directory on Windows, it must match what is used as &lsquo;bin_dir&rsquo; under
+[plugins]
+[plugins.&ldquo;io.containerd.grpc.v1.cri&rdquo;]
+[plugins.&ldquo;io.containerd.grpc.v1.cri&rdquo;.cni]
+on the containerd &lsquo;config.toml&rsquo; file on the Windows nodes.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cniConfigDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CNIConfigDir is the path to the CNI configuration directory on Windows, it must match what is used as &lsquo;conf_dir&rsquo; under
+[plugins]
+[plugins.&ldquo;io.containerd.grpc.v1.cri&rdquo;]
+[plugins.&ldquo;io.containerd.grpc.v1.cri&rdquo;.cni]
+on the containerd &lsquo;config.toml&rsquo; file on the Windows nodes.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cniLogDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CNILogDir is the path to the Calico CNI logs directory on Windows.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>vxlanMACPrefix</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>VXLANMACPrefix is the prefix used when generating MAC addresses for virtual NICs</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>vxlanAdapter</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>VXLANAdapter is the Network Adapter used for VXLAN, leave blank for primary NIC</p>
+</td>
+</tr>
+</tbody>
+</table>
 <hr/>

--- a/calico-enterprise_versioned_docs/version-3.16/reference/installation/_api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/reference/installation/_api.mdx
@@ -381,6 +381,20 @@ LogCollectionSpec
 <p>Specification for application layer (L7) log collection.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>applicationLayerPolicy</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+ApplicationLayerPolicyStatusType
+</a>
+</em>
+</td>
+<td>
+<p>Application Layer Policy controls whether or not ALP enforcement is enabled for the cluster.
+When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in workloads for traffic enforcement on the application layer.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -2889,6 +2903,12 @@ This field is not used for managed clusters in a Multi-cluster management setup.
 </tr>
 </tbody>
 </table>
+<h3 id="operator.tigera.io/v1.ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+</p>
 <h3 id="operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec
 </h3>
 <p>
@@ -2929,6 +2949,20 @@ LogCollectionSpec
 </td>
 <td>
 <p>Specification for application layer (L7) log collection.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>applicationLayerPolicy</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+ApplicationLayerPolicyStatusType
+</a>
+</em>
+</td>
+<td>
+<p>Application Layer Policy controls whether or not ALP enforcement is enabled for the cluster.
+When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in workloads for traffic enforcement on the application layer.</p>
 </td>
 </tr>
 </tbody>

--- a/calico-enterprise_versioned_docs/version-3.17/reference/installation/_api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/reference/installation/_api.mdx
@@ -397,6 +397,19 @@ ApplicationLayerPolicyStatusType
 When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in workloads for traffic enforcement on the application layer.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>envoy</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.EnvoySettings">
+EnvoySettings
+</a>
+</em>
+</td>
+<td>
+<p>User-configurable settings for the Envoy proxy.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -3065,6 +3078,19 @@ ApplicationLayerPolicyStatusType
 <td>
 <p>Application Layer Policy controls whether or not ALP enforcement is enabled for the cluster.
 When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in workloads for traffic enforcement on the application layer.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>envoy</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.EnvoySettings">
+EnvoySettings
+</a>
+</em>
+</td>
+<td>
+<p>User-configurable settings for the Envoy proxy.</p>
 </td>
 </tr>
 </tbody>
@@ -5850,6 +5876,50 @@ Default: 60</p>
 </p>
 <p>EncryptionOption specifies the traffic encryption mode when connecting to a Syslog server.</p>
 <p>One of: None, TLS</p>
+<h3 id="operator.tigera.io/v1.EnvoySettings">EnvoySettings
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>xffNumTrustedHops</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The number of additional ingress proxy hops from the right side of the
+x-forwarded-for HTTP header to trust when determining the origin client’s
+IP address. 0 is permitted, but &gt;=1 is the typical setting.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>useRemoteAddress</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>If set to true, the Envoy connection manager will use the real remote address
+of the client connection when determining internal versus external origin and
+manipulating various headers.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="operator.tigera.io/v1.FIPSMode">FIPSMode
 (<code>string</code> alias)</h3>
 <p>

--- a/calico/reference/installation/_api.mdx
+++ b/calico/reference/installation/_api.mdx
@@ -22,6 +22,8 @@ Resource Types:
 </li><li>
 <a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>
 </li><li>
+<a href="#operator.tigera.io/v1.Tenant">Tenant</a>
+</li><li>
 <a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>
 </li></ul>
 <h3 id="operator.tigera.io/v1.APIServer">APIServer
@@ -918,7 +920,21 @@ CalicoWindowsUpgradeDaemonSet
 </em>
 </td>
 <td>
-<p>CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.</p>
+<p>Deprecated. The CalicoWindowsUpgradeDaemonSet is deprecated and will be removed from the API in the future.
+CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoNodeWindowsDaemonSet</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+CalicoNodeWindowsDaemonSet
+</a>
+</em>
+</td>
+<td>
+<p>CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.</p>
 </td>
 </tr>
 <tr>
@@ -948,6 +964,32 @@ Logging
 <td>
 <em>(Optional)</em>
 <p>Logging Configuration for Components</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>windowsNodes</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+WindowsNodeSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Windows Configuration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceCIDRs</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Kubernetes Service CIDRs. Specifying this is required when using Calico for Windows.</p>
 </td>
 </tr>
 </table>
@@ -1106,6 +1148,89 @@ PolicyRecommendationSpec
 <em>
 <a href="#operator.tigera.io/v1.PolicyRecommendationStatus">
 PolicyRecommendationStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.Tenant">Tenant
+</h3>
+<p>Tenant is the Schema for the tenants API</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+operator.tigera.io/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>Tenant</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TenantSpec">
+TenantSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>id</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ID is the unique identifier for this tenant.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TenantStatus">
+TenantStatus
 </a>
 </em>
 </td>
@@ -1653,6 +1778,30 @@ Default: Disabled</p>
 <em>(Optional)</em>
 <p>ElasticIPs defines the set of elastic IPs that can be used for Egress Gateway pods.
 NativeIP must be Enabled if elastic IPs are set.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.AnomalyDetectionSpec">AnomalyDetectionSpec
+</h3>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>storageClassName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>StorageClassName is now deprecated, and configuring it has no effect.</p>
 </td>
 </tr>
 </tbody>
@@ -2498,6 +2647,23 @@ Default: Iptables</p>
 </tr>
 <tr>
 <td>
+<code>windowsDataplane</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.WindowsDataplaneOption">
+WindowsDataplaneOption
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>WindowsDataplane is used to select the dataplane used for Windows nodes. In particular, it
+causes the operator to add required mounts and environment variables for the particular dataplane.
+If not specified, it is disabled and the operator will not render the Calico Windows nodes daemonset.
+Default: Disabled</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>bgp</code><br/>
 <em>
 <a href="#operator.tigera.io/v1.BGPOption">
@@ -2950,13 +3116,348 @@ CalicoNodeDaemonSetPodTemplateSpec
 </tr>
 </tbody>
 </table>
+<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+</p>
+<p>CalicoNodeWindowsDaemonSet is the configuration for the calico-node-windows DaemonSet.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the DaemonSet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">
+CalicoNodeWindowsDaemonSetSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the specification of the calico-node-windows DaemonSet.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+</p>
+<p>CalicoNodeWindowsDaemonSetContainer is a calico-node-windows DaemonSet container.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the calico-node-windows DaemonSet container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named calico-node-windows DaemonSet container&rsquo;s resources.
+If omitted, the calico-node-windows DaemonSet will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+</p>
+<p>CalicoNodeWindowsDaemonSetInitContainer is a calico-node-windows DaemonSet init container.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the calico-node-windows DaemonSet init container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named calico-node-windows DaemonSet init container&rsquo;s resources.
+If omitted, the calico-node-windows DaemonSet will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
+</p>
+<p>CalicoNodeWindowsDaemonSetPodSpec is the calico-node-windows DaemonSet&rsquo;s PodSpec.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>initContainers</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">
+[]CalicoNodeWindowsDaemonSetInitContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>InitContainers is a list of calico-node-windows init containers.
+If specified, this overrides the specified calico-node-windows DaemonSet init containers.
+If omitted, the calico-node-windows DaemonSet will use its default values for its init containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containers</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">
+[]CalicoNodeWindowsDaemonSetContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Containers is a list of calico-node-windows containers.
+If specified, this overrides the specified calico-node-windows DaemonSet containers.
+If omitted, the calico-node-windows DaemonSet will use its default values for its containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Affinity is a group of affinity scheduling rules for the calico-node-windows pods.
+If specified, this overrides any affinity that may be set on the calico-node-windows DaemonSet.
+If omitted, the calico-node-windows DaemonSet will use its default value for affinity.
+WARNING: Please note that this field will override the default calico-node-windows DaemonSet affinity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeSelector is the calico-node-windows pod&rsquo;s scheduling constraints.
+If specified, each of the key/value pairs are added to the calico-node-windows DaemonSet nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If omitted, the calico-node-windows DaemonSet will use its default value for nodeSelector.
+WARNING: Please note that this field will modify the default calico-node-windows DaemonSet nodeSelector.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations is the calico-node-windows pod&rsquo;s tolerations.
+If specified, this overrides any tolerations that may be set on the calico-node-windows DaemonSet.
+If omitted, the calico-node-windows DaemonSet will use its default value for tolerations.
+WARNING: Please note that this field will override the default calico-node-windows DaemonSet tolerations.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
+</p>
+<p>CalicoNodeWindowsDaemonSetPodTemplateSpec is the calico-node-windows DaemonSet&rsquo;s PodTemplateSpec</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
+the pod&rsquo;s metadata.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">
+CalicoNodeWindowsDaemonSetPodSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the calico-node-windows DaemonSet&rsquo;s PodSpec.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
+</p>
+<p>CalicoNodeWindowsDaemonSetSpec defines configuration for the calico-node-windows DaemonSet.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minReadySeconds</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinReadySeconds is the minimum number of seconds for which a newly created DaemonSet pod should
+be ready without any of its container crashing, for it to be considered available.
+If specified, this overrides any minReadySeconds value that may be set on the calico-node-windows DaemonSet.
+If omitted, the calico-node-windows DaemonSet will use its default value for minReadySeconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">
+CalicoNodeWindowsDaemonSetPodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Template describes the calico-node-windows DaemonSet pod that will be created.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet
 </h3>
 <p>
 (<em>Appears on:</em>
 <a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
 </p>
-<p>CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrade DaemonSet.</p>
+<p>Deprecated. The CalicoWindowsUpgradeDaemonSet is deprecated and will be removed from the API in the future.
+CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrade DaemonSet.</p>
 <table>
 <thead>
 <tr>
@@ -4329,7 +4830,7 @@ must be specified.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>,
+<a href="#operator.tigera.io/v1.Installation">Installation</a>, 
 <a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
 </p>
 <p>InstallationSpec defines configuration for a Calico or Calico Enterprise installation.</p>
@@ -4708,7 +5209,21 @@ CalicoWindowsUpgradeDaemonSet
 </em>
 </td>
 <td>
-<p>CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.</p>
+<p>Deprecated. The CalicoWindowsUpgradeDaemonSet is deprecated and will be removed from the API in the future.
+CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoNodeWindowsDaemonSet</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+CalicoNodeWindowsDaemonSet
+</a>
+</em>
+</td>
+<td>
+<p>CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.</p>
 </td>
 </tr>
 <tr>
@@ -4738,6 +5253,32 @@ Logging
 <td>
 <em>(Optional)</em>
 <p>Logging Configuration for Components</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>windowsNodes</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+WindowsNodeSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Windows Configuration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceCIDRs</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Kubernetes Service CIDRs. Specifying this is required when using Calico for Windows.</p>
 </td>
 </tr>
 </tbody>
@@ -4924,7 +5465,7 @@ Default: -1</p>
 (<code>string</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNILogging">CNILogging</a>,
+<a href="#operator.tigera.io/v1.CNILogging">CNILogging</a>, 
 <a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
 </p>
 <h3 id="operator.tigera.io/v1.Logging">Logging
@@ -4961,17 +5502,19 @@ CNILogging
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>,
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>,
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>,
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>,
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>,
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>,
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>,
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>,
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>,
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>,
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>,
+<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>, 
+<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
+<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
+<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>, 
 <a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 </p>
 <p>Metadata contains the standard Kubernetes labels and annotations fields.</p>
@@ -5294,7 +5837,7 @@ string
 (<code>string</code> alias)</h3>
 <p>
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>,
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
 <a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
 </p>
 <p>ProductVariant represents the variant of the product.</p>
@@ -5352,6 +5895,39 @@ To reconnect existing managed clusters, change the tls.ca of the  managed cluste
 </tr>
 </tbody>
 </table>
+<h3 id="operator.tigera.io/v1.TenantSpec">TenantSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>id</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ID is the unique identifier for this tenant.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.TenantStatus">TenantStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+</p>
 <h3 id="operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition
 </h3>
 <p>
@@ -5940,4 +6516,94 @@ to be.</p>
 (<em>Appears on:</em>
 <a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
 </p>
+<h3 id="operator.tigera.io/v1.WindowsDataplaneOption">WindowsDataplaneOption
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+</p>
+<h3 id="operator.tigera.io/v1.WindowsNodeSpec">WindowsNodeSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>cniBinDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CNIBinDir is the path to the CNI binaries directory on Windows, it must match what is used as &lsquo;bin_dir&rsquo; under
+[plugins]
+[plugins.&ldquo;io.containerd.grpc.v1.cri&rdquo;]
+[plugins.&ldquo;io.containerd.grpc.v1.cri&rdquo;.cni]
+on the containerd &lsquo;config.toml&rsquo; file on the Windows nodes.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cniConfigDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CNIConfigDir is the path to the CNI configuration directory on Windows, it must match what is used as &lsquo;conf_dir&rsquo; under
+[plugins]
+[plugins.&ldquo;io.containerd.grpc.v1.cri&rdquo;]
+[plugins.&ldquo;io.containerd.grpc.v1.cri&rdquo;.cni]
+on the containerd &lsquo;config.toml&rsquo; file on the Windows nodes.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cniLogDir</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CNILogDir is the path to the Calico CNI logs directory on Windows.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>vxlanMACPrefix</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>VXLANMACPrefix is the prefix used when generating MAC addresses for virtual NICs</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>vxlanAdapter</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>VXLANAdapter is the Network Adapter used for VXLAN, leave blank for primary NIC</p>
+</td>
+</tr>
+</tbody>
+</table>
 <hr/>

--- a/calico_versioned_docs/version-3.24/reference/installation/_api.mdx
+++ b/calico_versioned_docs/version-3.24/reference/installation/_api.mdx
@@ -1,4296 +1,4327 @@
 <p>Packages:</p>
 <ul>
-  <li>
-    <a href='#operator.tigera.io%2fv1'>operator.tigera.io/v1</a>
-  </li>
+<li>
+<a href="#operator.tigera.io%2fv1">operator.tigera.io/v1</a>
+</li>
 </ul>
-<h2 id='operator.tigera.io/v1'>operator.tigera.io/v1</h2>
+<h2 id="operator.tigera.io/v1">operator.tigera.io/v1</h2>
 <p>API Schema definitions for configuring the installation of Calico and Calico Enterprise</p>
 Resource Types:
-<ul>
-  <li>
-    <a href='#operator.tigera.io/v1.APIServer'>APIServer</a>
-  </li>
-  <li>
-    <a href='#operator.tigera.io/v1.ApplicationLayer'>ApplicationLayer</a>
-  </li>
-  <li>
-    <a href='#operator.tigera.io/v1.ImageSet'>ImageSet</a>
-  </li>
-  <li>
-    <a href='#operator.tigera.io/v1.Installation'>Installation</a>
-  </li>
-  <li>
-    <a href='#operator.tigera.io/v1.Monitor'>Monitor</a>
-  </li>
-  <li>
-    <a href='#operator.tigera.io/v1.TigeraStatus'>TigeraStatus</a>
-  </li>
-</ul>
-<h3 id='operator.tigera.io/v1.APIServer'>APIServer</h3>
-<p>
-  APIServer installs the Tigera API server and related resources. At most one instance of this resource is supported. It
-  must be named &ldquo;tigera-secure&rdquo;.
-</p>
+<ul><li>
+<a href="#operator.tigera.io/v1.APIServer">APIServer</a>
+</li><li>
+<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>
+</li><li>
+<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>
+</li><li>
+<a href="#operator.tigera.io/v1.Installation">Installation</a>
+</li><li>
+<a href="#operator.tigera.io/v1.Monitor">Monitor</a>
+</li><li>
+<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>
+</li></ul>
+<h3 id="operator.tigera.io/v1.APIServer">APIServer
+</h3>
+<p>APIServer installs the Tigera API server and related resources. At most one instance
+of this resource is supported. It must be named &ldquo;default&rdquo; or &ldquo;tigera-secure&rdquo;.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>apiVersion</code>
-        <br />
-        string
-      </td>
-      <td>
-        <code>operator.tigera.io/v1</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>kind</code>
-        <br />
-        string
-      </td>
-      <td>
-        <code>APIServer</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>metadata</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta'>
-            Kubernetes meta/v1.ObjectMeta
-          </a>
-        </em>
-      </td>
-      <td>
-        Refer to the Kubernetes API documentation for the fields of the
-        <code>metadata</code> field.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>spec</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.APIServerSpec'>APIServerSpec</a>
-        </em>
-      </td>
-      <td>
-        <p>Specification of the desired state for the Tigera API server.</p>
-        <br />
-        <br />
-        <table>
-          <tr>
-            <td>
-              <code>apiServerDeployment</code>
-              <br />
-              <em>
-                <a href='#operator.tigera.io/v1.APIServerDeployment'>APIServerDeployment</a>
-              </em>
-            </td>
-            <td>
-              <p>
-                APIServerDeployment configures the calico-apiserver (or tigera-apiserver in Enterprise) Deployment. If
-                used in conjunction with ControlPlaneNodeSelector or ControlPlaneTolerations, then these overrides take
-                precedence.
-              </p>
-            </td>
-          </tr>
-        </table>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>status</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.APIServerStatus'>APIServerStatus</a>
-        </em>
-      </td>
-      <td>
-        <p>Most recently observed status for the Tigera API server.</p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+operator.tigera.io/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>APIServer</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.APIServerSpec">
+APIServerSpec
+</a>
+</em>
+</td>
+<td>
+<p>Specification of the desired state for the Tigera API server.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>apiServerDeployment</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.APIServerDeployment">
+APIServerDeployment
+</a>
+</em>
+</td>
+<td>
+<p>APIServerDeployment configures the calico-apiserver (or tigera-apiserver in Enterprise) Deployment. If
+used in conjunction with ControlPlaneNodeSelector or ControlPlaneTolerations, then these overrides
+take precedence.</p>
+</td>
+</tr>
 </table>
-<h3 id='operator.tigera.io/v1.ApplicationLayer'>ApplicationLayer</h3>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.APIServerStatus">
+APIServerStatus
+</a>
+</em>
+</td>
+<td>
+<p>Most recently observed status for the Tigera API server.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.ApplicationLayer">ApplicationLayer
+</h3>
 <p>ApplicationLayer is the Schema for the applicationlayers API</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>apiVersion</code>
-        <br />
-        string
-      </td>
-      <td>
-        <code>operator.tigera.io/v1</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>kind</code>
-        <br />
-        string
-      </td>
-      <td>
-        <code>ApplicationLayer</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>metadata</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta'>
-            Kubernetes meta/v1.ObjectMeta
-          </a>
-        </em>
-      </td>
-      <td>
-        Refer to the Kubernetes API documentation for the fields of the
-        <code>metadata</code> field.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>spec</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.ApplicationLayerSpec'>ApplicationLayerSpec</a>
-        </em>
-      </td>
-      <td>
-        <br />
-        <br />
-        <table>
-          <tr>
-            <td>
-              <code>logCollection</code>
-              <br />
-              <em>
-                <a href='#operator.tigera.io/v1.LogCollectionSpec'>LogCollectionSpec</a>
-              </em>
-            </td>
-            <td>
-              <p>Specification for application layer (L7) log collection.</p>
-            </td>
-          </tr>
-        </table>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>status</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.ApplicationLayerStatus'>ApplicationLayerStatus</a>
-        </em>
-      </td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
-<h3 id='operator.tigera.io/v1.ImageSet'>ImageSet</h3>
-<p>
-  ImageSet is used to specify image digests for the images that the operator deploys. The name of the ImageSet is
-  expected to be in the format <code>&lt;variang&gt;-&lt;release&gt;</code>. The <code>variant</code> used is{' '}
-  <code>enterprise</code> if the InstallationSpec Variant is
-  <code>TigeraSecureEnterprise</code> otherwise it is <code>calico</code>. The <code>release</code> must match the version
-  of the variant that the operator is built to deploy, this version can be obtained by passing the <code>
-    --version
-  </code> flag to the operator binary.
-</p>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+operator.tigera.io/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>ApplicationLayer</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.ApplicationLayerSpec">
+ApplicationLayerSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>apiVersion</code>
-        <br />
-        string
-      </td>
-      <td>
-        <code>operator.tigera.io/v1</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>kind</code>
-        <br />
-        string
-      </td>
-      <td>
-        <code>ImageSet</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>metadata</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta'>
-            Kubernetes meta/v1.ObjectMeta
-          </a>
-        </em>
-      </td>
-      <td>
-        Refer to the Kubernetes API documentation for the fields of the
-        <code>metadata</code> field.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>spec</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.ImageSetSpec'>ImageSetSpec</a>
-        </em>
-      </td>
-      <td>
-        <br />
-        <br />
-        <table>
-          <tr>
-            <td>
-              <code>images</code>
-              <br />
-              <em>
-                <a href='#operator.tigera.io/v1.Image'>[]Image</a>
-              </em>
-            </td>
-            <td>
-              <p>
-                Images is the list of images to use digests. All images that the operator will deploy must be specified.
-              </p>
-            </td>
-          </tr>
-        </table>
-      </td>
-    </tr>
-  </tbody>
+<tr>
+<td>
+<code>webApplicationFirewall</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.WAFStatusType">
+WAFStatusType
+</a>
+</em>
+</td>
+<td>
+<p>WebApplicationFirewall controls whether or not ModSecurity enforcement is enabled for the cluster.
+When enabled, Services may opt-in to having ingress traffic examed by ModSecurity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>logCollection</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.LogCollectionSpec">
+LogCollectionSpec
+</a>
+</em>
+</td>
+<td>
+<p>Specification for application layer (L7) log collection.</p>
+</td>
+</tr>
 </table>
-<h3 id='operator.tigera.io/v1.Installation'>Installation</h3>
-<p>
-  Installation configures an installation of Calico or Calico Enterprise. At most one instance of this resource is
-  supported. It must be named &ldquo;default&rdquo;. The Installation API installs core networking and network policy
-  components, and provides general install-time configuration.
-</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.ApplicationLayerStatus">
+ApplicationLayerStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.ImageSet">ImageSet
+</h3>
+<p>ImageSet is used to specify image digests for the images that the operator deploys.
+The name of the ImageSet is expected to be in the format <code>&lt;variant&gt;-&lt;release&gt;</code>.
+The <code>variant</code> used is <code>enterprise</code> if the InstallationSpec Variant is
+<code>TigeraSecureEnterprise</code> otherwise it is <code>calico</code>.
+The <code>release</code> must match the version of the variant that the operator is built to deploy,
+this version can be obtained by passing the <code>--version</code> flag to the operator binary.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>apiVersion</code>
-        <br />
-        string
-      </td>
-      <td>
-        <code>operator.tigera.io/v1</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>kind</code>
-        <br />
-        string
-      </td>
-      <td>
-        <code>Installation</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>metadata</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta'>
-            Kubernetes meta/v1.ObjectMeta
-          </a>
-        </em>
-      </td>
-      <td>
-        Refer to the Kubernetes API documentation for the fields of the
-        <code>metadata</code> field.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>spec</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.InstallationSpec'>InstallationSpec</a>
-        </em>
-      </td>
-      <td>
-        <p>Specification of the desired state for the Calico or Calico Enterprise installation.</p>
-        <br />
-        <br />
-        <table>
-          <tr>
-            <td>
-              <code>variant</code>
-              <br />
-              <em>
-                <a href='#operator.tigera.io/v1.ProductVariant'>ProductVariant</a>
-              </em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>Variant is the product to install - one of Calico or TigeraSecureEnterprise Default: Calico</p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>registry</code>
-              <br />
-              <em>string</em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>
-                Registry is the default Docker registry used for component Docker images. If specified then the given
-                value must end with a slash character (<code>/</code>) and all images will be pulled from this registry.
-                If not specified then the default registries will be used. A special case value, UseDefault, is
-                supported to explicitly specify the default registries will be used.
-              </p>
-              <p>
-                Image format:
-                <code>&lt;registry&gt;&lt;imagePath&gt;/&lt;imagePrefix&gt;&lt;imageName&gt;:&lt;image-tag&gt;</code>
-              </p>
-              <p>
-                This option allows configuring the <code>&lt;registry&gt;</code> portion of the above format.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>imagePath</code>
-              <br />
-              <em>string</em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>
-                ImagePath allows for the path part of an image to be specified. If specified then the specified value
-                will be used as the image path for each image. If not specified or empty, the default for each image
-                will be used. A special case value, UseDefault, is supported to explicitly specify the default image
-                path will be used for each image.
-              </p>
-              <p>
-                Image format:
-                <code>&lt;registry&gt;&lt;imagePath&gt;/&lt;imagePrefix&gt;&lt;imageName&gt;:&lt;image-tag&gt;</code>
-              </p>
-              <p>
-                This option allows configuring the <code>&lt;imagePath&gt;</code> portion of the above format.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>imagePrefix</code>
-              <br />
-              <em>string</em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>
-                ImagePrefix allows for the prefix part of an image to be specified. If specified then the given value
-                will be used as a prefix on each image. If not specified or empty, no prefix will be used. A special
-                case value, UseDefault, is supported to explicitly specify the default image prefix will be used for
-                each image.
-              </p>
-              <p>
-                Image format:
-                <code>&lt;registry&gt;&lt;imagePath&gt;/&lt;imagePrefix&gt;&lt;imageName&gt;:&lt;image-tag&gt;</code>
-              </p>
-              <p>
-                This option allows configuring the <code>&lt;imagePrefix&gt;</code> portion of the above format.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>imagePullSecrets</code>
-              <br />
-              <em>
-                <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#localobjectreference-v1-core'>
-                  []Kubernetes core/v1.LocalObjectReference
-                </a>
-              </em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>
-                ImagePullSecrets is an array of references to container registry pull secrets to use. These are applied
-                to all images to be pulled.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>kubernetesProvider</code>
-              <br />
-              <em>
-                <a href='#operator.tigera.io/v1.Provider'>Provider</a>
-              </em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>
-                KubernetesProvider specifies a particular provider of the Kubernetes platform and enables
-                provider-specific configuration. If the specified value is empty, the Operator will attempt to
-                automatically determine the current provider. If the specified value is not empty, the Operator will
-                still attempt auto-detection, but will additionally compare the auto-detected value to the specified
-                value to confirm they match.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>cni</code>
-              <br />
-              <em>
-                <a href='#operator.tigera.io/v1.CNISpec'>CNISpec</a>
-              </em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>CNI specifies the CNI that will be used by this installation.</p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>calicoNetwork</code>
-              <br />
-              <em>
-                <a href='#operator.tigera.io/v1.CalicoNetworkSpec'>CalicoNetworkSpec</a>
-              </em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>CalicoNetwork specifies networking configuration options for Calico.</p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>typhaAffinity</code>
-              <br />
-              <em>
-                <a href='#operator.tigera.io/v1.TyphaAffinity'>TyphaAffinity</a>
-              </em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>
-                Deprecated. Please use Installation.Spec.TyphaDeployment instead. TyphaAffinity allows configuration of
-                node affinity characteristics for Typha pods.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>controlPlaneNodeSelector</code>
-              <br />
-              <em>map[string]string</em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>
-                ControlPlaneNodeSelector is used to select control plane nodes on which to run Calico components. This
-                is globally applied to all resources created by the operator excluding daemonsets.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>controlPlaneTolerations</code>
-              <br />
-              <em>
-                <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core'>
-                  []Kubernetes core/v1.Toleration
-                </a>
-              </em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>
-                ControlPlaneTolerations specify tolerations which are then globally applied to all resources created by
-                the operator.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>controlPlaneReplicas</code>
-              <br />
-              <em>int32</em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>
-                ControlPlaneReplicas defines how many replicas of the control plane core components will be deployed.
-                This field applies to all control plane components that support High Availability. Defaults to 2.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>nodeMetricsPort</code>
-              <br />
-              <em>int32</em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>
-                NodeMetricsPort specifies which port calico/node serves prometheus metrics on. By default, metrics are
-                not enabled. If specified, this overrides any FelixConfiguration resources which may exist. If omitted,
-                then prometheus metrics may still be configured through FelixConfiguration.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>typhaMetricsPort</code>
-              <br />
-              <em>int32</em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>
-                TyphaMetricsPort specifies which port calico/typha serves prometheus metrics on. By default, metrics are
-                not enabled.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>flexVolumePath</code>
-              <br />
-              <em>string</em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>
-                FlexVolumePath optionally specifies a custom path for FlexVolume. If not specified, FlexVolume will be
-                enabled by default. If set to &lsquo;None&rsquo;, FlexVolume will be disabled. The default is based on
-                the kubernetesProvider.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>kubeletVolumePluginPath</code>
-              <br />
-              <em>string</em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>
-                KubeletVolumePluginPath optionally specifies enablement of Calico CSI plugin. If not specified, CSI will
-                be enabled by default. If set to &lsquo;None&rsquo;, CSI will be disabled. Default: /var/lib/kubelet
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>nodeUpdateStrategy</code>
-              <br />
-              <em>
-                <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#daemonsetupdatestrategy-v1-apps'>
-                  Kubernetes apps/v1.DaemonSetUpdateStrategy
-                </a>
-              </em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>
-                NodeUpdateStrategy can be used to customize the desired update strategy, such as the MaxUnavailable
-                field.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>componentResources</code>
-              <br />
-              <em>
-                <a href='#operator.tigera.io/v1.ComponentResource'>[]ComponentResource</a>
-              </em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>
-                Deprecated. Please use CalicoNodeDaemonSet, TyphaDeployment, and KubeControllersDeployment.
-                ComponentResources can be used to customize the resource requirements for each component. Node, Typha,
-                and KubeControllers are supported for installations.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>certificateManagement</code>
-              <br />
-              <em>
-                <a href='#operator.tigera.io/v1.CertificateManagement'>CertificateManagement</a>
-              </em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>
-                CertificateManagement configures pods to submit a CertificateSigningRequest to the
-                certificates.k8s.io/v1beta1 API in order to obtain TLS certificates. This feature requires that you
-                bring your own CSR signing and approval process, otherwise pods will be stuck during initialization.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>nonPrivileged</code>
-              <br />
-              <em>
-                <a href='#operator.tigera.io/v1.NonPrivilegedType'>NonPrivilegedType</a>
-              </em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>
-                NonPrivileged configures Calico to be run in non-privileged containers as non-root users where possible.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>calicoNodeDaemonSet</code>
-              <br />
-              <em>
-                <a href='#operator.tigera.io/v1.CalicoNodeDaemonSet'>CalicoNodeDaemonSet</a>
-              </em>
-            </td>
-            <td>
-              <p>
-                CalicoNodeDaemonSet configures the calico-node DaemonSet. If used in conjunction with the deprecated
-                ComponentResources, then these overrides take precedence.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>calicoKubeControllersDeployment</code>
-              <br />
-              <em>
-                <a href='#operator.tigera.io/v1.CalicoKubeControllersDeployment'>CalicoKubeControllersDeployment</a>
-              </em>
-            </td>
-            <td>
-              <p>
-                CalicoKubeControllersDeployment configures the calico-kube-controllers Deployment. If used in
-                conjunction with the deprecated ComponentResources, then these overrides take precedence.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>typhaDeployment</code>
-              <br />
-              <em>
-                <a href='#operator.tigera.io/v1.TyphaDeployment'>TyphaDeployment</a>
-              </em>
-            </td>
-            <td>
-              <p>
-                TyphaDeployment configures the typha Deployment. If used in conjunction with the deprecated
-                ComponentResources or TyphaAffinity, then these overrides take precedence.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>calicoWindowsUpgradeDaemonSet</code>
-              <br />
-              <em>
-                <a href='#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet'>CalicoWindowsUpgradeDaemonSet</a>
-              </em>
-            </td>
-            <td>
-              <p>CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.</p>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>fipsMode</code>
-              <br />
-              <em>
-                <a href='#operator.tigera.io/v1.FIPSMode'>FIPSMode</a>
-              </em>
-            </td>
-            <td>
-              <em>(Optional)</em>
-              <p>
-                FIPSMode uses images and features only that are using FIPS 140-2 validated cryptographic modules and
-                standards. Default: Disabled
-              </p>
-            </td>
-          </tr>
-        </table>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>status</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.InstallationStatus'>InstallationStatus</a>
-        </em>
-      </td>
-      <td>
-        <p>Most recently observed state for the Calico or Calico Enterprise installation.</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h3 id='operator.tigera.io/v1.Monitor'>Monitor</h3>
-<p>
-  Monitor is the Schema for the monitor API. At most one instance of this resource is supported. It must be named
-  &ldquo;tigera-secure&rdquo;.
-</p>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+operator.tigera.io/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>ImageSet</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.ImageSetSpec">
+ImageSetSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>apiVersion</code>
-        <br />
-        string
-      </td>
-      <td>
-        <code>operator.tigera.io/v1</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>kind</code>
-        <br />
-        string
-      </td>
-      <td>
-        <code>Monitor</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>metadata</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta'>
-            Kubernetes meta/v1.ObjectMeta
-          </a>
-        </em>
-      </td>
-      <td>
-        Refer to the Kubernetes API documentation for the fields of the
-        <code>metadata</code> field.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>spec</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.MonitorSpec'>MonitorSpec</a>
-        </em>
-      </td>
-      <td>
-        <br />
-        <br />
-        <table></table>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>status</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.MonitorStatus'>MonitorStatus</a>
-        </em>
-      </td>
-      <td></td>
-    </tr>
-  </tbody>
+<tr>
+<td>
+<code>images</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Image">
+[]Image
+</a>
+</em>
+</td>
+<td>
+<p>Images is the list of images to use digests. All images that the operator will deploy
+must be specified.</p>
+</td>
+</tr>
 </table>
-<h3 id='operator.tigera.io/v1.TigeraStatus'>TigeraStatus</h3>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.Installation">Installation
+</h3>
+<p>Installation configures an installation of Calico or Calico Enterprise. At most one instance
+of this resource is supported. It must be named &ldquo;default&rdquo;. The Installation API installs core networking
+and network policy components, and provides general install-time configuration.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+operator.tigera.io/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>Installation</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.InstallationSpec">
+InstallationSpec
+</a>
+</em>
+</td>
+<td>
+<p>Specification of the desired state for the Calico or Calico Enterprise installation.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>variant</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.ProductVariant">
+ProductVariant
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Variant is the product to install - one of Calico or TigeraSecureEnterprise
+Default: Calico</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>registry</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Registry is the default Docker registry used for component Docker images.
+If specified then the given value must end with a slash character (<code>/</code>) and all images will be pulled from this registry.
+If not specified then the default registries will be used. A special case value, UseDefault, is
+supported to explicitly specify the default registries will be used.</p>
+<p>Image format:
+<code>&lt;registry&gt;&lt;imagePath&gt;/&lt;imagePrefix&gt;&lt;imageName&gt;:&lt;image-tag&gt;</code></p>
+<p>This option allows configuring the <code>&lt;registry&gt;</code> portion of the above format.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ImagePath allows for the path part of an image to be specified. If specified
+then the specified value will be used as the image path for each image. If not specified
+or empty, the default for each image will be used.
+A special case value, UseDefault, is supported to explicitly specify the default
+image path will be used for each image.</p>
+<p>Image format:
+<code>&lt;registry&gt;&lt;imagePath&gt;/&lt;imagePrefix&gt;&lt;imageName&gt;:&lt;image-tag&gt;</code></p>
+<p>This option allows configuring the <code>&lt;imagePath&gt;</code> portion of the above format.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePrefix</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ImagePrefix allows for the prefix part of an image to be specified. If specified
+then the given value will be used as a prefix on each image. If not specified
+or empty, no prefix will be used.
+A special case value, UseDefault, is supported to explicitly specify the default
+image prefix will be used for each image.</p>
+<p>Image format:
+<code>&lt;registry&gt;&lt;imagePath&gt;/&lt;imagePrefix&gt;&lt;imageName&gt;:&lt;image-tag&gt;</code></p>
+<p>This option allows configuring the <code>&lt;imagePrefix&gt;</code> portion of the above format.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePullSecrets</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#localobjectreference-v1-core">
+[]Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ImagePullSecrets is an array of references to container registry pull secrets to use. These are
+applied to all images to be pulled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kubernetesProvider</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Provider">
+Provider
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>KubernetesProvider specifies a particular provider of the Kubernetes platform and enables provider-specific configuration.
+If the specified value is empty, the Operator will attempt to automatically determine the current provider.
+If the specified value is not empty, the Operator will still attempt auto-detection, but
+will additionally compare the auto-detected value to the specified value to confirm they match.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cni</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CNISpec">
+CNISpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CNI specifies the CNI that will be used by this installation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoNetwork</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+CalicoNetworkSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CalicoNetwork specifies networking configuration options for Calico.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>typhaAffinity</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TyphaAffinity">
+TyphaAffinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Deprecated. Please use Installation.Spec.TyphaDeployment instead.
+TyphaAffinity allows configuration of node affinity characteristics for Typha pods.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>controlPlaneNodeSelector</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ControlPlaneNodeSelector is used to select control plane nodes on which to run Calico
+components. This is globally applied to all resources created by the operator excluding daemonsets.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>controlPlaneTolerations</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ControlPlaneTolerations specify tolerations which are then globally applied to all resources
+created by the operator.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>controlPlaneReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ControlPlaneReplicas defines how many replicas of the control plane core components will be deployed.
+This field applies to all control plane components that support High Availability. Defaults to 2.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeMetricsPort</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeMetricsPort specifies which port calico/node serves prometheus metrics on. By default, metrics are not enabled.
+If specified, this overrides any FelixConfiguration resources which may exist. If omitted, then
+prometheus metrics may still be configured through FelixConfiguration.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>typhaMetricsPort</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TyphaMetricsPort specifies which port calico/typha serves prometheus metrics on. By default, metrics are not enabled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>flexVolumePath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FlexVolumePath optionally specifies a custom path for FlexVolume. If not specified, FlexVolume will be
+enabled by default. If set to &lsquo;None&rsquo;, FlexVolume will be disabled. The default is based on the
+kubernetesProvider.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kubeletVolumePluginPath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>KubeletVolumePluginPath optionally specifies enablement of Calico CSI plugin. If not specified,
+CSI will be enabled by default. If set to &lsquo;None&rsquo;, CSI will be disabled.
+Default: /var/lib/kubelet</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeUpdateStrategy</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#daemonsetupdatestrategy-v1-apps">
+Kubernetes apps/v1.DaemonSetUpdateStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeUpdateStrategy can be used to customize the desired update strategy, such as the MaxUnavailable
+field.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>componentResources</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.ComponentResource">
+[]ComponentResource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Deprecated. Please use CalicoNodeDaemonSet, TyphaDeployment, and KubeControllersDeployment.
+ComponentResources can be used to customize the resource requirements for each component.
+Node, Typha, and KubeControllers are supported for installations.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>certificateManagement</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CertificateManagement">
+CertificateManagement
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CertificateManagement configures pods to submit a CertificateSigningRequest to the certificates.k8s.io/v1beta1 API in order
+to obtain TLS certificates. This feature requires that you bring your own CSR signing and approval process, otherwise
+pods will be stuck during initialization.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nonPrivileged</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.NonPrivilegedType">
+NonPrivilegedType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NonPrivileged configures Calico to be run in non-privileged containers as non-root users where possible.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoNodeDaemonSet</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+CalicoNodeDaemonSet
+</a>
+</em>
+</td>
+<td>
+<p>CalicoNodeDaemonSet configures the calico-node DaemonSet. If used in
+conjunction with the deprecated ComponentResources, then these overrides take precedence.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoKubeControllersDeployment</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+CalicoKubeControllersDeployment
+</a>
+</em>
+</td>
+<td>
+<p>CalicoKubeControllersDeployment configures the calico-kube-controllers Deployment. If used in
+conjunction with the deprecated ComponentResources, then these overrides take precedence.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>typhaDeployment</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TyphaDeployment">
+TyphaDeployment
+</a>
+</em>
+</td>
+<td>
+<p>TyphaDeployment configures the typha Deployment. If used in conjunction with the deprecated
+ComponentResources or TyphaAffinity, then these overrides take precedence.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoWindowsUpgradeDaemonSet</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+CalicoWindowsUpgradeDaemonSet
+</a>
+</em>
+</td>
+<td>
+<p>CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>fipsMode</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.FIPSMode">
+FIPSMode
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FIPSMode uses images and features only that are using FIPS 140-2 validated cryptographic modules and standards.
+Default: Disabled</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.InstallationStatus">
+InstallationStatus
+</a>
+</em>
+</td>
+<td>
+<p>Most recently observed state for the Calico or Calico Enterprise installation.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.Monitor">Monitor
+</h3>
+<p>Monitor is the Schema for the monitor API. At most one instance
+of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+operator.tigera.io/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>Monitor</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.MonitorSpec">
+MonitorSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.MonitorStatus">
+MonitorStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.TigeraStatus">TigeraStatus
+</h3>
 <p>TigeraStatus represents the most recently observed status for Calico or a Calico Enterprise functional area.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>apiVersion</code>
-        <br />
-        string
-      </td>
-      <td>
-        <code>operator.tigera.io/v1</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>kind</code>
-        <br />
-        string
-      </td>
-      <td>
-        <code>TigeraStatus</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>metadata</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta'>
-            Kubernetes meta/v1.ObjectMeta
-          </a>
-        </em>
-      </td>
-      <td>
-        Refer to the Kubernetes API documentation for the fields of the
-        <code>metadata</code> field.
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>spec</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.TigeraStatusSpec'>TigeraStatusSpec</a>
-        </em>
-      </td>
-      <td>
-        <br />
-        <br />
-        <table></table>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>status</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.TigeraStatusStatus'>TigeraStatusStatus</a>
-        </em>
-      </td>
-      <td></td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code><br/>
+string</td>
+<td>
+<code>
+operator.tigera.io/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code><br/>
+string
+</td>
+<td><code>TigeraStatus</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TigeraStatusSpec">
+TigeraStatusSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
 </table>
-<h3 id='operator.tigera.io/v1.APIServerDeployment'>APIServerDeployment</h3>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TigeraStatusStatus">
+TigeraStatusStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.APIServerDeployment">APIServerDeployment
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.APIServerSpec'>APIServerSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.APIServerSpec">APIServerSpec</a>)
 </p>
 <p>APIServerDeployment is the configuration for the API server Deployment.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>metadata</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.Metadata'>Metadata</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the Deployment.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>spec</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.APIServerDeploymentSpec'>APIServerDeploymentSpec</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Spec is the specification of the API server Deployment.</p>
-        <br />
-        <br />
-        <table></table>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the Deployment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">
+APIServerDeploymentSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the specification of the API server Deployment.</p>
+<br/>
+<br/>
+<table>
 </table>
-<h3 id='operator.tigera.io/v1.APIServerDeploymentContainer'>APIServerDeploymentContainer</h3>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.APIServerDeploymentContainer">APIServerDeploymentContainer
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.APIServerDeploymentPodSpec'>APIServerDeploymentPodSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 </p>
 <p>APIServerDeploymentContainer is an API server Deployment container.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>name</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p>Name is an enum which identifies the API server Deployment container by name.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>resources</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core'>
-            Kubernetes core/v1.ResourceRequirements
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Resources allows customization of limits and requests for compute resources such as cpu and memory. If
-          specified, this overrides the named API server Deployment container&rsquo;s resources. If omitted, the API
-          server Deployment will use its default value for this container&rsquo;s resources. If used in conjunction with
-          the deprecated ComponentResources, then this value takes precedence.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the API server Deployment container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named API server Deployment container&rsquo;s resources.
+If omitted, the API server Deployment will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.APIServerDeploymentInitContainer'>APIServerDeploymentInitContainer</h3>
+<h3 id="operator.tigera.io/v1.APIServerDeploymentInitContainer">APIServerDeploymentInitContainer
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.APIServerDeploymentPodSpec'>APIServerDeploymentPodSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 </p>
 <p>APIServerDeploymentInitContainer is an API server Deployment init container.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>name</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p>Name is an enum which identifies the API server Deployment init container by name.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>resources</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core'>
-            Kubernetes core/v1.ResourceRequirements
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Resources allows customization of limits and requests for compute resources such as cpu and memory. If
-          specified, this overrides the named API server Deployment init container&rsquo;s resources. If omitted, the
-          API server Deployment will use its default value for this init container&rsquo;s resources.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the API server Deployment init container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named API server Deployment init container&rsquo;s resources.
+If omitted, the API server Deployment will use its default value for this init container&rsquo;s resources.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.APIServerDeploymentPodSpec'>APIServerDeploymentPodSpec</h3>
+<h3 id="operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec'>APIServerDeploymentPodTemplateSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
 </p>
 <p>APIServerDeploymentDeploymentPodSpec is the API server Deployment&rsquo;s PodSpec.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>initContainers</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.APIServerDeploymentInitContainer'>[]APIServerDeploymentInitContainer</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          InitContainers is a list of API server init containers. If specified, this overrides the specified API server
-          Deployment init containers. If omitted, the API server Deployment will use its default values for its init
-          containers.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>containers</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.APIServerDeploymentContainer'>[]APIServerDeploymentContainer</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Containers is a list of API server containers. If specified, this overrides the specified API server
-          Deployment containers. If omitted, the API server Deployment will use its default values for its containers.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>affinity</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core'>
-            Kubernetes core/v1.Affinity
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Affinity is a group of affinity scheduling rules for the API server pods. If specified, this overrides any
-          affinity that may be set on the API server Deployment. If omitted, the API server Deployment will use its
-          default value for affinity. WARNING: Please note that this field will override the default API server
-          Deployment affinity.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>nodeSelector</code>
-        <br />
-        <em>map[string]string</em>
-      </td>
-      <td>
-        <p>
-          NodeSelector is the API server pod&rsquo;s scheduling constraints. If specified, each of the key/value pairs
-          are added to the API server Deployment nodeSelector provided the key does not already exist in the
-          object&rsquo;s nodeSelector. If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on
-          the API server Deployment and each of this field&rsquo;s key/value pairs are added to the API server
-          Deployment nodeSelector provided the key does not already exist in the object&rsquo;s nodeSelector. If
-          omitted, the API server Deployment will use its default value for nodeSelector. WARNING: Please note that this
-          field will modify the default API server Deployment nodeSelector.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>tolerations</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core'>
-            []Kubernetes core/v1.Toleration
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Tolerations is the API server pod&rsquo;s tolerations. If specified, this overrides any tolerations that may
-          be set on the API server Deployment. If omitted, the API server Deployment will use its default value for
-          tolerations. WARNING: Please note that this field will override the default API server Deployment tolerations.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>initContainers</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.APIServerDeploymentInitContainer">
+[]APIServerDeploymentInitContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>InitContainers is a list of API server init containers.
+If specified, this overrides the specified API server Deployment init containers.
+If omitted, the API server Deployment will use its default values for its init containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containers</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.APIServerDeploymentContainer">
+[]APIServerDeploymentContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Containers is a list of API server containers.
+If specified, this overrides the specified API server Deployment containers.
+If omitted, the API server Deployment will use its default values for its containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Affinity is a group of affinity scheduling rules for the API server pods.
+If specified, this overrides any affinity that may be set on the API server Deployment.
+If omitted, the API server Deployment will use its default value for affinity.
+WARNING: Please note that this field will override the default API server Deployment affinity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>NodeSelector is the API server pod&rsquo;s scheduling constraints.
+If specified, each of the key/value pairs are added to the API server Deployment nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on the API server Deployment
+and each of this field&rsquo;s key/value pairs are added to the API server Deployment nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If omitted, the API server Deployment will use its default value for nodeSelector.
+WARNING: Please note that this field will modify the default API server Deployment nodeSelector.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations is the API server pod&rsquo;s tolerations.
+If specified, this overrides any tolerations that may be set on the API server Deployment.
+If omitted, the API server Deployment will use its default value for tolerations.
+WARNING: Please note that this field will override the default API server Deployment tolerations.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec'>APIServerDeploymentPodTemplateSpec</h3>
+<h3 id="operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.APIServerDeploymentSpec'>APIServerDeploymentSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
 </p>
 <p>APIServerDeploymentPodTemplateSpec is the API server Deployment&rsquo;s PodTemplateSpec</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>metadata</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.Metadata'>Metadata</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the pod&rsquo;s metadata.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>spec</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.APIServerDeploymentPodSpec'>APIServerDeploymentPodSpec</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Spec is the API server Deployment&rsquo;s PodSpec.</p>
-        <br />
-        <br />
-        <table></table>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
+the pod&rsquo;s metadata.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">
+APIServerDeploymentPodSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the API server Deployment&rsquo;s PodSpec.</p>
+<br/>
+<br/>
+<table>
 </table>
-<h3 id='operator.tigera.io/v1.APIServerDeploymentSpec'>APIServerDeploymentSpec</h3>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.APIServerDeployment'>APIServerDeployment</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>)
 </p>
 <p>APIServerDeploymentSpec defines configuration for the API server Deployment.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>minReadySeconds</code>
-        <br />
-        <em>int32</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should be ready
-          without any of its container crashing, for it to be considered available. If specified, this overrides any
-          minReadySeconds value that may be set on the API server Deployment. If omitted, the API server Deployment will
-          use its default value for minReadySeconds.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>template</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec'>APIServerDeploymentPodTemplateSpec</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Template describes the API server Deployment pod that will be created.</p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minReadySeconds</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should
+be ready without any of its container crashing, for it to be considered available.
+If specified, this overrides any minReadySeconds value that may be set on the API server Deployment.
+If omitted, the API server Deployment will use its default value for minReadySeconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">
+APIServerDeploymentPodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Template describes the API server Deployment pod that will be created.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.APIServerSpec'>APIServerSpec</h3>
+<h3 id="operator.tigera.io/v1.APIServerSpec">APIServerSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.APIServer'>APIServer</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
 </p>
 <p>APIServerSpec defines the desired state of Tigera API server.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>apiServerDeployment</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.APIServerDeployment'>APIServerDeployment</a>
-        </em>
-      </td>
-      <td>
-        <p>
-          APIServerDeployment configures the calico-apiserver (or tigera-apiserver in Enterprise) Deployment. If used in
-          conjunction with ControlPlaneNodeSelector or ControlPlaneTolerations, then these overrides take precedence.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiServerDeployment</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.APIServerDeployment">
+APIServerDeployment
+</a>
+</em>
+</td>
+<td>
+<p>APIServerDeployment configures the calico-apiserver (or tigera-apiserver in Enterprise) Deployment. If
+used in conjunction with ControlPlaneNodeSelector or ControlPlaneTolerations, then these overrides
+take precedence.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.APIServerStatus'>APIServerStatus</h3>
+<h3 id="operator.tigera.io/v1.APIServerStatus">APIServerStatus
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.APIServer'>APIServer</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
 </p>
 <p>APIServerStatus defines the observed state of Tigera API server.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>state</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p>State provides user-readable status.</p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>state</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>State provides user-readable status.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.ApplicationLayerSpec'>ApplicationLayerSpec</h3>
+<h3 id="operator.tigera.io/v1.AnomalyDetectionSpec">AnomalyDetectionSpec
+</h3>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>storageClassName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>StorageClassName will be used to query for an existing StorageClass with the same as the field value. It will also
+populate the PersistentVolumeClaim.StorageClassName that is used to provision disks for the Anomaly Detection API
+pod for model storage. If the field is left blank, Anomaly Detection API will be using EmptyDir VolumeSource.
+The StorageClassName should only be modified when no StorageClass is currently active. We recommend choosing a
+storage class dedicated to AnomalyDetection only. Otherwise, model retention cannot be guaranteed during upgrades.
+See <a href="https://docs.tigera.io/maintenance/upgrading">https://docs.tigera.io/maintenance/upgrading</a> for up-to-date instructions.
+This field is not used for managed clusters in a Multi-cluster management setup.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.ApplicationLayer'>ApplicationLayer</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
 </p>
 <p>ApplicationLayerSpec defines the desired state of ApplicationLayer</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>logCollection</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.LogCollectionSpec'>LogCollectionSpec</a>
-        </em>
-      </td>
-      <td>
-        <p>Specification for application layer (L7) log collection.</p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>webApplicationFirewall</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.WAFStatusType">
+WAFStatusType
+</a>
+</em>
+</td>
+<td>
+<p>WebApplicationFirewall controls whether or not ModSecurity enforcement is enabled for the cluster.
+When enabled, Services may opt-in to having ingress traffic examed by ModSecurity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>logCollection</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.LogCollectionSpec">
+LogCollectionSpec
+</a>
+</em>
+</td>
+<td>
+<p>Specification for application layer (L7) log collection.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.ApplicationLayerStatus'>ApplicationLayerStatus</h3>
+<h3 id="operator.tigera.io/v1.ApplicationLayerStatus">ApplicationLayerStatus
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.ApplicationLayer'>ApplicationLayer</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
 </p>
 <p>ApplicationLayerStatus defines the observed state of ApplicationLayer</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>state</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p>State provides user-readable status.</p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>state</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>State provides user-readable status.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.BGPOption'>
-  BGPOption (<code>string</code> alias)
-</h3>
+<h3 id="operator.tigera.io/v1.BGPOption">BGPOption
+(<code>string</code> alias)</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoNetworkSpec'>CalicoNetworkSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
 </p>
 <p>BGPOption describes the mode of BGP to use.</p>
 <p>One of: Enabled, Disabled</p>
-<h3 id='operator.tigera.io/v1.CAType'>
-  CAType (<code>string</code> alias)
-</h3>
-<p>
-  CAType specifies which verification method the tunnel client should use to verify the tunnel server&rsquo;s identity.
-</p>
+<h3 id="operator.tigera.io/v1.CAType">CAType
+(<code>string</code> alias)</h3>
+<p>CAType specifies which verification method the tunnel client should use to verify the tunnel server&rsquo;s identity.</p>
 <p>One of: Tigera, Public</p>
-<h3 id='operator.tigera.io/v1.CNIPluginType'>
-  CNIPluginType (<code>string</code> alias)
-</h3>
+<h3 id="operator.tigera.io/v1.CNIPluginType">CNIPluginType
+(<code>string</code> alias)</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CNISpec'>CNISpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
 </p>
 <p>CNIPluginType describes the type of CNI plugin used.</p>
 <p>One of: Calico, GKE, AmazonVPC, AzureVNET</p>
-<h3 id='operator.tigera.io/v1.CNISpec'>CNISpec</h3>
+<h3 id="operator.tigera.io/v1.CNISpec">CNISpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.InstallationSpec'>InstallationSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
 </p>
 <p>CNISpec contains configuration for the CNI plugin.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>type</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CNIPluginType'>CNIPluginType</a>
-        </em>
-      </td>
-      <td>
-        <p>
-          Specifies the CNI plugin that will be used in the Calico or Calico Enterprise installation. * For
-          KubernetesProvider GKE, this field defaults to GKE. * For KubernetesProvider AKS, this field defaults to
-          AzureVNET. * For KubernetesProvider EKS, this field defaults to AmazonVPC. * If aws-node daemonset exists in
-          kube-system when the Installation resource is created, this field defaults to AmazonVPC. * For all other cases
-          this field defaults to Calico.
-        </p>
-        <p>
-          For the value Calico, the CNI plugin binaries and CNI config will be installed as part of deployment, for all
-          other values the CNI plugin binaries and CNI config is a dependency that is expected to be installed
-          separately.
-        </p>
-        <p>Default: Calico</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>ipam</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.IPAMSpec'>IPAMSpec</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          IPAM specifies the pod IP address management that will be used in the Calico or Calico Enterprise
-          installation.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CNIPluginType">
+CNIPluginType
+</a>
+</em>
+</td>
+<td>
+<p>Specifies the CNI plugin that will be used in the Calico or Calico Enterprise installation.
+* For KubernetesProvider GKE, this field defaults to GKE.
+* For KubernetesProvider AKS, this field defaults to AzureVNET.
+* For KubernetesProvider EKS, this field defaults to AmazonVPC.
+* If aws-node daemonset exists in kube-system when the Installation resource is created, this field defaults to AmazonVPC.
+* For all other cases this field defaults to Calico.</p>
+<p>For the value Calico, the CNI plugin binaries and CNI config will be installed as part of deployment,
+for all other values the CNI plugin binaries and CNI config is a dependency that is expected
+to be installed separately.</p>
+<p>Default: Calico</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ipam</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.IPAMSpec">
+IPAMSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>IPAM specifies the pod IP address management that will be used in the Calico or
+Calico Enterprise installation.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.CalicoKubeControllersDeployment'>CalicoKubeControllersDeployment</h3>
+<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.InstallationSpec'>InstallationSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
 </p>
 <p>CalicoKubeControllersDeployment is the configuration for the calico-kube-controllers Deployment.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>metadata</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.Metadata'>Metadata</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the Deployment.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>spec</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec'>CalicoKubeControllersDeploymentSpec</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Spec is the specification of the calico-kube-controllers Deployment.</p>
-        <br />
-        <br />
-        <table></table>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the Deployment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">
+CalicoKubeControllersDeploymentSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the specification of the calico-kube-controllers Deployment.</p>
+<br/>
+<br/>
+<table>
 </table>
-<h3 id='operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer'>CalicoKubeControllersDeploymentContainer</h3>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec'>CalicoKubeControllersDeploymentPodSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
 </p>
 <p>CalicoKubeControllersDeploymentContainer is a calico-kube-controllers Deployment container.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>name</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p>Name is an enum which identifies the calico-kube-controllers Deployment container by name.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>resources</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core'>
-            Kubernetes core/v1.ResourceRequirements
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Resources allows customization of limits and requests for compute resources such as cpu and memory. If
-          specified, this overrides the named calico-kube-controllers Deployment container&rsquo;s resources. If
-          omitted, the calico-kube-controllers Deployment will use its default value for this container&rsquo;s
-          resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the calico-kube-controllers Deployment container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named calico-kube-controllers Deployment container&rsquo;s resources.
+If omitted, the calico-kube-controllers Deployment will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec'>CalicoKubeControllersDeploymentPodSpec</h3>
+<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec'>
-    CalicoKubeControllersDeploymentPodTemplateSpec
-  </a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
 </p>
 <p>CalicoKubeControllersDeploymentPodSpec is the calico-kube-controller Deployment&rsquo;s PodSpec.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>containers</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer'>
-            []CalicoKubeControllersDeploymentContainer
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Containers is a list of calico-kube-controllers containers. If specified, this overrides the specified
-          calico-kube-controllers Deployment containers. If omitted, the calico-kube-controllers Deployment will use its
-          default values for its containers.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>affinity</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core'>
-            Kubernetes core/v1.Affinity
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Affinity is a group of affinity scheduling rules for the calico-kube-controllers pods. If specified, this
-          overrides any affinity that may be set on the calico-kube-controllers Deployment. If omitted, the
-          calico-kube-controllers Deployment will use its default value for affinity. WARNING: Please note that this
-          field will override the default calico-kube-controllers Deployment affinity.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>nodeSelector</code>
-        <br />
-        <em>map[string]string</em>
-      </td>
-      <td>
-        <p>
-          NodeSelector is the calico-kube-controllers pod&rsquo;s scheduling constraints. If specified, each of the
-          key/value pairs are added to the calico-kube-controllers Deployment nodeSelector provided the key does not
-          already exist in the object&rsquo;s nodeSelector. If used in conjunction with ControlPlaneNodeSelector, that
-          nodeSelector is set on the calico-kube-controllers Deployment and each of this field&rsquo;s key/value pairs
-          are added to the calico-kube-controllers Deployment nodeSelector provided the key does not already exist in
-          the object&rsquo;s nodeSelector. If omitted, the calico-kube-controllers Deployment will use its default value
-          for nodeSelector. WARNING: Please note that this field will modify the default calico-kube-controllers
-          Deployment nodeSelector.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>tolerations</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core'>
-            []Kubernetes core/v1.Toleration
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Tolerations is the calico-kube-controllers pod&rsquo;s tolerations. If specified, this overrides any
-          tolerations that may be set on the calico-kube-controllers Deployment. If omitted, the calico-kube-controllers
-          Deployment will use its default value for tolerations. WARNING: Please note that this field will override the
-          default calico-kube-controllers Deployment tolerations.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>containers</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">
+[]CalicoKubeControllersDeploymentContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Containers is a list of calico-kube-controllers containers.
+If specified, this overrides the specified calico-kube-controllers Deployment containers.
+If omitted, the calico-kube-controllers Deployment will use its default values for its containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Affinity is a group of affinity scheduling rules for the calico-kube-controllers pods.
+If specified, this overrides any affinity that may be set on the calico-kube-controllers Deployment.
+If omitted, the calico-kube-controllers Deployment will use its default value for affinity.
+WARNING: Please note that this field will override the default calico-kube-controllers Deployment affinity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>NodeSelector is the calico-kube-controllers pod&rsquo;s scheduling constraints.
+If specified, each of the key/value pairs are added to the calico-kube-controllers Deployment nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on the calico-kube-controllers Deployment
+and each of this field&rsquo;s key/value pairs are added to the calico-kube-controllers Deployment nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If omitted, the calico-kube-controllers Deployment will use its default value for nodeSelector.
+WARNING: Please note that this field will modify the default calico-kube-controllers Deployment nodeSelector.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations is the calico-kube-controllers pod&rsquo;s tolerations.
+If specified, this overrides any tolerations that may be set on the calico-kube-controllers Deployment.
+If omitted, the calico-kube-controllers Deployment will use its default value for tolerations.
+WARNING: Please note that this field will override the default calico-kube-controllers Deployment tolerations.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec'>
-  CalicoKubeControllersDeploymentPodTemplateSpec
+<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec
 </h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec'>CalicoKubeControllersDeploymentSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
 </p>
 <p>CalicoKubeControllersDeploymentPodTemplateSpec is the calico-kube-controllers Deployment&rsquo;s PodTemplateSpec</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>metadata</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.Metadata'>Metadata</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the pod&rsquo;s metadata.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>spec</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec'>
-            CalicoKubeControllersDeploymentPodSpec
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Spec is the calico-kube-controllers Deployment&rsquo;s PodSpec.</p>
-        <br />
-        <br />
-        <table></table>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
+the pod&rsquo;s metadata.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">
+CalicoKubeControllersDeploymentPodSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the calico-kube-controllers Deployment&rsquo;s PodSpec.</p>
+<br/>
+<br/>
+<table>
 </table>
-<h3 id='operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec'>CalicoKubeControllersDeploymentSpec</h3>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoKubeControllersDeployment'>CalicoKubeControllersDeployment</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
 </p>
 <p>CalicoKubeControllersDeploymentSpec defines configuration for the calico-kube-controllers Deployment.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>minReadySeconds</code>
-        <br />
-        <em>int32</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should be ready
-          without any of its container crashing, for it to be considered available. If specified, this overrides any
-          minReadySeconds value that may be set on the calico-kube-controllers Deployment. If omitted, the
-          calico-kube-controllers Deployment will use its default value for minReadySeconds.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>template</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec'>
-            CalicoKubeControllersDeploymentPodTemplateSpec
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Template describes the calico-kube-controllers Deployment pod that will be created.</p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minReadySeconds</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should
+be ready without any of its container crashing, for it to be considered available.
+If specified, this overrides any minReadySeconds value that may be set on the calico-kube-controllers Deployment.
+If omitted, the calico-kube-controllers Deployment will use its default value for minReadySeconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">
+CalicoKubeControllersDeploymentPodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Template describes the calico-kube-controllers Deployment pod that will be created.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.CalicoNetworkSpec'>CalicoNetworkSpec</h3>
+<h3 id="operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.InstallationSpec'>InstallationSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
 </p>
 <p>CalicoNetworkSpec specifies configuration options for Calico provided pod networking.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>linuxDataplane</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.LinuxDataplaneOption'>LinuxDataplaneOption</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          LinuxDataplane is used to select the dataplane used for Linux nodes. In particular, it causes the operator to
-          add required mounts and environment variables for the particular dataplane. If not specified, iptables mode is
-          used. Default: Iptables
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>bgp</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.BGPOption'>BGPOption</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>BGP configures whether or not to enable Calico&rsquo;s BGP capabilities.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>ipPools</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.IPPool'>[]IPPool</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          IPPools contains a list of IP pools to create if none exist. At most one IP pool of each address family may be
-          specified. If omitted, a single pool will be configured if needed.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>mtu</code>
-        <br />
-        <em>int32</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          MTU specifies the maximum transmission unit to use on the pod network. If not specified, Calico will perform
-          MTU auto-detection based on the cluster network.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>nodeAddressAutodetectionV4</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.NodeAddressAutodetection'>NodeAddressAutodetection</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          NodeAddressAutodetectionV4 specifies an approach to automatically detect node IPv4 addresses. If not
-          specified, will use default auto-detection settings to acquire an IPv4 address for each node.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>nodeAddressAutodetectionV6</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.NodeAddressAutodetection'>NodeAddressAutodetection</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          NodeAddressAutodetectionV6 specifies an approach to automatically detect node IPv6 addresses. If not
-          specified, IPv6 addresses will not be auto-detected.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>hostPorts</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.HostPortsType'>HostPortsType</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          HostPorts configures whether or not Calico will support Kubernetes HostPorts. Valid only when using the Calico
-          CNI plugin. Default: Enabled
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>multiInterfaceMode</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.MultiInterfaceMode'>MultiInterfaceMode</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          MultiInterfaceMode configures what will configure multiple interface per pod. Only valid for Calico Enterprise
-          installations using the Calico CNI plugin. Default: None
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>containerIPForwarding</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.ContainerIPForwardingType'>ContainerIPForwardingType</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          ContainerIPForwarding configures whether ip forwarding will be enabled for containers in the CNI
-          configuration. Default: Disabled
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>linuxDataplane</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.LinuxDataplaneOption">
+LinuxDataplaneOption
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LinuxDataplane is used to select the dataplane used for Linux nodes. In particular, it
+causes the operator to add required mounts and environment variables for the particular dataplane.
+If not specified, iptables mode is used.
+Default: Iptables</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>bgp</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.BGPOption">
+BGPOption
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BGP configures whether or not to enable Calico&rsquo;s BGP capabilities.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ipPools</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.IPPool">
+[]IPPool
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>IPPools contains a list of IP pools to create if none exist. At most one IP pool of each
+address family may be specified. If omitted, a single pool will be configured if needed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mtu</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MTU specifies the maximum transmission unit to use on the pod network.
+If not specified, Calico will perform MTU auto-detection based on the cluster network.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeAddressAutodetectionV4</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+NodeAddressAutodetection
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeAddressAutodetectionV4 specifies an approach to automatically detect node IPv4 addresses. If not specified,
+will use default auto-detection settings to acquire an IPv4 address for each node.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeAddressAutodetectionV6</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+NodeAddressAutodetection
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeAddressAutodetectionV6 specifies an approach to automatically detect node IPv6 addresses. If not specified,
+IPv6 addresses will not be auto-detected.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>hostPorts</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.HostPortsType">
+HostPortsType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>HostPorts configures whether or not Calico will support Kubernetes HostPorts. Valid only when using the Calico CNI plugin.
+Default: Enabled</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>multiInterfaceMode</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.MultiInterfaceMode">
+MultiInterfaceMode
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MultiInterfaceMode configures what will configure multiple interface per pod. Only valid for Calico Enterprise installations
+using the Calico CNI plugin.
+Default: None</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containerIPForwarding</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.ContainerIPForwardingType">
+ContainerIPForwardingType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ContainerIPForwarding configures whether ip forwarding will be enabled for containers in the CNI configuration.
+Default: Disabled</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.CalicoNodeDaemonSet'>CalicoNodeDaemonSet</h3>
+<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.InstallationSpec'>InstallationSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
 </p>
 <p>CalicoNodeDaemonSet is the configuration for the calico-node DaemonSet.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>metadata</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.Metadata'>Metadata</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the DaemonSet.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>spec</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CalicoNodeDaemonSetSpec'>CalicoNodeDaemonSetSpec</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Spec is the specification of the calico-node DaemonSet.</p>
-        <br />
-        <br />
-        <table></table>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the DaemonSet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">
+CalicoNodeDaemonSetSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the specification of the calico-node DaemonSet.</p>
+<br/>
+<br/>
+<table>
 </table>
-<h3 id='operator.tigera.io/v1.CalicoNodeDaemonSetContainer'>CalicoNodeDaemonSetContainer</h3>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec'>CalicoNodeDaemonSetPodSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 </p>
 <p>CalicoNodeDaemonSetContainer is a calico-node DaemonSet container.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>name</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p>Name is an enum which identifies the calico-node DaemonSet container by name.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>resources</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core'>
-            Kubernetes core/v1.ResourceRequirements
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Resources allows customization of limits and requests for compute resources such as cpu and memory. If
-          specified, this overrides the named calico-node DaemonSet container&rsquo;s resources. If omitted, the
-          calico-node DaemonSet will use its default value for this container&rsquo;s resources. If used in conjunction
-          with the deprecated ComponentResources, then this value takes precedence.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the calico-node DaemonSet container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named calico-node DaemonSet container&rsquo;s resources.
+If omitted, the calico-node DaemonSet will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer'>CalicoNodeDaemonSetInitContainer</h3>
+<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec'>CalicoNodeDaemonSetPodSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 </p>
 <p>CalicoNodeDaemonSetInitContainer is a calico-node DaemonSet init container.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>name</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p>Name is an enum which identifies the calico-node DaemonSet init container by name.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>resources</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core'>
-            Kubernetes core/v1.ResourceRequirements
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Resources allows customization of limits and requests for compute resources such as cpu and memory. If
-          specified, this overrides the named calico-node DaemonSet init container&rsquo;s resources. If omitted, the
-          calico-node DaemonSet will use its default value for this container&rsquo;s resources. If used in conjunction
-          with the deprecated ComponentResources, then this value takes precedence.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the calico-node DaemonSet init container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named calico-node DaemonSet init container&rsquo;s resources.
+If omitted, the calico-node DaemonSet will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec'>CalicoNodeDaemonSetPodSpec</h3>
+<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec'>CalicoNodeDaemonSetPodTemplateSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
 </p>
 <p>CalicoNodeDaemonSetPodSpec is the calico-node DaemonSet&rsquo;s PodSpec.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>initContainers</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer'>[]CalicoNodeDaemonSetInitContainer</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          InitContainers is a list of calico-node init containers. If specified, this overrides the specified
-          calico-node DaemonSet init containers. If omitted, the calico-node DaemonSet will use its default values for
-          its init containers.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>containers</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CalicoNodeDaemonSetContainer'>[]CalicoNodeDaemonSetContainer</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Containers is a list of calico-node containers. If specified, this overrides the specified calico-node
-          DaemonSet containers. If omitted, the calico-node DaemonSet will use its default values for its containers.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>affinity</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core'>
-            Kubernetes core/v1.Affinity
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Affinity is a group of affinity scheduling rules for the calico-node pods. If specified, this overrides any
-          affinity that may be set on the calico-node DaemonSet. If omitted, the calico-node DaemonSet will use its
-          default value for affinity. WARNING: Please note that this field will override the default calico-node
-          DaemonSet affinity.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>nodeSelector</code>
-        <br />
-        <em>map[string]string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          NodeSelector is the calico-node pod&rsquo;s scheduling constraints. If specified, each of the key/value pairs
-          are added to the calico-node DaemonSet nodeSelector provided the key does not already exist in the
-          object&rsquo;s nodeSelector. If omitted, the calico-node DaemonSet will use its default value for
-          nodeSelector. WARNING: Please note that this field will modify the default calico-node DaemonSet nodeSelector.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>tolerations</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core'>
-            []Kubernetes core/v1.Toleration
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Tolerations is the calico-node pod&rsquo;s tolerations. If specified, this overrides any tolerations that may
-          be set on the calico-node DaemonSet. If omitted, the calico-node DaemonSet will use its default value for
-          tolerations. WARNING: Please note that this field will override the default calico-node DaemonSet tolerations.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>initContainers</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">
+[]CalicoNodeDaemonSetInitContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>InitContainers is a list of calico-node init containers.
+If specified, this overrides the specified calico-node DaemonSet init containers.
+If omitted, the calico-node DaemonSet will use its default values for its init containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containers</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetContainer">
+[]CalicoNodeDaemonSetContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Containers is a list of calico-node containers.
+If specified, this overrides the specified calico-node DaemonSet containers.
+If omitted, the calico-node DaemonSet will use its default values for its containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Affinity is a group of affinity scheduling rules for the calico-node pods.
+If specified, this overrides any affinity that may be set on the calico-node DaemonSet.
+If omitted, the calico-node DaemonSet will use its default value for affinity.
+WARNING: Please note that this field will override the default calico-node DaemonSet affinity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeSelector is the calico-node pod&rsquo;s scheduling constraints.
+If specified, each of the key/value pairs are added to the calico-node DaemonSet nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If omitted, the calico-node DaemonSet will use its default value for nodeSelector.
+WARNING: Please note that this field will modify the default calico-node DaemonSet nodeSelector.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations is the calico-node pod&rsquo;s tolerations.
+If specified, this overrides any tolerations that may be set on the calico-node DaemonSet.
+If omitted, the calico-node DaemonSet will use its default value for tolerations.
+WARNING: Please note that this field will override the default calico-node DaemonSet tolerations.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec'>CalicoNodeDaemonSetPodTemplateSpec</h3>
+<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoNodeDaemonSetSpec'>CalicoNodeDaemonSetSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
 </p>
 <p>CalicoNodeDaemonSetPodTemplateSpec is the calico-node DaemonSet&rsquo;s PodTemplateSpec</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>metadata</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.Metadata'>Metadata</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the pod&rsquo;s metadata.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>spec</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec'>CalicoNodeDaemonSetPodSpec</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Spec is the calico-node DaemonSet&rsquo;s PodSpec.</p>
-        <br />
-        <br />
-        <table></table>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
+the pod&rsquo;s metadata.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">
+CalicoNodeDaemonSetPodSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the calico-node DaemonSet&rsquo;s PodSpec.</p>
+<br/>
+<br/>
+<table>
 </table>
-<h3 id='operator.tigera.io/v1.CalicoNodeDaemonSetSpec'>CalicoNodeDaemonSetSpec</h3>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoNodeDaemonSet'>CalicoNodeDaemonSet</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
 </p>
 <p>CalicoNodeDaemonSetSpec defines configuration for the calico-node DaemonSet.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>minReadySeconds</code>
-        <br />
-        <em>int32</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          MinReadySeconds is the minimum number of seconds for which a newly created DaemonSet pod should be ready
-          without any of its container crashing, for it to be considered available. If specified, this overrides any
-          minReadySeconds value that may be set on the calico-node DaemonSet. If omitted, the calico-node DaemonSet will
-          use its default value for minReadySeconds.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>template</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec'>CalicoNodeDaemonSetPodTemplateSpec</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Template describes the calico-node DaemonSet pod that will be created.</p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minReadySeconds</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinReadySeconds is the minimum number of seconds for which a newly created DaemonSet pod should
+be ready without any of its container crashing, for it to be considered available.
+If specified, this overrides any minReadySeconds value that may be set on the calico-node DaemonSet.
+If omitted, the calico-node DaemonSet will use its default value for minReadySeconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">
+CalicoNodeDaemonSetPodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Template describes the calico-node DaemonSet pod that will be created.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet'>CalicoWindowsUpgradeDaemonSet</h3>
+<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.InstallationSpec'>InstallationSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
 </p>
 <p>CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrade DaemonSet.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>metadata</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.Metadata'>Metadata</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the Deployment.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>spec</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec'>CalicoWindowsUpgradeDaemonSetSpec</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Spec is the specification of the calico-windows-upgrade DaemonSet.</p>
-        <br />
-        <br />
-        <table></table>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the Deployment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">
+CalicoWindowsUpgradeDaemonSetSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the specification of the calico-windows-upgrade DaemonSet.</p>
+<br/>
+<br/>
+<table>
 </table>
-<h3 id='operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer'>CalicoWindowsUpgradeDaemonSetContainer</h3>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec'>CalicoWindowsUpgradeDaemonSetPodSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
 </p>
 <p>CalicoWindowsUpgradeDaemonSetContainer is a calico-windows-upgrade DaemonSet container.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>name</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p>Name is an enum which identifies the calico-windows-upgrade DaemonSet container by name.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>resources</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core'>
-            Kubernetes core/v1.ResourceRequirements
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Resources allows customization of limits and requests for compute resources such as cpu and memory. If
-          specified, this overrides the named calico-windows-upgrade DaemonSet container&rsquo;s resources. If omitted,
-          the calico-windows-upgrade DaemonSet will use its default value for this container&rsquo;s resources.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the calico-windows-upgrade DaemonSet container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named calico-windows-upgrade DaemonSet container&rsquo;s resources.
+If omitted, the calico-windows-upgrade DaemonSet will use its default value for this container&rsquo;s resources.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec'>CalicoWindowsUpgradeDaemonSetPodSpec</h3>
+<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec'>
-    CalicoWindowsUpgradeDaemonSetPodTemplateSpec
-  </a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
 </p>
 <p>CalicoWindowsUpgradeDaemonSetPodSpec is the calico-windows-upgrade DaemonSet&rsquo;s PodSpec.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>containers</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer'>
-            []CalicoWindowsUpgradeDaemonSetContainer
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Containers is a list of calico-windows-upgrade containers. If specified, this overrides the specified
-          calico-windows-upgrade DaemonSet containers. If omitted, the calico-windows-upgrade DaemonSet will use its
-          default values for its containers.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>affinity</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core'>
-            Kubernetes core/v1.Affinity
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Affinity is a group of affinity scheduling rules for the calico-windows-upgrade pods. If specified, this
-          overrides any affinity that may be set on the calico-windows-upgrade DaemonSet. If omitted, the
-          calico-windows-upgrade DaemonSet will use its default value for affinity. WARNING: Please note that this field
-          will override the default calico-windows-upgrade DaemonSet affinity.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>nodeSelector</code>
-        <br />
-        <em>map[string]string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          NodeSelector is the calico-windows-upgrade pod&rsquo;s scheduling constraints. If specified, each of the
-          key/value pairs are added to the calico-windows-upgrade DaemonSet nodeSelector provided the key does not
-          already exist in the object&rsquo;s nodeSelector. If omitted, the calico-windows-upgrade DaemonSet will use
-          its default value for nodeSelector. WARNING: Please note that this field will modify the default
-          calico-windows-upgrade DaemonSet nodeSelector.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>tolerations</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core'>
-            []Kubernetes core/v1.Toleration
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Tolerations is the calico-windows-upgrade pod&rsquo;s tolerations. If specified, this overrides any
-          tolerations that may be set on the calico-windows-upgrade DaemonSet. If omitted, the calico-windows-upgrade
-          DaemonSet will use its default value for tolerations. WARNING: Please note that this field will override the
-          default calico-windows-upgrade DaemonSet tolerations.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>containers</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">
+[]CalicoWindowsUpgradeDaemonSetContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Containers is a list of calico-windows-upgrade containers.
+If specified, this overrides the specified calico-windows-upgrade DaemonSet containers.
+If omitted, the calico-windows-upgrade DaemonSet will use its default values for its containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Affinity is a group of affinity scheduling rules for the calico-windows-upgrade pods.
+If specified, this overrides any affinity that may be set on the calico-windows-upgrade DaemonSet.
+If omitted, the calico-windows-upgrade DaemonSet will use its default value for affinity.
+WARNING: Please note that this field will override the default calico-windows-upgrade DaemonSet affinity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeSelector is the calico-windows-upgrade pod&rsquo;s scheduling constraints.
+If specified, each of the key/value pairs are added to the calico-windows-upgrade DaemonSet nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If omitted, the calico-windows-upgrade DaemonSet will use its default value for nodeSelector.
+WARNING: Please note that this field will modify the default calico-windows-upgrade DaemonSet nodeSelector.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations is the calico-windows-upgrade pod&rsquo;s tolerations.
+If specified, this overrides any tolerations that may be set on the calico-windows-upgrade DaemonSet.
+If omitted, the calico-windows-upgrade DaemonSet will use its default value for tolerations.
+WARNING: Please note that this field will override the default calico-windows-upgrade DaemonSet tolerations.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec'>
-  CalicoWindowsUpgradeDaemonSetPodTemplateSpec
+<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec
 </h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec'>CalicoWindowsUpgradeDaemonSetSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
 </p>
 <p>CalicoWindowsUpgradeDaemonSetPodTemplateSpec is the calico-windows-upgrade DaemonSet&rsquo;s PodTemplateSpec</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>metadata</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.Metadata'>Metadata</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the pod&rsquo;s metadata.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>spec</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec'>CalicoWindowsUpgradeDaemonSetPodSpec</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Spec is the calico-windows-upgrade DaemonSet&rsquo;s PodSpec.</p>
-        <br />
-        <br />
-        <table></table>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
+the pod&rsquo;s metadata.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">
+CalicoWindowsUpgradeDaemonSetPodSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the calico-windows-upgrade DaemonSet&rsquo;s PodSpec.</p>
+<br/>
+<br/>
+<table>
 </table>
-<h3 id='operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec'>CalicoWindowsUpgradeDaemonSetSpec</h3>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet'>CalicoWindowsUpgradeDaemonSet</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
 </p>
 <p>CalicoWindowsUpgradeDaemonSetSpec defines configuration for the calico-windows-upgrade DaemonSet.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>minReadySeconds</code>
-        <br />
-        <em>int32</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should be ready
-          without any of its container crashing, for it to be considered available. If specified, this overrides any
-          minReadySeconds value that may be set on the calico-windows-upgrade DaemonSet. If omitted, the
-          calico-windows-upgrade DaemonSet will use its default value for minReadySeconds.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>template</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec'>
-            CalicoWindowsUpgradeDaemonSetPodTemplateSpec
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Template describes the calico-windows-upgrade DaemonSet pod that will be created.</p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minReadySeconds</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should
+be ready without any of its container crashing, for it to be considered available.
+If specified, this overrides any minReadySeconds value that may be set on the calico-windows-upgrade DaemonSet.
+If omitted, the calico-windows-upgrade DaemonSet will use its default value for minReadySeconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
+CalicoWindowsUpgradeDaemonSetPodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Template describes the calico-windows-upgrade DaemonSet pod that will be created.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.CertificateManagement'>CertificateManagement</h3>
+<h3 id="operator.tigera.io/v1.CertificateManagement">CertificateManagement
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.InstallationSpec'>InstallationSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
 </p>
-<p>
-  CertificateManagement configures pods to submit a CertificateSigningRequest to the certificates.k8s.io/v1beta1 API in
-  order to obtain TLS certificates. This feature requires that you bring your own CSR signing and approval process,
-  otherwise pods will be stuck during initialization.
-</p>
+<p>CertificateManagement configures pods to submit a CertificateSigningRequest to the certificates.k8s.io/v1beta1 API in order
+to obtain TLS certificates. This feature requires that you bring your own CSR signing and approval process, otherwise
+pods will be stuck during initialization.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>caCert</code>
-        <br />
-        <em>[]byte</em>
-      </td>
-      <td>
-        <p>Certificate of the authority that signs the CertificateSigningRequests in PEM format.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>signerName</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p>
-          When a CSR is issued to the certificates.k8s.io API, the signerName is added to the request in order to
-          accommodate for clusters with multiple signers. Must be formatted as:{' '}
-          <code>&lt;my-domain&gt;/&lt;my-signername&gt;</code>.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>keyAlgorithm</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Specify the algorithm used by pods to generate a key pair that is associated with the X.509 certificate
-          request. Default: RSAWithSize2048
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>signatureAlgorithm</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Specify the algorithm used for the signature of the X.509 certificate request. Default: SHA256WithRSA</p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>caCert</code><br/>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<p>Certificate of the authority that signs the CertificateSigningRequests in PEM format.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>signerName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>When a CSR is issued to the certificates.k8s.io API, the signerName is added to the request in order to accommodate for clusters
+with multiple signers.
+Must be formatted as: <code>&lt;my-domain&gt;/&lt;my-signername&gt;</code>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>keyAlgorithm</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specify the algorithm used by pods to generate a key pair that is associated with the X.509 certificate request.
+Default: RSAWithSize2048</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>signatureAlgorithm</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specify the algorithm used for the signature of the X.509 certificate request.
+Default: SHA256WithRSA</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.CollectProcessPathOption'>
-  CollectProcessPathOption (<code>string</code> alias)
-</h3>
-<h3 id='operator.tigera.io/v1.ComponentName'>
-  ComponentName (<code>string</code> alias)
-</h3>
+<h3 id="operator.tigera.io/v1.CollectProcessPathOption">CollectProcessPathOption
+(<code>string</code> alias)</h3>
+<h3 id="operator.tigera.io/v1.ComponentName">ComponentName
+(<code>string</code> alias)</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.ComponentResource'>ComponentResource</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.ComponentResource">ComponentResource</a>)
 </p>
 <p>ComponentName represents a single component.</p>
 <p>One of: Node, Typha, KubeControllers</p>
-<h3 id='operator.tigera.io/v1.ComponentResource'>ComponentResource</h3>
-<p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.InstallationSpec'>InstallationSpec</a>)
-</p>
-<p>
-  Deprecated. Please use component resource config fields in Installation.Spec instead. The ComponentResource struct
-  associates a ResourceRequirements with a component by name
-</p>
-<table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>componentName</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.ComponentName'>ComponentName</a>
-        </em>
-      </td>
-      <td>
-        <p>ComponentName is an enum which identifies the component</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>resourceRequirements</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core'>
-            Kubernetes core/v1.ResourceRequirements
-          </a>
-        </em>
-      </td>
-      <td>
-        <p>
-          ResourceRequirements allows customization of limits and requests for compute resources such as cpu and memory.
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h3 id='operator.tigera.io/v1.ConditionStatus'>
-  ConditionStatus (<code>string</code> alias)
+<h3 id="operator.tigera.io/v1.ComponentResource">ComponentResource
 </h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.TigeraStatusCondition'>TigeraStatusCondition</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+</p>
+<p>Deprecated. Please use component resource config fields in Installation.Spec instead.
+The ComponentResource struct associates a ResourceRequirements with a component by name</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>componentName</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.ComponentName">
+ComponentName
+</a>
+</em>
+</td>
+<td>
+<p>ComponentName is an enum which identifies the component</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resourceRequirements</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<p>ResourceRequirements allows customization of limits and requests for compute resources such as cpu and memory.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.ConditionStatus">ConditionStatus
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
 </p>
 <p>ConditionStatus represents the status of a particular condition. A condition may be one of: True, False, Unknown.</p>
-<h3 id='operator.tigera.io/v1.ContainerIPForwardingType'>
-  ContainerIPForwardingType (<code>string</code> alias)
-</h3>
+<h3 id="operator.tigera.io/v1.ContainerIPForwardingType">ContainerIPForwardingType
+(<code>string</code> alias)</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoNetworkSpec'>CalicoNetworkSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
 </p>
 <p>ContainerIPForwardingType specifies whether the CNI config for container ip forwarding is enabled.</p>
-<h3 id='operator.tigera.io/v1.EncapsulationType'>
-  EncapsulationType (<code>string</code> alias)
-</h3>
+<h3 id="operator.tigera.io/v1.EncapsulationType">EncapsulationType
+(<code>string</code> alias)</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.IPPool'>IPPool</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
 </p>
 <p>EncapsulationType is the type of encapsulation to use on an IP pool.</p>
 <p>One of: IPIP, VXLAN, IPIPCrossSubnet, VXLANCrossSubnet, None</p>
-<h3 id='operator.tigera.io/v1.FIPSMode'>
-  FIPSMode (<code>string</code> alias)
-</h3>
+<h3 id="operator.tigera.io/v1.EncryptionOption">EncryptionOption
+(<code>string</code> alias)</h3>
+<p>EncryptionOption specifies the traffic encryption mode when connecting to a Syslog server.</p>
+<p>One of: None, TLS</p>
+<h3 id="operator.tigera.io/v1.FIPSMode">FIPSMode
+(<code>string</code> alias)</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.InstallationSpec'>InstallationSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
 </p>
-<h3 id='operator.tigera.io/v1.HostPortsType'>
-  HostPortsType (<code>string</code> alias)
-</h3>
+<h3 id="operator.tigera.io/v1.HostPortsType">HostPortsType
+(<code>string</code> alias)</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoNetworkSpec'>CalicoNetworkSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
 </p>
 <p>HostPortsType specifies host port support.</p>
 <p>One of: Enabled, Disabled</p>
-<h3 id='operator.tigera.io/v1.IPAMPluginType'>
-  IPAMPluginType (<code>string</code> alias)
+<h3 id="operator.tigera.io/v1.IPAMPluginType">IPAMPluginType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.IPAMSpec">IPAMSpec</a>)
+</p>
+<h3 id="operator.tigera.io/v1.IPAMSpec">IPAMSpec
 </h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.IPAMSpec'>IPAMSpec</a>)
-</p>
-<h3 id='operator.tigera.io/v1.IPAMSpec'>IPAMSpec</h3>
-<p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CNISpec'>CNISpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
 </p>
 <p>IPAMSpec contains configuration for pod IP address management.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>type</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.IPAMPluginType'>IPAMPluginType</a>
-        </em>
-      </td>
-      <td>
-        <p>
-          Specifies the IPAM plugin that will be used in the Calico or Calico Enterprise installation. * For CNI Plugin
-          Calico, this field defaults to Calico. * For CNI Plugin GKE, this field defaults to HostLocal. * For CNI
-          Plugin AzureVNET, this field defaults to AzureVNET. * For CNI Plugin AmazonVPC, this field defaults to
-          AmazonVPC.
-        </p>
-        <p>
-          The IPAM plugin is installed and configured only if the CNI plugin is set to Calico, for all other values of
-          the CNI plugin the plugin binaries and CNI config is a dependency that is expected to be installed separately.
-        </p>
-        <p>Default: Calico</p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.IPAMPluginType">
+IPAMPluginType
+</a>
+</em>
+</td>
+<td>
+<p>Specifies the IPAM plugin that will be used in the Calico or Calico Enterprise installation.
+* For CNI Plugin Calico, this field defaults to Calico.
+* For CNI Plugin GKE, this field defaults to HostLocal.
+* For CNI Plugin AzureVNET, this field defaults to AzureVNET.
+* For CNI Plugin AmazonVPC, this field defaults to AmazonVPC.</p>
+<p>The IPAM plugin is installed and configured only if the CNI plugin is set to Calico,
+for all other values of the CNI plugin the plugin binaries and CNI config is a dependency
+that is expected to be installed separately.</p>
+<p>Default: Calico</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.IPPool'>IPPool</h3>
+<h3 id="operator.tigera.io/v1.IPPool">IPPool
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoNetworkSpec'>CalicoNetworkSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
 </p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>cidr</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p>CIDR contains the address range for the IP Pool in classless inter-domain routing format.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>encapsulation</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.EncapsulationType'>EncapsulationType</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Encapsulation specifies the encapsulation type that will be used with the IP Pool. Default: IPIP</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>natOutgoing</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.NATOutgoingType'>NATOutgoingType</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>NATOutgoing specifies if NAT will be enabled or disabled for outgoing traffic. Default: Enabled</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>nodeSelector</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>NodeSelector specifies the node selector that will be set for the IP Pool. Default: &lsquo;all()&rsquo;</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>blockSize</code>
-        <br />
-        <em>int32</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          BlockSize specifies the CIDR prefex length to use when allocating per-node IP blocks from the main IP pool
-          CIDR. Default: 26 (IPv4), 122 (IPv6)
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>disableBGPExport</code>
-        <br />
-        <em>bool</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          DisableBGPExport specifies whether routes from this IP pool&rsquo;s CIDR are exported over BGP. Default: false
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>cidr</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>CIDR contains the address range for the IP Pool in classless inter-domain routing format.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>encapsulation</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.EncapsulationType">
+EncapsulationType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Encapsulation specifies the encapsulation type that will be used with
+the IP Pool.
+Default: IPIP</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>natOutgoing</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.NATOutgoingType">
+NATOutgoingType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NATOutgoing specifies if NAT will be enabled or disabled for outgoing traffic.
+Default: Enabled</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeSelector specifies the node selector that will be set for the IP Pool.
+Default: &lsquo;all()&rsquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>blockSize</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BlockSize specifies the CIDR prefex length to use when allocating per-node IP blocks from
+the main IP pool CIDR.
+Default: 26 (IPv4), 122 (IPv6)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>disableBGPExport</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DisableBGPExport specifies whether routes from this IP pool&rsquo;s CIDR are exported over BGP.
+Default: false</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.Image'>Image</h3>
+<h3 id="operator.tigera.io/v1.Image">Image
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.ImageSetSpec'>ImageSetSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</a>)
 </p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>image</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p>
-          Image is an image that the operator deploys and instead of using the built in tag the operator will use the
-          Digest for the image identifier. The value should be the image name without registry or tag or digest. For the
-          image <code>docker.io/calico/node:v3.17.1</code> it should be represented as <code>calico/node</code>
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>digest</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p>
-          Digest is the image identifier that will be used for the Image. The field should not include a leading{' '}
-          <code>@</code> and must be prefixed with <code>sha256:</code>.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>image</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Image is an image that the operator deploys and instead of using the built in tag
+the operator will use the Digest for the image identifier.
+The value should be the image name without registry or tag or digest.
+For the image <code>docker.io/calico/node:v3.17.1</code> it should be represented as <code>calico/node</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>digest</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Digest is the image identifier that will be used for the Image.
+The field should not include a leading <code>@</code> and must be prefixed with <code>sha256:</code>.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.ImageSetSpec'>ImageSetSpec</h3>
+<h3 id="operator.tigera.io/v1.ImageSetSpec">ImageSetSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.ImageSet'>ImageSet</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>)
 </p>
 <p>ImageSetSpec defines the desired state of ImageSet.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>images</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.Image'>[]Image</a>
-        </em>
-      </td>
-      <td>
-        <p>Images is the list of images to use digests. All images that the operator will deploy must be specified.</p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>images</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Image">
+[]Image
+</a>
+</em>
+</td>
+<td>
+<p>Images is the list of images to use digests. All images that the operator will deploy
+must be specified.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.InstallationSpec'>InstallationSpec</h3>
+<h3 id="operator.tigera.io/v1.InstallationSpec">InstallationSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.Installation'>Installation</a>,<a href='#operator.tigera.io/v1.InstallationStatus'>
-    InstallationStatus
-  </a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.Installation">Installation</a>, 
+<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
 </p>
 <p>InstallationSpec defines configuration for a Calico or Calico Enterprise installation.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>variant</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.ProductVariant'>ProductVariant</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Variant is the product to install - one of Calico or TigeraSecureEnterprise Default: Calico</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>registry</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Registry is the default Docker registry used for component Docker images. If specified then the given value
-          must end with a slash character (<code>/</code>) and all images will be pulled from this registry. If not
-          specified then the default registries will be used. A special case value, UseDefault, is supported to
-          explicitly specify the default registries will be used.
-        </p>
-        <p>
-          Image format:
-          <code>&lt;registry&gt;&lt;imagePath&gt;/&lt;imagePrefix&gt;&lt;imageName&gt;:&lt;image-tag&gt;</code>
-        </p>
-        <p>
-          This option allows configuring the <code>&lt;registry&gt;</code> portion of the above format.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>imagePath</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          ImagePath allows for the path part of an image to be specified. If specified then the specified value will be
-          used as the image path for each image. If not specified or empty, the default for each image will be used. A
-          special case value, UseDefault, is supported to explicitly specify the default image path will be used for
-          each image.
-        </p>
-        <p>
-          Image format:
-          <code>&lt;registry&gt;&lt;imagePath&gt;/&lt;imagePrefix&gt;&lt;imageName&gt;:&lt;image-tag&gt;</code>
-        </p>
-        <p>
-          This option allows configuring the <code>&lt;imagePath&gt;</code> portion of the above format.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>imagePrefix</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          ImagePrefix allows for the prefix part of an image to be specified. If specified then the given value will be
-          used as a prefix on each image. If not specified or empty, no prefix will be used. A special case value,
-          UseDefault, is supported to explicitly specify the default image prefix will be used for each image.
-        </p>
-        <p>
-          Image format:
-          <code>&lt;registry&gt;&lt;imagePath&gt;/&lt;imagePrefix&gt;&lt;imageName&gt;:&lt;image-tag&gt;</code>
-        </p>
-        <p>
-          This option allows configuring the <code>&lt;imagePrefix&gt;</code> portion of the above format.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>imagePullSecrets</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#localobjectreference-v1-core'>
-            []Kubernetes core/v1.LocalObjectReference
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          ImagePullSecrets is an array of references to container registry pull secrets to use. These are applied to all
-          images to be pulled.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>kubernetesProvider</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.Provider'>Provider</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          KubernetesProvider specifies a particular provider of the Kubernetes platform and enables provider-specific
-          configuration. If the specified value is empty, the Operator will attempt to automatically determine the
-          current provider. If the specified value is not empty, the Operator will still attempt auto-detection, but
-          will additionally compare the auto-detected value to the specified value to confirm they match.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>cni</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CNISpec'>CNISpec</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>CNI specifies the CNI that will be used by this installation.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>calicoNetwork</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CalicoNetworkSpec'>CalicoNetworkSpec</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>CalicoNetwork specifies networking configuration options for Calico.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>typhaAffinity</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.TyphaAffinity'>TyphaAffinity</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Deprecated. Please use Installation.Spec.TyphaDeployment instead. TyphaAffinity allows configuration of node
-          affinity characteristics for Typha pods.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>controlPlaneNodeSelector</code>
-        <br />
-        <em>map[string]string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          ControlPlaneNodeSelector is used to select control plane nodes on which to run Calico components. This is
-          globally applied to all resources created by the operator excluding daemonsets.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>controlPlaneTolerations</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core'>
-            []Kubernetes core/v1.Toleration
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          ControlPlaneTolerations specify tolerations which are then globally applied to all resources created by the
-          operator.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>controlPlaneReplicas</code>
-        <br />
-        <em>int32</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          ControlPlaneReplicas defines how many replicas of the control plane core components will be deployed. This
-          field applies to all control plane components that support High Availability. Defaults to 2.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>nodeMetricsPort</code>
-        <br />
-        <em>int32</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          NodeMetricsPort specifies which port calico/node serves prometheus metrics on. By default, metrics are not
-          enabled. If specified, this overrides any FelixConfiguration resources which may exist. If omitted, then
-          prometheus metrics may still be configured through FelixConfiguration.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>typhaMetricsPort</code>
-        <br />
-        <em>int32</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          TyphaMetricsPort specifies which port calico/typha serves prometheus metrics on. By default, metrics are not
-          enabled.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>flexVolumePath</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          FlexVolumePath optionally specifies a custom path for FlexVolume. If not specified, FlexVolume will be enabled
-          by default. If set to &lsquo;None&rsquo;, FlexVolume will be disabled. The default is based on the
-          kubernetesProvider.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>kubeletVolumePluginPath</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          KubeletVolumePluginPath optionally specifies enablement of Calico CSI plugin. If not specified, CSI will be
-          enabled by default. If set to &lsquo;None&rsquo;, CSI will be disabled. Default: /var/lib/kubelet
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>nodeUpdateStrategy</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#daemonsetupdatestrategy-v1-apps'>
-            Kubernetes apps/v1.DaemonSetUpdateStrategy
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          NodeUpdateStrategy can be used to customize the desired update strategy, such as the MaxUnavailable field.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>componentResources</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.ComponentResource'>[]ComponentResource</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Deprecated. Please use CalicoNodeDaemonSet, TyphaDeployment, and KubeControllersDeployment. ComponentResources
-          can be used to customize the resource requirements for each component. Node, Typha, and KubeControllers are
-          supported for installations.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>certificateManagement</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CertificateManagement'>CertificateManagement</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          CertificateManagement configures pods to submit a CertificateSigningRequest to the certificates.k8s.io/v1beta1
-          API in order to obtain TLS certificates. This feature requires that you bring your own CSR signing and
-          approval process, otherwise pods will be stuck during initialization.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>nonPrivileged</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.NonPrivilegedType'>NonPrivilegedType</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>NonPrivileged configures Calico to be run in non-privileged containers as non-root users where possible.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>calicoNodeDaemonSet</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CalicoNodeDaemonSet'>CalicoNodeDaemonSet</a>
-        </em>
-      </td>
-      <td>
-        <p>
-          CalicoNodeDaemonSet configures the calico-node DaemonSet. If used in conjunction with the deprecated
-          ComponentResources, then these overrides take precedence.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>calicoKubeControllersDeployment</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CalicoKubeControllersDeployment'>CalicoKubeControllersDeployment</a>
-        </em>
-      </td>
-      <td>
-        <p>
-          CalicoKubeControllersDeployment configures the calico-kube-controllers Deployment. If used in conjunction with
-          the deprecated ComponentResources, then these overrides take precedence.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>typhaDeployment</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.TyphaDeployment'>TyphaDeployment</a>
-        </em>
-      </td>
-      <td>
-        <p>
-          TyphaDeployment configures the typha Deployment. If used in conjunction with the deprecated ComponentResources
-          or TyphaAffinity, then these overrides take precedence.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>calicoWindowsUpgradeDaemonSet</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet'>CalicoWindowsUpgradeDaemonSet</a>
-        </em>
-      </td>
-      <td>
-        <p>CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>fipsMode</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.FIPSMode'>FIPSMode</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          FIPSMode uses images and features only that are using FIPS 140-2 validated cryptographic modules and
-          standards. Default: Disabled
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>variant</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.ProductVariant">
+ProductVariant
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Variant is the product to install - one of Calico or TigeraSecureEnterprise
+Default: Calico</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>registry</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Registry is the default Docker registry used for component Docker images.
+If specified then the given value must end with a slash character (<code>/</code>) and all images will be pulled from this registry.
+If not specified then the default registries will be used. A special case value, UseDefault, is
+supported to explicitly specify the default registries will be used.</p>
+<p>Image format:
+<code>&lt;registry&gt;&lt;imagePath&gt;/&lt;imagePrefix&gt;&lt;imageName&gt;:&lt;image-tag&gt;</code></p>
+<p>This option allows configuring the <code>&lt;registry&gt;</code> portion of the above format.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ImagePath allows for the path part of an image to be specified. If specified
+then the specified value will be used as the image path for each image. If not specified
+or empty, the default for each image will be used.
+A special case value, UseDefault, is supported to explicitly specify the default
+image path will be used for each image.</p>
+<p>Image format:
+<code>&lt;registry&gt;&lt;imagePath&gt;/&lt;imagePrefix&gt;&lt;imageName&gt;:&lt;image-tag&gt;</code></p>
+<p>This option allows configuring the <code>&lt;imagePath&gt;</code> portion of the above format.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePrefix</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ImagePrefix allows for the prefix part of an image to be specified. If specified
+then the given value will be used as a prefix on each image. If not specified
+or empty, no prefix will be used.
+A special case value, UseDefault, is supported to explicitly specify the default
+image prefix will be used for each image.</p>
+<p>Image format:
+<code>&lt;registry&gt;&lt;imagePath&gt;/&lt;imagePrefix&gt;&lt;imageName&gt;:&lt;image-tag&gt;</code></p>
+<p>This option allows configuring the <code>&lt;imagePrefix&gt;</code> portion of the above format.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imagePullSecrets</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#localobjectreference-v1-core">
+[]Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ImagePullSecrets is an array of references to container registry pull secrets to use. These are
+applied to all images to be pulled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kubernetesProvider</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Provider">
+Provider
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>KubernetesProvider specifies a particular provider of the Kubernetes platform and enables provider-specific configuration.
+If the specified value is empty, the Operator will attempt to automatically determine the current provider.
+If the specified value is not empty, the Operator will still attempt auto-detection, but
+will additionally compare the auto-detected value to the specified value to confirm they match.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cni</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CNISpec">
+CNISpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CNI specifies the CNI that will be used by this installation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoNetwork</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+CalicoNetworkSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CalicoNetwork specifies networking configuration options for Calico.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>typhaAffinity</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TyphaAffinity">
+TyphaAffinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Deprecated. Please use Installation.Spec.TyphaDeployment instead.
+TyphaAffinity allows configuration of node affinity characteristics for Typha pods.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>controlPlaneNodeSelector</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ControlPlaneNodeSelector is used to select control plane nodes on which to run Calico
+components. This is globally applied to all resources created by the operator excluding daemonsets.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>controlPlaneTolerations</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ControlPlaneTolerations specify tolerations which are then globally applied to all resources
+created by the operator.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>controlPlaneReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ControlPlaneReplicas defines how many replicas of the control plane core components will be deployed.
+This field applies to all control plane components that support High Availability. Defaults to 2.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeMetricsPort</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeMetricsPort specifies which port calico/node serves prometheus metrics on. By default, metrics are not enabled.
+If specified, this overrides any FelixConfiguration resources which may exist. If omitted, then
+prometheus metrics may still be configured through FelixConfiguration.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>typhaMetricsPort</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TyphaMetricsPort specifies which port calico/typha serves prometheus metrics on. By default, metrics are not enabled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>flexVolumePath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FlexVolumePath optionally specifies a custom path for FlexVolume. If not specified, FlexVolume will be
+enabled by default. If set to &lsquo;None&rsquo;, FlexVolume will be disabled. The default is based on the
+kubernetesProvider.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kubeletVolumePluginPath</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>KubeletVolumePluginPath optionally specifies enablement of Calico CSI plugin. If not specified,
+CSI will be enabled by default. If set to &lsquo;None&rsquo;, CSI will be disabled.
+Default: /var/lib/kubelet</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeUpdateStrategy</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#daemonsetupdatestrategy-v1-apps">
+Kubernetes apps/v1.DaemonSetUpdateStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeUpdateStrategy can be used to customize the desired update strategy, such as the MaxUnavailable
+field.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>componentResources</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.ComponentResource">
+[]ComponentResource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Deprecated. Please use CalicoNodeDaemonSet, TyphaDeployment, and KubeControllersDeployment.
+ComponentResources can be used to customize the resource requirements for each component.
+Node, Typha, and KubeControllers are supported for installations.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>certificateManagement</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CertificateManagement">
+CertificateManagement
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CertificateManagement configures pods to submit a CertificateSigningRequest to the certificates.k8s.io/v1beta1 API in order
+to obtain TLS certificates. This feature requires that you bring your own CSR signing and approval process, otherwise
+pods will be stuck during initialization.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nonPrivileged</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.NonPrivilegedType">
+NonPrivilegedType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NonPrivileged configures Calico to be run in non-privileged containers as non-root users where possible.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoNodeDaemonSet</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+CalicoNodeDaemonSet
+</a>
+</em>
+</td>
+<td>
+<p>CalicoNodeDaemonSet configures the calico-node DaemonSet. If used in
+conjunction with the deprecated ComponentResources, then these overrides take precedence.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoKubeControllersDeployment</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+CalicoKubeControllersDeployment
+</a>
+</em>
+</td>
+<td>
+<p>CalicoKubeControllersDeployment configures the calico-kube-controllers Deployment. If used in
+conjunction with the deprecated ComponentResources, then these overrides take precedence.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>typhaDeployment</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TyphaDeployment">
+TyphaDeployment
+</a>
+</em>
+</td>
+<td>
+<p>TyphaDeployment configures the typha Deployment. If used in conjunction with the deprecated
+ComponentResources or TyphaAffinity, then these overrides take precedence.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>calicoWindowsUpgradeDaemonSet</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+CalicoWindowsUpgradeDaemonSet
+</a>
+</em>
+</td>
+<td>
+<p>CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>fipsMode</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.FIPSMode">
+FIPSMode
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FIPSMode uses images and features only that are using FIPS 140-2 validated cryptographic modules and standards.
+Default: Disabled</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.InstallationStatus'>InstallationStatus</h3>
+<h3 id="operator.tigera.io/v1.InstallationStatus">InstallationStatus
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.Installation'>Installation</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.Installation">Installation</a>)
 </p>
 <p>InstallationStatus defines the observed state of the Calico or Calico Enterprise installation.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>variant</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.ProductVariant'>ProductVariant</a>
-        </em>
-      </td>
-      <td>
-        <p>Variant is the most recently observed installed variant - one of Calico or TigeraSecureEnterprise</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>mtu</code>
-        <br />
-        <em>int32</em>
-      </td>
-      <td>
-        <p>
-          MTU is the most recently observed value for pod network MTU. This may be an explicitly configured value, or
-          based on Calico&rsquo;s native auto-detetion.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>imageSet</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          ImageSet is the name of the ImageSet being used, if there is an ImageSet that is being used. If an ImageSet is
-          not being used then this will not be set.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>computed</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.InstallationSpec'>InstallationSpec</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Computed is the final installation including overlaid resources.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>conditions</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#condition-v1-meta'>
-            []Kubernetes meta/v1.Condition
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Conditions represents the latest observed set of conditions for the component. A component may be one or more
-          of Ready, Progressing, Degraded or other customer types.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>variant</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.ProductVariant">
+ProductVariant
+</a>
+</em>
+</td>
+<td>
+<p>Variant is the most recently observed installed variant - one of Calico or TigeraSecureEnterprise</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mtu</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>MTU is the most recently observed value for pod network MTU. This may be an explicitly
+configured value, or based on Calico&rsquo;s native auto-detetion.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imageSet</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ImageSet is the name of the ImageSet being used, if there is an ImageSet
+that is being used. If an ImageSet is not being used then this will not be set.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>computed</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.InstallationSpec">
+InstallationSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Computed is the final installation including overlaid resources.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>conditions</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#condition-v1-meta">
+[]Kubernetes meta/v1.Condition
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Conditions represents the latest observed set of conditions for the component. A component may be one or more of
+Ready, Progressing, Degraded or other customer types.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.KubernetesAutodetectionMethod'>
-  KubernetesAutodetectionMethod (<code>string</code> alias)
-</h3>
+<h3 id="operator.tigera.io/v1.KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
+(<code>string</code> alias)</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.NodeAddressAutodetection'>NodeAddressAutodetection</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</a>)
 </p>
 <p>KubernetesAutodetectionMethod is a method of detecting an IP address based on the Kubernetes API.</p>
 <p>One of: NodeInternalIP</p>
-<h3 id='operator.tigera.io/v1.LinuxDataplaneOption'>
-  LinuxDataplaneOption (<code>string</code> alias)
-</h3>
+<h3 id="operator.tigera.io/v1.LinuxDataplaneOption">LinuxDataplaneOption
+(<code>string</code> alias)</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoNetworkSpec'>CalicoNetworkSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
 </p>
 <p>LinuxDataplaneOption controls which dataplane is to be used on Linux nodes.</p>
 <p>One of: Iptables, BPF</p>
-<h3 id='operator.tigera.io/v1.LogCollectionSpec'>LogCollectionSpec</h3>
-<p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.ApplicationLayerSpec'>ApplicationLayerSpec</a>)
-</p>
-<table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>collectLogs</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.LogCollectionStatusType'>LogCollectionStatusType</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>This setting enables or disable log collection. Allowed values are Enabled or Disabled.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>logIntervalSeconds</code>
-        <br />
-        <em>int64</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Interval in seconds for sending L7 log information for processing. Default: 5 sec</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>logRequestsPerInterval</code>
-        <br />
-        <em>int64</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Maximum number of unique L7 logs that are sent LogIntervalSeconds. Adjust this to limit the number of L7 logs
-          sent per LogIntervalSeconds to felix for further processing, use negative number to ignore limits. Default: -1
-        </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-<h3 id='operator.tigera.io/v1.LogCollectionStatusType'>
-  LogCollectionStatusType (<code>string</code> alias)
+<h3 id="operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec
 </h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.LogCollectionSpec'>LogCollectionSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
 </p>
-<h3 id='operator.tigera.io/v1.Metadata'>Metadata</h3>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>collectLogs</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.LogCollectionStatusType">
+LogCollectionStatusType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This setting enables or disable log collection.
+Allowed values are Enabled or Disabled.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>logIntervalSeconds</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Interval in seconds for sending L7 log information for processing.
+Default: 5 sec</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>logRequestsPerInterval</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Maximum number of unique L7 logs that are sent LogIntervalSeconds.
+Adjust this to limit the number of L7 logs sent per LogIntervalSeconds
+to felix for further processing, use negative number to ignore limits.
+Default: -1</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.LogCollectionStatusType">LogCollectionStatusType
+(<code>string</code> alias)</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.APIServerDeployment'>APIServerDeployment</a>,<a href='#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec'>
-    APIServerDeploymentPodTemplateSpec
-  </a>,<a href='#operator.tigera.io/v1.CalicoKubeControllersDeployment'>CalicoKubeControllersDeployment</a>,<a href='#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec'>
-    CalicoKubeControllersDeploymentPodTemplateSpec
-  </a>,<a href='#operator.tigera.io/v1.CalicoNodeDaemonSet'>CalicoNodeDaemonSet</a>,<a href='#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec'>
-    CalicoNodeDaemonSetPodTemplateSpec
-  </a>,<a href='#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet'>CalicoWindowsUpgradeDaemonSet</a>,<a href='#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec'>
-    CalicoWindowsUpgradeDaemonSetPodTemplateSpec
-  </a>,<a href='#operator.tigera.io/v1.TyphaDeployment'>TyphaDeployment</a>,<a href='#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec'>
-    TyphaDeploymentPodTemplateSpec
-  </a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</a>)
+</p>
+<h3 id="operator.tigera.io/v1.Metadata">Metadata
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>, 
+<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
+<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
+<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
+<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
+<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>, 
+<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 </p>
 <p>Metadata contains the standard Kubernetes labels and annotations fields.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>labels</code>
-        <br />
-        <em>map[string]string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Labels is a map of string keys and values that may match replicaset and service selectors. Each of these
-          key/value pairs are added to the object&rsquo;s labels provided the key does not already exist in the
-          object&rsquo;s labels.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>annotations</code>
-        <br />
-        <em>map[string]string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the
-          object&rsquo;s annotations provided the key does not already exist in the object&rsquo;s annotations.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>labels</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Labels is a map of string keys and values that may match replicaset and
+service selectors. Each of these key/value pairs are added to the
+object&rsquo;s labels provided the key does not already exist in the object&rsquo;s labels.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>annotations</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Annotations is a map of arbitrary non-identifying metadata. Each of these
+key/value pairs are added to the object&rsquo;s annotations provided the key does not
+already exist in the object&rsquo;s annotations.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.MonitorSpec'>MonitorSpec</h3>
+<h3 id="operator.tigera.io/v1.MonitorSpec">MonitorSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.Monitor'>Monitor</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
 </p>
 <p>MonitorSpec defines the desired state of Tigera monitor.</p>
-<h3 id='operator.tigera.io/v1.MonitorStatus'>MonitorStatus</h3>
+<h3 id="operator.tigera.io/v1.MonitorStatus">MonitorStatus
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.Monitor'>Monitor</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
 </p>
 <p>MonitorStatus defines the observed state of Tigera monitor.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>state</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p>State provides user-readable status.</p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>state</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>State provides user-readable status.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.MultiInterfaceMode'>
-  MultiInterfaceMode (<code>string</code> alias)
-</h3>
+<h3 id="operator.tigera.io/v1.MultiInterfaceMode">MultiInterfaceMode
+(<code>string</code> alias)</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoNetworkSpec'>CalicoNetworkSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
 </p>
 <p>MultiInterfaceMode describes the method of providing multiple pod interfaces.</p>
 <p>One of: None, Multus</p>
-<h3 id='operator.tigera.io/v1.NATOutgoingType'>
-  NATOutgoingType (<code>string</code> alias)
-</h3>
+<h3 id="operator.tigera.io/v1.NATOutgoingType">NATOutgoingType
+(<code>string</code> alias)</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.IPPool'>IPPool</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
 </p>
 <p>NATOutgoingType describe the type of outgoing NAT to use.</p>
 <p>One of: Enabled, Disabled</p>
-<h3 id='operator.tigera.io/v1.NodeAddressAutodetection'>NodeAddressAutodetection</h3>
+<h3 id="operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.CalicoNetworkSpec'>CalicoNetworkSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
 </p>
-<p>
-  NodeAddressAutodetection provides configuration options for auto-detecting node addresses. At most one option can be
-  used. If no detection option is specified, then IP auto detection will be disabled for this address family and IPs
-  must be specified directly on the Node resource.
-</p>
+<p>NodeAddressAutodetection provides configuration options for auto-detecting node addresses. At most one option
+can be used. If no detection option is specified, then IP auto detection will be disabled for this address family and IPs
+must be specified directly on the Node resource.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>firstFound</code>
-        <br />
-        <em>bool</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          FirstFound uses default interface matching parameters to select an interface, performing best-effort filtering
-          based on well-known interface names.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>kubernetes</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.KubernetesAutodetectionMethod'>KubernetesAutodetectionMethod</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Kubernetes configures Calico to detect node addresses based on the Kubernetes API.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>interface</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Interface enables IP auto-detection based on interfaces that match the given regex.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>skipInterface</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>SkipInterface enables IP auto-detection based on interfaces that do not match the given regex.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>canReach</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          CanReach enables IP auto-detection based on which source address on the node is used to reach the specified IP
-          or domain.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>cidrs</code>
-        <br />
-        <em>[]string</em>
-      </td>
-      <td>
-        <p>
-          CIDRS enables IP auto-detection based on which addresses on the nodes are within one of the provided CIDRs.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>firstFound</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>FirstFound uses default interface matching parameters to select an interface, performing best-effort
+filtering based on well-known interface names.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kubernetes</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.KubernetesAutodetectionMethod">
+KubernetesAutodetectionMethod
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Kubernetes configures Calico to detect node addresses based on the Kubernetes API.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>interface</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Interface enables IP auto-detection based on interfaces that match the given regex.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>skipInterface</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SkipInterface enables IP auto-detection based on interfaces that do not match
+the given regex.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>canReach</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CanReach enables IP auto-detection based on which source address on the node is used to reach the
+specified IP or domain.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cidrs</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>CIDRS enables IP auto-detection based on which addresses on the nodes are within
+one of the provided CIDRs.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.NodeAffinity'>NodeAffinity</h3>
+<h3 id="operator.tigera.io/v1.NodeAffinity">NodeAffinity
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.TyphaAffinity'>TyphaAffinity</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</a>)
 </p>
 <p>NodeAffinity is similar to *v1.NodeAffinity, but allows us to limit available schedulers.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>preferredDuringSchedulingIgnoredDuringExecution</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#preferredschedulingterm-v1-core'>
-            []Kubernetes core/v1.PreferredSchedulingTerm
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this
-          field, but it may choose a node that violates one or more of the expressions.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>requiredDuringSchedulingIgnoredDuringExecution</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#nodeselector-v1-core'>
-            Kubernetes core/v1.NodeSelector
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          WARNING: Please note that if the affinity requirements specified by this field are not met at scheduling time,
-          the pod will NOT be scheduled onto the node. There is no fallback to another affinity rules with this setting.
-          This may cause networking disruption or even catastrophic failure!
-          PreferredDuringSchedulingIgnoredDuringExecution should be used for affinity unless there is a specific well
-          understood reason to use RequiredDuringSchedulingIgnoredDuringExecution and you can guarantee that the
-          RequiredDuringSchedulingIgnoredDuringExecution will always have sufficient nodes to satisfy the requirement.
-          NOTE: RequiredDuringSchedulingIgnoredDuringExecution is set by default for AKS nodes, to avoid scheduling
-          Typhas on virtual-nodes. If the affinity requirements specified by this field cease to be met at some point
-          during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from
-          its node.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>preferredDuringSchedulingIgnoredDuringExecution</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#preferredschedulingterm-v1-core">
+[]Kubernetes core/v1.PreferredSchedulingTerm
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The scheduler will prefer to schedule pods to nodes that satisfy
+the affinity expressions specified by this field, but it may choose
+a node that violates one or more of the expressions.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>requiredDuringSchedulingIgnoredDuringExecution</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#nodeselector-v1-core">
+Kubernetes core/v1.NodeSelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>WARNING: Please note that if the affinity requirements specified by this field are not met at
+scheduling time, the pod will NOT be scheduled onto the node.
+There is no fallback to another affinity rules with this setting.
+This may cause networking disruption or even catastrophic failure!
+PreferredDuringSchedulingIgnoredDuringExecution should be used for affinity
+unless there is a specific well understood reason to use RequiredDuringSchedulingIgnoredDuringExecution and
+you can guarantee that the RequiredDuringSchedulingIgnoredDuringExecution will always have sufficient nodes to satisfy the requirement.
+NOTE: RequiredDuringSchedulingIgnoredDuringExecution is set by default for AKS nodes,
+to avoid scheduling Typhas on virtual-nodes.
+If the affinity requirements specified by this field cease to be met
+at some point during pod execution (e.g. due to an update), the system
+may or may not try to eventually evict the pod from its node.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.NonPrivilegedType'>
-  NonPrivilegedType (<code>string</code> alias)
-</h3>
+<h3 id="operator.tigera.io/v1.NonPrivilegedType">NonPrivilegedType
+(<code>string</code> alias)</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.InstallationSpec'>InstallationSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
 </p>
 <p>NonPrivilegedType specifies whether Calico runs as permissioned or not</p>
 <p>One of: Enabled, Disabled</p>
-<h3 id='operator.tigera.io/v1.OIDCType'>
-  OIDCType (<code>string</code> alias)
-</h3>
+<h3 id="operator.tigera.io/v1.OIDCType">OIDCType
+(<code>string</code> alias)</h3>
+<p>OIDCType defines how OIDC is configured for Tigera Enterprise. Dex should be the best option for most use-cases.
+The Tigera option can help in specific use-cases, for instance, when you are unable to configure a client secret.
+One of: Dex, Tigera</p>
+<h3 id="operator.tigera.io/v1.ProductVariant">ProductVariant
+(<code>string</code> alias)</h3>
 <p>
-  OIDCType defines how OIDC is configured for Tigera Enterprise. Dex should be the best option for most use-cases. The
-  Tigera option can help in specific use-cases, for instance, when you are unable to configure a client secret. One of:
-  Dex, Tigera
-</p>
-<h3 id='operator.tigera.io/v1.ProductVariant'>
-  ProductVariant (<code>string</code> alias)
-</h3>
-<p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.InstallationSpec'>InstallationSpec</a>,<a href='#operator.tigera.io/v1.InstallationStatus'>
-    InstallationStatus
-  </a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
+<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
 </p>
 <p>ProductVariant represents the variant of the product.</p>
 <p>One of: Calico, TigeraSecureEnterprise</p>
-<h3 id='operator.tigera.io/v1.PromptType'>
-  PromptType (<code>string</code> alias)
-</h3>
+<h3 id="operator.tigera.io/v1.PromptType">PromptType
+(<code>string</code> alias)</h3>
+<p>PromptType is a value that specifies whether the identity provider prompts the end user for re-authentication and
+consent.
+One of: None, Login, Consent, SelectAccount.</p>
+<h3 id="operator.tigera.io/v1.Provider">Provider
+(<code>string</code> alias)</h3>
 <p>
-  PromptType is a value that specifies whether the identity provider prompts the end user for re-authentication and
-  consent. One of: None, Login, Consent, SelectAccount.
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
 </p>
-<h3 id='operator.tigera.io/v1.Provider'>
-  Provider (<code>string</code> alias)
-</h3>
+<p>Provider represents a particular provider or flavor of Kubernetes. Valid options
+are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise.</p>
+<h3 id="operator.tigera.io/v1.StatusConditionType">StatusConditionType
+(<code>string</code> alias)</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.InstallationSpec'>InstallationSpec</a>)
-</p>
-<p>
-  Provider represents a particular provider or flavor of Kubernetes. Valid options are: EKS, GKE, AKS, RKE2, OpenShift,
-  DockerEnterprise.
-</p>
-<h3 id='operator.tigera.io/v1.StatusConditionType'>
-  StatusConditionType (<code>string</code> alias)
-</h3>
-<p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.TigeraStatusCondition'>TigeraStatusCondition</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
 </p>
 <p>StatusConditionType is a type of condition that may apply to a particular component.</p>
-<h3 id='operator.tigera.io/v1.TLS'>TLS</h3>
+<h3 id="operator.tigera.io/v1.TLS">TLS
+</h3>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>secretName</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          SecretName indicates the name of the secret in the tigera-operator namespace that contains the private key and
-          certificate that the management cluster uses when it listens for incoming connections.
-        </p>
-        <p>
-          When set to tigera-management-cluster-connection voltron will use the same cert bundle which Guardian client
-          certs are signed with.
-        </p>
-        <p>
-          When set to manager-tls, voltron will use the same cert bundle which Manager UI is served with. This cert
-          bundle must be a publicly signed cert created by the user. Note that Tigera Operator will generate a
-          self-signed manager-tls cert if one does not exist, and use of that cert will result in Guardian being unable
-          to verify Voltron&rsquo;s identity.
-        </p>
-        <p>
-          If changed on a running cluster with connected managed clusters, all managed clusters will disconnect as they
-          will no longer be able to verify Voltron&rsquo;s identity. To reconnect existing managed clusters, change the
-          tls.ca of the managed clusters&rsquo; ManagementClusterConnection resource.
-        </p>
-        <p>One of: tigera-management-cluster-connection, manager-tls</p>
-        <p>Default: tigera-management-cluster-connection</p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>secretName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecretName indicates the name of the secret in the tigera-operator namespace that contains the private key and certificate that the management cluster uses when it listens for incoming connections.</p>
+<p>When set to tigera-management-cluster-connection voltron will use the same cert bundle which Guardian client certs are signed with.</p>
+<p>When set to manager-tls, voltron will use the same cert bundle which Manager UI is served with.
+This cert bundle must be a publicly signed cert created by the user.
+Note that Tigera Operator will generate a self-signed manager-tls cert if one does not exist,
+and use of that cert will result in Guardian being unable to verify Voltron&rsquo;s identity.</p>
+<p>If changed on a running cluster with connected managed clusters, all managed clusters will disconnect as they will no longer be able to verify Voltron&rsquo;s identity.
+To reconnect existing managed clusters, change the tls.ca of the  managed clusters&rsquo; ManagementClusterConnection resource.</p>
+<p>One of: tigera-management-cluster-connection, manager-tls</p>
+<p>Default: tigera-management-cluster-connection</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.TigeraStatusCondition'>TigeraStatusCondition</h3>
+<h3 id="operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.TigeraStatusStatus'>TigeraStatusStatus</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</a>)
 </p>
 <p>TigeraStatusCondition represents a condition attached to a particular component.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>type</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.StatusConditionType'>StatusConditionType</a>
-        </em>
-      </td>
-      <td>
-        <p>The type of condition. May be Available, Progressing, or Degraded.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>status</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.ConditionStatus'>ConditionStatus</a>
-        </em>
-      </td>
-      <td>
-        <p>The status of the condition. May be True, False, or Unknown.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>lastTransitionTime</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#time-v1-meta'>
-            Kubernetes meta/v1.Time
-          </a>
-        </em>
-      </td>
-      <td>
-        <p>The timestamp representing the start time for the current status.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>reason</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p>A brief reason explaining the condition.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>message</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p>Optionally, a detailed message providing additional context.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>observedGeneration</code>
-        <br />
-        <em>int64</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          observedGeneration represents the generation that the condition was set based upon. For instance, if
-          generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of
-          date with respect to the current state of the instance.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.StatusConditionType">
+StatusConditionType
+</a>
+</em>
+</td>
+<td>
+<p>The type of condition. May be Available, Progressing, or Degraded.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.ConditionStatus">
+ConditionStatus
+</a>
+</em>
+</td>
+<td>
+<p>The status of the condition. May be True, False, or Unknown.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastTransitionTime</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>The timestamp representing the start time for the current status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reason</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>A brief reason explaining the condition.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>message</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Optionally, a detailed message providing additional context.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>observedGeneration represents the generation that the condition was set based upon.
+For instance, if generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+with respect to the current state of the instance.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.TigeraStatusReason'>
-  TigeraStatusReason (<code>string</code> alias)
-</h3>
+<h3 id="operator.tigera.io/v1.TigeraStatusReason">TigeraStatusReason
+(<code>string</code> alias)</h3>
 <p>TigeraStatusReason represents the reason for a particular condition.</p>
-<h3 id='operator.tigera.io/v1.TigeraStatusSpec'>TigeraStatusSpec</h3>
+<h3 id="operator.tigera.io/v1.TigeraStatusSpec">TigeraStatusSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.TigeraStatus'>TigeraStatus</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
 </p>
 <p>TigeraStatusSpec defines the desired state of TigeraStatus</p>
-<h3 id='operator.tigera.io/v1.TigeraStatusStatus'>TigeraStatusStatus</h3>
+<h3 id="operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.TigeraStatus'>TigeraStatus</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
 </p>
 <p>TigeraStatusStatus defines the observed state of TigeraStatus</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>conditions</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.TigeraStatusCondition'>[]TigeraStatusCondition</a>
-        </em>
-      </td>
-      <td>
-        <p>
-          Conditions represents the latest observed set of conditions for this component. A component may be one or more
-          of Available, Progressing, or Degraded.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>conditions</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TigeraStatusCondition">
+[]TigeraStatusCondition
+</a>
+</em>
+</td>
+<td>
+<p>Conditions represents the latest observed set of conditions for this component. A component may be one or more of
+Available, Progressing, or Degraded.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.TyphaAffinity'>TyphaAffinity</h3>
+<h3 id="operator.tigera.io/v1.TyphaAffinity">TyphaAffinity
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.InstallationSpec'>InstallationSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
 </p>
-<p>
-  Deprecated. Please use TyphaDeployment instead. TyphaAffinity allows configuration of node affinity characteristics
-  for Typha pods.
-</p>
+<p>Deprecated. Please use TyphaDeployment instead.
+TyphaAffinity allows configuration of node affinity characteristics for Typha pods.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>nodeAffinity</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.NodeAffinity'>NodeAffinity</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>NodeAffinity describes node affinity scheduling rules for typha.</p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>nodeAffinity</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.NodeAffinity">
+NodeAffinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeAffinity describes node affinity scheduling rules for typha.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.TyphaDeployment'>TyphaDeployment</h3>
+<h3 id="operator.tigera.io/v1.TyphaDeployment">TyphaDeployment
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.InstallationSpec'>InstallationSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
 </p>
 <p>TyphaDeployment is the configuration for the typha Deployment.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>metadata</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.Metadata'>Metadata</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the Deployment.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>spec</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.TyphaDeploymentSpec'>TyphaDeploymentSpec</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Spec is the specification of the typha Deployment.</p>
-        <br />
-        <br />
-        <table></table>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the Deployment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">
+TyphaDeploymentSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the specification of the typha Deployment.</p>
+<br/>
+<br/>
+<table>
 </table>
-<h3 id='operator.tigera.io/v1.TyphaDeploymentContainer'>TyphaDeploymentContainer</h3>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.TyphaDeploymentContainer">TyphaDeploymentContainer
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.TyphaDeploymentPodSpec'>TyphaDeploymentPodSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 </p>
 <p>TyphaDeploymentContainer is a typha Deployment container.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>name</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p>Name is an enum which identifies the typha Deployment container by name.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>resources</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core'>
-            Kubernetes core/v1.ResourceRequirements
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Resources allows customization of limits and requests for compute resources such as cpu and memory. If
-          specified, this overrides the named typha Deployment container&rsquo;s resources. If omitted, the typha
-          Deployment will use its default value for this container&rsquo;s resources. If used in conjunction with the
-          deprecated ComponentResources, then this value takes precedence.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the typha Deployment container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named typha Deployment container&rsquo;s resources.
+If omitted, the typha Deployment will use its default value for this container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.TyphaDeploymentInitContainer'>TyphaDeploymentInitContainer</h3>
+<h3 id="operator.tigera.io/v1.TyphaDeploymentInitContainer">TyphaDeploymentInitContainer
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.TyphaDeploymentPodSpec'>TyphaDeploymentPodSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 </p>
 <p>TyphaDeploymentInitContainer is a typha Deployment init container.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>name</code>
-        <br />
-        <em>string</em>
-      </td>
-      <td>
-        <p>Name is an enum which identifies the typha Deployment init container by name.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>resources</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core'>
-            Kubernetes core/v1.ResourceRequirements
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Resources allows customization of limits and requests for compute resources such as cpu and memory. If
-          specified, this overrides the named typha Deployment init container&rsquo;s resources. If omitted, the typha
-          Deployment will use its default value for this init container&rsquo;s resources. If used in conjunction with
-          the deprecated ComponentResources, then this value takes precedence.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is an enum which identifies the typha Deployment init container by name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
+Kubernetes core/v1.ResourceRequirements
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Resources allows customization of limits and requests for compute resources such as cpu and memory.
+If specified, this overrides the named typha Deployment init container&rsquo;s resources.
+If omitted, the typha Deployment will use its default value for this init container&rsquo;s resources.
+If used in conjunction with the deprecated ComponentResources, then this value takes precedence.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.TyphaDeploymentPodSpec'>TyphaDeploymentPodSpec</h3>
+<h3 id="operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec'>TyphaDeploymentPodTemplateSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 </p>
-<p>TyphaDeploymentDeploymentPodSpec is the typha Deployment&rsquo;s PodSpec.</p>
+<p>TyphaDeploymentPodSpec is the typha Deployment&rsquo;s PodSpec.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>initContainers</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.TyphaDeploymentInitContainer'>[]TyphaDeploymentInitContainer</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          InitContainers is a list of typha init containers. If specified, this overrides the specified typha Deployment
-          init containers. If omitted, the typha Deployment will use its default values for its init containers.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>containers</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.TyphaDeploymentContainer'>[]TyphaDeploymentContainer</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Containers is a list of typha containers. If specified, this overrides the specified typha Deployment
-          containers. If omitted, the typha Deployment will use its default values for its containers.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>affinity</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core'>
-            Kubernetes core/v1.Affinity
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Affinity is a group of affinity scheduling rules for the typha pods. If specified, this overrides any affinity
-          that may be set on the typha Deployment. If omitted, the typha Deployment will use its default value for
-          affinity. If used in conjunction with the deprecated TyphaAffinity, then this value takes precedence. WARNING:
-          Please note that this field will override the default calico-typha Deployment affinity.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>nodeSelector</code>
-        <br />
-        <em>map[string]string</em>
-      </td>
-      <td>
-        <p>
-          NodeSelector is the calico-typha pod&rsquo;s scheduling constraints. If specified, each of the key/value pairs
-          are added to the calico-typha Deployment nodeSelector provided the key does not already exist in the
-          object&rsquo;s nodeSelector. If omitted, the calico-typha Deployment will use its default value for
-          nodeSelector. WARNING: Please note that this field will modify the default calico-typha Deployment
-          nodeSelector.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>tolerations</code>
-        <br />
-        <em>
-          <a href='https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core'>
-            []Kubernetes core/v1.Toleration
-          </a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          Tolerations is the typha pod&rsquo;s tolerations. If specified, this overrides any tolerations that may be set
-          on the typha Deployment. If omitted, the typha Deployment will use its default value for tolerations. WARNING:
-          Please note that this field will override the default calico-typha Deployment tolerations.
-        </p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>initContainers</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentInitContainer">
+[]TyphaDeploymentInitContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>InitContainers is a list of typha init containers.
+If specified, this overrides the specified typha Deployment init containers.
+If omitted, the typha Deployment will use its default values for its init containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containers</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentContainer">
+[]TyphaDeploymentContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Containers is a list of typha containers.
+If specified, this overrides the specified typha Deployment containers.
+If omitted, the typha Deployment will use its default values for its containers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Affinity is a group of affinity scheduling rules for the typha pods.
+If specified, this overrides any affinity that may be set on the typha Deployment.
+If omitted, the typha Deployment will use its default value for affinity.
+If used in conjunction with the deprecated TyphaAffinity, then this value takes precedence.
+WARNING: Please note that this field will override the default calico-typha Deployment affinity.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>NodeSelector is the calico-typha pod&rsquo;s scheduling constraints.
+If specified, each of the key/value pairs are added to the calico-typha Deployment nodeSelector provided
+the key does not already exist in the object&rsquo;s nodeSelector.
+If omitted, the calico-typha Deployment will use its default value for nodeSelector.
+WARNING: Please note that this field will modify the default calico-typha Deployment nodeSelector.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>terminationGracePeriodSeconds</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+Value must be non-negative integer. The value zero indicates stop immediately via
+the kill signal (no opportunity to shut down).
+If this value is nil, the default grace period will be used instead.
+The grace period is the duration in seconds after the processes running in the pod are sent
+a termination signal and the time when the processes are forcibly halted with a kill signal.
+Set this value longer than the expected cleanup time for your process.
+Defaults to 30 seconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tolerations</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
+[]Kubernetes core/v1.Toleration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Tolerations is the typha pod&rsquo;s tolerations.
+If specified, this overrides any tolerations that may be set on the typha Deployment.
+If omitted, the typha Deployment will use its default value for tolerations.
+WARNING: Please note that this field will override the default calico-typha Deployment tolerations.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<h3 id='operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec'>TyphaDeploymentPodTemplateSpec</h3>
+<h3 id="operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.TyphaDeploymentSpec'>TyphaDeploymentSpec</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 </p>
 <p>TyphaDeploymentPodTemplateSpec is the typha Deployment&rsquo;s PodTemplateSpec</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>metadata</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.Metadata'>Metadata</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the pod&rsquo;s metadata.</p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>spec</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.TyphaDeploymentPodSpec'>TyphaDeploymentPodSpec</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Spec is the typha Deployment&rsquo;s PodSpec.</p>
-        <br />
-        <br />
-        <table></table>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.Metadata">
+Metadata
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
+the pod&rsquo;s metadata.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">
+TyphaDeploymentPodSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the typha Deployment&rsquo;s PodSpec.</p>
+<br/>
+<br/>
+<table>
 </table>
-<h3 id='operator.tigera.io/v1.TyphaDeploymentSpec'>TyphaDeploymentSpec</h3>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec
+</h3>
 <p>
-  (<em>Appears on:</em>
-  <a href='#operator.tigera.io/v1.TyphaDeployment'>TyphaDeployment</a>)
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>)
 </p>
 <p>TyphaDeploymentSpec defines configuration for the typha Deployment.</p>
 <table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <code>minReadySeconds</code>
-        <br />
-        <em>int32</em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>
-          MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should be ready
-          without any of its container crashing, for it to be considered available. If specified, this overrides any
-          minReadySeconds value that may be set on the typha Deployment. If omitted, the typha Deployment will use its
-          default value for minReadySeconds.
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>template</code>
-        <br />
-        <em>
-          <a href='#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec'>TyphaDeploymentPodTemplateSpec</a>
-        </em>
-      </td>
-      <td>
-        <em>(Optional)</em>
-        <p>Template describes the typha Deployment pod that will be created.</p>
-      </td>
-    </tr>
-  </tbody>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>minReadySeconds</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should
+be ready without any of its container crashing, for it to be considered available.
+If specified, this overrides any minReadySeconds value that may be set on the typha Deployment.
+If omitted, the typha Deployment will use its default value for minReadySeconds.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">
+TyphaDeploymentPodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Template describes the typha Deployment pod that will be created.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>strategy</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentStrategy">
+TyphaDeploymentStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The deployment strategy to use to replace existing pods with new ones.</p>
+</td>
+</tr>
+</tbody>
 </table>
-<hr />
+<h3 id="operator.tigera.io/v1.TyphaDeploymentStrategy">TyphaDeploymentStrategy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+</p>
+<p>TyphaDeploymentStrategy describes how to replace existing pods with new ones.  Only RollingUpdate is supported
+at this time so the Type field is not exposed.</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>rollingUpdate</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#rollingupdatedeployment-v1-apps">
+Kubernetes apps/v1.RollingUpdateDeployment
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Rolling update config params. Present only if DeploymentStrategyType =
+RollingUpdate.
+to be.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="operator.tigera.io/v1.WAFStatusType">WAFStatusType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+</p>
+<hr/>

--- a/calico_versioned_docs/version-3.26/reference/installation/_api.mdx
+++ b/calico_versioned_docs/version-3.26/reference/installation/_api.mdx
@@ -210,6 +210,19 @@ ApplicationLayerPolicyStatusType
 When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in workloads for traffic enforcement on the application layer.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>envoy</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.EnvoySettings">
+EnvoySettings
+</a>
+</em>
+</td>
+<td>
+<p>User-configurable settings for the Envoy proxy.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -1734,6 +1747,19 @@ ApplicationLayerPolicyStatusType
 <td>
 <p>Application Layer Policy controls whether or not ALP enforcement is enabled for the cluster.
 When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in workloads for traffic enforcement on the application layer.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>envoy</code><br/>
+<em>
+<a href="#operator.tigera.io/v1.EnvoySettings">
+EnvoySettings
+</a>
+</em>
+</td>
+<td>
+<p>User-configurable settings for the Envoy proxy.</p>
 </td>
 </tr>
 </tbody>
@@ -3946,6 +3972,50 @@ Ready, Progressing, Degraded or other customer types.</p>
 (<code>string</code> alias)</h3>
 <p>EncryptionOption specifies the traffic encryption mode when connecting to a Syslog server.</p>
 <p>One of: None, TLS</p>
+<h3 id="operator.tigera.io/v1.EnvoySettings">EnvoySettings
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>xffNumTrustedHops</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The number of additional ingress proxy hops from the right side of the
+x-forwarded-for HTTP header to trust when determining the origin client’s
+IP address. 0 is permitted, but &gt;=1 is the typical setting.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>useRemoteAddress</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>If set to true, the Envoy connection manager will use the real remote address
+of the client connection when determining internal versus external origin and
+manipulating various headers.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="operator.tigera.io/v1.FIPSMode">FIPSMode
 (<code>string</code> alias)</h3>
 <p>


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->
* Calico (unversioned)
* Calico Enterprise (unversioned)
* Calico Cloud (unversioned)
* Calico v3.24
* Calico v3.26
* Calico Enterprise v3.16
* Calico Enterprise v3.17
* Calico Cloud v3.17

Issue: N/A
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
The documentation files are meant to be regenerated on each Calico release; as these files are
no longer in the calico or calico-private repositories, this has not been done. Likewise, this
does not seem to have been done as part of docs release either.

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->
