### PR TITLE
DOCS-Add-link-skip-list

### DIFF
--- a/__tests__/crawler.test.js
+++ b/__tests__/crawler.test.js
@@ -149,6 +149,7 @@ test("Crawl the docs and execute tests", async () => {
     'https://www.tigera.io/tutorials/?_sf_s=WireGuard',
     'https://www.elastic.co/guide/en/apm/server/current/configuring-howto-apm-server.html',
     'https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html',
+    'https://www.wireguard.com/formal-verification/',
   ];
 
   const lc = linkChecker();


### PR DESCRIPTION
Link is consistently showing up as a dead link in PRs, as well as main publishing site this week. 

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->