### PR TITLE
Fix up operator API generation rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ YARN=docker run -i --rm -v "$(shell pwd):/docs" -p 127.0.0.1:3000:3000 -w /docs 
 YARN_ACTION_SUFFIX=-container
 endif
 
+# Generate a list of all the calico/ent/cloud branches (including the 'unversioned' docs, which
+# represent the `next` branch.
 CALICO_BRANCHES=calico__operator_reference $(addsuffix __operator_reference,$(wildcard calico_versioned_docs/*))
 CALICO_ENT_BRANCHES=calico-enterprise__operator_reference $(addsuffix __operator_reference,$(wildcard calico-enterprise_versioned_docs/*))
 CALICO_CLOUD_BRANCHES=calico-cloud__operator_reference $(addsuffix __operator_reference,$(wildcard calico-cloud_versioned_docs/*))
@@ -62,13 +64,20 @@ index:
 	docker run -it -e APPLICATION_ID -e API_KEY --env-file=.env.local algolia/docsearch-scraper
 
 .PHONY: $(CALICO_BRANCHES) $(CALICO_ENT_BRANCHES) $(CALICO_CLOUD_BRANCHES)
+# This represents the list of branches  for Calico and Calico Enterprise,
+# which need the `build-operator-reference` target executed.
 $(CALICO_BRANCHES) $(CALICO_ENT_BRANCHES): %__operator_reference : %
-	PRODUCT=$< $(MAKE) build-operator-reference
+	PRODUCT=$< $(MAKE) build-operator-reference 2>&1 | sed 's|^|[$<] |'
 
+# Calico Cloud requires `build-operator-reference` but also requires
+# the `build-ia-operator-reference` target to be run as well.
 $(CALICO_CLOUD_BRANCHES) : %__operator_reference : %
-	PRODUCT=$< $(MAKE) build-operator-reference
-	PRODUCT=$< $(MAKE) build-ia-operator-reference
+	PRODUCT=$< $(MAKE) build-operator-reference  2>&1 | sed 's|^|[$<] |'
+	PRODUCT=$< $(MAKE) build-ia-operator-reference  2>&1 | sed 's|^|[$<] |'
 
+# This breaks up automatic generation by the three product
+# categories - OSS, cloud, and enterprise - but also retains
+# the `autogen` target, which updates all three.
 .PHONY: autogen autogen_calico autogen_enterprise autogen_cloud
 autogen: autogen_calico autogen_enterprise autogen_cloud
 autogen_calico: $(CALICO_BRANCHES)
@@ -77,7 +86,7 @@ autogen_cloud: $(CALICO_CLOUD_BRANCHES)
 
 .PHONY: build-operator-reference
 build-operator-reference:
-	mkdir -p .go-pkg-cache && \
+	@mkdir -p .go-pkg-cache && \
 		docker run --rm \
 			--net=host \
 			-v $(CURDIR):/go/src/$(PACKAGE_NAME):rw \
@@ -100,7 +109,7 @@ build-operator-reference:
 GIT_CONFIG_SSH ?= git config --global url."ssh://git@github.com/".insteadOf "https://github.com/";
 
 build-ia-operator-reference:
-	mkdir -p .go-pkg-cache && \
+	@mkdir -p .go-pkg-cache && \
 		docker run --rm \
 			--net=host \
 			-v $(CURDIR):/go/src/$(PACKAGE_NAME):rw \

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@ YARN=docker run -i --rm -v "$(shell pwd):/docs" -p 127.0.0.1:3000:3000 -w /docs 
 YARN_ACTION_SUFFIX=-container
 endif
 
-CALICO_BRANCHES=$(addsuffix __operator_reference,$(wildcard calico_versioned_docs/*))
-CALICO_ENT_BRANCHES=$(addsuffix __operator_reference,$(wildcard calico-enterprise_versioned_docs/*))
-CALICO_CLOUD_BRANCHES=$(addsuffix __operator_reference,$(wildcard calico-cloud_versioned_docs/*))
+CALICO_BRANCHES=calico__operator_reference $(addsuffix __operator_reference,$(wildcard calico_versioned_docs/*))
+CALICO_ENT_BRANCHES=calico-enterprise__operator_reference $(addsuffix __operator_reference,$(wildcard calico-enterprise_versioned_docs/*))
+CALICO_CLOUD_BRANCHES=calico-cloud__operator_reference $(addsuffix __operator_reference,$(wildcard calico-cloud_versioned_docs/*))
 
 build: init
 	$(YARN) build


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s): N/A (PR is for docs repo tooling itself)

Issue: N/A

Link to docs preview: N/A

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
Operator API documentation regeneration has not been happening. This change updates
the Makefile so that it's possible to update individual docs trees, but also update
all trees at once to ensure everything is correct and up-to-date.

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->
