### PR TITLE
Add 'make start-with-vnext' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ build: init
 start: init
 	$(YARN) start$(YARN_ACTION_SUFFIX)
 
+.PHONY: start-with-vnext
+start-with-vnext: init
+	$(YARN) start-with-vnext$(YARN_ACTION_SUFFIX)
+
 .PHONY: test
 test: init
 	./scripts/serve-test.sh

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ build: init
 start: init
 	$(YARN) start$(YARN_ACTION_SUFFIX)
 
-.PHONY: start-with-vnext
-start-with-vnext: init
-	$(YARN) start-with-vnext$(YARN_ACTION_SUFFIX)
+.PHONY: start-next
+start-next: init
+	$(YARN) start-next$(YARN_ACTION_SUFFIX)
 
 .PHONY: test
 test: init

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ CALICO_CLOUD_BRANCHES=calico-cloud__operator_reference $(addsuffix __operator_re
 build: init
 	$(YARN) build
 
+build-next: init
+	$(YARN) build-next
+
 .PHONY: start
 start: init
 	$(YARN) start$(YARN_ACTION_SUFFIX)

--- a/docusaurus.config.with-vnext.js
+++ b/docusaurus.config.with-vnext.js
@@ -1,0 +1,17 @@
+// This file imports the config from docusaurus.config.js and adds the 'current' version to
+// onlyIncludeVersions, so that the 'next' version is available when running
+// 'make start-with-vnext' locally.
+
+let config = require('./docusaurus.config.js');
+
+for (let i = 0; i < config['plugins'].length; i++) {
+    let onlyIncludeVersions = config['plugins'][i][1].onlyIncludeVersions;
+    if (onlyIncludeVersions !== undefined) {
+        if (!config['plugins'][i][1].onlyIncludeVersions.includes('current')) {
+            config['plugins'][i][1].onlyIncludeVersions = ['current', ...onlyIncludeVersions];
+            console.log(config['plugins'][i][1].onlyIncludeVersions);
+        }
+    }
+}
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "start-container": "docusaurus start -h 0.0.0.0",
+    "start-with-vnext": "docusaurus start --config docusaurus.config.with-vnext.js",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "start-container": "docusaurus start -h 0.0.0.0",
-    "start-with-vnext": "docusaurus start --config docusaurus.config.with-vnext.js",
+    "start-next": "docusaurus start --config scripts/docusaurus.config.with-vnext.js",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start-container": "docusaurus start -h 0.0.0.0",
     "start-next": "docusaurus start --config scripts/docusaurus.config.with-vnext.js",
     "build": "docusaurus build",
+    "build-next": "docusaurus build --config scripts/docusaurus.config.with-vnext.js",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/scripts/docusaurus.config.with-vnext.js
+++ b/scripts/docusaurus.config.with-vnext.js
@@ -1,8 +1,10 @@
 // This file imports the config from docusaurus.config.js and adds the 'current' version to
 // onlyIncludeVersions, so that the 'next' version is available when running
-// 'make start-with-vnext' locally.
+// 'make start-next' locally.
 
-let config = require('./docusaurus.config.js');
+// TODO: Replace this line with the one below it when upgrading to docusaurus v3
+let config = require('../docusaurus.config.js');
+//import { config } from '../docusaurus.config.js';
 
 for (let i = 0; i < config['plugins'].length; i++) {
     let onlyIncludeVersions = config['plugins'][i][1].onlyIncludeVersions;
@@ -14,4 +16,6 @@ for (let i = 0; i < config['plugins'].length; i++) {
     }
 }
 
+// TODO: Replace this line with the one below it when upgrading to docusaurus v3
 module.exports = config;
+//export { config };


### PR DESCRIPTION
Add 'make start-with-vnext' command that includes the 'current' version in onlyIncludeVersions in the docusaurus config, so that one can visualize the 'next' version of the locally rendered website (which doesn't show up in 'make start' since this PR: https://github.com/tigera/docs/pull/1052/)

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->