### PR TITLE
Allow TCP DNS queries to kube-dns in the default deny policy

### DIFF
--- a/calico/network-policy/get-started/kubernetes-default-deny.mdx
+++ b/calico/network-policy/get-started/kubernetes-default-deny.mdx
@@ -95,6 +95,12 @@ spec:
       selector: 'k8s-app == "kube-dns"'
       ports:
       - 53
+  - action: Allow
+    protocol: TCP
+    destination:
+      selector: 'k8s-app == "kube-dns"'
+      ports:
+      - 53
 ```
 
 It is important to note the above policy deliberately excludes the `kube-system`, `calico-system` and `calico-apiserver` namespaces by using a negative `namespaceSelector` to avoid impacting any control plane components. To secure the control plane you can write specific policies for each control plane component, though you should do so with care, ideally at cluster creation time, since getting these wrong can leave your cluster in a broken state. We recommend you always make sure you have the correct {{prodname}} [failsafe ports](../../reference/felix/configuration.mdx) in place before you start trying to create policies for the control plane.


### PR DESCRIPTION
In https://github.com/cert-manager/website/pull/1344#discussion_r1393908103 we're discussing whether the default Calico deny policy should also allow TCP DNS queries.

Is there a reason to block them?

Fixes: https://github.com/projectcalico/calico/issues/8224

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->