### PR TITLE
Fix indentation in monitor-component-visual.mdx

### DIFF
--- a/calico/operations/monitor/monitor-component-visual.mdx
+++ b/calico/operations/monitor/monitor-component-visual.mdx
@@ -54,8 +54,8 @@ metadata:
   namespace: calico-monitoring
 spec:
   selector:
-      app:  prometheus-pod
-      role: monitoring
+    app:  prometheus-pod
+    role: monitoring
   ports:
   - port: 9090
     targetPort: 9090

--- a/calico_versioned_docs/version-3.24/operations/monitor/monitor-component-visual.mdx
+++ b/calico_versioned_docs/version-3.24/operations/monitor/monitor-component-visual.mdx
@@ -54,8 +54,8 @@ metadata:
   namespace: calico-monitoring
 spec:
   selector:
-      app:  prometheus-pod
-      role: monitoring
+    app:  prometheus-pod
+    role: monitoring
   ports:
   - port: 9090
     targetPort: 9090

--- a/calico_versioned_docs/version-3.25/operations/monitor/monitor-component-visual.mdx
+++ b/calico_versioned_docs/version-3.25/operations/monitor/monitor-component-visual.mdx
@@ -54,8 +54,8 @@ metadata:
   namespace: calico-monitoring
 spec:
   selector:
-      app:  prometheus-pod
-      role: monitoring
+    app:  prometheus-pod
+    role: monitoring
   ports:
   - port: 9090
     targetPort: 9090

--- a/calico_versioned_docs/version-3.26/operations/monitor/monitor-component-visual.mdx
+++ b/calico_versioned_docs/version-3.26/operations/monitor/monitor-component-visual.mdx
@@ -54,8 +54,8 @@ metadata:
   namespace: calico-monitoring
 spec:
   selector:
-      app:  prometheus-pod
-      role: monitoring
+    app:  prometheus-pod
+    role: monitoring
   ports:
   - port: 9090
     targetPort: 9090


### PR DESCRIPTION
The selector fields were indented too much

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->