### PR TITLE
Improve cluster mesh docs

### DIFF
--- a/calico-cloud/multicluster/kubeconfig.mdx
+++ b/calico-cloud/multicluster/kubeconfig.mdx
@@ -188,7 +188,7 @@ In this setup, the cluster mesh will be configured to meet the pod IP routabilit
       --from-file=kubeconfig=<kubeconfig file>
    ```
 
-1. If RBAC is enabled in cluster A, create a Role and RoleBinding that {{prodname}} will use to access the secret that contains the kubeconfig for cluster B:
+1. If RBAC is enabled in cluster A, create a Role and RoleBinding for {{prodname}} to use to access the secret that contains the kubeconfig for cluster B:
    ```bash
    kubectl create -f - <<EOF
    apiVersion: rbac.authorization.k8s.io/v1
@@ -260,7 +260,7 @@ In this setup, the cluster mesh will rely on the [underlying network](#other-net
       --from-file=kubeconfig=<kubeconfig file>
    ```
 
-1. If RBAC is enabled in cluster A, create a Role and RoleBinding that {{prodname}} will use to access the secret that contains the kubeconfig for cluster B:
+1. If RBAC is enabled in cluster A, create a Role and RoleBinding for {{prodname}} to use to access the secret that contains the kubeconfig for cluster B:
    ```bash
    kubectl create -f - <<EOF
    apiVersion: rbac.authorization.k8s.io/v1
@@ -310,7 +310,7 @@ In this setup, the cluster mesh will rely on the [underlying network](#other-net
 
 1. If you have no IP pools in cluster A with NAT-outgoing enabled, skip this step.
 
-   Otherwise, if you have IP pools in cluster A with NAT-outgoing enabled and workloads in that pool will egress to workloads in cluster B, you need to instruct {{prodname}} to not perform NAT on traffic destined for IP pools in cluster B.
+   Otherwise, if you have IP pools in cluster A with NAT-outgoing enabled, and workloads in that pool will egress to workloads in cluster B, you need to instruct {{prodname}} to not perform NAT on traffic destined for IP pools in cluster B.
 
    You can achieve this by creating a disabled IP pool in cluster A for each CIDR in cluster B. This IP pool should have NAT-outgoing disabled. For example:
 
@@ -339,17 +339,17 @@ After completing the above steps for all cluster pairs in the cluster mesh, your
 :::
 
 ### Switch to multi-cluster networking
-The steps above assume that you are configuring federated endpoint identity and multi-cluster networking for the first time. If you already have federated endpoint identity and are looking to utilize multi-cluster networking, the steps below outline the changes that must be made if you had previously set up federated endpoint identity prior to the introduction of multi-cluster networking:
+The steps above assume that you are configuring both federated endpoint identity and multi-cluster networking for the first time. If you already have federated endpoint identity, and want to use multi-cluster networking, follow these steps:
 
 1. Validate that all [requirements](#calico-enterprise-multi-cluster-networking) for multi-cluster networking have been met.
 2. Update the ClusterRole in each cluster in the cluster mesh using the RBAC manifest found in [Create kubeconfig files](#create-kubeconfig-files)
-3. Update all RemoteClusterConfigurations to set `Spec.OverlayRoutingMode` to `Enabled`
-4. Ensure that all RemoteClusterConfigurations are bidirectional, i.e. ensure that RemoteClusterConfigurations were established following the [instructions](#create-remoteclusterconfigurations) for in both directions for each cluster pair.
+3. In all RemoteClusterConfigurations, set `Spec.OverlayRoutingMode` to `Enabled`.
+4. Verify that all RemoteClusterConfigurations are bidirectional (in both directions for each cluster pair) using these [instructions](#create-remoteclusterconfigurations).
 5. If you had previously created disabled IP pools to prevent NAT outgoing from applying to remote cluster destinations, those disabled IP pools are no longer needed when using multi-cluster networking and must be deleted.
 
 
 ### Validate federated endpoint identity & multi-cluster networking
-#### Validate RemoteClusterConfiguration & federated endpoint identity
+#### Validate RemoteClusterConfiguration and federated endpoint identity
 ##### Check remote cluster connection
 You can check the Typha logs for remote cluster connection status. Run the following command:
 ```bash
@@ -391,7 +391,7 @@ spec:
 ```
 
 ### Troubleshoot
-#### Troubleshoot RemoteClusterConfiguration & federated endpoint identity
+#### Troubleshoot RemoteClusterConfiguration and federated endpoint identity
 
 ##### Verify configuration
 For each impacted remote cluster pair (between cluster A and cluster B):
@@ -412,7 +412,7 @@ For each impacted remote cluster pair (between cluster A and cluster B):
 
     If you do not see the nodes of cluster B listed in response to the command above, verify that you [created](#create-kubeconfig-files) the kubeconfig for cluster B correctly, and that you [stored](#create-remoteclusterconfigurations) it in cluster A correctly.
 
-    If you do see the nodes of cluster B listed in response to the command above, you may wish to run this test (or a similar test) on a node in cluster A to verify that cluster A nodes can connect to the API server of cluster B.
+    If you do see the nodes of cluster B listed in response to the command above, you can run this test (or a similar test) on a node in cluster A to verify that cluster A nodes can connect to the API server of cluster B.
 
 2. Validate that the Typha service account in Cluster A is authorized to retrieve the kubeconfig secret for cluster B.
    ```bash
@@ -424,7 +424,7 @@ For each impacted remote cluster pair (between cluster A and cluster B):
     yes
     ```
 
-    If the command does not return this output, verify that you [configured RBAC](#create-remoteclusterconfigurations) in cluster A correctly
+    If the command does not return this output, verify that you correctly [configured RBAC](#create-remoteclusterconfigurations) in cluster A.
 
 3. Repeat the above, switching cluster A to cluster B.
 
@@ -432,20 +432,20 @@ For each impacted remote cluster pair (between cluster A and cluster B):
 ##### Check logs
 Validate that querying Typha logs yield the expected result outlined in the [validation](#validate-federated-endpoint-identity--multi-cluster-networking) section.
 
-If the Typha logs do not yield the expected result, warning or error related logs in `typha` or `calico-node` may provide insight into where issues are occurring.
+If the Typha logs do not yield the expected result, review the warning or error-related logs in `typha` or `calico-node` for insights.
 
 #### Troubleshoot multi-cluster networking
 ##### Basic validation
-* Ensure that RemoteClusterConfiguration and federated endpoint identity are [functioning correctly](#validate-federated-endpoint-identity--multi-cluster-networking).
-* Verify that you have met all of the [prerequisites](#calico-enterprise-multi-cluster-networking) for multi-cluster networking to be established.
-* If you had previously setup RemoteClusterConfigurations without multi-cluster networking and are upgrading to use the feature, review the [switching considerations](#switch-to-multi-cluster-networking).
-* Verify that traffic between clusters is not being denied by network policy.
+* Ensure that RemoteClusterConfiguration and federated endpoint identity are [functioning correctly](#validate-federated-endpoint-identity--multi-cluster-networking)
+* Verify that you have met the [prerequisites](#calico-enterprise-multi-cluster-networking) for multi-cluster networking
+* If you had previously set up RemoteClusterConfigurations without multi-cluster networking, and are upgrading to use the feature, review the [switching considerations](#switch-to-multi-cluster-networking)
+* Verify that traffic between clusters is not being denied by network policy
 
 ##### Check overlayRoutingMode
 Ensure that `overlayRoutingMode` is set to `"Enabled"` on all RemoteClusterConfigurations.
 
 If overlay routing is successfully enabled, you can view the logs of a Typha instance using:
-```
+```bash
 kubectl logs deployment/calico-typha -n calico-system
 ```
 
@@ -464,7 +464,7 @@ If you do not see the each of the resource types above, overlay routing was not 
 
 
 ###### Check logs
-Warning or error related logs in `typha` or `calico-node` may provide insight into where issues are occurring.
+Warning or error logs in `typha` or `calico-node` may provide insight into where issues are occurring.
 
 ## Next steps
 

--- a/calico-cloud/multicluster/kubeconfig.mdx
+++ b/calico-cloud/multicluster/kubeconfig.mdx
@@ -2,6 +2,9 @@
 description: Configure a local cluster to pull endpoint data from a remote cluster.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Configure federated endpoint identity and multi-cluster networking
 
 ## Big picture
@@ -45,9 +48,8 @@ Each cluster in the cluster mesh should have a dedicated kubeconfig file used by
 ## Before you begin
 <!--//TODO-CC-XREFS
 **Required**
-
-- [Install {{prodname}}](/getting-started/install-on-clusters/kubernetes/index)
-- [Install and configure calicoq](/operations/clis/calicoq/installing)
+- [Install {{prodname}}](../../getting-started/install-on-clusters/kubernetes/index.mdx)
+- [Ensure pod IP routability](#ensure-pod-ip-routability)
 -->
 
 ## How to
@@ -65,10 +67,10 @@ Federation of workload endpoint identities requires [Pod IP routability](./overv
 #### {{prodname}} multi-cluster networking
 {{prodname}} can automatically extend the overlay networking in your clusters to establish pod IP routes across clusters and thus meet the requirement for Pod IP routability. Only VXLAN overlay is supported at this time.
 
-Ensure the following requirements are met:
-- All nodes in the cluster mesh can establish connections to each other via their private IP.
-- VXLAN must be enabled on participating IP pools in all clusters and their IP pool CIDRs must not overlap.
-- `routeSource` and `vxlan*` FelixConfiguration options must be aligned across clusters, and traffic on the `vxlanPort` must be allowed between nodes in the cluster mesh.
+Ensure the following requirements are met if utilizing {{prodname}} multi-cluster networking to achieve pod IP routability:
+- All nodes in the cluster mesh must be able to establish connections to each other via their private IP, and must have unique node names.
+- VXLAN must be enabled on participating IP pools in all clusters, and these IP pool CIDRs must not overlap.
+- `routeSource` and `vxlan*` FelixConfiguration values must be aligned across clusters, and traffic on the `vxlanPort` must be allowed between nodes in the cluster mesh.
 - RemoteClusterConfigurations must be established in both directions for cluster pairs in the cluster mesh.
 - CNI must be Calico.
 
@@ -77,6 +79,9 @@ With these requirements met, multi-cluster networking will be automatically esta
 #### Other networking configurations
 Alternatively, you can meet the requirement for Pod IP routability by configuring {{prodname}} with BGP or with VPC routing to establish unencapsulated Pod IP routes in your environment.
 
+:::caution
+If you have already configured federated endpoint identity without multi-cluster networking, and you wish to switch to using multi-cluster networking, you should note that the steps below are intended for establishing new RemoteClusterConfigurations. You may wish to consult the [switch to multi-cluster networking](#switch-to-multi-cluster-networking) section.
+:::
 
 ### Create kubeconfig files
 
@@ -166,14 +171,19 @@ Create a kubeconfig file, for each cluster, that will be used by other clusters 
 ### Create RemoteClusterConfigurations
 We'll now create the RemoteClusterConfigurations that establish synchronization between clusters. This enables remote-identity aware policy, federated services, and can establish multi-cluster networking.
 
+<Tabs>
+<TabItem value="Overlay Routing" label="Overlay Routing">
+
+In this setup, the cluster mesh will be configured to meet the pod IP routability requirement by establishing routes between clusters using [{{prodname}} multi-cluster networking](#calico-enterprise-multi-cluster-networking).
+
 **For each pair** of clusters in the cluster mesh (e.g. cluster A and cluster B):
 
 1. In cluster A, create a secret that contains the kubeconfig for cluster B:
 
-   Determine the namespace (`<namespace>`) for the secret to replace in all steps.
+   Determine the namespace (`<secret-namespace>`) for the secret to replace in all steps.
    The simplest method to create a secret for a remote cluster is to use the `kubectl` command because it correctly encodes the data and formats the file.
    ```bash
-   kubectl create secret generic remote-cluster-secret-name -n <namespace> \
+   kubectl create secret generic remote-cluster-secret-name -n <secret-namespace> \
       --from-literal=datastoreType=kubernetes \
       --from-file=kubeconfig=<kubeconfig file>
    ```
@@ -185,7 +195,7 @@ We'll now create the RemoteClusterConfigurations that establish synchronization 
    kind: Role
    metadata:
      name: remote-cluster-secret-access
-     namespace: <namespace>
+     namespace: <secret-namespace>
    rules:
    - apiGroups: [""]
      resources: ["secrets"]
@@ -195,7 +205,7 @@ We'll now create the RemoteClusterConfigurations that establish synchronization 
    kind: RoleBinding
    metadata:
      name: remote-cluster-secret-access
-     namespace: <namespace>
+     namespace: <secret-namespace>
    roleRef:
      apiGroup: rbac.authorization.k8s.io
      kind: Role
@@ -219,46 +229,137 @@ We'll now create the RemoteClusterConfigurations that establish synchronization 
    spec:
      clusterAccessSecret:
        name: remote-cluster-secret-name
-       namespace: <namespace>
+       namespace: <secret-namespace>
        kind: Secret
      syncOptions:
        overlayRoutingMode: Enabled
    EOF
    ```
 
-1. If you have IPPools in cluster A with NAT-outgoing enabled, you must [configure IP pool resources](#configure-ip-pool-resources).
-
-1. [Validate](#validate-federation-and-multi-cluster-networking) that the remote cluster connection can be established.
+1. [Validate](#check-remote-cluster-connection) the that the remote cluster connection can be established.
 
 1. Repeat the above steps, switching cluster A and cluster B.
 
 
 After completing the above steps for all cluster pairs in the cluster mesh, your clusters should now be ready to utilize remote-identity-aware policy and federated services, along with multi-cluster networking if requirements were met.
 
-:::note
+</TabItem>
+<TabItem value="Unencapsulated Routing" label="Unencapsulated Routing">
+
+In this setup, the cluster mesh will rely on the [underlying network](#other-networking-configurations) to meet the pod IP routability requirement.
+
+**For each pair** of clusters in the cluster mesh (e.g. cluster A and cluster B):
+
+1. In cluster A, create a secret that contains the kubeconfig for cluster B:
+
+   Determine the namespace (`<secret-namespace>`) for the secret to replace in all steps.
+   The simplest method to create a secret for a remote cluster is to use the `kubectl` command because it correctly encodes the data and formats the file.
+   ```bash
+   kubectl create secret generic remote-cluster-secret-name -n <secret-namespace> \
+      --from-literal=datastoreType=kubernetes \
+      --from-file=kubeconfig=<kubeconfig file>
+   ```
+
+1. If RBAC is enabled in cluster A, create a Role and RoleBinding that {{prodname}} will use to access the secret that contains the kubeconfig for cluster B:
+   ```bash
+   kubectl create -f - <<EOF
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: Role
+   metadata:
+     name: remote-cluster-secret-access
+     namespace: <secret-namespace>
+   rules:
+   - apiGroups: [""]
+     resources: ["secrets"]
+     verbs: ["watch", "list", "get"]
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: RoleBinding
+   metadata:
+     name: remote-cluster-secret-access
+     namespace: <secret-namespace>
+   roleRef:
+     apiGroup: rbac.authorization.k8s.io
+     kind: Role
+     name: remote-cluster-secret-access
+   subjects:
+   - kind: ServiceAccount
+     name: calico-typha
+     namespace: calico-system
+   EOF
+   ```
+
+1. Create the RemoteClusterConfiguration in cluster A:
+
+   Within the RemoteClusterConfiguration, we specify the secret used to access cluster B, and the overlay routing mode which toggles the establishment of cross-cluster overlay routes.
+   ```bash
+   kubectl create -f - <<EOF
+   apiVersion: projectcalico.org/v3
+   kind: RemoteClusterConfiguration
+   metadata:
+     name: cluster-b
+   spec:
+     clusterAccessSecret:
+       name: remote-cluster-secret-name
+       namespace: <secret-namespace>
+       kind: Secret
+     syncOptions:
+       overlayRoutingMode: Disabled
+   EOF
+   ```
+
+1. If you have no IP pools in cluster A with NAT-outgoing enabled, skip this step.
+
+   Otherwise, if you have IP pools in cluster A with NAT-outgoing enabled and workloads in that pool will egress to workloads in cluster B, you need to instruct {{prodname}} to not perform NAT on traffic destined for IP pools in cluster B.
+
+   You can achieve this by creating a disabled IP pool in cluster A for each CIDR in cluster B. This IP pool should have NAT-outgoing disabled. For example:
+
+    ```yaml
+    apiVersion: projectcalico.org/v3
+    kind: IPPool
+    metadata:
+      name: clusterB-main-pool
+    spec:
+      cidr: <Cluster B CIDR>
+      disabled: true
+    ```
+
+1. [Validate](#check-remote-cluster-connection) the that the remote cluster connection can be established.
+
+1. Repeat the above steps, switching cluster A and cluster B.
+
+
+After completing the above steps for all cluster pairs in the cluster mesh, your clusters should now be ready to utilize remote-identity-aware policy and federated services.
+
+</TabItem>
+</Tabs>
+
+:::caution
  This tutorial sets up RemoteClusterConfigurations in both directions. This is required for {{prodname}} to manage multi-cluster networking, and also ensures you can write identity-aware policy on both sides of a cross-cluster connection. Unidirectional connections can be made at your own discretion.
 :::
 
-### Validate federation and multi-cluster networking
-#### RemoteClusterConfiguration & federated endpoint identity
-calicoq can be used to ensure that a local cluster has connected to it's configured remote clusters. Use the following command:
+### Switch to multi-cluster networking
+The steps above assume that you are configuring federated endpoint identity and multi-cluster networking for the first time. If you already have federated endpoint identity and are looking to utilize multi-cluster networking, the steps below outline the changes that must be made if you had previously set up federated endpoint identity prior to the introduction of multi-cluster networking:
+
+1. Validate that all [requirements](#calico-enterprise-multi-cluster-networking) for multi-cluster networking have been met.
+2. Update the ClusterRole in each cluster in the cluster mesh using the RBAC manifest found in [Create kubeconfig files](#create-kubeconfig-files)
+3. Update all RemoteClusterConfigurations to set `Spec.OverlayRoutingMode` to `Enabled`
+4. Ensure that all RemoteClusterConfigurations are bidirectional, i.e. ensure that RemoteClusterConfigurations were established following the [instructions](#create-remoteclusterconfigurations) for in both directions for each cluster pair.
+5. If you had previously created disabled IP pools to prevent NAT outgoing from applying to remote cluster destinations, those disabled IP pools are no longer needed when using multi-cluster networking and must be deleted.
+
+
+### Validate federated endpoint identity & multi-cluster networking
+#### Validate RemoteClusterConfiguration & federated endpoint identity
+##### Check remote cluster connection
+You can check the Typha logs for remote cluster connection status. Run the following command:
 ```bash
-calicoq eval "all()"
+kubectl logs deployment/calico-typha -n calico-system | grep "Sending in-sync update"
 ```
-If all remote clusters are accessible, calicoq returns something like the following. Note the remote cluster prefixes: there should be endpoints prefixed with the name of each RemoteClusterConfiguration in the local cluster.
-```
-Endpoints matching selector all():
-  Workload endpoint remote-cluster-1/host-1/k8s/kube-system.kube-dns-5fbcb4d67b-h6686/eth0
-  Workload endpoint remote-cluster-1/host-2/k8s/kube-system.cnx-manager-66c4dbc5b7-6d9xv/eth0
-  Workload endpoint host-a/k8s/kube-system.kube-dns-5fbcb4d67b-7wbhv/eth0
-  Workload endpoint host-b/k8s/kube-system.cnx-manager-66c4dbc5b7-6ghsm/eth0
-```
+You should see an entry for each RemoteClusterConfiguration in the local cluster.
 
-You can also view the Prometheus metrics for Typha to check the remote cluster connection status.
+If the output contains unexpected results, proceed to the [troubleshooting](#troubleshoot) section.
 
-If either output contains unexpected results, proceed to the troubleshooting section.
-
-#### Multi-cluster networking
+#### Validate multi-cluster networking
 If all requirements were met for {{prodname}} to establish multi-cluster networking, you can test the functionality by establishing a connection from a pod in a local cluster to the IP of a pod in a remote cluster. Ensure that there is no policy in either cluster that may block this connection.
 
 If the connection fails, proceed to the [troubleshooting](#troubleshoot) section.
@@ -290,50 +391,80 @@ spec:
 ```
 
 ### Troubleshoot
-#### RemoteClusterConfiguration & federated endpoint identity
+#### Troubleshoot RemoteClusterConfiguration & federated endpoint identity
+
+##### Verify configuration
 For each impacted remote cluster pair (between cluster A and cluster B):
-1. Retrieve the kubeconfig from the secret stored in cluster A. Manually verify that it can be used to connect to Cluster B.
+1. Retrieve the kubeconfig from the secret stored in cluster A. Manually verify that it can be used to connect to cluster B.
    ```bash
-   kubectl get secret -n <namespace> remote-cluster-secret-name -o=jsonpath="{.data.kubeconfig}" | base64 -d > verify_kubeconfig_b
+   kubectl get secret -n <secret-namespace> remote-cluster-secret-name -o=jsonpath="{.data.kubeconfig}" | base64 -d > verify_kubeconfig_b
    kubectl --kubeconfig=verify_kubeconfig_b get nodes
    ```
-2. Validate that the Typha service account in Cluster A is authorized to retrieve the kubeconfig secret for Cluster B.
-   ```bash
-    kubectl auth can-i list secrets --namespace <namespace> --as=system:serviceaccount:calico-system:calico-typha
+   This validates that the credentials used by Typha to connect to cluster B's API server are stored in the correct location and provide sufficient access.
+
+   The command above should yield a result like the following:
    ```
+    NAME              STATUS   ROLES    AGE   VERSION
+    clusterB-master   Ready    master   7d    v1.27.0
+    clusterB-worker-1 Ready    worker   7d    v1.27.0
+    clusterB-worker-2 Ready    worker   7d    v1.27.0
+   ```
+
+    If you do not see the nodes of cluster B listed in response to the command above, verify that you [created](#create-kubeconfig-files) the kubeconfig for cluster B correctly, and that you [stored](#create-remoteclusterconfigurations) it in cluster A correctly.
+
+    If you do see the nodes of cluster B listed in response to the command above, you may wish to run this test (or a similar test) on a node in cluster A to verify that cluster A nodes can connect to the API server of cluster B.
+
+2. Validate that the Typha service account in Cluster A is authorized to retrieve the kubeconfig secret for cluster B.
+   ```bash
+    kubectl auth can-i list secrets --namespace <secret-namespace> --as=system:serviceaccount:calico-system:calico-typha
+   ```
+
+    This command should yield the following output:
+    ```
+    yes
+    ```
+
+    If the command does not return this output, verify that you [configured RBAC](#create-remoteclusterconfigurations) in cluster A correctly
+
 3. Repeat the above, switching cluster A to cluster B.
 
-The output from [calicoq](#remoteclusterconfiguration--federated-endpoint-identity) may also provide insight into where issues may be occurring.
 
-If the above steps provide no useful information, consider looking at the `typha` and `calico-node` logs for any relevant errors or warnings.
+##### Check logs
+Validate that querying Typha logs yield the expected result outlined in the [validation](#validate-federated-endpoint-identity--multi-cluster-networking) section.
 
+If the Typha logs do not yield the expected result, warning or error related logs in `typha` or `calico-node` may provide insight into where issues are occurring.
 
-#### Multi-cluster networking
-First, ensure that RemoteClusterConfiguration and federated endpoint identity are [functioning correctly](#remoteclusterconfiguration--federated-endpoint-identity-1).
+#### Troubleshoot multi-cluster networking
+##### Basic validation
+* Ensure that RemoteClusterConfiguration and federated endpoint identity are [functioning correctly](#validate-federated-endpoint-identity--multi-cluster-networking).
+* Verify that you have met all of the [prerequisites](#calico-enterprise-multi-cluster-networking) for multi-cluster networking to be established.
+* If you had previously setup RemoteClusterConfigurations without multi-cluster networking and are upgrading to use the feature, review the [switching considerations](#switch-to-multi-cluster-networking).
+* Verify that traffic between clusters is not being denied by network policy.
 
-Next, carefully validate that **all** [requirements](#calico-enterprise-multi-cluster-networking) for multi-cluster networking have been met. If all requirements are satisfied, consider:
-* Validating that no network policy or firewall is causing packets to be dropped.
-* Checking the `typha` and `calico-node` logs for any relevant errors or warnings.
+##### Check overlayRoutingMode
+Ensure that `overlayRoutingMode` is set to `"Enabled"` on all RemoteClusterConfigurations.
 
-
-### Configure IP pool resources
-For local clusters with `NATOutgoing` configured on your IP pools, verify the following:
-
-- Configure additional IP pools to cover the IP ranges of your remote clusters. This ensures that outgoing NAT is not performed on packets bound for the remote clusters.
-- On the new IP pools, ensure that `disabled` is set to `true` to ensure the pools are not used for IP assignment on the local cluster.
-- Verify that the IP pool CIDR used for pod IP allocation does not overlap with any of the IP ranges used by the pods and nodes of any other federated cluster.
-
-For example, you can configure the following on your local cluster, referring to the `IPPool` on a remote cluster:
-
-```yaml
-apiVersion: projectcalico.org/v3
-kind: IPPool
-metadata:
-  name: cluster1-main-pool
-spec:
-  cidr: 192.168.0.0/18
-  disabled: true
+If overlay routing is successfully enabled, you can view the logs of a Typha instance using:
 ```
+kubectl logs deployment/calico-typha -n calico-system
+```
+
+You should see an output for each connected remote cluster that looks like this:
+```
+18:49:35.394 [INFO][14] wrappedcallbacks.go 443: Creating syncer for RemoteClusterConfiguration(my-cluster)
+18:49:35.394 [INFO][14] watchercache.go 186: Full resync is required ListRoot="/calico/ipam/v2/assignment/"
+18:49:35.395 [INFO][14] watchercache.go 186: Full resync is required ListRoot="/calico/resources/v3/projectcalico.org/workloadendpoints"
+18:49:35.396 [INFO][14] watchercache.go 186: Full resync is required ListRoot="/calico/resources/v3/projectcalico.org/hostendpoints"
+18:49:35.396 [INFO][14] watchercache.go 186: Full resync is required ListRoot="/calico/resources/v3/projectcalico.org/profiles"
+18:49:35.396 [INFO][14] watchercache.go 186: Full resync is required ListRoot="/calico/resources/v3/projectcalico.org/nodes"
+18:49:35.397 [INFO][14] watchercache.go 186: Full resync is required ListRoot="/calico/resources/v3/projectcalico.org/ippools"
+```
+
+If you do not see the each of the resource types above, overlay routing was not successfully enabled in your cluster. Verify that you followed the [setup](#create-remoteclusterconfigurations) correctly for overlay routing, and that the cluster is using a version of {{prodname}} that supports multi-cluster networking.
+
+
+###### Check logs
+Warning or error related logs in `typha` or `calico-node` may provide insight into where issues are occurring.
 
 ## Next steps
 

--- a/calico-enterprise/multicluster/federation/kubeconfig.mdx
+++ b/calico-enterprise/multicluster/federation/kubeconfig.mdx
@@ -186,7 +186,7 @@ In this setup, the cluster mesh will be configured to meet the pod IP routabilit
       --from-file=kubeconfig=<kubeconfig file>
    ```
 
-1. If RBAC is enabled in cluster A, create a Role and RoleBinding that {{prodname}} will use to access the secret that contains the kubeconfig for cluster B:
+1. If RBAC is enabled in cluster A, create a Role and RoleBinding for {{prodname}} to use to access the secret that contains the kubeconfig for cluster B:
    ```bash
    kubectl create -f - <<EOF
    apiVersion: rbac.authorization.k8s.io/v1
@@ -258,7 +258,7 @@ In this setup, the cluster mesh will rely on the [underlying network](#other-net
       --from-file=kubeconfig=<kubeconfig file>
    ```
 
-1. If RBAC is enabled in cluster A, create a Role and RoleBinding that {{prodname}} will use to access the secret that contains the kubeconfig for cluster B:
+1. If RBAC is enabled in cluster A, create a Role and RoleBinding for {{prodname}} to use to access the secret that contains the kubeconfig for cluster B:
    ```bash
    kubectl create -f - <<EOF
    apiVersion: rbac.authorization.k8s.io/v1
@@ -308,7 +308,7 @@ In this setup, the cluster mesh will rely on the [underlying network](#other-net
 
 1. If you have no IP pools in cluster A with NAT-outgoing enabled, skip this step.
 
-   Otherwise, if you have IP pools in cluster A with NAT-outgoing enabled and workloads in that pool will egress to workloads in cluster B, you need to instruct {{prodname}} to not perform NAT on traffic destined for IP pools in cluster B.
+   Otherwise, if you have IP pools in cluster A with NAT-outgoing enabled, and workloads in that pool will egress to workloads in cluster B, you need to instruct {{prodname}} to not perform NAT on traffic destined for IP pools in cluster B.
 
    You can achieve this by creating a disabled IP pool in cluster A for each CIDR in cluster B. This IP pool should have NAT-outgoing disabled. For example:
 
@@ -337,17 +337,17 @@ After completing the above steps for all cluster pairs in the cluster mesh, your
 :::
 
 ### Switch to multi-cluster networking
-The steps above assume that you are configuring federated endpoint identity and multi-cluster networking for the first time. If you already have federated endpoint identity and are looking to utilize multi-cluster networking, the steps below outline the changes that must be made if you had previously set up federated endpoint identity prior to the introduction of multi-cluster networking:
+The steps above assume that you are configuring both federated endpoint identity and multi-cluster networking for the first time. If you already have federated endpoint identity, and want to use multi-cluster networking, follow these steps:
 
 1. Validate that all [requirements](#calico-enterprise-multi-cluster-networking) for multi-cluster networking have been met.
 2. Update the ClusterRole in each cluster in the cluster mesh using the RBAC manifest found in [Create kubeconfig files](#create-kubeconfig-files)
-3. Update all RemoteClusterConfigurations to set `Spec.OverlayRoutingMode` to `Enabled`
-4. Ensure that all RemoteClusterConfigurations are bidirectional, i.e. ensure that RemoteClusterConfigurations were established following the [instructions](#create-remoteclusterconfigurations) for in both directions for each cluster pair.
+3. In all RemoteClusterConfigurations, set `Spec.OverlayRoutingMode` to `Enabled`.
+4. Verify that all RemoteClusterConfigurations are bidirectional (in both directions for each cluster pair) using these [instructions](#create-remoteclusterconfigurations).
 5. If you had previously created disabled IP pools to prevent NAT outgoing from applying to remote cluster destinations, those disabled IP pools are no longer needed when using multi-cluster networking and must be deleted.
 
 
 ### Validate federated endpoint identity & multi-cluster networking
-#### Validate RemoteClusterConfiguration & federated endpoint identity
+#### Validate RemoteClusterConfiguration and federated endpoint identity
 ##### Check remote cluster connection
 You can validate in a local cluster that Typha has synced to the remote cluster through the [Prometheus metrics for Typha](../../reference/component-resources/typha/prometheus#metric-reference).
 
@@ -391,7 +391,7 @@ spec:
 ```
 
 ### Troubleshoot
-#### Troubleshoot RemoteClusterConfiguration & federated endpoint identity
+#### Troubleshoot RemoteClusterConfiguration and federated endpoint identity
 
 ##### Verify configuration
 For each impacted remote cluster pair (between cluster A and cluster B):
@@ -412,7 +412,7 @@ For each impacted remote cluster pair (between cluster A and cluster B):
 
     If you do not see the nodes of cluster B listed in response to the command above, verify that you [created](#create-kubeconfig-files) the kubeconfig for cluster B correctly, and that you [stored](#create-remoteclusterconfigurations) it in cluster A correctly.
 
-    If you do see the nodes of cluster B listed in response to the command above, you may wish to run this test (or a similar test) on a node in cluster A to verify that cluster A nodes can connect to the API server of cluster B.
+    If you do see the nodes of cluster B listed in response to the command above, you can run this test (or a similar test) on a node in cluster A to verify that cluster A nodes can connect to the API server of cluster B.
 
 2. Validate that the Typha service account in Cluster A is authorized to retrieve the kubeconfig secret for cluster B.
    ```bash
@@ -424,7 +424,7 @@ For each impacted remote cluster pair (between cluster A and cluster B):
     yes
     ```
 
-    If the command does not return this output, verify that you [configured RBAC](#create-remoteclusterconfigurations) in cluster A correctly
+    If the command does not return this output, verify that you correctly [configured RBAC](#create-remoteclusterconfigurations) in cluster A.
 
 3. Repeat the above, switching cluster A to cluster B.
 
@@ -432,7 +432,7 @@ For each impacted remote cluster pair (between cluster A and cluster B):
 ##### Check logs
 Validate that querying Typha logs yield the expected result outlined in the [validation](#validate-federated-endpoint-identity--multi-cluster-networking) section.
 
-If the Typha logs do not yield the expected result, warning or error related logs in `typha` or `calico-node` may provide insight into where issues are occurring.
+If the Typha logs do not yield the expected result, review the warning or error-related logs in `typha` or `calico-node` for insights.
 
 
 ###### calicoq
@@ -454,16 +454,16 @@ If this command fails, the error messages returned by the command may provide in
 
 #### Troubleshoot multi-cluster networking
 ##### Basic validation
-* Ensure that RemoteClusterConfiguration and federated endpoint identity are [functioning correctly](#validate-federated-endpoint-identity--multi-cluster-networking).
-* Verify that you have met all of the [prerequisites](#calico-enterprise-multi-cluster-networking) for multi-cluster networking to be established.
-* If you had previously setup RemoteClusterConfigurations without multi-cluster networking and are upgrading to use the feature, review the [switching considerations](#switch-to-multi-cluster-networking).
-* Verify that traffic between clusters is not being denied by network policy.
+* Ensure that RemoteClusterConfiguration and federated endpoint identity are [functioning correctly](#validate-federated-endpoint-identity--multi-cluster-networking)
+* Verify that you have met the [prerequisites](#calico-enterprise-multi-cluster-networking) for multi-cluster networking
+* If you had previously set up RemoteClusterConfigurations without multi-cluster networking, and are upgrading to use the feature, review the [switching considerations](#switch-to-multi-cluster-networking)
+* Verify that traffic between clusters is not being denied by network policy
 
 ##### Check overlayRoutingMode
 Ensure that `overlayRoutingMode` is set to `"Enabled"` on all RemoteClusterConfigurations.
 
 If overlay routing is successfully enabled, you can view the logs of a Typha instance using:
-```
+```bash
 kubectl logs deployment/calico-typha -n calico-system
 ```
 
@@ -482,7 +482,7 @@ If you do not see the each of the resource types above, overlay routing was not 
 
 
 ###### Check logs
-Warning or error related logs in `typha` or `calico-node` may provide insight into where issues are occurring.
+Warning or error logs in `typha` or `calico-node` may provide insight into where issues are occurring.
 
 ## Next steps
 

--- a/calico-enterprise/multicluster/federation/kubeconfig.mdx
+++ b/calico-enterprise/multicluster/federation/kubeconfig.mdx
@@ -2,6 +2,9 @@
 description: Configure a local cluster to pull endpoint data from a remote cluster.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Configure federated endpoint identity and multi-cluster networking
 
 ## Big picture
@@ -62,10 +65,10 @@ Federation of workload endpoint identities requires [Pod IP routability](./overv
 #### {{prodname}} multi-cluster networking
 {{prodname}} can automatically extend the overlay networking in your clusters to establish pod IP routes across clusters and thus meet the requirement for Pod IP routability. Only VXLAN overlay is supported at this time.
 
-Ensure the following requirements are met:
-- All nodes in the cluster mesh can establish connections to each other via their private IP.
-- VXLAN must be enabled on participating IP pools in all clusters and their IP pool CIDRs must not overlap.
-- `routeSource` and `vxlan*` FelixConfiguration options must be aligned across clusters, and traffic on the `vxlanPort` must be allowed between nodes in the cluster mesh.
+Ensure the following requirements are met if utilizing {{prodname}} multi-cluster networking to achieve pod IP routability:
+- All nodes in the cluster mesh must be able to establish connections to each other via their private IP, and must have unique node names.
+- VXLAN must be enabled on participating IP pools in all clusters, and these IP pool CIDRs must not overlap.
+- `routeSource` and `vxlan*` FelixConfiguration values must be aligned across clusters, and traffic on the `vxlanPort` must be allowed between nodes in the cluster mesh.
 - RemoteClusterConfigurations must be established in both directions for cluster pairs in the cluster mesh.
 - CNI must be Calico.
 
@@ -74,6 +77,9 @@ With these requirements met, multi-cluster networking will be automatically esta
 #### Other networking configurations
 Alternatively, you can meet the requirement for Pod IP routability by configuring {{prodname}} with BGP or with VPC routing to establish unencapsulated Pod IP routes in your environment.
 
+:::caution
+If you have already configured federated endpoint identity without multi-cluster networking, and you wish to switch to using multi-cluster networking, you should note that the steps below are intended for establishing new RemoteClusterConfigurations. You may wish to consult the [switch to multi-cluster networking](#switch-to-multi-cluster-networking) section.
+:::
 
 ### Create kubeconfig files
 
@@ -163,14 +169,19 @@ Create a kubeconfig file, for each cluster, that will be used by other clusters 
 ### Create RemoteClusterConfigurations
 We'll now create the RemoteClusterConfigurations that establish synchronization between clusters. This enables remote-identity aware policy, federated services, and can establish multi-cluster networking.
 
+<Tabs>
+<TabItem value="Overlay Routing" label="Overlay Routing">
+
+In this setup, the cluster mesh will be configured to meet the pod IP routability requirement by establishing routes between clusters using [{{prodname}} multi-cluster networking](#calico-enterprise-multi-cluster-networking).
+
 **For each pair** of clusters in the cluster mesh (e.g. cluster A and cluster B):
 
 1. In cluster A, create a secret that contains the kubeconfig for cluster B:
 
-   Determine the namespace (`<namespace>`) for the secret to replace in all steps.
+   Determine the namespace (`<secret-namespace>`) for the secret to replace in all steps.
    The simplest method to create a secret for a remote cluster is to use the `kubectl` command because it correctly encodes the data and formats the file.
    ```bash
-   kubectl create secret generic remote-cluster-secret-name -n <namespace> \
+   kubectl create secret generic remote-cluster-secret-name -n <secret-namespace> \
       --from-literal=datastoreType=kubernetes \
       --from-file=kubeconfig=<kubeconfig file>
    ```
@@ -182,7 +193,7 @@ We'll now create the RemoteClusterConfigurations that establish synchronization 
    kind: Role
    metadata:
      name: remote-cluster-secret-access
-     namespace: <namespace>
+     namespace: <secret-namespace>
    rules:
    - apiGroups: [""]
      resources: ["secrets"]
@@ -192,7 +203,7 @@ We'll now create the RemoteClusterConfigurations that establish synchronization 
    kind: RoleBinding
    metadata:
      name: remote-cluster-secret-access
-     namespace: <namespace>
+     namespace: <secret-namespace>
    roleRef:
      apiGroup: rbac.authorization.k8s.io
      kind: Role
@@ -216,46 +227,139 @@ We'll now create the RemoteClusterConfigurations that establish synchronization 
    spec:
      clusterAccessSecret:
        name: remote-cluster-secret-name
-       namespace: <namespace>
+       namespace: <secret-namespace>
        kind: Secret
      syncOptions:
        overlayRoutingMode: Enabled
    EOF
    ```
 
-1. If you have IPPools in cluster A with NAT-outgoing enabled, you must [configure IP pool resources](#configure-ip-pool-resources).
-
-1. Validate the that the remote cluster connection can be established using [calicoq](#validate-federation-and-multi-cluster-networking).
+1. [Validate](#check-remote-cluster-connection) the that the remote cluster connection can be established.
 
 1. Repeat the above steps, switching cluster A and cluster B.
 
 
 After completing the above steps for all cluster pairs in the cluster mesh, your clusters should now be ready to utilize remote-identity-aware policy and federated services, along with multi-cluster networking if requirements were met.
 
-:::note
+</TabItem>
+<TabItem value="Unencapsulated Routing" label="Unencapsulated Routing">
+
+In this setup, the cluster mesh will rely on the [underlying network](#other-networking-configurations) to meet the pod IP routability requirement.
+
+**For each pair** of clusters in the cluster mesh (e.g. cluster A and cluster B):
+
+1. In cluster A, create a secret that contains the kubeconfig for cluster B:
+
+   Determine the namespace (`<secret-namespace>`) for the secret to replace in all steps.
+   The simplest method to create a secret for a remote cluster is to use the `kubectl` command because it correctly encodes the data and formats the file.
+   ```bash
+   kubectl create secret generic remote-cluster-secret-name -n <secret-namespace> \
+      --from-literal=datastoreType=kubernetes \
+      --from-file=kubeconfig=<kubeconfig file>
+   ```
+
+1. If RBAC is enabled in cluster A, create a Role and RoleBinding that {{prodname}} will use to access the secret that contains the kubeconfig for cluster B:
+   ```bash
+   kubectl create -f - <<EOF
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: Role
+   metadata:
+     name: remote-cluster-secret-access
+     namespace: <secret-namespace>
+   rules:
+   - apiGroups: [""]
+     resources: ["secrets"]
+     verbs: ["watch", "list", "get"]
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: RoleBinding
+   metadata:
+     name: remote-cluster-secret-access
+     namespace: <secret-namespace>
+   roleRef:
+     apiGroup: rbac.authorization.k8s.io
+     kind: Role
+     name: remote-cluster-secret-access
+   subjects:
+   - kind: ServiceAccount
+     name: calico-typha
+     namespace: calico-system
+   EOF
+   ```
+
+1. Create the RemoteClusterConfiguration in cluster A:
+
+   Within the RemoteClusterConfiguration, we specify the secret used to access cluster B, and the overlay routing mode which toggles the establishment of cross-cluster overlay routes.
+   ```bash
+   kubectl create -f - <<EOF
+   apiVersion: projectcalico.org/v3
+   kind: RemoteClusterConfiguration
+   metadata:
+     name: cluster-b
+   spec:
+     clusterAccessSecret:
+       name: remote-cluster-secret-name
+       namespace: <secret-namespace>
+       kind: Secret
+     syncOptions:
+       overlayRoutingMode: Disabled
+   EOF
+   ```
+
+1. If you have no IP pools in cluster A with NAT-outgoing enabled, skip this step.
+
+   Otherwise, if you have IP pools in cluster A with NAT-outgoing enabled and workloads in that pool will egress to workloads in cluster B, you need to instruct {{prodname}} to not perform NAT on traffic destined for IP pools in cluster B.
+
+   You can achieve this by creating a disabled IP pool in cluster A for each CIDR in cluster B. This IP pool should have NAT-outgoing disabled. For example:
+
+    ```yaml
+    apiVersion: projectcalico.org/v3
+    kind: IPPool
+    metadata:
+      name: clusterB-main-pool
+    spec:
+      cidr: <Cluster B CIDR>
+      disabled: true
+    ```
+
+1. [Validate](#check-remote-cluster-connection) the that the remote cluster connection can be established.
+
+1. Repeat the above steps, switching cluster A and cluster B.
+
+
+After completing the above steps for all cluster pairs in the cluster mesh, your clusters should now be ready to utilize remote-identity-aware policy and federated services.
+
+</TabItem>
+</Tabs>
+
+:::caution
  This tutorial sets up RemoteClusterConfigurations in both directions. This is required for {{prodname}} to manage multi-cluster networking, and also ensures you can write identity-aware policy on both sides of a cross-cluster connection. Unidirectional connections can be made at your own discretion.
 :::
 
-### Validate federation and multi-cluster networking
-#### RemoteClusterConfiguration & federated endpoint identity
-[calicoq](../../operations/clis/calicoq/installing) can be used to ensure that a local cluster has connected to it's configured remote clusters. Use the following command:
+### Switch to multi-cluster networking
+The steps above assume that you are configuring federated endpoint identity and multi-cluster networking for the first time. If you already have federated endpoint identity and are looking to utilize multi-cluster networking, the steps below outline the changes that must be made if you had previously set up federated endpoint identity prior to the introduction of multi-cluster networking:
+
+1. Validate that all [requirements](#calico-enterprise-multi-cluster-networking) for multi-cluster networking have been met.
+2. Update the ClusterRole in each cluster in the cluster mesh using the RBAC manifest found in [Create kubeconfig files](#create-kubeconfig-files)
+3. Update all RemoteClusterConfigurations to set `Spec.OverlayRoutingMode` to `Enabled`
+4. Ensure that all RemoteClusterConfigurations are bidirectional, i.e. ensure that RemoteClusterConfigurations were established following the [instructions](#create-remoteclusterconfigurations) for in both directions for each cluster pair.
+5. If you had previously created disabled IP pools to prevent NAT outgoing from applying to remote cluster destinations, those disabled IP pools are no longer needed when using multi-cluster networking and must be deleted.
+
+
+### Validate federated endpoint identity & multi-cluster networking
+#### Validate RemoteClusterConfiguration & federated endpoint identity
+##### Check remote cluster connection
+You can validate in a local cluster that Typha has synced to the remote cluster through the [Prometheus metrics for Typha](../../reference/component-resources/typha/prometheus#metric-reference).
+
+Alternatively, you can check the Typha logs for remote cluster connection status. Run the following command:
 ```bash
-calicoq eval "all()"
+kubectl logs deployment/calico-typha -n calico-system | grep "Sending in-sync update"
 ```
-If all remote clusters are accessible, calicoq returns something like the following. Note the remote cluster prefixes: there should be endpoints prefixed with the name of each RemoteClusterConfiguration in the local cluster.
-```
-Endpoints matching selector all():
-  Workload endpoint remote-cluster-1/host-1/k8s/kube-system.kube-dns-5fbcb4d67b-h6686/eth0
-  Workload endpoint remote-cluster-1/host-2/k8s/kube-system.cnx-manager-66c4dbc5b7-6d9xv/eth0
-  Workload endpoint host-a/k8s/kube-system.kube-dns-5fbcb4d67b-7wbhv/eth0
-  Workload endpoint host-b/k8s/kube-system.cnx-manager-66c4dbc5b7-6ghsm/eth0
-```
+You should see an entry for each RemoteClusterConfiguration in the local cluster.
 
-You can also view the [Prometheus metrics for Typha](../../reference/component-resources/typha/prometheus#metric-reference) to check the remote cluster connection status.
+If either output contains unexpected results, proceed to the [troubleshooting](#troubleshoot) section.
 
-If either output contains unexpected results, proceed to the troubleshooting section.
-
-#### Multi-cluster networking
+#### Validate multi-cluster networking
 If all requirements were met for {{prodname}} to establish multi-cluster networking, you can test the functionality by establishing a connection from a pod in a local cluster to the IP of a pod in a remote cluster. Ensure that there is no policy in either cluster that may block this connection.
 
 If the connection fails, proceed to the [troubleshooting](#troubleshoot) section.
@@ -287,50 +391,98 @@ spec:
 ```
 
 ### Troubleshoot
-#### RemoteClusterConfiguration & federated endpoint identity
+#### Troubleshoot RemoteClusterConfiguration & federated endpoint identity
+
+##### Verify configuration
 For each impacted remote cluster pair (between cluster A and cluster B):
-1. Retrieve the kubeconfig from the secret stored in cluster A. Manually verify that it can be used to connect to Cluster B.
+1. Retrieve the kubeconfig from the secret stored in cluster A. Manually verify that it can be used to connect to cluster B.
    ```bash
-   kubectl get secret -n <namespace> remote-cluster-secret-name -o=jsonpath="{.data.kubeconfig}" | base64 -d > verify_kubeconfig_b
+   kubectl get secret -n <secret-namespace> remote-cluster-secret-name -o=jsonpath="{.data.kubeconfig}" | base64 -d > verify_kubeconfig_b
    kubectl --kubeconfig=verify_kubeconfig_b get nodes
    ```
-2. Validate that the Typha service account in Cluster A is authorized to retrieve the kubeconfig secret for Cluster B.
-   ```bash
-    kubectl auth can-i list secrets --namespace <namespace> --as=system:serviceaccount:calico-system:calico-typha
+   This validates that the credentials used by Typha to connect to cluster B's API server are stored in the correct location and provide sufficient access.
+
+   The command above should yield a result like the following:
    ```
+    NAME              STATUS   ROLES    AGE   VERSION
+    clusterB-master   Ready    master   7d    v1.27.0
+    clusterB-worker-1 Ready    worker   7d    v1.27.0
+    clusterB-worker-2 Ready    worker   7d    v1.27.0
+   ```
+
+    If you do not see the nodes of cluster B listed in response to the command above, verify that you [created](#create-kubeconfig-files) the kubeconfig for cluster B correctly, and that you [stored](#create-remoteclusterconfigurations) it in cluster A correctly.
+
+    If you do see the nodes of cluster B listed in response to the command above, you may wish to run this test (or a similar test) on a node in cluster A to verify that cluster A nodes can connect to the API server of cluster B.
+
+2. Validate that the Typha service account in Cluster A is authorized to retrieve the kubeconfig secret for cluster B.
+   ```bash
+    kubectl auth can-i list secrets --namespace <secret-namespace> --as=system:serviceaccount:calico-system:calico-typha
+   ```
+
+    This command should yield the following output:
+    ```
+    yes
+    ```
+
+    If the command does not return this output, verify that you [configured RBAC](#create-remoteclusterconfigurations) in cluster A correctly
+
 3. Repeat the above, switching cluster A to cluster B.
 
-The output from [calicoq](#remoteclusterconfiguration--federated-endpoint-identity) may also provide insight into where issues may be occurring.
 
-If the above steps provide no useful information, consider looking at the `typha` and `calico-node` logs for any relevant errors or warnings.
+##### Check logs
+Validate that querying Typha logs yield the expected result outlined in the [validation](#validate-federated-endpoint-identity--multi-cluster-networking) section.
 
-
-#### Multi-cluster networking
-First, ensure that RemoteClusterConfiguration and federated endpoint identity are [functioning correctly](#remoteclusterconfiguration--federated-endpoint-identity-1).
-
-Next, carefully validate that **all** [requirements](#calico-enterprise-multi-cluster-networking) for multi-cluster networking have been met. If all requirements are satisfied, consider:
-* Validating that no network policy or firewall is causing packets to be dropped.
-* Checking the `typha` and `calico-node` logs for any relevant errors or warnings.
+If the Typha logs do not yield the expected result, warning or error related logs in `typha` or `calico-node` may provide insight into where issues are occurring.
 
 
-### Configure IP pool resources
-For local clusters with `NATOutgoing` configured on your IP pools, verify the following:
-
-- Configure additional IP pools to cover the IP ranges of your remote clusters. This ensures that outgoing NAT is not performed on packets bound for the remote clusters.
-- On the new IP pools, ensure that `disabled` is set to `true` to ensure the pools are not used for IP assignment on the local cluster.
-- Verify that the IP pool CIDR used for pod IP allocation does not overlap with any of the IP ranges used by the pods and nodes of any other federated cluster.
-
-For example, you can configure the following on your local cluster, referring to the `IPPool` on a remote cluster:
-
-```yaml
-apiVersion: projectcalico.org/v3
-kind: IPPool
-metadata:
-  name: cluster1-main-pool
-spec:
-  cidr: 192.168.0.0/18
-  disabled: true
+###### calicoq
+[calicoq](../../operations/clis/calicoq/installing) can be used to emulate the connection that Typha will make to remote clusters. Use the following command:
+```bash
+calicoq eval "all()"
 ```
+If all remote clusters are accessible, calicoq returns something like the following. Note the remote cluster prefixes: there should be endpoints prefixed with the name of each RemoteClusterConfiguration in the local cluster.
+```
+Endpoints matching selector all():
+  Workload endpoint remote-cluster-1/host-1/k8s/kube-system.kube-dns-5fbcb4d67b-h6686/eth0
+  Workload endpoint remote-cluster-1/host-2/k8s/kube-system.cnx-manager-66c4dbc5b7-6d9xv/eth0
+  Workload endpoint host-a/k8s/kube-system.kube-dns-5fbcb4d67b-7wbhv/eth0
+  Workload endpoint host-b/k8s/kube-system.cnx-manager-66c4dbc5b7-6ghsm/eth0
+```
+
+If this command fails, the error messages returned by the command may provide insight into where issues are occurring.
+
+
+#### Troubleshoot multi-cluster networking
+##### Basic validation
+* Ensure that RemoteClusterConfiguration and federated endpoint identity are [functioning correctly](#validate-federated-endpoint-identity--multi-cluster-networking).
+* Verify that you have met all of the [prerequisites](#calico-enterprise-multi-cluster-networking) for multi-cluster networking to be established.
+* If you had previously setup RemoteClusterConfigurations without multi-cluster networking and are upgrading to use the feature, review the [switching considerations](#switch-to-multi-cluster-networking).
+* Verify that traffic between clusters is not being denied by network policy.
+
+##### Check overlayRoutingMode
+Ensure that `overlayRoutingMode` is set to `"Enabled"` on all RemoteClusterConfigurations.
+
+If overlay routing is successfully enabled, you can view the logs of a Typha instance using:
+```
+kubectl logs deployment/calico-typha -n calico-system
+```
+
+You should see an output for each connected remote cluster that looks like this:
+```
+18:49:35.394 [INFO][14] wrappedcallbacks.go 443: Creating syncer for RemoteClusterConfiguration(my-cluster)
+18:49:35.394 [INFO][14] watchercache.go 186: Full resync is required ListRoot="/calico/ipam/v2/assignment/"
+18:49:35.395 [INFO][14] watchercache.go 186: Full resync is required ListRoot="/calico/resources/v3/projectcalico.org/workloadendpoints"
+18:49:35.396 [INFO][14] watchercache.go 186: Full resync is required ListRoot="/calico/resources/v3/projectcalico.org/hostendpoints"
+18:49:35.396 [INFO][14] watchercache.go 186: Full resync is required ListRoot="/calico/resources/v3/projectcalico.org/profiles"
+18:49:35.396 [INFO][14] watchercache.go 186: Full resync is required ListRoot="/calico/resources/v3/projectcalico.org/nodes"
+18:49:35.397 [INFO][14] watchercache.go 186: Full resync is required ListRoot="/calico/resources/v3/projectcalico.org/ippools"
+```
+
+If you do not see the each of the resource types above, overlay routing was not successfully enabled in your cluster. Verify that you followed the [setup](#create-remoteclusterconfigurations) correctly for overlay routing, and that the cluster is using a version of {{prodname}} that supports multi-cluster networking.
+
+
+###### Check logs
+Warning or error related logs in `typha` or `calico-node` may provide insight into where issues are occurring.
 
 ## Next steps
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Goals
* Correct NAT Outgoing guidance for both encapsulated and unencapsulated routing modes
* Clearer distinction between setup for encapsulated and unencapsulated routing mode
* Clearer (and more) troubleshooting steps that cover what the expected result is, and what to do if an unexpected result is returned
* De-emphasize calicoq as it is not a true validation that federation is working
* Remove enterprise-specific validation and troubleshooting references from cloud docs

Product Version(s): CE 3.18 EP2, CC 3.18
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://deploy-preview-1136--calico-docs-preview-next.netlify.app/calico-enterprise/next/multicluster/federation/kubeconfig/
https://deploy-preview-1136--calico-docs-preview-next.netlify.app/calico-cloud/next/multicluster/kubeconfig

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->