### PR TITLE
Fix typo in IP autodetection docs

### DIFF
--- a/calico-cloud/networking/ipam/ip-autodetection.mdx
+++ b/calico-cloud/networking/ipam/ip-autodetection.mdx
@@ -218,7 +218,7 @@ spec:
   ...
   calicoNetwork:
     nodeAddressAutodetectionV4: {}
-    # nodeAddressAutodetectionV4: {}
+    # nodeAddressAutodetectionV6: {}
 ```
 
 #### Configure IP and subnet using node resource

--- a/calico-cloud_versioned_docs/version-18-2/networking/ipam/ip-autodetection.mdx
+++ b/calico-cloud_versioned_docs/version-18-2/networking/ipam/ip-autodetection.mdx
@@ -218,7 +218,7 @@ spec:
   ...
   calicoNetwork:
     nodeAddressAutodetectionV4: {}
-    # nodeAddressAutodetectionV4: {}
+    # nodeAddressAutodetectionV6: {}
 ```
 
 #### Configure IP and subnet using node resource

--- a/calico-cloud_versioned_docs/version-18/networking/ipam/ip-autodetection.mdx
+++ b/calico-cloud_versioned_docs/version-18/networking/ipam/ip-autodetection.mdx
@@ -218,7 +218,7 @@ spec:
   ...
   calicoNetwork:
     nodeAddressAutodetectionV4: {}
-    # nodeAddressAutodetectionV4: {}
+    # nodeAddressAutodetectionV6: {}
 ```
 
 #### Configure IP and subnet using node resource

--- a/calico-cloud_versioned_docs/version-3.17/networking/ipam/ip-autodetection.mdx
+++ b/calico-cloud_versioned_docs/version-3.17/networking/ipam/ip-autodetection.mdx
@@ -218,7 +218,7 @@ spec:
   ...
   calicoNetwork:
     nodeAddressAutodetectionV4: {}
-    # nodeAddressAutodetectionV4: {}
+    # nodeAddressAutodetectionV6: {}
 ```
 
 #### Configure IP and subnet using node resource

--- a/calico-enterprise/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise/networking/ipam/ip-autodetection.mdx
@@ -218,7 +218,7 @@ spec:
   ...
   calicoNetwork:
     nodeAddressAutodetectionV4: {}
-    nodeAddressAutodetectionV4: {}
+    nodeAddressAutodetectionV6: {}
 ```
 
 #### Configure IP and subnet using node resource

--- a/calico-enterprise_versioned_docs/version-3.15/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/networking/ipam/ip-autodetection.mdx
@@ -218,7 +218,7 @@ spec:
   ...
   calicoNetwork:
     nodeAddressAutodetectionV4: {}
-    nodeAddressAutodetectionV4: {}
+    nodeAddressAutodetectionV6: {}
 ```
 
 #### Configure IP and subnet using node resource

--- a/calico-enterprise_versioned_docs/version-3.16/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/networking/ipam/ip-autodetection.mdx
@@ -218,7 +218,7 @@ spec:
   ...
   calicoNetwork:
     nodeAddressAutodetectionV4: {}
-    nodeAddressAutodetectionV4: {}
+    nodeAddressAutodetectionV6: {}
 ```
 
 #### Configure IP and subnet using node resource

--- a/calico-enterprise_versioned_docs/version-3.17/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/networking/ipam/ip-autodetection.mdx
@@ -218,7 +218,7 @@ spec:
   ...
   calicoNetwork:
     nodeAddressAutodetectionV4: {}
-    nodeAddressAutodetectionV4: {}
+    nodeAddressAutodetectionV6: {}
 ```
 
 #### Configure IP and subnet using node resource

--- a/calico-enterprise_versioned_docs/version-3.18-2/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/networking/ipam/ip-autodetection.mdx
@@ -218,7 +218,7 @@ spec:
   ...
   calicoNetwork:
     nodeAddressAutodetectionV4: {}
-    nodeAddressAutodetectionV4: {}
+    nodeAddressAutodetectionV6: {}
 ```
 
 #### Configure IP and subnet using node resource

--- a/calico-enterprise_versioned_docs/version-3.18/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18/networking/ipam/ip-autodetection.mdx
@@ -218,7 +218,7 @@ spec:
   ...
   calicoNetwork:
     nodeAddressAutodetectionV4: {}
-    nodeAddressAutodetectionV4: {}
+    nodeAddressAutodetectionV6: {}
 ```
 
 #### Configure IP and subnet using node resource

--- a/calico/networking/ipam/ip-autodetection.mdx
+++ b/calico/networking/ipam/ip-autodetection.mdx
@@ -245,7 +245,7 @@ metadata:
 spec:
   calicoNetwork:
     nodeAddressAutodetectionV4: {}
-    nodeAddressAutodetectionV4: {}
+    nodeAddressAutodetectionV6: {}
 ```
 
 #### Configure IP and subnet using node resource

--- a/calico_versioned_docs/version-3.24/networking/ipam/ip-autodetection.mdx
+++ b/calico_versioned_docs/version-3.24/networking/ipam/ip-autodetection.mdx
@@ -245,7 +245,7 @@ metadata:
 spec:
   calicoNetwork:
     nodeAddressAutodetectionV4: {}
-    nodeAddressAutodetectionV4: {}
+    nodeAddressAutodetectionV6: {}
 ```
 
 #### Configure IP and subnet using node resource

--- a/calico_versioned_docs/version-3.25/networking/ipam/ip-autodetection.mdx
+++ b/calico_versioned_docs/version-3.25/networking/ipam/ip-autodetection.mdx
@@ -245,7 +245,7 @@ metadata:
 spec:
   calicoNetwork:
     nodeAddressAutodetectionV4: {}
-    nodeAddressAutodetectionV4: {}
+    nodeAddressAutodetectionV6: {}
 ```
 
 #### Configure IP and subnet using node resource

--- a/calico_versioned_docs/version-3.26/networking/ipam/ip-autodetection.mdx
+++ b/calico_versioned_docs/version-3.26/networking/ipam/ip-autodetection.mdx
@@ -245,7 +245,7 @@ metadata:
 spec:
   calicoNetwork:
     nodeAddressAutodetectionV4: {}
-    nodeAddressAutodetectionV4: {}
+    nodeAddressAutodetectionV6: {}
 ```
 
 #### Configure IP and subnet using node resource

--- a/calico_versioned_docs/version-3.27/networking/ipam/ip-autodetection.mdx
+++ b/calico_versioned_docs/version-3.27/networking/ipam/ip-autodetection.mdx
@@ -245,7 +245,7 @@ metadata:
 spec:
   calicoNetwork:
     nodeAddressAutodetectionV4: {}
-    nodeAddressAutodetectionV4: {}
+    nodeAddressAutodetectionV6: {}
 ```
 
 #### Configure IP and subnet using node resource


### PR DESCRIPTION
'nodeAddressAutodetectionV4' appeared twice. From the context, we either want 'nodeAddressAutodetectionV4' and 'nodeAddressAutodetectionV6' (I went with this) or to only have v4 appear once. Fixed it everywhere this happened.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->