### PR TITLE
Update 3.17.3 release notes

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.17/_includes/release-notes/_v3.17.3-release-notes.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/_includes/release-notes/_v3.17.3-release-notes.mdx
@@ -11,6 +11,5 @@
 - The canvas on Service Graph may zoom and pan unexpectedly when modifying Views or Layers
 - Dragging tiers to modify their order is currently not working in the UI, though you can still change its order when editing a tier
 - Policy recommendations may generate rules with ports and protocols for intra-namespace traffic. This will be modified in the next patch release to exclude ports and protocols and provide an option to Allow or Pass this traffic.
-- Installing {{prodname}} on OpenShift Container Platform (OCP) 4.13 with the eBPF dataplane is currently not working
 - Upgrading to {{prodname}} 3.17.3 on Rancher/RKE from {{prodname}} 3.13.0 currently requires manually terminating the calico-node container for an upgrade to proceed.
 - Multi-cluster management of managed clusters with version before v3.17.0 is currently not working.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

CE 3.17.3 says ```Installing Calico Enterprise on OpenShift Container Platform (OCP) 4.13 with the eBPF dataplane is currently not working```. Issue was fixed in 3.17.3.


Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->