### PR TITLE
[CORE-10007] Add note about Windows Openshift support to relevant pages

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/windows-calico/manual-install/openshift-installation.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/windows-calico/manual-install/openshift-installation.mdx
@@ -6,6 +6,12 @@ description: Install Calico Enterprise on an OpenShift 4 cluster on Windows node
 
 :::note
 
+Currently, {{prodnameWindows}} supports Openshift versions only up to v4.5 because it requires the Windows Machine Config Bootstrapper binary (wmcb.exe) for adding Windows nodes to clusters. OpenShift v4.6+ does not support the Windows Machine Config Bootstrapper binary and uses the Red Hat Windows Machine Config Operator (WMCO), which does not correctly recognize {{prodname}} networking in the cluster.
+
+:::
+
+:::note
+
 The manual method for installing {{prodnameWindows}} is deprecated in favor of using [the Operator and Windows HostProcess containers (HPC)](../operator.mdx#install-{{prodnamedashWindows}}-using-the-operator). Support for this method will be dropped in a future {{prodname}} version.
 
 :::

--- a/calico-enterprise_versioned_docs/version-3.15/getting-started/install-on-clusters/windows-calico/openshift-installation.mdx
+++ b/calico-enterprise_versioned_docs/version-3.15/getting-started/install-on-clusters/windows-calico/openshift-installation.mdx
@@ -4,6 +4,12 @@ description: Install Calico Enterprise on an OpenShift 4 cluster on Windows node
 
 # Install an OpenShift 4 cluster on Windows nodes
 
+:::note
+
+Currently, {{prodnameWindows}} supports Openshift versions only up to v4.5 because it requires the Windows Machine Config Bootstrapper binary (wmcb.exe) for adding Windows nodes to clusters. OpenShift v4.6+ does not support the Windows Machine Config Bootstrapper binary and uses the Red Hat Windows Machine Config Operator (WMCO), which does not correctly recognize {{prodname}} networking in the cluster.
+
+:::
+
 ## Big picture
 
 Install an OpenShift 4 cluster on AWS with {{prodname}} on Windows nodes.

--- a/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/windows-calico/openshift-installation.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/windows-calico/openshift-installation.mdx
@@ -4,6 +4,12 @@ description: Install Calico Enterprise on an OpenShift 4 cluster on Windows node
 
 # Install an OpenShift 4 cluster on Windows nodes
 
+:::note
+
+Currently, {{prodnameWindows}} supports Openshift versions only up to v4.5 because it requires the Windows Machine Config Bootstrapper binary (wmcb.exe) for adding Windows nodes to clusters. OpenShift v4.6+ does not support the Windows Machine Config Bootstrapper binary and uses the Red Hat Windows Machine Config Operator (WMCO), which does not correctly recognize {{prodname}} networking in the cluster.
+
+:::
+
 ## Big picture
 
 Install an OpenShift 4 cluster on AWS with {{prodname}} on Windows nodes.

--- a/calico-enterprise_versioned_docs/version-3.17/getting-started/install-on-clusters/windows-calico/openshift-installation.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/getting-started/install-on-clusters/windows-calico/openshift-installation.mdx
@@ -4,6 +4,12 @@ description: Install Calico Enterprise on an OpenShift 4 cluster on Windows node
 
 # Install an OpenShift 4 cluster on Windows nodes
 
+:::note
+
+Currently, {{prodnameWindows}} supports Openshift versions only up to v4.5 because it requires the Windows Machine Config Bootstrapper binary (wmcb.exe) for adding Windows nodes to clusters. OpenShift v4.6+ does not support the Windows Machine Config Bootstrapper binary and uses the Red Hat Windows Machine Config Operator (WMCO), which does not correctly recognize {{prodname}} networking in the cluster.
+
+:::
+
 ## Big picture
 
 Install an OpenShift 4 cluster on AWS with {{prodname}} on Windows nodes.

--- a/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/windows-calico/manual-install/openshift-installation.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/windows-calico/manual-install/openshift-installation.mdx
@@ -6,6 +6,12 @@ description: Install Calico Enterprise on an OpenShift 4 cluster on Windows node
 
 :::note
 
+Currently, {{prodnameWindows}} supports Openshift versions only up to v4.5 because it requires the Windows Machine Config Bootstrapper binary (wmcb.exe) for adding Windows nodes to clusters. OpenShift v4.6+ does not support the Windows Machine Config Bootstrapper binary and uses the Red Hat Windows Machine Config Operator (WMCO), which does not correctly recognize {{prodname}} networking in the cluster.
+
+:::
+
+:::note
+
 The manual method for installing {{prodnameWindows}} is deprecated in favor of using [the Operator and Windows HostProcess containers (HPC)](../operator.mdx#install-{{prodnamedashWindows}}-using-the-operator). Support for this method will be dropped in a future {{prodname}} version.
 
 :::

--- a/calico-enterprise_versioned_docs/version-3.18/getting-started/install-on-clusters/windows-calico/openshift-installation.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18/getting-started/install-on-clusters/windows-calico/openshift-installation.mdx
@@ -4,6 +4,12 @@ description: Install Calico Enterprise on an OpenShift 4 cluster on Windows node
 
 # Install an OpenShift 4 cluster on Windows nodes
 
+:::note
+
+Currently, {{prodnameWindows}} supports Openshift versions only up to v4.5 because it requires the Windows Machine Config Bootstrapper binary (wmcb.exe) for adding Windows nodes to clusters. OpenShift v4.6+ does not support the Windows Machine Config Bootstrapper binary and uses the Red Hat Windows Machine Config Operator (WMCO), which does not correctly recognize {{prodname}} networking in the cluster.
+
+:::
+
 ## Big picture
 
 Install an OpenShift 4 cluster on AWS with {{prodname}} on Windows nodes.

--- a/calico/getting-started/kubernetes/windows-calico/manual-install/openshift-installation.mdx
+++ b/calico/getting-started/kubernetes/windows-calico/manual-install/openshift-installation.mdx
@@ -6,6 +6,12 @@ description: Install Calico on an OpenShift 4 cluster on Windows nodes
 
 :::note
 
+Currently, {{prodnameWindows}} supports Openshift versions only up to v4.5 because it requires the Windows Machine Config Bootstrapper binary (wmcb.exe) for adding Windows nodes to clusters. OpenShift v4.6+ does not support the Windows Machine Config Bootstrapper binary and uses the Red Hat Windows Machine Config Operator (WMCO), which does not correctly recognize {{prodname}} networking in the cluster.
+
+:::
+
+:::note
+
 The manual method for installing {{prodnameWindows}} is deprecated in favor of using [the Operator and Windows HostProcess containers (HPC)](../operator.mdx#install-{{prodnamedashWindows}}-using-the-operator). Support for this method will be dropped in a future {{prodname}} version.
 
 :::
@@ -251,7 +257,7 @@ curl https://github.com/openshift/windows-machine-config-bootstrapper/releases/d
 
 :::note
 
-For OpenShift 4.6, use the latest wmcb.exe for OpenShift 4.5. A wmcb.ex binary for OpenShift 4.6 is not published yet.
+For OpenShift 4.6, use the latest wmcb.exe for OpenShift 4.5. A wmcb.exe binary for OpenShift 4.6 is not published yet.
 
 :::
 

--- a/calico_versioned_docs/version-3.24/getting-started/kubernetes/windows-calico/openshift-installation.mdx
+++ b/calico_versioned_docs/version-3.24/getting-started/kubernetes/windows-calico/openshift-installation.mdx
@@ -4,6 +4,12 @@ description: Install Calico on an OpenShift 4 cluster on Windows nodes
 
 # Install an OpenShift 4 cluster on Windows nodes
 
+:::note
+
+Currently, {{prodnameWindows}} supports Openshift versions only up to v4.5 because it requires the Windows Machine Config Bootstrapper binary (wmcb.exe) for adding Windows nodes to clusters. OpenShift v4.6+ does not support the Windows Machine Config Bootstrapper binary and uses the Red Hat Windows Machine Config Operator (WMCO), which does not correctly recognize {{prodname}} networking in the cluster.
+
+:::
+
 ## Big picture
 
 Install an OpenShift 4 cluster on AWS with {{prodname}} on Windows nodes.
@@ -242,7 +248,7 @@ curl https://github.com/openshift/windows-machine-config-bootstrapper/releases/d
 
 :::note
 
-For OpenShift 4.6, use the latest wmcb.exe for OpenShift 4.5. A wmcb.ex binary for OpenShift 4.6 is not published yet.
+For OpenShift 4.6, use the latest wmcb.exe for OpenShift 4.5. A wmcb.exe binary for OpenShift 4.6 is not published yet.
 
 :::
 

--- a/calico_versioned_docs/version-3.25/getting-started/kubernetes/windows-calico/openshift-installation.mdx
+++ b/calico_versioned_docs/version-3.25/getting-started/kubernetes/windows-calico/openshift-installation.mdx
@@ -4,6 +4,12 @@ description: Install Calico on an OpenShift 4 cluster on Windows nodes
 
 # Install an OpenShift 4 cluster on Windows nodes
 
+:::note
+
+Currently, {{prodnameWindows}} supports Openshift versions only up to v4.5 because it requires the Windows Machine Config Bootstrapper binary (wmcb.exe) for adding Windows nodes to clusters. OpenShift v4.6+ does not support the Windows Machine Config Bootstrapper binary and uses the Red Hat Windows Machine Config Operator (WMCO), which does not correctly recognize {{prodname}} networking in the cluster.
+
+:::
+
 ## Big picture
 
 Install an OpenShift 4 cluster on AWS with {{prodname}} on Windows nodes.
@@ -242,7 +248,7 @@ curl https://github.com/openshift/windows-machine-config-bootstrapper/releases/d
 
 :::note
 
-For OpenShift 4.6, use the latest wmcb.exe for OpenShift 4.5. A wmcb.ex binary for OpenShift 4.6 is not published yet.
+For OpenShift 4.6, use the latest wmcb.exe for OpenShift 4.5. A wmcb.exe binary for OpenShift 4.6 is not published yet.
 
 :::
 

--- a/calico_versioned_docs/version-3.26/getting-started/kubernetes/windows-calico/openshift-installation.mdx
+++ b/calico_versioned_docs/version-3.26/getting-started/kubernetes/windows-calico/openshift-installation.mdx
@@ -4,6 +4,12 @@ description: Install Calico on an OpenShift 4 cluster on Windows nodes
 
 # Install an OpenShift 4 cluster on Windows nodes
 
+:::note
+
+Currently, {{prodnameWindows}} supports Openshift versions only up to v4.5 because it requires the Windows Machine Config Bootstrapper binary (wmcb.exe) for adding Windows nodes to clusters. OpenShift v4.6+ does not support the Windows Machine Config Bootstrapper binary and uses the Red Hat Windows Machine Config Operator (WMCO), which does not correctly recognize {{prodname}} networking in the cluster.
+
+:::
+
 ## Big picture
 
 Install an OpenShift 4 cluster on AWS with {{prodname}} on Windows nodes.
@@ -242,7 +248,7 @@ curl https://github.com/openshift/windows-machine-config-bootstrapper/releases/d
 
 :::note
 
-For OpenShift 4.6, use the latest wmcb.exe for OpenShift 4.5. A wmcb.ex binary for OpenShift 4.6 is not published yet.
+For OpenShift 4.6, use the latest wmcb.exe for OpenShift 4.5. A wmcb.exe binary for OpenShift 4.6 is not published yet.
 
 :::
 

--- a/calico_versioned_docs/version-3.27/getting-started/kubernetes/windows-calico/manual-install/openshift-installation.mdx
+++ b/calico_versioned_docs/version-3.27/getting-started/kubernetes/windows-calico/manual-install/openshift-installation.mdx
@@ -6,6 +6,12 @@ description: Install Calico on an OpenShift 4 cluster on Windows nodes
 
 :::note
 
+Currently, {{prodnameWindows}} supports Openshift versions only up to v4.5 because it requires the Windows Machine Config Bootstrapper binary (wmcb.exe) for adding Windows nodes to clusters. OpenShift v4.6+ does not support the Windows Machine Config Bootstrapper binary and uses the Red Hat Windows Machine Config Operator (WMCO), which does not correctly recognize {{prodname}} networking in the cluster.
+
+:::
+
+:::note
+
 The manual method for installing {{prodnameWindows}} is deprecated in favor of using [the Operator and Windows HostProcess containers (HPC)](../operator.mdx#install-{{prodnamedashWindows}}-using-the-operator). Support for this method will be dropped in a future {{prodname}} version.
 
 :::
@@ -251,7 +257,7 @@ curl https://github.com/openshift/windows-machine-config-bootstrapper/releases/d
 
 :::note
 
-For OpenShift 4.6, use the latest wmcb.exe for OpenShift 4.5. A wmcb.ex binary for OpenShift 4.6 is not published yet.
+For OpenShift 4.6, use the latest wmcb.exe for OpenShift 4.5. A wmcb.exe binary for OpenShift 4.6 is not published yet.
 
 :::
 


### PR DESCRIPTION
Add a note to Windows Openshift docs regarding the drop of support for the Windows Machine Config Bootstrapper binary (wmcb.exe) since Openshift v4.6.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->