### PR TITLE
Fix vppbranch var to point to right versions of Calico VPP

### DIFF
--- a/calico/variables.js
+++ b/calico/variables.js
@@ -18,7 +18,7 @@ const variables = {
   manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.27.0',
   releases,
   registry: '',
-  vppbranch: 'v3.26.0',
+  vppbranch: 'master',
   tigeraOperator: releases[0]['tigera-operator'],
   tigeraOperatorVersionShort: releases[0]['tigera-operator'].version.split('.').slice(0, 2).join('.'),
   imageNames: {

--- a/calico_versioned_docs/version-3.27/variables.js
+++ b/calico_versioned_docs/version-3.27/variables.js
@@ -18,7 +18,7 @@ const variables = {
   manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.27.0',
   releases,
   registry: '',
-  vppbranch: 'v3.26.0',
+  vppbranch: 'v3.27.0',
   tigeraOperator: releases[0]['tigera-operator'],
   tigeraOperatorVersionShort: releases[0]['tigera-operator'].version.split('.').slice(0, 2).join('.'),
   imageNames: {


### PR DESCRIPTION
Fix vppbranch var to point to right versions of Calico VPP

Product Version(s):
v3.27.0

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->