### PR TITLE
DOCS-Remove-AD-components-3.18

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.18-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.18-2/releases.json
@@ -166,14 +166,6 @@
         "version": "v1.1.15",
         "registry": "quay.io"
       },
-      "anomaly_detection_jobs": {
-        "image": "tigera/anomaly_detection_jobs",
-        "version": "v3.18.0-2.0"
-      },
-      "anomaly-detection-api": {
-        "image": "tigera/anomaly-detection-api",
-        "version": "v3.18.0-2.0"
-      },
       "elasticsearch-metrics": {
         "image": "tigera/elasticsearch-metrics",
         "version": "v3.18.0-2.0"


### PR DESCRIPTION
Verified with Nell that we no longer use the AD components in 3.18.

Product Version(s):
CE 3.18-2

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->