### PR TITLE
update windows component images

### DIFF
--- a/calico-cloud/releases.json
+++ b/calico-cloud/releases.json
@@ -51,6 +51,10 @@
         "image": "tigera/cnx-node",
         "version": "master"
       },
+      "cnx-node-windows": {
+        "image": "tigera/cnx-node-windows",
+        "version": "master"
+      },
       "dikastes": {
         "image": "tigera/dikastes",
         "version": "master"
@@ -141,6 +145,10 @@
         "image": "tigera/cni",
         "version": "master"
       },
+      "tigera-cni-windows": {
+        "image": "tigera/cni-windows",
+        "version": "master"
+      },
       "firewall-integration": {
         "image": "tigera/firewall-integration",
         "version": "master"
@@ -221,14 +229,6 @@
       },
       "envoy-init": {
         "image": "tigera/envoy-init",
-        "version": "master"
-      },
-      "windows": {
-        "image": "tigera/calico-windows",
-        "version": "master"
-      },
-      "windows-upgrade": {
-        "image": "tigera/calico-windows-upgrade",
         "version": "master"
       },
       "flexvol": {

--- a/calico-cloud_versioned_docs/version-18-2/releases.json
+++ b/calico-cloud_versioned_docs/version-18-2/releases.json
@@ -51,6 +51,10 @@
         "image": "tigera/cnx-node",
         "version": "master"
       },
+      "cnx-node-windows": {
+        "image": "tigera/cnx-node-windows",
+        "version": "master"
+      },
       "dikastes": {
         "image": "tigera/dikastes",
         "version": "master"
@@ -141,6 +145,10 @@
         "image": "tigera/cni",
         "version": "master"
       },
+      "tigera-cni-windows": {
+        "image": "tigera/cni-windows",
+        "version": "master"
+      },
       "firewall-integration": {
         "image": "tigera/firewall-integration",
         "version": "master"
@@ -221,14 +229,6 @@
       },
       "envoy-init": {
         "image": "tigera/envoy-init",
-        "version": "master"
-      },
-      "windows": {
-        "image": "tigera/calico-windows",
-        "version": "master"
-      },
-      "windows-upgrade": {
-        "image": "tigera/calico-windows-upgrade",
         "version": "master"
       },
       "flexvol": {

--- a/calico-enterprise/releases.json
+++ b/calico-enterprise/releases.json
@@ -51,6 +51,10 @@
         "image": "tigera/cnx-node",
         "version": "master"
       },
+      "cnx-node-windows": {
+        "image": "tigera/cnx-node-windows",
+        "version": "master"
+      },
       "dikastes": {
         "image": "tigera/dikastes",
         "version": "master"
@@ -141,6 +145,10 @@
         "image": "tigera/cni",
         "version": "master"
       },
+      "tigera-cni-windows": {
+        "image": "tigera/cni-windows",
+        "version": "master"
+      },
       "firewall-integration": {
         "image": "tigera/firewall-integration",
         "version": "master"
@@ -221,14 +229,6 @@
       },
       "envoy-init": {
         "image": "tigera/envoy-init",
-        "version": "master"
-      },
-      "windows": {
-        "image": "tigera/calico-windows",
-        "version": "master"
-      },
-      "windows-upgrade": {
-        "image": "tigera/calico-windows-upgrade",
         "version": "master"
       },
       "flexvol": {

--- a/calico-enterprise_versioned_docs/version-3.18-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.18-2/releases.json
@@ -51,6 +51,10 @@
         "image": "tigera/cnx-node",
         "version": "v3.18.0-2.0"
       },
+      "cnx-node-windows": {
+        "image": "tigera/cnx-node-windows",
+        "version": "v3.18.0-2.0"
+      },
       "dikastes": {
         "image": "tigera/dikastes",
         "version": "v3.18.0-2.0"
@@ -141,6 +145,10 @@
         "image": "tigera/cni",
         "version": "v3.18.0-2.0"
       },
+      "tigera-cni-windows": {
+        "image": "tigera/cni-windows",
+        "version": "v3.18.0-2.0"
+      },
       "firewall-integration": {
         "image": "tigera/firewall-integration",
         "version": "v3.18.0-2.0"
@@ -227,14 +235,6 @@
       },
       "envoy-init": {
         "image": "tigera/envoy-init",
-        "version": "v3.18.0-2.0"
-      },
-      "windows": {
-        "image": "tigera/calico-windows",
-        "version": "v3.18.0-2.0"
-      },
-      "windows-upgrade": {
-        "image": "tigera/calico-windows-upgrade",
         "version": "v3.18.0-2.0"
       },
       "policy-recommendation": {


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):

- Calico Enterprise >= 3.18.0-2.0
- Calico Cloud based on Calico Enterprise in use

Issue:
N/A

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
This updates the component images for windows from `tigera/calico-windows` and `tigera/calico-windows-upgrade` to `tigera/cni-windows` and `tigera/cnx-node-windows`.

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->