### PR TITLE
[GH #calico-8364] Update calicoctl binary command

### DIFF
--- a/calico-enterprise/operations/clis/calicoctl/install.mdx
+++ b/calico-enterprise/operations/clis/calicoctl/install.mdx
@@ -302,7 +302,7 @@ You can also [view the YAML in a new tab]({{filesUrl}}/manifests/calicoctl.yaml)
 You can then run commands using kubectl as shown below.
 
 ```bash
-kubectl exec -ti -n kube-system calicoctl -- /calicoctl get profiles -o wide
+kubectl exec -ti -n kube-system calicoctl -- calicoctl get profiles -o wide
 ```
 
 An example response follows.
@@ -316,7 +316,7 @@ kns.kube-system      kns.kube-system
 We recommend setting an alias as follows.
 
 ```bash
-alias calicoctl="kubectl exec -i -n kube-system calicoctl -- /calicoctl"
+alias calicoctl="kubectl exec -i -n kube-system calicoctl -- calicoctl"
 ```
 
 :::note

--- a/calico/_includes/components/HostEndpointsUpgrade.js
+++ b/calico/_includes/components/HostEndpointsUpgrade.js
@@ -45,8 +45,8 @@ export default function HostEndpointsUpgrade(props) {
         calicoctl get hep -owide | grep '*' | awk '"{'print $1'}"' \
         <br />
         {props.orch === 'OpenShift'
-          ? '| xargs -I {} oc exec -i -n kube-system calicoctl -- /calicoctl label hostendpoint {} host-endpoint-upgrade='
-          : '| xargs -I {} kubectl exec -i -n kube-system calicoctl -- /calicoctl label hostendpoint {} host-endpoint-upgrade=	'}
+          ? '| xargs -I {} oc exec -i -n kube-system calicoctl -- calicoctl label hostendpoint {} host-endpoint-upgrade='
+          : '| xargs -I {} kubectl exec -i -n kube-system calicoctl -- calicoctl label hostendpoint {} host-endpoint-upgrade=	'}
       </CodeBlock>
       <p>
         Now that the nodes with an all-interfaces host endpoint are labeled with <strong>host-endpoint-upgrade</strong>,

--- a/calico/operations/calicoctl/install.mdx
+++ b/calico/operations/calicoctl/install.mdx
@@ -439,7 +439,7 @@ Use the YAML that matches your datastore type to deploy the `calicoctl` containe
 You can then run commands using kubectl as shown below.
 
 ```bash
-kubectl exec -ti -n kube-system calicoctl -- /calicoctl get profiles -o wide
+kubectl exec -ti -n kube-system calicoctl -- calicoctl get profiles -o wide
 ```
 
 An example response follows.
@@ -453,7 +453,7 @@ kns.kube-system      kns.kube-system
 We recommend setting an alias as follows.
 
 ```bash
-alias calicoctl="kubectl exec -i -n kube-system calicoctl -- /calicoctl"
+alias calicoctl="kubectl exec -i -n kube-system calicoctl -- calicoctl"
 ```
 
 :::note


### PR DESCRIPTION
Remove the leading '/' from the 'calicoctl' command when running it as a pod, due to the calicoctl container being updated in https://github.com/projectcalico/calico/pull/8364

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->