### PR TITLE
DOCS-550-Update-default-deny

### DIFF
--- a/calico_versioned_docs/version-3.27/network-policy/get-started/kubernetes-default-deny.mdx
+++ b/calico_versioned_docs/version-3.27/network-policy/get-started/kubernetes-default-deny.mdx
@@ -2,7 +2,7 @@
 description: Create a default deny network policy so pods that are missing policy are not allowed traffic until appropriate network policy is defined.
 ---
 
-# Enable default deny for Kubernetes pods
+# Enable a default deny policy for Kubernetes pods
 
 ## Big picture
 
@@ -10,7 +10,7 @@ Enable a default deny policy for Kubernetes pods using Kubernetes or {{prodname}
 
 ## Value
 
-A **default deny** network policy provides an enhanced security posture -- so pods without policy (or incorrect policy) are not allowed traffic until appropriate network policy is defined.
+A **default deny** network policy provides an enhanced security posture so pods without policy (or incorrect policy) are not allowed traffic until appropriate network policy is defined.
 
 ## Features
 
@@ -33,37 +33,27 @@ For compatibility with Kubernetes, **{{prodname}} network policy** enforcement f
 
 For other endpoint types (VMs, host interfaces), the default behavior is to deny traffic. Only traffic specifically allowed by network policy is allowed, even if no network policies apply to the endpoint.
 
-### Best practice: implicit default deny policy
+## Before you begin
 
-We recommend creating an implicit default deny policy for your Kubernetes pods, regardless of whether you use {{prodname}} or Kubernetes network policy. This ensures that unwanted traffic is denied by default. Note that implicit default deny policy always occurs last; if any other policy allows the traffic, then the deny does not come into effect. The deny is executed only after all other policies are evaluated.
-
-## Before we begin
-
-If you haven't already, you will need to [install calicoctl](../../operations/calicoctl/install.mdx) to apply the example {{prodname}} network policies from this page.
+To apply the sample {{prodname}} network policies in the following section, [install calicoctl](../../operations/calicoctl/install.mdx).
 
 ## How to
 
-Although you can use any of the following policies to create default deny policy for Kubernetes pods, we recommend using the {{prodname}} global network policy. A {{prodname}} global network policy applies to all workloads (VMs and containers) in all namespaces, as well as hosts (computers that run the hypervisor for VMs, or container runtime for containers). Using a {{prodname}} global network policy supports a conservative security stance for protecting resources.
+- [Create a default deny network policy](#crate-a-default-deny-network-policy)
+- [Create a global default deny network policy](#create-a-global-default-deny-network-policy)
 
-- [Enable default deny {{prodname}} global network policy, non-namespaced](#enable-default-deny-calico-global-network-policy-non-namespaced)
-- [Enable default deny {{prodname}} network policy, namespaced](#enable-default-deny-calico-network-policy-namespaced)
-- [Enable default deny Kubernetes policy, namespaced](#enable-default-deny-Kubernetes-policy-namespaced)
+### Create a default deny network policy
 
-### Enable default deny {{prodname}} global network policy, non-namespaced
+Immediately after installation, a best practice is to create a namespaced default deny network policy to secure pods without policy or incorrect policy until you can put policies in place and test them.
 
-You can use a {{prodname}} global network policy to enable a default deny across your whole cluster. The following example applies to all workloads (VMs and containers) in all namespaces, as well as hosts (computers that run the hypervisor for VMs, or container runtime for containers).
-
-:::note
-
-Before applying the following please continue reading the rest of this section to find out why this might not be the best policy to apply to your cluster.
-
-:::
+In the following example, we create a {{prodname}} default deny **NetworkPolicy** for all workloads in the namespace, **engineering**.
 
 ```yaml
 apiVersion: projectcalico.org/v3
-kind: GlobalNetworkPolicy
+kind: NetworkPolicy
 metadata:
   name: default-deny
+  namespace: engineering
 spec:
   selector: all()
   types:
@@ -71,11 +61,38 @@ spec:
     - Egress
 ```
 
-The above policy applies to all pods and host endpoints, including Kubernetes control plane and {{prodname}} control plane nodes and pods.
-Such policy has the potential to break your cluster if you do not already have the correct "Allow" policies and {{prodname}} [failsafe ports](../../reference/felix/configuration.mdx) in place to ensure control plane traffic does not get blocked.
+Here's an equivalent default deny **Kubernetes network policy** for all pods in the namespace, **engineering**
 
-As an alternative best practice we recommend to use the following example, which applies a default-deny behaviour to all non-system pods. The policy
-also allows access kube-dns, which simplifies per pod policies since you don't need to duplicate the DNS rules in every policy.
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: engineering
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+```
+
+### Create a global default deny policy
+
+A default deny policy ensures that unwanted traffic (ingress and egress) is denied by default without you having to remember default deny/allow behavior of Kubernetes and {{prodname}} policies. This policy can also help mitigate risks of lateral malicious attacks.
+
+#### Best practice #1: Allow, stage, then deny
+
+We recommend that you create a global default deny policy after you complete writing policy for the traffic that you want to allow. The following steps summarizes the best practice to test and lock down the cluster to block unwanted traffic:
+
+1. Create a global default deny policy and test it in a staging environment. (The policy will show all the traffic that would be blocked if it were converted into a deny.)
+1. Create network policies to individually allow the traffic shown as blocked in step 1 until no connections are denied.
+1. Enforce the global default deny policy.
+
+#### Best practice #2: Keep the scope to non-system pods
+
+A global default deny policy applies to the entire cluster including all workloads in all namespaces, hosts (computers that run the hypervisor for VMs or container runtime for containers), including Kubernetes control plane and {{prodname}} control plane nodes and pods.
+
+For this reason, the best practice is to create a global default deny policy for **non-system pods** as shown in the following example.
 
 ```yaml
 apiVersion: projectcalico.org/v3
@@ -83,12 +100,12 @@ kind: GlobalNetworkPolicy
 metadata:
   name: deny-app-policy
 spec:
-  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system", "calico-apiserver"}
+  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system", "tigera-system"}
   types:
   - Ingress
   - Egress
   egress:
-  # allow all namespaces to communicate to DNS pods
+   # allow all namespaces to communicate to DNS pods
   - action: Allow
     protocol: UDP
     destination:
@@ -103,38 +120,27 @@ spec:
       - 53
 ```
 
-It is important to note the above policy deliberately excludes the `kube-system`, `calico-system` and `calico-apiserver` namespaces by using a negative `namespaceSelector` to avoid impacting any control plane components. To secure the control plane you can write specific policies for each control plane component, though you should do so with care, ideally at cluster creation time, since getting these wrong can leave your cluster in a broken state. We recommend you always make sure you have the correct {{prodname}} [failsafe ports](../../reference/felix/configuration.mdx) in place before you start trying to create policies for the control plane.
+Note the following:
 
-### Enable default deny {{prodname}} network policy, namespaced
+- Even though we call this policy "global default deny", the above policy is not explicitly denying traffic. By selecting the traffic with the `namespaceSelector` but not specifying an allow, the traffic is denied after all other policy is evaluated. This design also makes it unnecessary to ensure any specific order (priority) for the default-deny policy.
+- Allowing access to `kube-dns` simplifies per-pod policies because you don't need to duplicate the DNS rules in every policy
+- The policy deliberately excludes the `kube-system`, `calico-system`, and `tigera-system` namespaces by using a negative `namespaceSelector` to avoid impacting any control plane components
 
-In the following example, we enable a default deny **NetworkPolicy** for all workloads in the namespace, **engineering**.
+In a staging environment, verify that the policy does not block any necessary traffic before enforcing it.
+
+### Don't try this!
+
+The following policy works and looks fine on the surface. But as described in Best practices #2, the policy is too broad in scope and could break your cluster. Therefore, we do not recommend adding this type of policy, even if you have verified allowed traffic in your staging environment.
 
 ```yaml
 apiVersion: projectcalico.org/v3
-kind: NetworkPolicy
+kind: GlobalNetworkPolicy
 metadata:
-  name: default-deny
-  namespace: engineering
+  name: default.default-deny
 spec:
+  tier: default
   selector: all()
   types:
-    - Ingress
-    - Egress
-```
-
-### Enable default deny Kubernetes policy, namespaced
-
-In the following example, we enable a default deny **Kubernetes network policy** for all pods in the namespace, **engineering**.
-
-```yaml
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: default-deny
-  namespace: engineering
-spec:
-  podSelector: {}
-  policyTypes:
     - Ingress
     - Egress
 ```


### PR DESCRIPTION
Fix wording around default deny policy for OSS.

Product Version(s):
All OSS active versions

Issue:
https://tigera.atlassian.net/browse/DOCS-550 and discussion: https://tigera.slack.com/archives/CGMG75AUV/p1656880509050909

Link to docs preview:
https://deploy-preview-1230--tigera.netlify.app/calico/latest/network-policy/get-started/kubernetes-default-deny

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->