### PR TITLE
add target to auto update component versions and API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,3 +154,61 @@ run-update-cloud-image-list:
 	done
 	@if [ "$$(git diff --stat ./calico-cloud*/**/get-started/connect/setup-private-registry.mdx)" != "" ]; then \
 	echo "You might need to run 'make run-update-cloud-image-list' and commit the changes"; exit 1; fi
+
+# This allow generating the components version for a specific product
+# NOTE: currently only implemented for calico-enterprise; there is validation in the script to check this
+# If you want to use a different product branch from the dafault, specify GIT_VERSION_REF
+# 	e.g. for new versions of v3.18.0-1, GIT_VERSION_REF=3.18-1
+# If you want to use a different doc folder from the dafault, specify DOCS_VERSION_STREAM
+# 	e.g. for new versions of v3.18.0-2, DOCS_VERSION_STREAM=3.18-2
+version/autogen:
+	$(if $(GITHUB_TOKEN),,$(error GITHUB_TOKEN is not set or empty, but is required))
+	$(if $(PRODUCT),,$(error PRODUCT is not set or empty, but is required))
+	$(if $(VERSION),,$(error VERSION is not set or empty, but is required))
+	./scripts/update-component-versions.sh
+
+# Call the github API. $(1) is the http method type for the https request, $(2) is the repo slug, and is $(3) is for json
+# data (if omitted then no data is set for the request). If GITHUB_API_EXIT_ON_FAILURE is set then the macro exits with 1
+# on failure. On success, the ENV variable GITHUB_API_RESPONSE will contain the response from github
+define github_call_api
+	$(eval CMD := curl -f -X$(1) \
+		-H "Content-Type: application/json"\
+		-H "Authorization: token ${GITHUB_TOKEN}"\
+		https://api.github.com/repos/$(2) $(if $(3),--data '$(3)',))
+	$(eval GITHUB_API_RESPONSE := $(shell $(CMD) | sed -e 's/#/\\\#/g'))
+	$(if $(GITHUB_API_EXIT_ON_FAILURE), $(if $(GITHUB_API_RESPONSE),,exit 1),)
+endef
+
+# Create the pull request. $(1) is the repo slug, $(2) is the title, $(3) is the head branch and $(4) is the base branch.
+# If the call was successful then the ENV variable PR_NUMBER will contain the pull request number of the created pull request.
+define github_pr_create
+	$(eval JSON := {"title": "$(2)", "head": "$(3)", "base": "$(4)"})
+	$(call github_call_api,POST,$(1)/pulls,$(JSON))
+	$(eval PR_NUMBER := $(filter-out null,$(shell echo '$(GITHUB_API_RESPONSE)' | jq '.number')))
+endef
+
+release-prep: version/autogen autogen_$(lastword $(subst -, ,$(PRODUCT)))
+	$(MAKE) release-prep/create-and-push-branch
+
+GIT_REMOTE?=origin
+ifneq ($(if $(GIT_REPO_SLUG),$(shell dirname $(GIT_REPO_SLUG)),), $(shell dirname `git config remote.$(GIT_REMOTE).url | cut -d: -f2`))
+GIT_FORK_USER:=$(shell dirname `git config remote.$(GIT_REMOTE).url | cut -d: -f2`)
+endif
+GIT_PR_BRANCH_BASE?=$(if $(SEMAPHORE),$(SEMAPHORE_GIT_BRANCH),)
+GIT_REPO_SLUG?=$(if $(SEMAPHORE),$(SEMAPHORE_GIT_REPO_SLUG),)
+RELEASE_UPDATE_BRANCH?=$(if $(SEMAPHORE),semaphore-,)auto-build-updates-$(PRODUCT)-$(VERSION)
+GIT_PR_BRANCH_HEAD?=$(if $(GIT_FORK_USER),$(GIT_FORK_USER):$(RELEASE_UPDATE_BRANCH),$(RELEASE_UPDATE_BRANCH))
+release-prep/create-and-push-branch:
+ifeq ($(shell git rev-parse --abbrev-ref HEAD),$(RELEASE_UPDATE_BRANCH))
+	$(error Current branch is pull request head, cannot set it up.)
+endif
+	-git branch -D $(RELEASE_UPDATE_BRANCH)
+	-git push $(GIT_REMOTE) --delete $(RELEASE_UPDATE_BRANCH)
+	git checkout -b $(RELEASE_UPDATE_BRANCH)
+	git add $(PRODUCT)*/\*_api.mdx $(PRODUCT)*/\*releases.json
+	git commit -m "Automatic updates for $(PRODUCT) $(VERSION) release"
+	$(GIT) push $(GIT_REMOTE) $(RELEASE_UPDATE_BRANCH)
+
+release-prep/create-pr:
+	$(call github_pr_create,$(GIT_REPO_SLUG),[$(GIT_PR_BRANCH_BASE)] $(if $(SEMAPHORE), Semaphore,) Auto Release Update for $(PRODUCT) $(VERSION),$(GIT_PR_BRANCH_HEAD),$(GIT_PR_BRANCH_BASE))
+	echo 'Created release update pull request for $(VERSION): $(PR_NUMBER)'

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,8 @@ run-update-cloud-image-list:
 # 	e.g. for new versions of v3.18.0-1, GIT_VERSION_REF=3.18-1
 # If you want to use a different doc folder from the dafault, specify DOCS_VERSION_STREAM
 # 	e.g. for new versions of v3.18.0-2, DOCS_VERSION_STREAM=3.18-2
+# If the version to updates is the latest version for the product, specify IS_LATEST=true
+# 	e.g. if 3,18,1 is the latest version, IS_LATEST=true
 version/autogen:
 	$(if $(GITHUB_TOKEN),,$(error GITHUB_TOKEN is not set or empty, but is required))
 	$(if $(PRODUCT),,$(error PRODUCT is not set or empty, but is required))

--- a/scripts/update-component-versions.sh
+++ b/scripts/update-component-versions.sh
@@ -4,6 +4,7 @@ set -eu
 : ${VERSION:?"Product version not specified, set using 'VERSION' e.g. VERSION=3.15.4"}
 : ${PRODUCT:?"Product not specified, set using 'PRODUCT'"}
 : ${GITHUB_TOKEN:?"GitHub API token not specified, set using 'GITHUB_TOKEN'"}
+: ${IS_LATEST:=false}:?"Set \"true\" if this is the latest version for the product"
 
 declare -A products=(
   "calico-enterprise"
@@ -12,11 +13,11 @@ declare -A products=(
 declare -A product_repo_dict=(
   ["calico-enterprise"]="tigera/calico-private"
 )
-declare -A product_branch_prefix=(
+declare -A product_branch_prefix_dict=(
   ["calico-enterprise"]="release-calient"
 )
 
-valid_product() {
+is_valid_product() {
   local search=$1
   for product in "${!products[@]}"; do
     if [ $product == $search ]; then
@@ -26,15 +27,26 @@ valid_product() {
   return 1
 }
 
-git_branch_ref() {
+get_product_branch_ref() {
   local version=$1
   if [ $version != "master" ]; then
     : ${GIT_VERSION_REF:=$(echo "$version" | cut -d. -f1,2)}
-    echo "?ref=${product_branch_prefix[$PRODUCT]}-v${GIT_VERSION_REF#v}"
+    echo "?ref=${product_branch_prefix_dict[$PRODUCT]}-v${GIT_VERSION_REF#v}"
   fi
 }
 
-docs_folder_path() {
+get_product_version_info() {
+  local version=$1
+  product_branch_ref=$(get_product_branch_ref $version)
+  api_url="https://${GITHUB_TOKEN}:@api.github.com/repos/${product_repo_dict[$PRODUCT]}/contents/calico/_data/versions.yml${product_branch_ref}"
+  versions_yml=$(curl -H 'Accept: application/vnd.github.v3.raw' "${api_url}")
+  yq "
+  ... comments=\"\" | .[] |
+  select(.title == \"v${VERSION}\" or .title == \"${VERSION}\")
+  " <(echo "$versions_yml")
+}
+
+get_docs_folder_path() {
   local version=$1
   if [ $version == "master" ]; then
     echo $PRODUCT
@@ -45,37 +57,86 @@ docs_folder_path() {
   fi
 }
 
-if ! valid_product "$PRODUCT"; then
+update_calico_enterprise_version() {
+  new_version=$(yq -o=json '. |= pick(["title", "tigera-operator", "calico", "components"]) | del(.components.[].fips-image)' <(echo "$product_version_info"))
+  # add new version as first item in array
+  releases_json=$(cat $releases_json_file | jq --argjson newVersion "$(echo $new_version)" '. = [$newVersion] + .')
+  jq '.' <(echo $releases_json) >$releases_json_file
+  # update variables.js
+  local helm_version=$(yq ".helmRelease" <(echo "$product_version_info") || echo "")
+  if [ -z "$helm_version" -a "$helm_version" != " " ]; then
+    helm_version=""
+  else
+    helm_version="-${helm_version}"
+  fi
+  local release_title=v${VERSION}
+  local release_stream=$(echo ${VERSION} | cut -d. -f1,2)
+  local docs_base_url="/calico-enterprise/${release_stream}"
+  if [ "${IS_LATEST}" == "true" ]; then
+    docs_base_url="/calico-enterprise/latest"
+  fi
+  cat <<EOF >${docs_folder_path}/variables.js
+const releases = require('./releases.json');
+
+const variables = {
+  releaseTitle: '${release_title}',
+  prodname: 'Calico Enterprise',
+  prodnamedash: 'calico-enterprise',
+  version: 'v${release_stream}',
+  baseUrl: '${docs_base_url}',
+  filesUrl: 'https://downloads.tigera.io/ee/${release_title}',
+  tutorialFilesURL: 'https://docs.tigera.io/files',
+  tmpScriptsURL: 'https://docs.tigera.io/calico-enterprise/${release_stream}',
+  prodnameWindows: 'Calico Enterprise for Windows',
+  downloadsurl: 'https://downloads.tigera.io',
+  nodecontainer: 'cnx-node',
+  noderunning: 'calico-node',
+  rootDirWindows: 'C:\\\\TigeraCalico',
+  registry: 'quay.io/',
+  chart_version_name: 'v${VERSION}${helm_version}',
+  tigeraOperator: releases[0]['tigera-operator'],
+  releases,
+  imageNames: {
+    node: 'tigera/cnx-node',
+    kubeControllers: 'tigera/kube-controllers',
+  },
+};
+
+module.exports = variables;
+EOF
+}
+
+if ! is_valid_product "$PRODUCT"; then
   echo "error: Invalid product specified: \"$PRODUCT\""
+  exit 1
 fi
 
 # sanitize product version
 VERSION=${VERSION#v}
-branchRef=$(git_branch_ref $VERSION)
-apiUrl="https://${GITHUB_TOKEN}:@api.github.com/repos/${product_repo_dict[$PRODUCT]}/contents/calico/_data/versions.yml${branchRef}"
-releases_json_file=$(docs_folder_path $VERSION)/releases.json
-
+# determine path to folder for update
+docs_folder_path=$(get_docs_folder_path $VERSION)
+# set version file
+releases_json_file=${docs_folder_path}/releases.json
+# Check if version exists in docs
 found_version=$(jq ".[] | select(.title| test(\"$VERSION\"))" $releases_json_file)
 if [ -n "$found_version" ]; then
-  # Skip updating if version already exists
-  echo "Component list for $VERSION already exists ...SKIPPING!"
-  exit 0
-  # Alternative option: delete existing and replace
-  # yq -o=json -i "del(.[]| select(.title | test(\"$VERSION\")))" $releases_json_file
+  # if version already exists, delete existing and replace
+  yq -o=json -i "del(.[]| select(.title | test(\"$VERSION\")))" $releases_json_file
 fi
 
-versions_yml=$(curl -H 'Accept: application/vnd.github.v3.raw' "${apiUrl}")
-version_info=$(yq "
-  ... comments=\"\" | .[] |
-  select(.title == \"v${VERSION}\" or .title == \"${VERSION}\")
-  " <(echo "$versions_yml"))
+product_version_info=$(get_product_version_info $VERSION)
 
-if [ -z "$version_info" -a "$version_info" != " " ]; then
-  echo "error: No component list found for $VERSION"
+if [ -z "$product_version_info" -a "$product_version_info" != " " ]; then
+  echo "error: No component list found for $PRODUCT $VERSION"
   exit 1
 else
-  new_version=$(yq -o=json '. |= pick(["title", "helmRelease", "tigera-operator", "calico", "components"]) | del(.components.[].fips-image)' <(echo "$version_info"))
-  # add new version as first item in array
-  releases_json=$(cat $releases_json_file | jq --argjson newVersion "$(echo $new_version)" '. = [$newVersion] + .')
-  jq '.' <(echo $releases_json) >$releases_json_file
+  case $PRODUCT in
+    calico-enterprise)
+      update_calico_enterprise_version
+      ;;
+    *)
+      echo "error: Invalid product specified: \"$PRODUCT\""
+      exit 1
+      ;;
+  esac
 fi

--- a/scripts/update-component-versions.sh
+++ b/scripts/update-component-versions.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -eu
+
+: ${VERSION:?"Product version not specified, set using 'VERSION' e.g. VERSION=3.15.4"}
+: ${PRODUCT:?"Product not specified, set using 'PRODUCT'"}
+: ${GITHUB_TOKEN:?"GitHub API token not specified, set using 'GITHUB_TOKEN'"}
+
+declare -A products=(
+  "calico-enterprise"
+)
+
+declare -A product_repo_dict=(
+  ["calico-enterprise"]="tigera/calico-private"
+)
+declare -A product_branch_prefix=(
+  ["calico-enterprise"]="release-calient"
+)
+
+valid_product() {
+  local search=$1
+  for product in "${!products[@]}"; do
+    if [ $product == $search ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+git_branch_ref() {
+  local version=$1
+  if [ $version != "master" ]; then
+    : ${GIT_VERSION_REF:=$(echo "$version" | cut -d. -f1,2)}
+    echo "?ref=${product_branch_prefix[$PRODUCT]}-v${GIT_VERSION_REF#v}"
+  fi
+}
+
+docs_folder_path() {
+  local version=$1
+  if [ $version == "master" ]; then
+    echo $PRODUCT
+  else
+    local version_stream=$(echo "${version}" | cut -d. -f1,2)
+    : ${DOCS_VERSION_STREAM:=${version_stream}}
+    echo ${PRODUCT}_versioned_docs/version-${DOCS_VERSION_STREAM#v}
+  fi
+}
+
+if ! valid_product "$PRODUCT"; then
+  echo "error: Invalid product specified: \"$PRODUCT\""
+fi
+
+# sanitize product version
+VERSION=${VERSION#v}
+branchRef=$(git_branch_ref $VERSION)
+apiUrl="https://${GITHUB_TOKEN}:@api.github.com/repos/${product_repo_dict[$PRODUCT]}/contents/calico/_data/versions.yml${branchRef}"
+releases_json_file=$(docs_folder_path $VERSION)/releases.json
+
+found_version=$(jq ".[] | select(.title| test(\"$VERSION\"))" $releases_json_file)
+if [ -n "$found_version" ]; then
+  # Skip updating if version already exists
+  echo "Component list for $VERSION already exists ...SKIPPING!"
+  exit 0
+  # Alternative option: delete existing and replace
+  # yq -o=json -i "del(.[]| select(.title | test(\"$VERSION\")))" $releases_json_file
+fi
+
+versions_yml=$(curl -H 'Accept: application/vnd.github.v3.raw' "${apiUrl}")
+version_info=$(yq "
+  ... comments=\"\" | .[] |
+  select(.title == \"v${VERSION}\" or .title == \"${VERSION}\")
+  " <(echo "$versions_yml"))
+
+if [ -z "$version_info" -a "$version_info" != " " ]; then
+  echo "error: No component list found for $VERSION"
+  exit 1
+else
+  new_version=$(yq -o=json '. |= pick(["title", "helmRelease", "tigera-operator", "calico", "components"]) | del(.components.[].fips-image)' <(echo "$version_info"))
+  # add new version as first item in array
+  releases_json=$(cat $releases_json_file | jq --argjson newVersion "$(echo $new_version)" '. = [$newVersion] + .')
+  jq '.' <(echo $releases_json) >$releases_json_file
+fi


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
Calico Enterprise

Issue:
[DE-2123](https://tigera.atlassian.net/browse/DE-2123)

Link to docs preview:
N/A

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
This is to allow automating the PR to update the Operator API and components versions for Enterprise docs. It should create a PR similar to [this](https://github.com/tigera/docs/pull/1010/files) (_sans release notes_)

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->

[DE-2123]: https://tigera.atlassian.net/browse/DE-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ