### PR TITLE
CC: Fix version for Cloud version-18

### DIFF
--- a/calico-cloud_versioned_docs/version-18/variables.js
+++ b/calico-cloud_versioned_docs/version-18/variables.js
@@ -12,7 +12,7 @@ const variables = {
   rootDirWindows: 'C:\\TigeraCalico',
   nodecontainer: 'cnx-node',
   noderunning: 'calico-node',
-  cloudversion: 'v3.18.0-1.1-1',
+  cloudversion: 'v3.18.0-1.1-2',
   clouddownloadurl: 'https://installer.calicocloud.io/manifests/v3.18.0-1.1-2',
   clouddownloadbase: 'https://installer.calicocloud.io',
   cloudoperatorimage: 'quay.io/tigera/cc-operator',


### PR DESCRIPTION
The cloudversion and clouddownloadurl should match versions. This fixes that in version-18.
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->