### PR TITLE
docs: use correct api-resource name when using `kubectl` command

### DIFF
--- a/calico_versioned_docs/version-3.27/operations/troubleshoot/component-logs.mdx
+++ b/calico_versioned_docs/version-3.27/operations/troubleshoot/component-logs.mdx
@@ -61,7 +61,7 @@ To modify the BGP log level:
 1. Get the current bgpconfig settings.
 
    ```bash
-   kubectl get bgpconfig -o yaml > bgp.yaml
+   kubectl get bgpconfiguration -o yaml > bgp.yaml
    ```
 
 1. Modify logSeverityScreen to the desired value.
@@ -98,7 +98,7 @@ To modify Felix's log level:
 1. Get the current felixconfig settings.
 
    ```bash
-   kubectl get felixconfig -o yaml > felixconfig.yaml
+   kubectl get felixconfiguration -o yaml > felixconfig.yaml
    ```
 
 1. Modify logSeverityScreen to desired value.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [x] Deploy preview inspected wherever changes were made 
- [x] Build completed successfully
- [x] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->