### PR TITLE
[EV-4549] Add a note about setting DelayDNSResponse for Staged DNS Policies

### DIFF
--- a/calico-enterprise/network-policy/domain-based-policy.mdx
+++ b/calico-enterprise/network-policy/domain-based-policy.mdx
@@ -227,6 +227,24 @@ spec:
       destination:
         selector: color == 'red'
 ```
+:::note
+
+Newly initialized pods sometimes fail to connect to domains that are allowed by a DNS policy (staged or enforced).
+In these cases, the pod tries to connect to a domain before {{prodname}} has finished processing the DNS policy that allows the connection.
+As soon as the processing is complete, the pod is able to connect.
+
+To avoid these failed connections, you can add the following to your `FelixConfiguration` resource:
+
+```yaml
+...
+spec:
+  DNSPolicyMode: DelayDNSResponse
+...
+```
+
+For more information, see [DNSPolicyMode](../reference/resources/felixconfig#dnspolicymode).
+
+:::
 
 ## Additional resources
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->
https://tigera.atlassian.net/browse/EV-4549

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
policy egress rule matches for domain names are not consistent for DNS staged policies when the domain address in policy rule is hit. The reason for that is felix is matching based on IP address not domain name and when we are using domain name instead of ip address, the first call will fail but will include the dns response that felix will use to update the rules. Based on the time to live of this domain to ip address matching, next hits will be successful. 
To resolve this inconsistency, there is a flag defined in felix called DNSPolicyMode. By setting this flag to DelayDNSResponse felix will replace domain name will ip address in policy rules before matching rules for the traffic.

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->