### PR TITLE
Older k8s versions are starting to be EoL'd support by certain providers

### DIFF
--- a/calico/getting-started/kubernetes/requirements.mdx
+++ b/calico/getting-started/kubernetes/requirements.mdx
@@ -10,7 +10,7 @@ description: Review requirements before installing Calico to ensure success.
 
 #### Supported versions
 
-We test {{prodname}} {{version}} against the following Kubernetes versions.
+We test {{prodname}} {{version}} against the following Kubernetes versions. Other versions may work, but we are not actively testing them.
 
 - v1.27
 - v1.28

--- a/calico_versioned_docs/version-3.25/getting-started/kubernetes/requirements.mdx
+++ b/calico_versioned_docs/version-3.25/getting-started/kubernetes/requirements.mdx
@@ -10,7 +10,7 @@ description: Review requirements before installing Calico to ensure success.
 
 #### Supported versions
 
-We test {{prodname}} {{version}} against the following Kubernetes versions.
+We test {{prodname}} {{version}} against the following Kubernetes versions. Other versions may work, but we are not actively testing them.
 
 - v1.23
 - v1.24

--- a/calico_versioned_docs/version-3.25/getting-started/kubernetes/requirements.mdx
+++ b/calico_versioned_docs/version-3.25/getting-started/kubernetes/requirements.mdx
@@ -12,6 +12,9 @@ description: Review requirements before installing Calico to ensure success.
 
 We test {{prodname}} {{version}} against the following Kubernetes versions.
 
+- v1.23
+- v1.24
+- v1.25
 - v1.26
 - v1.27
 - v1.28

--- a/calico_versioned_docs/version-3.25/getting-started/kubernetes/requirements.mdx
+++ b/calico_versioned_docs/version-3.25/getting-started/kubernetes/requirements.mdx
@@ -12,9 +12,6 @@ description: Review requirements before installing Calico to ensure success.
 
 We test {{prodname}} {{version}} against the following Kubernetes versions.
 
-- v1.23
-- v1.24
-- v1.25
 - v1.26
 - v1.27
 - v1.28

--- a/calico_versioned_docs/version-3.26/getting-started/kubernetes/requirements.mdx
+++ b/calico_versioned_docs/version-3.26/getting-started/kubernetes/requirements.mdx
@@ -10,7 +10,7 @@ description: Review requirements before installing Calico to ensure success.
 
 #### Supported versions
 
-We test {{prodname}} {{version}} against the following Kubernetes versions.
+We test {{prodname}} {{version}} against the following Kubernetes versions. Other versions may work, but we are not actively testing them.
 
 - v1.24
 - v1.25

--- a/calico_versioned_docs/version-3.26/getting-started/kubernetes/requirements.mdx
+++ b/calico_versioned_docs/version-3.26/getting-started/kubernetes/requirements.mdx
@@ -12,6 +12,8 @@ description: Review requirements before installing Calico to ensure success.
 
 We test {{prodname}} {{version}} against the following Kubernetes versions.
 
+- v1.24
+- v1.25
 - v1.26
 - v1.27
 - v1.28

--- a/calico_versioned_docs/version-3.26/getting-started/kubernetes/requirements.mdx
+++ b/calico_versioned_docs/version-3.26/getting-started/kubernetes/requirements.mdx
@@ -12,8 +12,6 @@ description: Review requirements before installing Calico to ensure success.
 
 We test {{prodname}} {{version}} against the following Kubernetes versions.
 
-- v1.24
-- v1.25
 - v1.26
 - v1.27
 - v1.28

--- a/calico_versioned_docs/version-3.27/getting-started/kubernetes/requirements.mdx
+++ b/calico_versioned_docs/version-3.27/getting-started/kubernetes/requirements.mdx
@@ -12,7 +12,6 @@ description: Review requirements before installing Calico to ensure success.
 
 We test {{prodname}} {{version}} against the following Kubernetes versions.
 
-- v1.26
 - v1.27
 - v1.28
 - v1.29

--- a/calico_versioned_docs/version-3.27/getting-started/kubernetes/requirements.mdx
+++ b/calico_versioned_docs/version-3.27/getting-started/kubernetes/requirements.mdx
@@ -12,8 +12,6 @@ description: Review requirements before installing Calico to ensure success.
 
 We test {{prodname}} {{version}} against the following Kubernetes versions.
 
-- v1.24
-- v1.25
 - v1.26
 - v1.27
 - v1.28

--- a/calico_versioned_docs/version-3.27/getting-started/kubernetes/requirements.mdx
+++ b/calico_versioned_docs/version-3.27/getting-started/kubernetes/requirements.mdx
@@ -10,7 +10,7 @@ description: Review requirements before installing Calico to ensure success.
 
 #### Supported versions
 
-We test {{prodname}} {{version}} against the following Kubernetes versions.
+We test {{prodname}} {{version}} against the following Kubernetes versions. Other versions may work, but we are not actively testing them.
 
 - v1.27
 - v1.28


### PR DESCRIPTION
*AKS and EKS have EoL'd 1.25

Product Version(s):
Applies to Calico v3.25, v3.26 and v3.27

Issue:


Link to docs preview:


SME review:
- [ ] An SME has approved this change. 
4

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->