### PR TITLE
Remove incorrect recommended felix metric

### DIFF
--- a/calico-cloud/operations/monitor/metrics/recommended-metrics.mdx
+++ b/calico-cloud/operations/monitor/metrics/recommended-metrics.mdx
@@ -543,18 +543,6 @@ The following policy metrics are a separate endpoint exposed by Felix that are u
 
 | Felix route table list seconds quantile 0.5/0.9/0.99 |                                                              |
 | ---------------------------------------------------- | ------------------------------------------------------------ |
-| Metric                                               | <code>felix_int_dataplane_apply_time_seconds{quantile="0.5"}</code> <br /><code>felix_int_dataplane_apply_time_seconds{quantile="0.9"}</code><br /><code>felix_int_dataplane_apply_time_seconds{quantile="0.99"}</code> |
-| Example value                                        | <code>felix_route_table_list_seconds{quantile="0.5"}:</code><code>felix_route_table_list_seconds{**endpoint**="metrics-port",</code><code>**instance**="10.0.1.30:9091",**job**="felix-metrics-svc",</code><code>**namespace**="calico-system", **pod**="calico-node-6pcqm",</code><code>quantile="0.5", **service**="felix-metrics-svc"} 0.000860426</code> |
-| Explanation                                          | Time to list all the interfaces during a resync, viewed at the median, 90th percentile and 99th percentile. |
-| Threshold value recommendation                       | Thresholds will vary depending on the number of cali interfaces per node. It is recommended that a baseline be set to determine a normal threshold value. |
-| Threshold breach symptoms                            | High values indicate high CPU usage in felix and slow dataplane updates. |
-| Threshold breach recommendations                     | Increase cluster resources. Reduce the number of cali interfaces per node where possible. |
-| Priority level                                       | Optional.                                                    |
-
-### Felix graph update time seconds quantile 0.5/0.9/0.99
-
-| Felix route table list seconds quantile 0.5/0.9/0.99 |                                                              |
-| ---------------------------------------------------- | ------------------------------------------------------------ |
 | Metric                                               | <code>felix_route_table_list_seconds{quantile="0.5"}</code><br /><code>felix_route_table_list_seconds{quantile="0.9"}</code><br /><code>felix_route_table_list_seconds{quantile="0.99"}</code> |
 | Example value                                        | <code>felix_route_table_list_seconds{quantile="0.5"}:</code><code>felix_route_table_list_seconds{**endpoint**="metrics-port",</code><code>**instance**="10.0.1.30:9091",**job**="felix-metrics-svc",</code><code>namespace="calico-system", **pod**="calico-node-6pcqm",</code><code>quantile="0.5", **service**="felix-metrics-svc"} 0.000860426</code> |
 | Explanation                                          | Time to list all the interfaces during a resync, viewed at the median, 90th percentile and 99th percentile. |

--- a/calico-cloud_versioned_docs/version-18-2/operations/monitor/metrics/recommended-metrics.mdx
+++ b/calico-cloud_versioned_docs/version-18-2/operations/monitor/metrics/recommended-metrics.mdx
@@ -543,18 +543,6 @@ The following policy metrics are a separate endpoint exposed by Felix that are u
 
 | Felix route table list seconds quantile 0.5/0.9/0.99 |                                                              |
 | ---------------------------------------------------- | ------------------------------------------------------------ |
-| Metric                                               | <code>felix_int_dataplane_apply_time_seconds{quantile="0.5"}</code> <br /><code>felix_int_dataplane_apply_time_seconds{quantile="0.9"}</code><br /><code>felix_int_dataplane_apply_time_seconds{quantile="0.99"}</code> |
-| Example value                                        | <code>felix_route_table_list_seconds{quantile="0.5"}:</code><code>felix_route_table_list_seconds{**endpoint**="metrics-port",</code><code>**instance**="10.0.1.30:9091",**job**="felix-metrics-svc",</code><code>**namespace**="calico-system", **pod**="calico-node-6pcqm",</code><code>quantile="0.5", **service**="felix-metrics-svc"} 0.000860426</code> |
-| Explanation                                          | Time to list all the interfaces during a resync, viewed at the median, 90th percentile and 99th percentile. |
-| Threshold value recommendation                       | Thresholds will vary depending on the number of cali interfaces per node. It is recommended that a baseline be set to determine a normal threshold value. |
-| Threshold breach symptoms                            | High values indicate high CPU usage in felix and slow dataplane updates. |
-| Threshold breach recommendations                     | Increase cluster resources. Reduce the number of cali interfaces per node where possible. |
-| Priority level                                       | Optional.                                                    |
-
-### Felix graph update time seconds quantile 0.5/0.9/0.99
-
-| Felix route table list seconds quantile 0.5/0.9/0.99 |                                                              |
-| ---------------------------------------------------- | ------------------------------------------------------------ |
 | Metric                                               | <code>felix_route_table_list_seconds{quantile="0.5"}</code><br /><code>felix_route_table_list_seconds{quantile="0.9"}</code><br /><code>felix_route_table_list_seconds{quantile="0.99"}</code> |
 | Example value                                        | <code>felix_route_table_list_seconds{quantile="0.5"}:</code><code>felix_route_table_list_seconds{**endpoint**="metrics-port",</code><code>**instance**="10.0.1.30:9091",**job**="felix-metrics-svc",</code><code>namespace="calico-system", **pod**="calico-node-6pcqm",</code><code>quantile="0.5", **service**="felix-metrics-svc"} 0.000860426</code> |
 | Explanation                                          | Time to list all the interfaces during a resync, viewed at the median, 90th percentile and 99th percentile. |

--- a/calico-cloud_versioned_docs/version-18/operations/monitor/metrics/recommended-metrics.mdx
+++ b/calico-cloud_versioned_docs/version-18/operations/monitor/metrics/recommended-metrics.mdx
@@ -543,18 +543,6 @@ The following policy metrics are a separate endpoint exposed by Felix that are u
 
 | Felix route table list seconds quantile 0.5/0.9/0.99 |                                                              |
 | ---------------------------------------------------- | ------------------------------------------------------------ |
-| Metric                                               | <code>felix_int_dataplane_apply_time_seconds{quantile="0.5"}</code> <br /><code>felix_int_dataplane_apply_time_seconds{quantile="0.9"}</code><br /><code>felix_int_dataplane_apply_time_seconds{quantile="0.99"}</code> |
-| Example value                                        | <code>felix_route_table_list_seconds{quantile="0.5"}:</code><code>felix_route_table_list_seconds{**endpoint**="metrics-port",</code><code>**instance**="10.0.1.30:9091",**job**="felix-metrics-svc",</code><code>**namespace**="calico-system", **pod**="calico-node-6pcqm",</code><code>quantile="0.5", **service**="felix-metrics-svc"} 0.000860426</code> |
-| Explanation                                          | Time to list all the interfaces during a resync, viewed at the median, 90th percentile and 99th percentile. |
-| Threshold value recommendation                       | Thresholds will vary depending on the number of cali interfaces per node. It is recommended that a baseline be set to determine a normal threshold value. |
-| Threshold breach symptoms                            | High values indicate high CPU usage in felix and slow dataplane updates. |
-| Threshold breach recommendations                     | Increase cluster resources. Reduce the number of cali interfaces per node where possible. |
-| Priority level                                       | Optional.                                                    |
-
-### Felix graph update time seconds quantile 0.5/0.9/0.99
-
-| Felix route table list seconds quantile 0.5/0.9/0.99 |                                                              |
-| ---------------------------------------------------- | ------------------------------------------------------------ |
 | Metric                                               | <code>felix_route_table_list_seconds{quantile="0.5"}</code><br /><code>felix_route_table_list_seconds{quantile="0.9"}</code><br /><code>felix_route_table_list_seconds{quantile="0.99"}</code> |
 | Example value                                        | <code>felix_route_table_list_seconds{quantile="0.5"}:</code><code>felix_route_table_list_seconds{**endpoint**="metrics-port",</code><code>**instance**="10.0.1.30:9091",**job**="felix-metrics-svc",</code><code>namespace="calico-system", **pod**="calico-node-6pcqm",</code><code>quantile="0.5", **service**="felix-metrics-svc"} 0.000860426</code> |
 | Explanation                                          | Time to list all the interfaces during a resync, viewed at the median, 90th percentile and 99th percentile. |

--- a/calico-enterprise/operations/monitor/metrics/recommended-metrics.mdx
+++ b/calico-enterprise/operations/monitor/metrics/recommended-metrics.mdx
@@ -543,18 +543,6 @@ The following policy metrics are a separate endpoint exposed by Felix that are u
 
 | Felix route table list seconds quantile 0.5/0.9/0.99 |                                                              |
 | ---------------------------------------------------- | ------------------------------------------------------------ |
-| Metric                                               | <code>felix_int_dataplane_apply_time_seconds{quantile="0.5"}</code> <br /><code>felix_int_dataplane_apply_time_seconds{quantile="0.9"}</code><br /><code>felix_int_dataplane_apply_time_seconds{quantile="0.99"}</code> |
-| Example value                                        | <code>felix_route_table_list_seconds{quantile="0.5"}:</code><code>felix_route_table_list_seconds{**endpoint**="metrics-port",</code><code>**instance**="10.0.1.30:9091",**job**="felix-metrics-svc",</code><code>**namespace**="calico-system", **pod**="calico-node-6pcqm",</code><code>quantile="0.5", **service**="felix-metrics-svc"} 0.000860426</code> |
-| Explanation                                          | Time to list all the interfaces during a resync, viewed at the median, 90th percentile and 99th percentile. |
-| Threshold value recommendation                       | Thresholds will vary depending on the number of cali interfaces per node. It is recommended that a baseline be set to determine a normal threshold value. |
-| Threshold breach symptoms                            | High values indicate high CPU usage in felix and slow dataplane updates. |
-| Threshold breach recommendations                     | Increase cluster resources. Reduce the number of cali interfaces per node where possible. |
-| Priority level                                       | Optional.                                                    |
-
-### Felix graph update time seconds quantile 0.5/0.9/0.99
-
-| Felix route table list seconds quantile 0.5/0.9/0.99 |                                                              |
-| ---------------------------------------------------- | ------------------------------------------------------------ |
 | Metric                                               | <code>felix_route_table_list_seconds{quantile="0.5"}</code><br /><code>felix_route_table_list_seconds{quantile="0.9"}</code><br /><code>felix_route_table_list_seconds{quantile="0.99"}</code> |
 | Example value                                        | <code>felix_route_table_list_seconds{quantile="0.5"}:</code><code>felix_route_table_list_seconds{**endpoint**="metrics-port",</code><code>**instance**="10.0.1.30:9091",**job**="felix-metrics-svc",</code><code>namespace="calico-system", **pod**="calico-node-6pcqm",</code><code>quantile="0.5", **service**="felix-metrics-svc"} 0.000860426</code> |
 | Explanation                                          | Time to list all the interfaces during a resync, viewed at the median, 90th percentile and 99th percentile. |

--- a/calico-enterprise_versioned_docs/version-3.18-2/operations/monitor/metrics/recommended-metrics.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/operations/monitor/metrics/recommended-metrics.mdx
@@ -543,18 +543,6 @@ The following policy metrics are a separate endpoint exposed by Felix that are u
 
 | Felix route table list seconds quantile 0.5/0.9/0.99 |                                                              |
 | ---------------------------------------------------- | ------------------------------------------------------------ |
-| Metric                                               | <code>felix_int_dataplane_apply_time_seconds{quantile="0.5"}</code> <br /><code>felix_int_dataplane_apply_time_seconds{quantile="0.9"}</code><br /><code>felix_int_dataplane_apply_time_seconds{quantile="0.99"}</code> |
-| Example value                                        | <code>felix_route_table_list_seconds{quantile="0.5"}:</code><code>felix_route_table_list_seconds{**endpoint**="metrics-port",</code><code>**instance**="10.0.1.30:9091",**job**="felix-metrics-svc",</code><code>**namespace**="calico-system", **pod**="calico-node-6pcqm",</code><code>quantile="0.5", **service**="felix-metrics-svc"} 0.000860426</code> |
-| Explanation                                          | Time to list all the interfaces during a resync, viewed at the median, 90th percentile and 99th percentile. |
-| Threshold value recommendation                       | Thresholds will vary depending on the number of cali interfaces per node. It is recommended that a baseline be set to determine a normal threshold value. |
-| Threshold breach symptoms                            | High values indicate high CPU usage in felix and slow dataplane updates. |
-| Threshold breach recommendations                     | Increase cluster resources. Reduce the number of cali interfaces per node where possible. |
-| Priority level                                       | Optional.                                                    |
-
-### Felix graph update time seconds quantile 0.5/0.9/0.99
-
-| Felix route table list seconds quantile 0.5/0.9/0.99 |                                                              |
-| ---------------------------------------------------- | ------------------------------------------------------------ |
 | Metric                                               | <code>felix_route_table_list_seconds{quantile="0.5"}</code><br /><code>felix_route_table_list_seconds{quantile="0.9"}</code><br /><code>felix_route_table_list_seconds{quantile="0.99"}</code> |
 | Example value                                        | <code>felix_route_table_list_seconds{quantile="0.5"}:</code><code>felix_route_table_list_seconds{**endpoint**="metrics-port",</code><code>**instance**="10.0.1.30:9091",**job**="felix-metrics-svc",</code><code>namespace="calico-system", **pod**="calico-node-6pcqm",</code><code>quantile="0.5", **service**="felix-metrics-svc"} 0.000860426</code> |
 | Explanation                                          | Time to list all the interfaces during a resync, viewed at the median, 90th percentile and 99th percentile. |

--- a/calico-enterprise_versioned_docs/version-3.19-1/operations/monitor/metrics/recommended-metrics.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-1/operations/monitor/metrics/recommended-metrics.mdx
@@ -543,18 +543,6 @@ The following policy metrics are a separate endpoint exposed by Felix that are u
 
 | Felix route table list seconds quantile 0.5/0.9/0.99 |                                                              |
 | ---------------------------------------------------- | ------------------------------------------------------------ |
-| Metric                                               | <code>felix_int_dataplane_apply_time_seconds{quantile="0.5"}</code> <br /><code>felix_int_dataplane_apply_time_seconds{quantile="0.9"}</code><br /><code>felix_int_dataplane_apply_time_seconds{quantile="0.99"}</code> |
-| Example value                                        | <code>felix_route_table_list_seconds{quantile="0.5"}:</code><code>felix_route_table_list_seconds{**endpoint**="metrics-port",</code><code>**instance**="10.0.1.30:9091",**job**="felix-metrics-svc",</code><code>**namespace**="calico-system", **pod**="calico-node-6pcqm",</code><code>quantile="0.5", **service**="felix-metrics-svc"} 0.000860426</code> |
-| Explanation                                          | Time to list all the interfaces during a resync, viewed at the median, 90th percentile and 99th percentile. |
-| Threshold value recommendation                       | Thresholds will vary depending on the number of cali interfaces per node. It is recommended that a baseline be set to determine a normal threshold value. |
-| Threshold breach symptoms                            | High values indicate high CPU usage in felix and slow dataplane updates. |
-| Threshold breach recommendations                     | Increase cluster resources. Reduce the number of cali interfaces per node where possible. |
-| Priority level                                       | Optional.                                                    |
-
-### Felix graph update time seconds quantile 0.5/0.9/0.99
-
-| Felix route table list seconds quantile 0.5/0.9/0.99 |                                                              |
-| ---------------------------------------------------- | ------------------------------------------------------------ |
 | Metric                                               | <code>felix_route_table_list_seconds{quantile="0.5"}</code><br /><code>felix_route_table_list_seconds{quantile="0.9"}</code><br /><code>felix_route_table_list_seconds{quantile="0.99"}</code> |
 | Example value                                        | <code>felix_route_table_list_seconds{quantile="0.5"}:</code><code>felix_route_table_list_seconds{**endpoint**="metrics-port",</code><code>**instance**="10.0.1.30:9091",**job**="felix-metrics-svc",</code><code>namespace="calico-system", **pod**="calico-node-6pcqm",</code><code>quantile="0.5", **service**="felix-metrics-svc"} 0.000860426</code> |
 | Explanation                                          | Time to list all the interfaces during a resync, viewed at the median, 90th percentile and 99th percentile. |


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->
CE and CC >= 3.18

Issue:
In the [current state](https://docs.tigera.io/calico-enterprise/latest/operations/monitor/metrics/recommended-metrics#felix-route-table-list-seconds-quantile-0509099), it looks like the "Felix route table list seconds quantile 0.5/0.9/0.99" table is erroneous, and the "Felix graph update time seconds quantile 0.5/0.9/0.99" table is what should be under the former table header.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->