### PR TITLE
Change component version to 3.19 rather than master

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.19-1/reference/component-versions.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-1/reference/component-versions.mdx
@@ -2,7 +2,7 @@
 description: A list of component versions for Calico Enterprise
 ---
 
-import ComponentVersions from '@site/calico-enterprise/_includes/components/ComponentVersions';
+import ComponentVersions from '@site/calico-enterprise_versioned_docs/version-3.19-1/_includes/components/ComponentVersions';
 
 # Component versions
 


### PR DESCRIPTION
Component version for 3.19 was showing as master. 
Hope this fixes the version to 3.19.0-1.0 related.

Product Version(s):
CE 3.19.0-1.0

Issue:
N/A

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->