### PR TITLE
[GH#calico/8503]: Add FLANNEL_DAEMONSET_NAMESPACE config option

### DIFF
--- a/calico/getting-started/kubernetes/flannel/migration-from-flannel.mdx
+++ b/calico/getting-started/kubernetes/flannel/migration-from-flannel.mdx
@@ -98,20 +98,21 @@ The migration controller autodetects your flannel configuration, and in most cas
 additional configuration. If you require special configuration, the migration tool provides the following options,
 which can be set as environment variables within the pod.
 
-| Configuration options     | Description                                                      | Default                  |
-| ------------------------- | ---------------------------------------------------------------- | ------------------------ |
-| FLANNEL_NETWORK           | IPv4 network CIDR used by flannel for the cluster.               | Automatically detected   |
-| FLANNEL_IPV6_NETWORK      | IPv6 network CIDR used by flannel for the cluster.               | Automatically detected   |
-| FLANNEL_DAEMONSET_NAME    | Name of the flannel daemon set in the kube-system namespace.     | kube-flannel-ds          |
-| FLANNEL_MTU               | MTU for the flannel VXLAN device.                                | Automatically detected   |
-| FLANNEL_IP_MASQ           | Whether masquerading is enabled for outbound traffic.            | Automatically detected   |
-| FLANNEL_SUBNET_LEN        | Per-node IPv4 subnet length used by flannel.                     | 24                       |
-| FLANNEL_IPV6_SUBNET_LEN   | Per-node IPv6 subnet length used by flannel.                     | 64                       |
-| FLANNEL_ANNOTATION_PREFIX | Value provided via the kube-annotation-prefix option to flannel. | flannel.alpha.coreos.com |
-| FLANNEL_VNI               | The VNI used for the flannel network.                            | 1                        |
-| FLANNEL_PORT              | UDP port used for VXLAN.                                         | 8472                     |
-| CALICO_DAEMONSET_NAME     | Name of the calico daemon set in the kube-system namespace.      | calico-node              |
-| CNI_CONFIG_DIR            | Full path on the host in which to search for CNI config files.   | /etc/cni/net.d           |
+| Configuration options       | Description                                                      | Default                  |
+| --------------------------- | ---------------------------------------------------------------- | ------------------------ |
+| FLANNEL_NETWORK             | IPv4 network CIDR used by flannel for the cluster.               | Automatically detected   |
+| FLANNEL_IPV6_NETWORK        | IPv6 network CIDR used by flannel for the cluster.               | Automatically detected   |
+| FLANNEL_DAEMONSET_NAME      | Name of the flannel daemon set.                                  | kube-flannel-ds          |
+| FLANNEL_DAEMONSET_NAMESPACE | Namespace containing the flannel daemon.                         | kube-flannel             |
+| FLANNEL_MTU                 | MTU for the flannel VXLAN device.                                | Automatically detected   |
+| FLANNEL_IP_MASQ             | Whether masquerading is enabled for outbound traffic.            | Automatically detected   |
+| FLANNEL_SUBNET_LEN          | Per-node IPv4 subnet length used by flannel.                     | 24                       |
+| FLANNEL_IPV6_SUBNET_LEN     | Per-node IPv6 subnet length used by flannel.                     | 64                       |
+| FLANNEL_ANNOTATION_PREFIX   | Value provided via the kube-annotation-prefix option to flannel. | flannel.alpha.coreos.com |
+| FLANNEL_VNI                 | The VNI used for the flannel network.                            | 1                        |
+| FLANNEL_PORT                | UDP port used for VXLAN.                                         | 8472                     |
+| CALICO_DAEMONSET_NAME       | Name of the calico daemon set in the kube-system namespace.      | calico-node              |
+| CNI_CONFIG_DIR              | Full path on the host in which to search for CNI config files.   | /etc/cni/net.d           |
 
 ### View migration status
 

--- a/calico_versioned_docs/version-3.27/getting-started/kubernetes/flannel/migration-from-flannel.mdx
+++ b/calico_versioned_docs/version-3.27/getting-started/kubernetes/flannel/migration-from-flannel.mdx
@@ -98,20 +98,21 @@ The migration controller autodetects your flannel configuration, and in most cas
 additional configuration. If you require special configuration, the migration tool provides the following options,
 which can be set as environment variables within the pod.
 
-| Configuration options     | Description                                                      | Default                  |
-| ------------------------- | ---------------------------------------------------------------- | ------------------------ |
-| FLANNEL_NETWORK           | IPv4 network CIDR used by flannel for the cluster.               | Automatically detected   |
-| FLANNEL_IPV6_NETWORK      | IPv6 network CIDR used by flannel for the cluster.               | Automatically detected   |
-| FLANNEL_DAEMONSET_NAME    | Name of the flannel daemon set in the kube-system namespace.     | kube-flannel-ds          |
-| FLANNEL_MTU               | MTU for the flannel VXLAN device.                                | Automatically detected   |
-| FLANNEL_IP_MASQ           | Whether masquerading is enabled for outbound traffic.            | Automatically detected   |
-| FLANNEL_SUBNET_LEN        | Per-node IPv4 subnet length used by flannel.                     | 24                       |
-| FLANNEL_IPV6_SUBNET_LEN   | Per-node IPv6 subnet length used by flannel.                     | 64                       |
-| FLANNEL_ANNOTATION_PREFIX | Value provided via the kube-annotation-prefix option to flannel. | flannel.alpha.coreos.com |
-| FLANNEL_VNI               | The VNI used for the flannel network.                            | 1                        |
-| FLANNEL_PORT              | UDP port used for VXLAN.                                         | 8472                     |
-| CALICO_DAEMONSET_NAME     | Name of the calico daemon set in the kube-system namespace.      | calico-node              |
-| CNI_CONFIG_DIR            | Full path on the host in which to search for CNI config files.   | /etc/cni/net.d           |
+| Configuration options       | Description                                                      | Default                  |
+| --------------------------- | ---------------------------------------------------------------- | ------------------------ |
+| FLANNEL_NETWORK             | IPv4 network CIDR used by flannel for the cluster.               | Automatically detected   |
+| FLANNEL_IPV6_NETWORK        | IPv6 network CIDR used by flannel for the cluster.               | Automatically detected   |
+| FLANNEL_DAEMONSET_NAME      | Name of the flannel daemon set.                                  | kube-flannel-ds          |
+| FLANNEL_DAEMONSET_NAMESPACE | Namespace containing the flannel daemon.                         | kube-flannel             |
+| FLANNEL_MTU                 | MTU for the flannel VXLAN device.                                | Automatically detected   |
+| FLANNEL_IP_MASQ             | Whether masquerading is enabled for outbound traffic.            | Automatically detected   |
+| FLANNEL_SUBNET_LEN          | Per-node IPv4 subnet length used by flannel.                     | 24                       |
+| FLANNEL_IPV6_SUBNET_LEN     | Per-node IPv6 subnet length used by flannel.                     | 64                       |
+| FLANNEL_ANNOTATION_PREFIX   | Value provided via the kube-annotation-prefix option to flannel. | flannel.alpha.coreos.com |
+| FLANNEL_VNI                 | The VNI used for the flannel network.                            | 1                        |
+| FLANNEL_PORT                | UDP port used for VXLAN.                                         | 8472                     |
+| CALICO_DAEMONSET_NAME       | Name of the calico daemon set in the kube-system namespace.      | calico-node              |
+| CNI_CONFIG_DIR              | Full path on the host in which to search for CNI config files.   | /etc/cni/net.d           |
 
 ### View migration status
 


### PR DESCRIPTION
Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Calico OSS v3.27+

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

https://github.com/projectcalico/calico/issues/8503

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

We added this new configuration option to Flannel migration without
documenting it.

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->