### PR TITLE
[CORE-10192] Use 'crane cp' for windows images

### DIFF
--- a/calico-enterprise/_includes/components/PrivateRegistryImagePath.js
+++ b/calico-enterprise/_includes/components/PrivateRegistryImagePath.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 
-import { prodname, prodnamedash, registry, releases, tigeraOperator } from '../../variables';
+import { prodname, prodnamedash, prodnameWindows, registry, releases, tigeraOperator } from '../../variables';
 
 export default function PrivateRegistryImagePath() {
     const components = releases[0].components;
@@ -26,10 +26,6 @@ export default function PrivateRegistryImagePath() {
                     {`docker pull ${tigeraOperator.registry}/${tigeraOperator.image}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map(renderPullCommand).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, pull the following Windows images.</p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map(renderPullCommand)}
-                </CodeBlock>
 
                 <li>
                     <p>
@@ -42,20 +38,6 @@ export default function PrivateRegistryImagePath() {
                         tigeraOperator.version
                     } $PRIVATE_REGISTRY/$IMAGE_PATH/${mapImageToImageName(tigeraOperator.image)}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map((component) => {
-                        const registry = mapComponentToRegistry(component);
-                        const imageName = mapImageToImageName(component.image);
-
-                        return (
-                            `docker tag ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`
-                        );
-                    }).join('')}
-                </CodeBlock>
-                <p>
-                    For hybrid Linux + Windows clusters, retag the following Windows images with the name of your private
-                    registry.
-                </p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map((component) => {
                         const registry = mapComponentToRegistry(component);
                         const imageName = mapImageToImageName(component.image);
 
@@ -78,15 +60,20 @@ export default function PrivateRegistryImagePath() {
                         return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
                     }).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, push the following Windows images to your private registry.</p>
+                <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+                <li>
+                    <p>Use <code>crane cp</code> to copy the Windows images to your private registry.</p>
+                </li>
+                <p>For hybrid Linux + Windows clusters, use <code>crane cp</code> on the following Windows images to copy them to your private registry.</p>
                 <CodeBlock language='bash'>
                     {componentsWithImage.filter(filters.isWindows).map((component) => {
                         const imageName = mapImageToImageName(component.image);
 
-                        return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
+                        return `crane cp ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
                     }).join('')}
                 </CodeBlock>
-                <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+
+                <Admonition type='caution'>Do not <code>crane cp</code> the private {prodnameWindows} images to a public registry.</Admonition>
             </ol>
 
             <h3 id='run-the-operator-using-images-from-your-private-registry-image-path'>

--- a/calico-enterprise/_includes/components/PrivateRegistryRegular.js
+++ b/calico-enterprise/_includes/components/PrivateRegistryRegular.js
@@ -4,7 +4,7 @@ import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 import Heading from '@theme/Heading';
 
-import { tigeraOperator, prodname, prodnamedash, registry, releases } from '../../variables';
+import { tigeraOperator, prodname, prodnamedash, prodnameWindows, registry, releases } from '../../variables';
 
 export default function PrivateRegistryRegular() {
     const components = releases[0].components;
@@ -30,10 +30,6 @@ export default function PrivateRegistryRegular() {
                     {`docker pull ${tigeraOperator.registry}/${tigeraOperator.image}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map(renderPullCommand).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, pull the following Windows images.</p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map(renderPullCommand).join('')}
-                </CodeBlock>
 
                 <li>
                     <p>
@@ -49,20 +45,6 @@ export default function PrivateRegistryRegular() {
                             );
                         }).join('')}
                     </CodeBlock>
-                    <p>
-                        For hybrid Linux + Windows clusters, retag the following Windows images with the name of your private
-                        registry.
-                    </p>
-                    <CodeBlock language='bash'>
-                        {componentsWithImage.filter(filters.isWindows).map((component) => {
-                            const registry = mapComponentToRegistry(component);
-                            const imageName = component.image.split('/').pop();
-
-                            return (
-                                `docker tag ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`
-                            );
-                        }).join('')}
-                    </CodeBlock>
                 </li>
 
                 <li>
@@ -73,15 +55,21 @@ export default function PrivateRegistryRegular() {
                             return `docker push $PRIVATE_REGISTRY/${component.image}:${component.version}\n`;
                         }).join('')}
                     </CodeBlock>
-                    <p>For hybrid Linux + Windows clusters, push the following Windows images to your private registry.</p>
-                    <CodeBlock language='bash'>
-                        {componentsWithImage.filter(filters.isWindows).map((component) => {
-                            const imageName = component.image.split('/').pop();
-
-                            return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
-                        }).join('')}
-                    </CodeBlock>
                     <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+                </li>
+                <li>
+                <p>Use <code>crane cp</code> to copy the Windows images to your private registry.</p>
+                <p>For hybrid Linux + Windows clusters, use <code>crane cp</code> on the following Windows images to copy them to your private registry.</p>
+                <CodeBlock language='bash'>
+                    {componentsWithImage.filter(filters.isWindows).map((component) => {
+                        const registry = mapComponentToRegistry(component);
+                        const imageName = component.image.split('/').pop();
+
+                        return `crane cp ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
+                    }).join('')}
+                </CodeBlock>
+
+                <Admonition type='caution'>Do not <code>crane cp</code> the private {prodnameWindows} images to a public registry.</Admonition>
                 </li>
             </ol>
 

--- a/calico-enterprise/getting-started/install-on-clusters/private-registry/private-registry-image-path.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/private-registry/private-registry-image-path.mdx
@@ -24,6 +24,7 @@ An **image pull secret** is used in Kubernetes to deploy container images from a
 
 - Configure pull access to your private registry
 - [Configure pull access to Tigera's private container registry](../calico-enterprise.mdx#get-private-registry-credentials-and-license-key).
+- Use the [Crane command](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) to manage the {{prodnameWindows}} images, as using `docker pull` commands for these images may not work depending on the operating system and version in which the commands are run.
 
 ## How to
 

--- a/calico-enterprise/getting-started/install-on-clusters/private-registry/private-registry-regular.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/private-registry/private-registry-regular.mdx
@@ -22,6 +22,7 @@ An **image pull secret** is used in Kubernetes to deploy container images from a
 
 - Configure pull access to your private registry
 - [Configure pull access to Tigera's private container registry](../calico-enterprise.mdx#get-private-registry-credentials-and-license-key).
+- Use the [Crane command](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) to manage the {{prodnameWindows}} images, as using `docker pull` commands for these images may not work depending on the operating system and version in which the commands are run.
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.16/_includes/components/PrivateRegistryImagePath.js
+++ b/calico-enterprise_versioned_docs/version-3.16/_includes/components/PrivateRegistryImagePath.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 
-import { prodname, prodnamedash, registry, releases, tigeraOperator } from '../../variables';
+import { prodname, prodnamedash, prodnameWindows, registry, releases, tigeraOperator } from '../../variables';
 
 export default function PrivateRegistryImagePath() {
     const components = releases[0].components;
@@ -26,10 +26,6 @@ export default function PrivateRegistryImagePath() {
                     {`docker pull ${tigeraOperator.registry}/${tigeraOperator.image}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map(renderPullCommand).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, pull the following Windows images.</p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map(renderPullCommand)}
-                </CodeBlock>
 
                 <li>
                     <p>
@@ -42,20 +38,6 @@ export default function PrivateRegistryImagePath() {
                         tigeraOperator.version
                     } $PRIVATE_REGISTRY/$IMAGE_PATH/${mapImageToImageName(tigeraOperator.image)}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map((component) => {
-                        const registry = mapComponentToRegistry(component);
-                        const imageName = mapImageToImageName(component.image);
-
-                        return (
-                            `docker tag ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`
-                        );
-                    }).join('')}
-                </CodeBlock>
-                <p>
-                    For hybrid Linux + Windows clusters, retag the following Windows images with the name of your private
-                    registry.
-                </p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map((component) => {
                         const registry = mapComponentToRegistry(component);
                         const imageName = mapImageToImageName(component.image);
 
@@ -78,15 +60,20 @@ export default function PrivateRegistryImagePath() {
                         return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
                     }).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, push the following Windows images to your private registry.</p>
+                <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+                <li>
+                    <p>Use <code>crane cp</code> to copy the Windows images to your private registry.</p>
+                </li>
+                <p>For hybrid Linux + Windows clusters, use <code>crane cp</code> on the following Windows images to copy them to your private registry.</p>
                 <CodeBlock language='bash'>
                     {componentsWithImage.filter(filters.isWindows).map((component) => {
                         const imageName = mapImageToImageName(component.image);
 
-                        return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
+                        return `crane cp ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
                     }).join('')}
                 </CodeBlock>
-                <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+
+                <Admonition type='caution'>Do not <code>crane cp</code> the private {prodnameWindows} images to a public registry.</Admonition>
             </ol>
 
             <h3 id='run-the-operator-using-images-from-your-private-registry-image-path'>

--- a/calico-enterprise_versioned_docs/version-3.16/_includes/components/PrivateRegistryRegular.js
+++ b/calico-enterprise_versioned_docs/version-3.16/_includes/components/PrivateRegistryRegular.js
@@ -4,7 +4,7 @@ import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 import Heading from '@theme/Heading';
 
-import { tigeraOperator, prodname, prodnamedash, registry, releases } from '../../variables';
+import { tigeraOperator, prodname, prodnamedash, prodnameWindows, registry, releases } from '../../variables';
 
 export default function PrivateRegistryRegular() {
     const components = releases[0].components;
@@ -30,10 +30,6 @@ export default function PrivateRegistryRegular() {
                     {`docker pull ${tigeraOperator.registry}/${tigeraOperator.image}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map(renderPullCommand).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, pull the following Windows images.</p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map(renderPullCommand).join('')}
-                </CodeBlock>
 
                 <li>
                     <p>
@@ -49,20 +45,6 @@ export default function PrivateRegistryRegular() {
                             );
                         }).join('')}
                     </CodeBlock>
-                    <p>
-                        For hybrid Linux + Windows clusters, retag the following Windows images with the name of your private
-                        registry.
-                    </p>
-                    <CodeBlock language='bash'>
-                        {componentsWithImage.filter(filters.isWindows).map((component) => {
-                            const registry = mapComponentToRegistry(component);
-                            const imageName = component.image.split('/').pop();
-
-                            return (
-                                `docker tag ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`
-                            );
-                        }).join('')}
-                    </CodeBlock>
                 </li>
 
                 <li>
@@ -73,15 +55,21 @@ export default function PrivateRegistryRegular() {
                             return `docker push $PRIVATE_REGISTRY/${component.image}:${component.version}\n`;
                         }).join('')}
                     </CodeBlock>
-                    <p>For hybrid Linux + Windows clusters, push the following Windows images to your private registry.</p>
-                    <CodeBlock language='bash'>
-                        {componentsWithImage.filter(filters.isWindows).map((component) => {
-                            const imageName = component.image.split('/').pop();
-
-                            return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
-                        }).join('')}
-                    </CodeBlock>
                     <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+                </li>
+                <li>
+                <p>Use <code>crane cp</code> to copy the Windows images to your private registry.</p>
+                <p>For hybrid Linux + Windows clusters, use <code>crane cp</code> on the following Windows images to copy them to your private registry.</p>
+                <CodeBlock language='bash'>
+                    {componentsWithImage.filter(filters.isWindows).map((component) => {
+                        const registry = mapComponentToRegistry(component);
+                        const imageName = component.image.split('/').pop();
+
+                        return `crane cp ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
+                    }).join('')}
+                </CodeBlock>
+
+                <Admonition type='caution'>Do not <code>crane cp</code> the private {prodnameWindows} images to a public registry.</Admonition>
                 </li>
             </ol>
 

--- a/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/private-registry/private-registry-image-path.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/private-registry/private-registry-image-path.mdx
@@ -24,6 +24,7 @@ An **image pull secret** is used in Kubernetes to deploy container images from a
 
 - Configure pull access to your private registry
 - [Configure pull access to Tigera's private container registry](../calico-enterprise.mdx#get-private-registry-credentials-and-license-key).
+- Use the [Crane command](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) to manage the {{prodnameWindows}} images, as using `docker pull` commands for these images may not work depending on the operating system and version in which the commands are run.
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/private-registry/private-registry-regular.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/getting-started/install-on-clusters/private-registry/private-registry-regular.mdx
@@ -22,6 +22,7 @@ An **image pull secret** is used in Kubernetes to deploy container images from a
 
 - Configure pull access to your private registry
 - [Configure pull access to Tigera's private container registry](../calico-enterprise.mdx#get-private-registry-credentials-and-license-key).
+- Use the [Crane command](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) to manage the {{prodnameWindows}} images, as using `docker pull` commands for these images may not work depending on the operating system and version in which the commands are run.
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.17/_includes/components/PrivateRegistryImagePath.js
+++ b/calico-enterprise_versioned_docs/version-3.17/_includes/components/PrivateRegistryImagePath.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 
-import { prodname, prodnamedash, registry, releases, tigeraOperator } from '../../variables';
+import { prodname, prodnamedash, prodnameWindows, registry, releases, tigeraOperator } from '../../variables';
 
 export default function PrivateRegistryImagePath() {
   const components = releases[0].components;
@@ -26,10 +26,6 @@ export default function PrivateRegistryImagePath() {
           {`docker pull ${tigeraOperator.registry}/${tigeraOperator.image}:${tigeraOperator.version}\n`}
           {componentsWithImage.filter(filters.isNotWindows).map(renderPullCommand).join('')}
         </CodeBlock>
-        <p>For hybrid Linux + Windows clusters, pull the following Windows images.</p>
-        <CodeBlock language='bash'>
-          {componentsWithImage.filter(filters.isWindows).map(renderPullCommand)}
-        </CodeBlock>
 
         <li>
           <p>
@@ -42,20 +38,6 @@ export default function PrivateRegistryImagePath() {
             tigeraOperator.version
           } $PRIVATE_REGISTRY/$IMAGE_PATH/${mapImageToImageName(tigeraOperator.image)}:${tigeraOperator.version}\n`}
           {componentsWithImage.filter(filters.isNotWindows).map((component) => {
-            const registry = mapComponentToRegistry(component);
-            const imageName = mapImageToImageName(component.image);
-
-            return (
-              `docker tag ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`
-            );
-          }).join('')}
-        </CodeBlock>
-        <p>
-          For hybrid Linux + Windows clusters, retag the following Windows images with the name of your private
-          registry.
-        </p>
-        <CodeBlock language='bash'>
-          {componentsWithImage.filter(filters.isWindows).map((component) => {
             const registry = mapComponentToRegistry(component);
             const imageName = mapImageToImageName(component.image);
 
@@ -78,15 +60,20 @@ export default function PrivateRegistryImagePath() {
             return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
           }).join('')}
         </CodeBlock>
-        <p>For hybrid Linux + Windows clusters, push the following Windows images to your private registry.</p>
-        <CodeBlock language='bash'>
-          {componentsWithImage.filter(filters.isWindows).map((component) => {
-            const imageName = mapImageToImageName(component.image);
-
-            return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
-          }).join('')}
-        </CodeBlock>
         <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+        <li>
+            <p>Use <code>crane cp</code> to copy the Windows images to your private registry.</p>
+        </li>
+        <p>For hybrid Linux + Windows clusters, use <code>crane cp</code> on the following Windows images to copy them to your private registry.</p>
+        <CodeBlock language='bash'>
+            {componentsWithImage.filter(filters.isWindows).map((component) => {
+                const imageName = mapImageToImageName(component.image);
+
+                return `crane cp ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
+            }).join('')}
+        </CodeBlock>
+
+        <Admonition type='caution'>Do not <code>crane cp</code> the private {prodnameWindows} images to a public registry.</Admonition>
       </ol>
 
       <h3 id='run-the-operator-using-images-from-your-private-registry-image-path'>

--- a/calico-enterprise_versioned_docs/version-3.17/_includes/components/PrivateRegistryRegular.js
+++ b/calico-enterprise_versioned_docs/version-3.17/_includes/components/PrivateRegistryRegular.js
@@ -4,7 +4,7 @@ import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 import Heading from '@theme/Heading';
 
-import { tigeraOperator, prodname, prodnamedash, registry, releases } from '../../variables';
+import { tigeraOperator, prodname, prodnamedash, prodnameWindows, registry, releases } from '../../variables';
 
 export default function PrivateRegistryRegular() {
     const components = releases[0].components;
@@ -30,10 +30,6 @@ export default function PrivateRegistryRegular() {
                     {`docker pull ${tigeraOperator.registry}/${tigeraOperator.image}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map(renderPullCommand).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, pull the following Windows images.</p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map(renderPullCommand).join('')}
-                </CodeBlock>
 
                 <li>
                     <p>
@@ -49,20 +45,6 @@ export default function PrivateRegistryRegular() {
                             );
                         }).join('')}
                     </CodeBlock>
-                    <p>
-                        For hybrid Linux + Windows clusters, retag the following Windows images with the name of your private
-                        registry.
-                    </p>
-                    <CodeBlock language='bash'>
-                        {componentsWithImage.filter(filters.isWindows).map((component) => {
-                            const registry = mapComponentToRegistry(component);
-                            const imageName = component.image.split('/').pop();
-
-                            return (
-                                `docker tag ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`
-                            );
-                        }).join('')}
-                    </CodeBlock>
                 </li>
 
                 <li>
@@ -73,15 +55,21 @@ export default function PrivateRegistryRegular() {
                             return `docker push $PRIVATE_REGISTRY/${component.image}:${component.version}\n`;
                         }).join('')}
                     </CodeBlock>
-                    <p>For hybrid Linux + Windows clusters, push the following Windows images to your private registry.</p>
-                    <CodeBlock language='bash'>
-                        {componentsWithImage.filter(filters.isWindows).map((component) => {
-                            const imageName = component.image.split('/').pop();
-
-                            return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
-                        }).join('')}
-                    </CodeBlock>
                     <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+                </li>
+                <li>
+                <p>Use <code>crane cp</code> to copy the Windows images to your private registry.</p>
+                <p>For hybrid Linux + Windows clusters, use <code>crane cp</code> on the following Windows images to copy them to your private registry.</p>
+                <CodeBlock language='bash'>
+                    {componentsWithImage.filter(filters.isWindows).map((component) => {
+                        const registry = mapComponentToRegistry(component);
+                        const imageName = component.image.split('/').pop();
+
+                        return `crane cp ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
+                    }).join('')}
+                </CodeBlock>
+
+                <Admonition type='caution'>Do not <code>crane cp</code> the private {prodnameWindows} images to a public registry.</Admonition>
                 </li>
             </ol>
 

--- a/calico-enterprise_versioned_docs/version-3.17/getting-started/install-on-clusters/private-registry/private-registry-image-path.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/getting-started/install-on-clusters/private-registry/private-registry-image-path.mdx
@@ -24,6 +24,7 @@ An **image pull secret** is used in Kubernetes to deploy container images from a
 
 - Configure pull access to your private registry
 - [Configure pull access to Tigera's private container registry](../calico-enterprise.mdx#get-private-registry-credentials-and-license-key).
+- Use the [Crane command](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) to manage the {{prodnameWindows}} images, as using `docker pull` commands for these images may not work depending on the operating system and version in which the commands are run.
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.17/getting-started/install-on-clusters/private-registry/private-registry-regular.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/getting-started/install-on-clusters/private-registry/private-registry-regular.mdx
@@ -22,6 +22,7 @@ An **image pull secret** is used in Kubernetes to deploy container images from a
 
 - Configure pull access to your private registry
 - [Configure pull access to Tigera's private container registry](../calico-enterprise.mdx#get-private-registry-credentials-and-license-key).
+- Use the [Crane command](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) to manage the {{prodnameWindows}} images, as using `docker pull` commands for these images may not work depending on the operating system and version in which the commands are run.
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/_includes/components-temp/PrivateRegistryImagePath-temp.js
+++ b/calico-enterprise_versioned_docs/version-3.18-2/_includes/components-temp/PrivateRegistryImagePath-temp.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 
-import { prodname, prodnamedash, registry, releases, tigeraOperator } from '../../variables';
+import { prodname, prodnamedash, prodnameWindows, registry, releases, tigeraOperator } from '../../variables';
 
 export default function PrivateRegistryImagePath() {
     const components = releases[0].components;
@@ -26,10 +26,6 @@ export default function PrivateRegistryImagePath() {
                     {`docker pull ${tigeraOperator.registry}/${tigeraOperator.image}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map(renderPullCommand).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, pull the following Windows images.</p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map(renderPullCommand)}
-                </CodeBlock>
 
                 <li>
                     <p>
@@ -42,20 +38,6 @@ export default function PrivateRegistryImagePath() {
                         tigeraOperator.version
                     } $PRIVATE_REGISTRY/$IMAGE_PATH/${mapImageToImageName(tigeraOperator.image)}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map((component) => {
-                        const registry = mapComponentToRegistry(component);
-                        const imageName = mapImageToImageName(component.image);
-
-                        return (
-                            `docker tag ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`
-                        );
-                    }).join('')}
-                </CodeBlock>
-                <p>
-                    For hybrid Linux + Windows clusters, retag the following Windows images with the name of your private
-                    registry.
-                </p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map((component) => {
                         const registry = mapComponentToRegistry(component);
                         const imageName = mapImageToImageName(component.image);
 
@@ -78,15 +60,20 @@ export default function PrivateRegistryImagePath() {
                         return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
                     }).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, push the following Windows images to your private registry.</p>
+                <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+                <li>
+                    <p>Use <code>crane cp</code> to copy the Windows images to your private registry.</p>
+                </li>
+                <p>For hybrid Linux + Windows clusters, use <code>crane cp</code> on the following Windows images to copy them to your private registry.</p>
                 <CodeBlock language='bash'>
                     {componentsWithImage.filter(filters.isWindows).map((component) => {
                         const imageName = mapImageToImageName(component.image);
 
-                        return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
+                        return `crane cp ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
                     }).join('')}
                 </CodeBlock>
-                <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+
+                <Admonition type='caution'>Do not <code>crane cp</code> the private {prodnameWindows} images to a public registry.</Admonition>
             </ol>
 
             <h3 id='run-the-operator-using-images-from-your-private-registry-image-path'>

--- a/calico-enterprise_versioned_docs/version-3.18-2/_includes/components-temp/PrivateRegistryRegular-temp.js
+++ b/calico-enterprise_versioned_docs/version-3.18-2/_includes/components-temp/PrivateRegistryRegular-temp.js
@@ -4,7 +4,7 @@ import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 import Heading from '@theme/Heading';
 
-import { tigeraOperator, prodname, prodnamedash, registry, releases } from '../../variables';
+import { tigeraOperator, prodname, prodnamedash, prodnameWindows, registry, releases } from '../../variables';
 
 export default function PrivateRegistryRegular() {
     const components = releases[0].components;
@@ -30,10 +30,6 @@ export default function PrivateRegistryRegular() {
                     {`docker pull ${tigeraOperator.registry}/${tigeraOperator.image}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map(renderPullCommand).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, pull the following Windows images.</p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map(renderPullCommand).join('')}
-                </CodeBlock>
 
                 <li>
                     <p>
@@ -49,20 +45,6 @@ export default function PrivateRegistryRegular() {
                             );
                         }).join('')}
                     </CodeBlock>
-                    <p>
-                        For hybrid Linux + Windows clusters, retag the following Windows images with the name of your private
-                        registry.
-                    </p>
-                    <CodeBlock language='bash'>
-                        {componentsWithImage.filter(filters.isWindows).map((component) => {
-                            const registry = mapComponentToRegistry(component);
-                            const imageName = component.image.split('/').pop();
-
-                            return (
-                                `docker tag ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`
-                            );
-                        }).join('')}
-                    </CodeBlock>
                 </li>
 
                 <li>
@@ -73,15 +55,21 @@ export default function PrivateRegistryRegular() {
                             return `docker push $PRIVATE_REGISTRY/${component.image}:${component.version}\n`;
                         }).join('')}
                     </CodeBlock>
-                    <p>For hybrid Linux + Windows clusters, push the following Windows images to your private registry.</p>
-                    <CodeBlock language='bash'>
-                        {componentsWithImage.filter(filters.isWindows).map((component) => {
-                            const imageName = component.image.split('/').pop();
-
-                            return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
-                        }).join('')}
-                    </CodeBlock>
                     <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+                </li>
+                <li>
+                <p>Use <code>crane cp</code> to copy the Windows images to your private registry.</p>
+                <p>For hybrid Linux + Windows clusters, use <code>crane cp</code> on the following Windows images to copy them to your private registry.</p>
+                <CodeBlock language='bash'>
+                    {componentsWithImage.filter(filters.isWindows).map((component) => {
+                        const registry = mapComponentToRegistry(component);
+                        const imageName = component.image.split('/').pop();
+
+                        return `crane cp ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
+                    }).join('')}
+                </CodeBlock>
+
+                <Admonition type='caution'>Do not <code>crane cp</code> the private {prodnameWindows} images to a public registry.</Admonition>
                 </li>
             </ol>
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/_includes/components/PrivateRegistryImagePath.js
+++ b/calico-enterprise_versioned_docs/version-3.18-2/_includes/components/PrivateRegistryImagePath.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 
-import { prodname, prodnamedash, registry, releases, tigeraOperator } from '../../variables';
+import { prodname, prodnamedash, prodnameWindows, registry, releases, tigeraOperator } from '../../variables';
 
 export default function PrivateRegistryImagePath() {
     const components = releases[0].components;
@@ -26,10 +26,6 @@ export default function PrivateRegistryImagePath() {
                     {`docker pull ${tigeraOperator.registry}/${tigeraOperator.image}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map(renderPullCommand).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, pull the following Windows images.</p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map(renderPullCommand)}
-                </CodeBlock>
 
                 <li>
                     <p>
@@ -42,20 +38,6 @@ export default function PrivateRegistryImagePath() {
                         tigeraOperator.version
                     } $PRIVATE_REGISTRY/$IMAGE_PATH/${mapImageToImageName(tigeraOperator.image)}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map((component) => {
-                        const registry = mapComponentToRegistry(component);
-                        const imageName = mapImageToImageName(component.image);
-
-                        return (
-                            `docker tag ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`
-                        );
-                    }).join('')}
-                </CodeBlock>
-                <p>
-                    For hybrid Linux + Windows clusters, retag the following Windows images with the name of your private
-                    registry.
-                </p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map((component) => {
                         const registry = mapComponentToRegistry(component);
                         const imageName = mapImageToImageName(component.image);
 
@@ -78,15 +60,20 @@ export default function PrivateRegistryImagePath() {
                         return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
                     }).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, push the following Windows images to your private registry.</p>
+                <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+                <li>
+                    <p>Use <code>crane cp</code> to copy the Windows images to your private registry.</p>
+                </li>
+                <p>For hybrid Linux + Windows clusters, use <code>crane cp</code> on the following Windows images to copy them to your private registry.</p>
                 <CodeBlock language='bash'>
                     {componentsWithImage.filter(filters.isWindows).map((component) => {
                         const imageName = mapImageToImageName(component.image);
 
-                        return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
+                        return `crane cp ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
                     }).join('')}
                 </CodeBlock>
-                <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+
+                <Admonition type='caution'>Do not <code>crane cp</code> the private {prodnameWindows} images to a public registry.</Admonition>
             </ol>
 
             <h3 id='run-the-operator-using-images-from-your-private-registry-image-path'>

--- a/calico-enterprise_versioned_docs/version-3.18-2/_includes/components/PrivateRegistryRegular.js
+++ b/calico-enterprise_versioned_docs/version-3.18-2/_includes/components/PrivateRegistryRegular.js
@@ -4,7 +4,7 @@ import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 import Heading from '@theme/Heading';
 
-import { tigeraOperator, prodname, prodnamedash, registry, releases } from '../../variables';
+import { tigeraOperator, prodname, prodnamedash, prodnameWindows, registry, releases } from '../../variables';
 
 export default function PrivateRegistryRegular() {
     const components = releases[0].components;
@@ -30,10 +30,6 @@ export default function PrivateRegistryRegular() {
                     {`docker pull ${tigeraOperator.registry}/${tigeraOperator.image}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map(renderPullCommand).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, pull the following Windows images.</p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map(renderPullCommand).join('')}
-                </CodeBlock>
 
                 <li>
                     <p>
@@ -49,20 +45,6 @@ export default function PrivateRegistryRegular() {
                             );
                         }).join('')}
                     </CodeBlock>
-                    <p>
-                        For hybrid Linux + Windows clusters, retag the following Windows images with the name of your private
-                        registry.
-                    </p>
-                    <CodeBlock language='bash'>
-                        {componentsWithImage.filter(filters.isWindows).map((component) => {
-                            const registry = mapComponentToRegistry(component);
-                            const imageName = component.image.split('/').pop();
-
-                            return (
-                                `docker tag ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`
-                            );
-                        }).join('')}
-                    </CodeBlock>
                 </li>
 
                 <li>
@@ -73,15 +55,21 @@ export default function PrivateRegistryRegular() {
                             return `docker push $PRIVATE_REGISTRY/${component.image}:${component.version}\n`;
                         }).join('')}
                     </CodeBlock>
-                    <p>For hybrid Linux + Windows clusters, push the following Windows images to your private registry.</p>
-                    <CodeBlock language='bash'>
-                        {componentsWithImage.filter(filters.isWindows).map((component) => {
-                            const imageName = component.image.split('/').pop();
-
-                            return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
-                        }).join('')}
-                    </CodeBlock>
                     <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+                </li>
+                <li>
+                <p>Use <code>crane cp</code> to copy the Windows images to your private registry.</p>
+                <p>For hybrid Linux + Windows clusters, use <code>crane cp</code> on the following Windows images to copy them to your private registry.</p>
+                <CodeBlock language='bash'>
+                    {componentsWithImage.filter(filters.isWindows).map((component) => {
+                        const registry = mapComponentToRegistry(component);
+                        const imageName = component.image.split('/').pop();
+
+                        return `crane cp ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
+                    }).join('')}
+                </CodeBlock>
+
+                <Admonition type='caution'>Do not <code>crane cp</code> the private {prodnameWindows} images to a public registry.</Admonition>
                 </li>
             </ol>
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/private-registry/private-registry-image-path.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/private-registry/private-registry-image-path.mdx
@@ -26,6 +26,7 @@ An **image pull secret** is used in Kubernetes to deploy container images from a
 
 - Configure pull access to your private registry
 - [Configure pull access to Tigera's private container registry](../calico-enterprise.mdx#get-private-registry-credentials-and-license-key).
+- Use the [Crane command](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) to manage the {{prodnameWindows}} images, as using `docker pull` commands for these images may not work depending on the operating system and version in which the commands are run.
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/private-registry/private-registry-regular.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/private-registry/private-registry-regular.mdx
@@ -24,6 +24,7 @@ An **image pull secret** is used in Kubernetes to deploy container images from a
 
 - Configure pull access to your private registry
 - [Configure pull access to Tigera's private container registry](../calico-enterprise.mdx#get-private-registry-credentials-and-license-key).
+- Use the [Crane command](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) to manage the {{prodnameWindows}} images, as using `docker pull` commands for these images may not work depending on the operating system and version in which the commands are run.
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.18/_includes/components/PrivateRegistryImagePath.js
+++ b/calico-enterprise_versioned_docs/version-3.18/_includes/components/PrivateRegistryImagePath.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 
-import { prodname, prodnamedash, registry, releases, tigeraOperator } from '../../variables';
+import { prodname, prodnamedash, prodnameWindows, registry, releases, tigeraOperator } from '../../variables';
 
 export default function PrivateRegistryImagePath() {
     const components = releases[0].components;
@@ -26,10 +26,6 @@ export default function PrivateRegistryImagePath() {
                     {`docker pull ${tigeraOperator.registry}/${tigeraOperator.image}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map(renderPullCommand).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, pull the following Windows images.</p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map(renderPullCommand)}
-                </CodeBlock>
 
                 <li>
                     <p>
@@ -42,20 +38,6 @@ export default function PrivateRegistryImagePath() {
                         tigeraOperator.version
                     } $PRIVATE_REGISTRY/$IMAGE_PATH/${mapImageToImageName(tigeraOperator.image)}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map((component) => {
-                        const registry = mapComponentToRegistry(component);
-                        const imageName = mapImageToImageName(component.image);
-
-                        return (
-                            `docker tag ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`
-                        );
-                    }).join('')}
-                </CodeBlock>
-                <p>
-                    For hybrid Linux + Windows clusters, retag the following Windows images with the name of your private
-                    registry.
-                </p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map((component) => {
                         const registry = mapComponentToRegistry(component);
                         const imageName = mapImageToImageName(component.image);
 
@@ -78,15 +60,20 @@ export default function PrivateRegistryImagePath() {
                         return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
                     }).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, push the following Windows images to your private registry.</p>
+                <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+                <li>
+                    <p>Use <code>crane cp</code> to copy the Windows images to your private registry.</p>
+                </li>
+                <p>For hybrid Linux + Windows clusters, use <code>crane cp</code> on the following Windows images to copy them to your private registry.</p>
                 <CodeBlock language='bash'>
                     {componentsWithImage.filter(filters.isWindows).map((component) => {
                         const imageName = mapImageToImageName(component.image);
 
-                        return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
+                        return `crane cp ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
                     }).join('')}
                 </CodeBlock>
-                <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+
+                <Admonition type='caution'>Do not <code>crane cp</code> the private {prodnameWindows} images to a public registry.</Admonition>
             </ol>
 
             <h3 id='run-the-operator-using-images-from-your-private-registry-image-path'>

--- a/calico-enterprise_versioned_docs/version-3.18/_includes/components/PrivateRegistryRegular.js
+++ b/calico-enterprise_versioned_docs/version-3.18/_includes/components/PrivateRegistryRegular.js
@@ -4,7 +4,7 @@ import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 import Heading from '@theme/Heading';
 
-import { tigeraOperator, prodname, prodnamedash, registry, releases } from '../../variables';
+import { tigeraOperator, prodname, prodnamedash, prodnameWindows, registry, releases } from '../../variables';
 
 export default function PrivateRegistryRegular() {
     const components = releases[0].components;
@@ -30,10 +30,6 @@ export default function PrivateRegistryRegular() {
                     {`docker pull ${tigeraOperator.registry}/${tigeraOperator.image}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map(renderPullCommand).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, pull the following Windows images.</p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map(renderPullCommand).join('')}
-                </CodeBlock>
 
                 <li>
                     <p>
@@ -49,20 +45,6 @@ export default function PrivateRegistryRegular() {
                             );
                         }).join('')}
                     </CodeBlock>
-                    <p>
-                        For hybrid Linux + Windows clusters, retag the following Windows images with the name of your private
-                        registry.
-                    </p>
-                    <CodeBlock language='bash'>
-                        {componentsWithImage.filter(filters.isWindows).map((component) => {
-                            const registry = mapComponentToRegistry(component);
-                            const imageName = component.image.split('/').pop();
-
-                            return (
-                                `docker tag ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`
-                            );
-                        }).join('')}
-                    </CodeBlock>
                 </li>
 
                 <li>
@@ -73,15 +55,21 @@ export default function PrivateRegistryRegular() {
                             return `docker push $PRIVATE_REGISTRY/${component.image}:${component.version}\n`;
                         }).join('')}
                     </CodeBlock>
-                    <p>For hybrid Linux + Windows clusters, push the following Windows images to your private registry.</p>
-                    <CodeBlock language='bash'>
-                        {componentsWithImage.filter(filters.isWindows).map((component) => {
-                            const imageName = component.image.split('/').pop();
-
-                            return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
-                        }).join('')}
-                    </CodeBlock>
                     <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+                </li>
+                <li>
+                <p>Use <code>crane cp</code> to copy the Windows images to your private registry.</p>
+                <p>For hybrid Linux + Windows clusters, use <code>crane cp</code> on the following Windows images to copy them to your private registry.</p>
+                <CodeBlock language='bash'>
+                    {componentsWithImage.filter(filters.isWindows).map((component) => {
+                        const registry = mapComponentToRegistry(component);
+                        const imageName = component.image.split('/').pop();
+
+                        return `crane cp ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
+                    }).join('')}
+                </CodeBlock>
+
+                <Admonition type='caution'>Do not <code>crane cp</code> the private {prodnameWindows} images to a public registry.</Admonition>
                 </li>
             </ol>
 

--- a/calico-enterprise_versioned_docs/version-3.18/getting-started/install-on-clusters/private-registry/private-registry-image-path.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18/getting-started/install-on-clusters/private-registry/private-registry-image-path.mdx
@@ -24,6 +24,7 @@ An **image pull secret** is used in Kubernetes to deploy container images from a
 
 - Configure pull access to your private registry
 - [Configure pull access to Tigera's private container registry](../calico-enterprise.mdx#get-private-registry-credentials-and-license-key).
+- Use the [Crane command](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) to manage the {{prodnameWindows}} images, as using `docker pull` commands for these images may not work depending on the operating system and version in which the commands are run.
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.18/getting-started/install-on-clusters/private-registry/private-registry-regular.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18/getting-started/install-on-clusters/private-registry/private-registry-regular.mdx
@@ -22,6 +22,7 @@ An **image pull secret** is used in Kubernetes to deploy container images from a
 
 - Configure pull access to your private registry
 - [Configure pull access to Tigera's private container registry](../calico-enterprise.mdx#get-private-registry-credentials-and-license-key).
+- Use the [Crane command](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) to manage the {{prodnameWindows}} images, as using `docker pull` commands for these images may not work depending on the operating system and version in which the commands are run.
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.19-1/_includes/components-temp/PrivateRegistryImagePath-temp.js
+++ b/calico-enterprise_versioned_docs/version-3.19-1/_includes/components-temp/PrivateRegistryImagePath-temp.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 
-import { prodname, prodnamedash, registry, releases, tigeraOperator } from '../../variables';
+import { prodname, prodnamedash, prodnameWindows, registry, releases, tigeraOperator } from '../../variables';
 
 export default function PrivateRegistryImagePath() {
     const components = releases[0].components;
@@ -26,10 +26,6 @@ export default function PrivateRegistryImagePath() {
                     {`docker pull ${tigeraOperator.registry}/${tigeraOperator.image}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map(renderPullCommand).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, pull the following Windows images.</p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map(renderPullCommand)}
-                </CodeBlock>
 
                 <li>
                     <p>
@@ -42,20 +38,6 @@ export default function PrivateRegistryImagePath() {
                         tigeraOperator.version
                     } $PRIVATE_REGISTRY/$IMAGE_PATH/${mapImageToImageName(tigeraOperator.image)}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map((component) => {
-                        const registry = mapComponentToRegistry(component);
-                        const imageName = mapImageToImageName(component.image);
-
-                        return (
-                            `docker tag ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`
-                        );
-                    }).join('')}
-                </CodeBlock>
-                <p>
-                    For hybrid Linux + Windows clusters, retag the following Windows images with the name of your private
-                    registry.
-                </p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map((component) => {
                         const registry = mapComponentToRegistry(component);
                         const imageName = mapImageToImageName(component.image);
 
@@ -78,15 +60,20 @@ export default function PrivateRegistryImagePath() {
                         return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
                     }).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, push the following Windows images to your private registry.</p>
+                <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+                <li>
+                    <p>Use <code>crane cp</code> to copy the Windows images to your private registry.</p>
+                </li>
+                <p>For hybrid Linux + Windows clusters, use <code>crane cp</code> on the following Windows images to copy them to your private registry.</p>
                 <CodeBlock language='bash'>
                     {componentsWithImage.filter(filters.isWindows).map((component) => {
                         const imageName = mapImageToImageName(component.image);
 
-                        return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
+                        return `crane cp ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
                     }).join('')}
                 </CodeBlock>
-                <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+
+                <Admonition type='caution'>Do not <code>crane cp</code> the private {prodnameWindows} images to a public registry.</Admonition>
             </ol>
 
             <h3 id='run-the-operator-using-images-from-your-private-registry-image-path'>

--- a/calico-enterprise_versioned_docs/version-3.19-1/_includes/components-temp/PrivateRegistryRegular-temp.js
+++ b/calico-enterprise_versioned_docs/version-3.19-1/_includes/components-temp/PrivateRegistryRegular-temp.js
@@ -4,7 +4,7 @@ import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 import Heading from '@theme/Heading';
 
-import { tigeraOperator, prodname, prodnamedash, registry, releases } from '../../variables';
+import { tigeraOperator, prodname, prodnamedash, prodnameWindows, registry, releases } from '../../variables';
 
 export default function PrivateRegistryRegular() {
     const components = releases[0].components;
@@ -30,10 +30,6 @@ export default function PrivateRegistryRegular() {
                     {`docker pull ${tigeraOperator.registry}/${tigeraOperator.image}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map(renderPullCommand).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, pull the following Windows images.</p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map(renderPullCommand).join('')}
-                </CodeBlock>
 
                 <li>
                     <p>
@@ -49,20 +45,6 @@ export default function PrivateRegistryRegular() {
                             );
                         }).join('')}
                     </CodeBlock>
-                    <p>
-                        For hybrid Linux + Windows clusters, retag the following Windows images with the name of your private
-                        registry.
-                    </p>
-                    <CodeBlock language='bash'>
-                        {componentsWithImage.filter(filters.isWindows).map((component) => {
-                            const registry = mapComponentToRegistry(component);
-                            const imageName = component.image.split('/').pop();
-
-                            return (
-                                `docker tag ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`
-                            );
-                        }).join('')}
-                    </CodeBlock>
                 </li>
 
                 <li>
@@ -73,15 +55,21 @@ export default function PrivateRegistryRegular() {
                             return `docker push $PRIVATE_REGISTRY/${component.image}:${component.version}\n`;
                         }).join('')}
                     </CodeBlock>
-                    <p>For hybrid Linux + Windows clusters, push the following Windows images to your private registry.</p>
-                    <CodeBlock language='bash'>
-                        {componentsWithImage.filter(filters.isWindows).map((component) => {
-                            const imageName = component.image.split('/').pop();
-
-                            return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
-                        }).join('')}
-                    </CodeBlock>
                     <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+                </li>
+                <li>
+                <p>Use <code>crane cp</code> to copy the Windows images to your private registry.</p>
+                <p>For hybrid Linux + Windows clusters, use <code>crane cp</code> on the following Windows images to copy them to your private registry.</p>
+                <CodeBlock language='bash'>
+                    {componentsWithImage.filter(filters.isWindows).map((component) => {
+                        const registry = mapComponentToRegistry(component);
+                        const imageName = component.image.split('/').pop();
+
+                        return `crane cp ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
+                    }).join('')}
+                </CodeBlock>
+
+                <Admonition type='caution'>Do not <code>crane cp</code> the private {prodnameWindows} images to a public registry.</Admonition>
                 </li>
             </ol>
 

--- a/calico-enterprise_versioned_docs/version-3.19-1/_includes/components/PrivateRegistryImagePath.js
+++ b/calico-enterprise_versioned_docs/version-3.19-1/_includes/components/PrivateRegistryImagePath.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 
-import { prodname, prodnamedash, registry, releases, tigeraOperator } from '../../variables';
+import { prodname, prodnamedash, prodnameWindows, registry, releases, tigeraOperator } from '../../variables';
 
 export default function PrivateRegistryImagePath() {
     const components = releases[0].components;
@@ -26,10 +26,6 @@ export default function PrivateRegistryImagePath() {
                     {`docker pull ${tigeraOperator.registry}/${tigeraOperator.image}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map(renderPullCommand).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, pull the following Windows images.</p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map(renderPullCommand)}
-                </CodeBlock>
 
                 <li>
                     <p>
@@ -42,20 +38,6 @@ export default function PrivateRegistryImagePath() {
                         tigeraOperator.version
                     } $PRIVATE_REGISTRY/$IMAGE_PATH/${mapImageToImageName(tigeraOperator.image)}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map((component) => {
-                        const registry = mapComponentToRegistry(component);
-                        const imageName = mapImageToImageName(component.image);
-
-                        return (
-                            `docker tag ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`
-                        );
-                    }).join('')}
-                </CodeBlock>
-                <p>
-                    For hybrid Linux + Windows clusters, retag the following Windows images with the name of your private
-                    registry.
-                </p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map((component) => {
                         const registry = mapComponentToRegistry(component);
                         const imageName = mapImageToImageName(component.image);
 
@@ -78,15 +60,20 @@ export default function PrivateRegistryImagePath() {
                         return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
                     }).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, push the following Windows images to your private registry.</p>
+                <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+                <li>
+                    <p>Use <code>crane cp</code> to copy the Windows images to your private registry.</p>
+                </li>
+                <p>For hybrid Linux + Windows clusters, use <code>crane cp</code> on the following Windows images to copy them to your private registry.</p>
                 <CodeBlock language='bash'>
                     {componentsWithImage.filter(filters.isWindows).map((component) => {
                         const imageName = mapImageToImageName(component.image);
 
-                        return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
+                        return `crane cp ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
                     }).join('')}
                 </CodeBlock>
-                <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+
+                <Admonition type='caution'>Do not <code>crane cp</code> the private {prodnameWindows} images to a public registry.</Admonition>
             </ol>
 
             <h3 id='run-the-operator-using-images-from-your-private-registry-image-path'>

--- a/calico-enterprise_versioned_docs/version-3.19-1/_includes/components/PrivateRegistryRegular.js
+++ b/calico-enterprise_versioned_docs/version-3.19-1/_includes/components/PrivateRegistryRegular.js
@@ -4,7 +4,7 @@ import Admonition from '@theme/Admonition';
 import CodeBlock from '@theme/CodeBlock';
 import Heading from '@theme/Heading';
 
-import { tigeraOperator, prodname, prodnamedash, registry, releases } from '../../variables';
+import { tigeraOperator, prodname, prodnamedash, prodnameWindows, registry, releases } from '../../variables';
 
 export default function PrivateRegistryRegular() {
     const components = releases[0].components;
@@ -30,10 +30,6 @@ export default function PrivateRegistryRegular() {
                     {`docker pull ${tigeraOperator.registry}/${tigeraOperator.image}:${tigeraOperator.version}\n`}
                     {componentsWithImage.filter(filters.isNotWindows).map(renderPullCommand).join('')}
                 </CodeBlock>
-                <p>For hybrid Linux + Windows clusters, pull the following Windows images.</p>
-                <CodeBlock language='bash'>
-                    {componentsWithImage.filter(filters.isWindows).map(renderPullCommand).join('')}
-                </CodeBlock>
 
                 <li>
                     <p>
@@ -49,20 +45,6 @@ export default function PrivateRegistryRegular() {
                             );
                         }).join('')}
                     </CodeBlock>
-                    <p>
-                        For hybrid Linux + Windows clusters, retag the following Windows images with the name of your private
-                        registry.
-                    </p>
-                    <CodeBlock language='bash'>
-                        {componentsWithImage.filter(filters.isWindows).map((component) => {
-                            const registry = mapComponentToRegistry(component);
-                            const imageName = component.image.split('/').pop();
-
-                            return (
-                                `docker tag ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`
-                            );
-                        }).join('')}
-                    </CodeBlock>
                 </li>
 
                 <li>
@@ -73,15 +55,21 @@ export default function PrivateRegistryRegular() {
                             return `docker push $PRIVATE_REGISTRY/${component.image}:${component.version}\n`;
                         }).join('')}
                     </CodeBlock>
-                    <p>For hybrid Linux + Windows clusters, push the following Windows images to your private registry.</p>
-                    <CodeBlock language='bash'>
-                        {componentsWithImage.filter(filters.isWindows).map((component) => {
-                            const imageName = component.image.split('/').pop();
-
-                            return `docker push $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
-                        }).join('')}
-                    </CodeBlock>
                     <Admonition type='caution'>Do not push the private {prodname} images to a public registry.</Admonition>
+                </li>
+                <li>
+                <p>Use <code>crane cp</code> to copy the Windows images to your private registry.</p>
+                <p>For hybrid Linux + Windows clusters, use <code>crane cp</code> on the following Windows images to copy them to your private registry.</p>
+                <CodeBlock language='bash'>
+                    {componentsWithImage.filter(filters.isWindows).map((component) => {
+                        const registry = mapComponentToRegistry(component);
+                        const imageName = component.image.split('/').pop();
+
+                        return `crane cp ${registry}${component.image}:${component.version} $PRIVATE_REGISTRY/$IMAGE_PATH/${imageName}:${component.version}\n`;
+                    }).join('')}
+                </CodeBlock>
+
+                <Admonition type='caution'>Do not <code>crane cp</code> the private {prodnameWindows} images to a public registry.</Admonition>
                 </li>
             </ol>
 

--- a/calico-enterprise_versioned_docs/version-3.19-1/getting-started/install-on-clusters/private-registry/private-registry-image-path.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-1/getting-started/install-on-clusters/private-registry/private-registry-image-path.mdx
@@ -26,6 +26,7 @@ An **image pull secret** is used in Kubernetes to deploy container images from a
 
 - Configure pull access to your private registry
 - [Configure pull access to Tigera's private container registry](../calico-enterprise.mdx#get-private-registry-credentials-and-license-key).
+- Use the [Crane command](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) to manage the {{prodnameWindows}} images, as using `docker pull` commands for these images may not work depending on the operating system and version in which the commands are run.
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.19-1/getting-started/install-on-clusters/private-registry/private-registry-regular.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-1/getting-started/install-on-clusters/private-registry/private-registry-regular.mdx
@@ -24,6 +24,7 @@ An **image pull secret** is used in Kubernetes to deploy container images from a
 
 - Configure pull access to your private registry
 - [Configure pull access to Tigera's private container registry](../calico-enterprise.mdx#get-private-registry-credentials-and-license-key).
+- Use the [Crane command](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) to manage the {{prodnameWindows}} images, as using `docker pull` commands for these images may not work depending on the operating system and version in which the commands are run.
 
 ## How to
 

--- a/calico/operations/image-options/alternate-registry.mdx
+++ b/calico/operations/image-options/alternate-registry.mdx
@@ -33,6 +33,7 @@ An **image path** is a directory in a registry that contains images required to 
 - {{prodname}} is managed by the operator
 - Configure pull access to your registry
 - If you are using a private registry that requires user authentication, ensure that an image pull secret is configured for your registry in the tigera-operator namespace. Set the environment variable, `REGISTRY_PULL_SECRET` to the secret name. For help, see `imagePullSecrets` and `registry` fields, in [Installation resource reference](../../reference/installation/api.mdx).
+- Use the [Crane command](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) to manage the {{prodnameWindows}} images, as using `docker pull` commands for these images may not work depending on the operating system and version in which the commands are run.
 
 ## How to
 
@@ -40,7 +41,7 @@ The following examples show the path format for public and private registry, `$R
 
 ### Push {{prodname}} images to your registry
 
-To install images from your registry, you must first pull the images from Tigera's registry, retag them with your own registry, and then push the newly-tagged images to your own registry.
+To install images from your registry, you must first pull the images from Tigera's registry, retag them with your own registry, and then push the newly-tagged images to your own registry. Use the `crane cp` command instead of pulling+retagging+pushing on the {{prodnameWindows}} images (`node-windows` and `cni-windows`).
 
 <MaintenanceImageOptionsAlternateRegistry />
 

--- a/calico/operations/image-options/imageset.mdx
+++ b/calico/operations/image-options/imageset.mdx
@@ -102,7 +102,7 @@ spec:
       digest: 'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
     - image: 'calico/pod2daemon-flexvol'
       digest: 'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
-    - image: 'calico/windows-upgrade'
+    - image: 'calico/node-windows'
       digest: 'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
     - image: 'tigera/operator'
       digest: 'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
@@ -167,7 +167,7 @@ This script will only work if using the default registries and image paths.
 ```
 #!/bin/bash -e
 
-images=(calico/apiserver calico/cni calico/kube-controllers calico/node calico/typha calico/pod2daemon-flexvol calico/windows-upgrade tigera/key-cert-provisioner tigera/operator)
+images=(calico/apiserver calico/cni calico/kube-controllers calico/node calico/typha calico/pod2daemon-flexvol calico/node-windows tigera/key-cert-provisioner tigera/operator)
 
 OPERATOR_IMAGE={{tigeraOperator.registry}}/{{tigeraOperator.image}}:{{tigeraOperator.version}}
 echo "Pulling $OPERATOR_IMAGE"

--- a/calico/releases.json
+++ b/calico/releases.json
@@ -1,53 +1,56 @@
 [
   {
-    "title": "v3.27.0",
+    "title": "v3.28.0",
     "tigera-operator": {
       "image": "tigera/operator",
       "registry": "quay.io",
-      "version": "v1.32.0"
+      "version": "v1.33.0"
     },
     "components": {
       "typha": {
-        "version": "v3.27.0"
+        "version": "v3.28.0"
       },
       "calicoctl": {
-        "version": "v3.27.0"
+        "version": "v3.28.0"
       },
       "calico/node": {
-        "version": "v3.27.0"
+        "version": "v3.28.0"
+      },
+      "calico/node-windows": {
+        "version": "v3.28.0"
       },
       "calico/cni": {
-        "version": "v3.27.0"
+        "version": "v3.28.0"
+      },
+      "calico/cni-windows": {
+        "version": "v3.28.0"
       },
       "calico/apiserver": {
-        "version": "v3.27.0"
+        "version": "v3.28.0"
       },
       "calico/kube-controllers": {
-        "version": "v3.27.0"
+        "version": "v3.28.0"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.27.0"
-      },
-      "calico/windows": {
-        "version": "v3.27.0"
+        "version": "v3.28.0"
       },
       "networking-calico": {
-        "version": "v3.27.0"
+        "version": "v3.28.0"
       },
       "flannel": {
         "version": "v0.16.3"
       },
       "calico/dikastes": {
-        "version": "v3.27.0"
+        "version": "v3.28.0"
       },
       "flexvol": {
-        "version": "v3.27.0"
+        "version": "v3.28.0"
       },
       "csi-driver": {
-        "version": "v3.27.0"
+        "version": "v3.28.0"
       },
       "csi-node-driver-registrar": {
-        "version": "v3.27.0"
+        "version": "v3.28.0"
       }
     }
   }

--- a/calico_versioned_docs/version-3.27/operations/image-options/alternate-registry.mdx
+++ b/calico_versioned_docs/version-3.27/operations/image-options/alternate-registry.mdx
@@ -33,6 +33,7 @@ An **image path** is a directory in a registry that contains images required to 
 - {{prodname}} is managed by the operator
 - Configure pull access to your registry
 - If you are using a private registry that requires user authentication, ensure that an image pull secret is configured for your registry in the tigera-operator namespace. Set the environment variable, `REGISTRY_PULL_SECRET` to the secret name. For help, see `imagePullSecrets` and `registry` fields, in [Installation resource reference](../../reference/installation/api.mdx).
+- Use the [Crane command](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) to manage the {{prodnameWindows}} images, as using `docker pull` commands for these images may not work depending on the operating system and version in which the commands are run.
 
 ## How to
 
@@ -40,7 +41,7 @@ The following examples show the path format for public and private registry, `$R
 
 ### Push {{prodname}} images to your registry
 
-To install images from your registry, you must first pull the images from Tigera's registry, retag them with your own registry, and then push the newly-tagged images to your own registry.
+To install images from your registry, you must first pull the images from Tigera's registry, retag them with your own registry, and then push the newly-tagged images to your own registry. Use the `crane cp` command instead of pulling+retagging+pushing on the {{prodnameWindows}} images (`node-windows` and `cni-windows`).
 
 <MaintenanceImageOptionsAlternateRegistry />
 

--- a/calico_versioned_docs/version-3.27/operations/image-options/imageset.mdx
+++ b/calico_versioned_docs/version-3.27/operations/image-options/imageset.mdx
@@ -102,7 +102,7 @@ spec:
       digest: 'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
     - image: 'calico/pod2daemon-flexvol'
       digest: 'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
-    - image: 'calico/windows-upgrade'
+    - image: 'calico/node-windows'
       digest: 'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
     - image: 'tigera/operator'
       digest: 'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
@@ -167,7 +167,7 @@ This script will only work if using the default registries and image paths.
 ```
 #!/bin/bash -e
 
-images=(calico/apiserver calico/cni calico/kube-controllers calico/node calico/typha calico/pod2daemon-flexvol calico/windows-upgrade tigera/key-cert-provisioner tigera/operator)
+images=(calico/apiserver calico/cni calico/kube-controllers calico/node calico/typha calico/pod2daemon-flexvol calico/node-windows tigera/key-cert-provisioner tigera/operator)
 
 OPERATOR_IMAGE={{tigeraOperator.registry}}/{{tigeraOperator.image}}:{{tigeraOperator.version}}
 echo "Pulling $OPERATOR_IMAGE"

--- a/calico_versioned_docs/version-3.27/releases.json
+++ b/calico_versioned_docs/version-3.27/releases.json
@@ -16,7 +16,13 @@
       "calico/node": {
         "version": "v3.27.2"
       },
+      "calico/node-windows": {
+        "version": "v3.27.2"
+      },
       "calico/cni": {
+        "version": "v3.27.2"
+      },
+      "calico/cni-windows": {
         "version": "v3.27.2"
       },
       "calico/apiserver": {
@@ -26,9 +32,6 @@
         "version": "v3.27.2"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.27.2"
-      },
-      "calico/windows": {
         "version": "v3.27.2"
       },
       "networking-calico": {
@@ -65,10 +68,13 @@
       "calicoctl": {
         "version": "v3.27.0"
       },
-      "calico/node": {
+      "calico/node-windows": {
         "version": "v3.27.0"
       },
       "calico/cni": {
+        "version": "v3.27.0"
+      },
+      "calico/cni-windows": {
         "version": "v3.27.0"
       },
       "calico/apiserver": {
@@ -78,9 +84,6 @@
         "version": "v3.27.0"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.27.0"
-      },
-      "calico/windows": {
         "version": "v3.27.0"
       },
       "networking-calico": {


### PR DESCRIPTION
Use 'crane cp' to copy windows images to private registries as docker 'pull+tag+push' doesn't work correctly for them.

Update OSS alternate registry docs to add windows images.

Update OSS releases.json for windows images and update vnext releases.json versions to v3.28.0.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->