### PR TITLE
Remove deprecated '-netAdapterName' argument from Install-Containerd.ps1 invocation

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/windows-calico/operator.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/windows-calico/operator.mdx
@@ -56,7 +56,7 @@ To install containerd on the Windows node and configure the containerd service:
 
 ```powershell
 Invoke-WebRequest {{windowsScriptsURL}}/Install-Containerd.ps1 -OutFile c:\Install-Containerd.ps1
-c:\Install-Containerd.ps1 -ContainerDVersion 1.6.22 -netAdapterName Ethernet -skipHypervisorSupportCheck -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
+c:\Install-Containerd.ps1 -ContainerDVersion 1.6.22 -skipHypervisorSupportCheck -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
 ```
 
 If you have an existing {{prodnameWindows}} installation using the manual method, your Windows nodes may have already joined the cluster.

--- a/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/windows-calico/operator.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/windows-calico/operator.mdx
@@ -58,7 +58,7 @@ To install containerd on the Windows node and configure the containerd service:
 
 ```powershell
 Invoke-WebRequest {{windowsScriptsURL}}/Install-Containerd.ps1 -OutFile c:\Install-Containerd.ps1
-c:\Install-Containerd.ps1 -ContainerDVersion 1.6.22 -netAdapterName Ethernet -skipHypervisorSupportCheck -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
+c:\Install-Containerd.ps1 -ContainerDVersion 1.6.22 -skipHypervisorSupportCheck -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
 ```
 
 If you have an existing {{prodnameWindows}} installation using the manual method, your Windows nodes may have already joined the cluster.

--- a/calico-enterprise_versioned_docs/version-3.19-1/getting-started/install-on-clusters/windows-calico/operator.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-1/getting-started/install-on-clusters/windows-calico/operator.mdx
@@ -58,7 +58,7 @@ To install containerd on the Windows node and configure the containerd service:
 
 ```powershell
 Invoke-WebRequest {{windowsScriptsURL}}/Install-Containerd.ps1 -OutFile c:\Install-Containerd.ps1
-c:\Install-Containerd.ps1 -ContainerDVersion 1.6.22 -netAdapterName Ethernet -skipHypervisorSupportCheck -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
+c:\Install-Containerd.ps1 -ContainerDVersion 1.6.22 -skipHypervisorSupportCheck -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
 ```
 
 If you have an existing {{prodnameWindows}} installation using the manual method, your Windows nodes may have already joined the cluster.

--- a/calico/getting-started/kubernetes/windows-calico/operator.mdx
+++ b/calico/getting-started/kubernetes/windows-calico/operator.mdx
@@ -62,7 +62,7 @@ To install containerd on the Windows node and configure the containerd service:
 
 ```powershell
 Invoke-WebRequest {{windowsScriptsURL}}/Install-Containerd.ps1 -OutFile c:\Install-Containerd.ps1
-c:\Install-Containerd.ps1 -ContainerDVersion 1.6.22 -netAdapterName Ethernet -skipHypervisorSupportCheck -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
+c:\Install-Containerd.ps1 -ContainerDVersion 1.6.22 -skipHypervisorSupportCheck -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
 ```
 
 If you have an existing {{prodnameWindows}} installation using the manual method, your Windows nodes may have already joined the cluster.

--- a/calico_versioned_docs/version-3.27/getting-started/kubernetes/windows-calico/operator.mdx
+++ b/calico_versioned_docs/version-3.27/getting-started/kubernetes/windows-calico/operator.mdx
@@ -62,7 +62,7 @@ To install containerd on the Windows node and configure the containerd service:
 
 ```powershell
 Invoke-WebRequest {{windowsScriptsURL}}/Install-Containerd.ps1 -OutFile c:\Install-Containerd.ps1
-c:\Install-Containerd.ps1 -ContainerDVersion 1.6.22 -netAdapterName Ethernet -skipHypervisorSupportCheck -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
+c:\Install-Containerd.ps1 -ContainerDVersion 1.6.22 -skipHypervisorSupportCheck -CNIConfigPath "c:/etc/cni/net.d" -CNIBinPath "c:/opt/cni/bin"
 ```
 
 If you have an existing {{prodnameWindows}} installation using the manual method, your Windows nodes may have already joined the cluster.


### PR DESCRIPTION


<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->