### PR TITLE
[TSLA-6447] Remove unused Azure AD delegated permission

### DIFF
--- a/calico-cloud/users/user-management.mdx
+++ b/calico-cloud/users/user-management.mdx
@@ -54,7 +54,6 @@ Enable "ID Token" for implicit flows.
 
 Add the following Microsoft Graph API delegated permissions:
 
-- Directory.Read.All
 - User.Read
 - OpenId permissions:
   - email

--- a/calico-cloud_versioned_docs/version-19-1/users/user-management.mdx
+++ b/calico-cloud_versioned_docs/version-19-1/users/user-management.mdx
@@ -54,7 +54,6 @@ Enable "ID Token" for implicit flows.
 
 Add the following Microsoft Graph API delegated permissions:
 
-- Directory.Read.All
 - User.Read
 - OpenId permissions:
   - email


### PR DESCRIPTION
The `Directory.Read.All` Azure AD delegated permission is not required for Azure AD integration anymore.
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->