### PR TITLE
Add simple meta-documentation to Makefile and README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,25 @@
+## This Makefile includes rules for building the docs site, as well as
+## utility rules for updating the Operator API docs.
+##
+## To build the docs site, these rules are the most interesting:
+##
+## init  - initializes the local environment
+## build - builds the site (implies init)
+## serve - starts a web server to serve the site (implies serve)
+## clean - removes the build artifacts
+##
+## To update the operator docs, these rules are the most interesting:
+##
+## autogen - Automatically detects all branches for Calico, Calico
+##           Enterprise, and Calico Cloud, and updates them one by
+##           one
+## autogen_calico / autogen_enterprise / autogen_cloud
+##         - As above, but only for that category of branch (but all
+##           versions of that branch)
+## show_current_branches
+##         - Outputs all of the branch-related targets that you can
+##           use to update a specific branch's operator docs.
+
 GO_BUILD_VER?=v0.87
 CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)
 LOCAL_USER_ID?=$(shell id -u $$USER)
@@ -90,6 +112,18 @@ autogen: autogen_calico autogen_enterprise autogen_cloud
 autogen_calico: $(CALICO_BRANCHES)
 autogen_enterprise: $(CALICO_ENT_BRANCHES)
 autogen_cloud: $(CALICO_CLOUD_BRANCHES)
+
+.PHONY: show_current_branches
+show_current_branches:
+	$(info Calico branch targets:)
+	$(foreach CAL_BRANCH,$(CALICO_BRANCHES),$(info * $(CAL_BRANCH)))
+	$(info )
+	$(info Calico enterprise branch targets:)
+	$(foreach CAL_BRANCH,$(CALICO_ENT_BRANCHES),$(info * $(CAL_BRANCH)))
+	$(info )
+	$(info Calico cloud branch targets:)
+	$(foreach CAL_BRANCH,$(CALICO_CLOUD_BRANCHES),$(info * $(CAL_BRANCH)))
+	@true
 
 .PHONY: build-operator-reference
 build-operator-reference:

--- a/README.md
+++ b/README.md
@@ -47,3 +47,50 @@ This command generates static content into the `build` directory and can be serv
 service. This is a full build which is exactly what Netlify runs to build the site, therefore, you will get more
 warning and error output. If you are trying to reproduce an error on Netlify, this is a great place to start.
 
+# Updating the Operator API docs
+
+This repo includes functionality to automatically update the Operator API docs from the current version of Operator
+for each branch. The following Makefile targets will help you update the docs you want to update:
+
+Automatically update all branches for all products:
+
+```bash
+make autogen
+```
+
+Automatically update all branches for a specific product:
+
+```bash
+make autogen_calico         # To update all Calico OSS releases
+make autogen_enterprise     # To update all Calico Enterprise releases
+make autogen_cloud          # To update all Calico Cloud releases
+```
+
+Detect and print a list of all of the makefile targets for each branch for all products. You
+can then run one of these targets to update the operator reference specifically for that branch.
+
+```bash
+# Get the list of operator reference update targets
+❯ make show_current_branches
+Calico branch targets:
+* calico__operator_reference
+* calico_versioned_docs/version-3.25__operator_reference
+* calico_versioned_docs/version-3.26__operator_reference
+* calico_versioned_docs/version-3.27__operator_reference
+
+Calico enterprise branch targets:
+* calico-enterprise__operator_reference
+* calico-enterprise_versioned_docs/version-3.16__operator_reference
+* calico-enterprise_versioned_docs/version-3.17__operator_reference
+* calico-enterprise_versioned_docs/version-3.18__operator_reference
+* calico-enterprise_versioned_docs/version-3.18-2__operator_reference
+* calico-enterprise_versioned_docs/version-3.19-1__operator_reference
+
+Calico cloud branch targets:
+* calico-cloud__operator_reference
+* calico-cloud_versioned_docs/version-19-1__operator_reference
+
+# Trigger the operator reference update for Calico Enterprise v3.18
+❯ make calico-enterprise_versioned_docs/version-3.18__operator_reference
+...build output here...
+```

--- a/calico-cloud/reference/installation/_README.mdx
+++ b/calico-cloud/reference/installation/_README.mdx
@@ -2,5 +2,6 @@
 
 The api.html doc in this directory is generated using https://github.com/tmjd/gen-crd-api-reference-docs/tree/kb_v2.
 
-To generate an updated file, run `make build-operator-reference OPERATOR_VERSION=<operator_branch>` using
-the operator_branch that deploys the components that go with the docs version.
+To generate an updated file, change to the root of the docs repository and run
+the appropriate Makefile target. See the `README.md` file for more details on
+how to list available targets and which ones to run.

--- a/calico-cloud_versioned_docs/version-19-1/reference/installation/_README.mdx
+++ b/calico-cloud_versioned_docs/version-19-1/reference/installation/_README.mdx
@@ -2,5 +2,6 @@
 
 The api.html doc in this directory is generated using https://github.com/tmjd/gen-crd-api-reference-docs/tree/kb_v2.
 
-To generate an updated file, run `make build-operator-reference OPERATOR_VERSION=<operator_branch>` using
-the operator_branch that deploys the components that go with the docs version.
+To generate an updated file, change to the root of the docs repository and run
+the appropriate Makefile target. See the `README.md` file for more details on
+how to list available targets and which ones to run.

--- a/calico-enterprise/reference/installation/_README.mdx
+++ b/calico-enterprise/reference/installation/_README.mdx
@@ -2,5 +2,6 @@
 
 The api.html doc in this directory is generated using https://github.com/tmjd/gen-crd-api-reference-docs/tree/kb_v2.
 
-To generate an updated file, run `make build-operator-reference OPERATOR_VERSION=<operator_branch>` using
-the operator_branch that deploys the components that go with the docs version.
+To generate an updated file, change to the root of the docs repository and run
+the appropriate Makefile target. See the `README.md` file for more details on
+how to list available targets and which ones to run.

--- a/calico-enterprise_versioned_docs/version-3.16/reference/installation/_README.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/reference/installation/_README.mdx
@@ -2,5 +2,6 @@
 
 The api.html doc in this directory is generated using https://github.com/tmjd/gen-crd-api-reference-docs/tree/kb_v2.
 
-To generate an updated file, run `make build-operator-reference OPERATOR_VERSION=<operator_branch>` using
-the operator_branch that deploys the components that go with the docs version.
+To generate an updated file, change to the root of the docs repository and run
+the appropriate Makefile target. See the `README.md` file for more details on
+how to list available targets and which ones to run.

--- a/calico-enterprise_versioned_docs/version-3.17/reference/installation/_README.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/reference/installation/_README.mdx
@@ -2,5 +2,6 @@
 
 The api.html doc in this directory is generated using https://github.com/tmjd/gen-crd-api-reference-docs/tree/kb_v2.
 
-To generate an updated file, run `make build-operator-reference OPERATOR_VERSION=<operator_branch>` using
-the operator_branch that deploys the components that go with the docs version.
+To generate an updated file, change to the root of the docs repository and run
+the appropriate Makefile target. See the `README.md` file for more details on
+how to list available targets and which ones to run.

--- a/calico-enterprise_versioned_docs/version-3.18-2/reference/installation/_README.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/reference/installation/_README.mdx
@@ -2,5 +2,6 @@
 
 The api.html doc in this directory is generated using https://github.com/tmjd/gen-crd-api-reference-docs/tree/kb_v2.
 
-To generate an updated file, run `make build-operator-reference OPERATOR_VERSION=<operator_branch>` using
-the operator_branch that deploys the components that go with the docs version.
+To generate an updated file, change to the root of the docs repository and run
+the appropriate Makefile target. See the `README.md` file for more details on
+how to list available targets and which ones to run.

--- a/calico-enterprise_versioned_docs/version-3.18/reference/installation/_README.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18/reference/installation/_README.mdx
@@ -2,5 +2,6 @@
 
 The api.html doc in this directory is generated using https://github.com/tmjd/gen-crd-api-reference-docs/tree/kb_v2.
 
-To generate an updated file, run `make build-operator-reference OPERATOR_VERSION=<operator_branch>` using
-the operator_branch that deploys the components that go with the docs version.
+To generate an updated file, change to the root of the docs repository and run
+the appropriate Makefile target. See the `README.md` file for more details on
+how to list available targets and which ones to run.

--- a/calico-enterprise_versioned_docs/version-3.19-1/reference/installation/_README.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-1/reference/installation/_README.mdx
@@ -2,5 +2,6 @@
 
 The api.html doc in this directory is generated using https://github.com/tmjd/gen-crd-api-reference-docs/tree/kb_v2.
 
-To generate an updated file, run `make build-operator-reference OPERATOR_VERSION=<operator_branch>` using
-the operator_branch that deploys the components that go with the docs version.
+To generate an updated file, change to the root of the docs repository and run
+the appropriate Makefile target. See the `README.md` file for more details on
+how to list available targets and which ones to run.

--- a/calico/reference/installation/_README.mdx
+++ b/calico/reference/installation/_README.mdx
@@ -2,5 +2,6 @@
 
 The api.html doc in this directory is generated using https://github.com/tmjd/gen-crd-api-reference-docs/tree/kb_v2.
 
-To generate an updated file, run `make build-operator-reference OPERATOR_VERSION=<operator_branch>` using
-the operator_branch that deploys the components that go with the docs version.
+To generate an updated file, change to the root of the docs repository and run
+the appropriate Makefile target. See the `README.md` file for more details on
+how to list available targets and which ones to run.

--- a/calico_versioned_docs/version-3.25/reference/installation/_README.mdx
+++ b/calico_versioned_docs/version-3.25/reference/installation/_README.mdx
@@ -2,5 +2,6 @@
 
 The api.html doc in this directory is generated using https://github.com/tmjd/gen-crd-api-reference-docs/tree/kb_v2.
 
-To generate an updated file, run `make build-operator-reference OPERATOR_VERSION=<operator_branch>` using
-the operator_branch that deploys the components that go with the docs version.
+To generate an updated file, change to the root of the docs repository and run
+the appropriate Makefile target. See the `README.md` file for more details on
+how to list available targets and which ones to run.

--- a/calico_versioned_docs/version-3.26/reference/installation/_README.mdx
+++ b/calico_versioned_docs/version-3.26/reference/installation/_README.mdx
@@ -2,5 +2,6 @@
 
 The api.html doc in this directory is generated using https://github.com/tmjd/gen-crd-api-reference-docs/tree/kb_v2.
 
-To generate an updated file, run `make build-operator-reference OPERATOR_VERSION=<operator_branch>` using
-the operator_branch that deploys the components that go with the docs version.
+To generate an updated file, change to the root of the docs repository and run
+the appropriate Makefile target. See the `README.md` file for more details on
+how to list available targets and which ones to run.

--- a/calico_versioned_docs/version-3.27/reference/installation/_README.mdx
+++ b/calico_versioned_docs/version-3.27/reference/installation/_README.mdx
@@ -2,5 +2,6 @@
 
 The api.html doc in this directory is generated using https://github.com/tmjd/gen-crd-api-reference-docs/tree/kb_v2.
 
-To generate an updated file, run `make build-operator-reference OPERATOR_VERSION=<operator_branch>` using
-the operator_branch that deploys the components that go with the docs version.
+To generate an updated file, change to the root of the docs repository and run
+the appropriate Makefile target. See the `README.md` file for more details on
+how to list available targets and which ones to run.


### PR DESCRIPTION
Add documentation for Makefile to Makefile; add documentation for operator reference updates to README.md
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> -->

Product Version(s): N/A
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue: N/A
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview: N/A
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:

This PR adds two sets of documentation; one, a large comment block at the top of Makefile,
includes a list of the most interesting/relevant Makefile targets for docs building and
for udpating the Operator reference for docs. The second is a small list of the most
interesting targets for updating the Operator reference, and how to use them.

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->
