### PR TITLE
Enterprise: Drop prometheus operator patch and pull secret

### DIFF
--- a/calico-enterprise/_includes/components/InstallAKS.js
+++ b/calico-enterprise/_includes/components/InstallAKS.js
@@ -45,17 +45,6 @@ export default function InstallAKS(props) {
     --type=kubernetes.io/dockerconfigjson -n tigera-operator \\
     --from-file=.dockerconfigjson=<path/to/pull/secret>`}
           </CodeBlock>
-          <p>
-            For the Prometheus operator, create the pull secret in the <code>tigera-prometheus</code> namespace and then
-            patch the deployment.
-          </p>
-          <CodeBlock>
-            {`kubectl create secret generic tigera-pull-secret \\
-    --type=kubernetes.io/dockerconfigjson -n tigera-prometheus \\
-    --from-file=.dockerconfigjson=<path/to/pull/secret>
-kubectl patch deployment -n tigera-prometheus calico-prometheus-operator \\
-    -p '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name": "tigera-pull-secret"}]}}}}'`}
-          </CodeBlock>
         </li>
         <li>
           <p>
@@ -165,17 +154,6 @@ spec:
             {`kubectl create secret generic tigera-pull-secret \\
     --type=kubernetes.io/dockerconfigjson -n tigera-operator \\
     --from-file=.dockerconfigjson=<path/to/pull/secret>`}
-          </CodeBlock>
-          <p>
-            For the Prometheus operator, create the pull secret in the <code>tigera-prometheus</code> namespace and then
-            patch the deployment.
-          </p>
-          <CodeBlock>
-            {`kubectl create secret generic tigera-pull-secret \\
-    --type=kubernetes.io/dockerconfigjson -n tigera-prometheus \\
-    --from-file=.dockerconfigjson=<path/to/pull/secret>
-kubectl patch deployment -n tigera-prometheus calico-prometheus-operator \\
-    -p '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name": "tigera-pull-secret"}]}}}}'`}
           </CodeBlock>
         </li>
         <li>

--- a/calico-enterprise/_includes/components/InstallEKS.js
+++ b/calico-enterprise/_includes/components/InstallEKS.js
@@ -47,17 +47,6 @@ export default function InstallEKS(props) {
     --type=kubernetes.io/dockerconfigjson -n tigera-operator \\
     --from-file=.dockerconfigjson=<path/to/pull/secret>`}
           </CodeBlock>
-          <p>
-            For the Prometheus operator, create the pull secret in the <code>tigera-prometheus</code> namespace and then
-            patch the deployment.
-          </p>
-          <CodeBlock>
-            {`kubectl create secret generic tigera-pull-secret \\
-    --type=kubernetes.io/dockerconfigjson -n tigera-prometheus \\
-    --from-file=.dockerconfigjson=<path/to/pull/secret>
-kubectl patch deployment -n tigera-prometheus calico-prometheus-operator \\
-    -p '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name": "tigera-pull-secret"}]}}}}'`}
-          </CodeBlock>
         </li>
         <li>
           <p>
@@ -216,17 +205,6 @@ spec:
             {`kubectl create secret generic tigera-pull-secret \\
     --type=kubernetes.io/dockerconfigjson -n tigera-operator \\
     --from-file=.dockerconfigjson=<path/to/pull/secret>`}
-          </CodeBlock>
-          <p>
-            For the Prometheus operator, create the pull secret in the <code>tigera-prometheus</code> namespace and then
-            patch the deployment.
-          </p>
-          <CodeBlock>
-            {`kubectl create secret generic tigera-pull-secret \\
-    --type=kubernetes.io/dockerconfigjson -n tigera-prometheus \\
-    --from-file=.dockerconfigjson=<path/to/pull/secret>
-kubectl patch deployment -n tigera-prometheus calico-prometheus-operator \\
-    -p '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name": "tigera-pull-secret"}]}}}}'`}
           </CodeBlock>
         </li>
         <li>

--- a/calico-enterprise/_includes/components/InstallGKE.js
+++ b/calico-enterprise/_includes/components/InstallGKE.js
@@ -46,17 +46,6 @@ export default function InstallGKE(props) {
     --type=kubernetes.io/dockerconfigjson -n tigera-operator \\
     --from-file=.dockerconfigjson=<path/to/pull/secret>`}
           </CodeBlock>
-          <p>
-            For the Prometheus operator, create the pull secret in the <code>tigera-prometheus</code> namespace and then
-            patch the deployment.
-          </p>
-          <CodeBlock>
-            {`kubectl create secret generic tigera-pull-secret \\
-    --type=kubernetes.io/dockerconfigjson -n tigera-prometheus \\
-    --from-file=.dockerconfigjson=<path/to/pull/secret>
-kubectl patch deployment -n tigera-prometheus calico-prometheus-operator \\
-    -p '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name": "tigera-pull-secret"}]}}}}'`}
-          </CodeBlock>
         </li>
         <li>
           <p>

--- a/calico-enterprise/_includes/components/InstallGeneric.js
+++ b/calico-enterprise/_includes/components/InstallGeneric.js
@@ -51,17 +51,6 @@ export default function InstallGeneric(props) {
   --type=kubernetes.io/dockerconfigjson -n tigera-operator \\
   --from-file=.dockerconfigjson=<path/to/pull/secret>`}
           </CodeBlock>
-          <p>
-            For the Prometheus operator, create the pull secret in the <code>tigera-prometheus</code> namespace and then
-            patch the deployment.
-          </p>
-          <CodeBlock>
-            {`kubectl create secret generic tigera-pull-secret \\
-  --type=kubernetes.io/dockerconfigjson -n tigera-prometheus \\
-  --from-file=.dockerconfigjson=<path/to/pull/secret>
-kubectl patch deployment -n tigera-prometheus calico-prometheus-operator \\
-  -p '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name": "tigera-pull-secret"}]}}}}'`}
-          </CodeBlock>
         </li>
         <li>
           (Optional) If your cluster architecture requires any custom{' '}

--- a/calico-enterprise/_includes/components/OpenShiftPrometheusOperator.js
+++ b/calico-enterprise/_includes/components/OpenShiftPrometheusOperator.js
@@ -23,14 +23,6 @@ export default function OpenShiftPrometheusOperator(props) {
         {props.operation === 'install'
             ? <CodeBlock language='bash'>oc create -f {filesUrl}/manifests/ocp/tigera-prometheus-operator.yaml</CodeBlock>
             : <CodeBlock language='bash'>oc apply -f {filesUrl}/manifests/ocp/tigera-prometheus-operator.yaml</CodeBlock>}
-      <p>
-        Create the pull secret in the <code>tigera-prometheus</code> namespace and then patch the Prometheus operator
-        deployment. Use the image pull secret provided to you by Tigera support representative.
-      </p>
-      <CodeBlock language='bash'>
-        {`${notOSCodeBlock}oc patch deployment -n tigera-prometheus calico-prometheus-operator \\
-    -p '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name": "tigera-pull-secret"}]}}}}'`}
-      </CodeBlock>
     </>
   );
 }

--- a/calico-enterprise/_includes/components/UpgradeOperatorSimple.js
+++ b/calico-enterprise/_includes/components/UpgradeOperatorSimple.js
@@ -100,17 +100,6 @@ export default function UpgradeOperatorSimple(props) {
   } \\
   --from-file=.dockerconfigjson=<path/to/pull/secret>`}
             </CodeBlock>
-            <p>
-              For the Prometheus operator, create the pull secret in the <code>tigera-prometheus</code> namespace and
-              then patch the deployment.
-            </p>
-            <CodeBlock>
-              {`kubectl create secret generic tigera-pull-secret \\
-    --type=kubernetes.io/dockerconfigjson -n tigera-prometheus \\
-    --from-file=.dockerconfigjson=<path/to/pull/secret>
-kubectl patch deployment -n tigera-prometheus calico-prometheus-operator \\
-    -p '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name": "tigera-pull-secret"}]}}}}'`}
-            </CodeBlock>
           </li>
         </When>
 

--- a/calico-enterprise/getting-started/install-on-clusters/docker-enterprise.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/docker-enterprise.mdx
@@ -84,16 +84,6 @@ The geeky details of what you get:
        --from-file=.dockerconfigjson=<path/to/pull/secret>
    ```
 
-   For the Prometheus operator, create the pull secret in the `tigera-prometheus` namespace and then patch the deployment.
-
-   ```bash
-   kubectl create secret generic tigera-pull-secret \
-       --type=kubernetes.io/dockerconfigjson -n tigera-prometheus \
-       --from-file=.dockerconfigjson=<path/to/pull/secret>
-   kubectl patch deployment -n tigera-prometheus calico-prometheus-operator \
-       -p '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name": "tigera-pull-secret"}]}}}}'
-   ```
-
 1. Install any extra [{{prodname}} resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
 1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).

--- a/calico-enterprise/getting-started/install-on-clusters/kubernetes/quickstart.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/kubernetes/quickstart.mdx
@@ -115,16 +115,6 @@ A Linux host that meets the following requirements.
        --from-file=.dockerconfigjson=<path/to/pull/secret>
    ```
 
-   For the Prometheus operator, create the pull secret in the `tigera-prometheus` namespace and then patch the deployment.
-
-   ```bash
-   kubectl create secret generic tigera-pull-secret \
-       --type=kubernetes.io/dockerconfigjson -n tigera-prometheus \
-       --from-file=.dockerconfigjson=<path/to/pull/secret>
-   kubectl patch deployment -n tigera-prometheus calico-prometheus-operator \
-       -p '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name": "tigera-pull-secret"}]}}}}'
-   ```
-
 1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
 
    ```bash

--- a/calico-enterprise/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/rancher.mdx
@@ -83,16 +83,6 @@ The geeky details of what you get:
        --from-file=.dockerconfigjson=<path/to/pull/secret>
    ```
 
-   For the Prometheus operator, create the pull secret in the `tigera-prometheus` namespace and then patch the deployment.
-
-   ```bash
-   kubectl create secret generic tigera-pull-secret \
-       --type=kubernetes.io/dockerconfigjson -n tigera-prometheus \
-       --from-file=.dockerconfigjson=<path/to/pull/secret>
-   kubectl patch deployment -n tigera-prometheus calico-prometheus-operator \
-       -p '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name": "tigera-pull-secret"}]}}}}'
-   ```
-
 1. Install any extra [{{prodname}} resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
 1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).

--- a/calico-enterprise/getting-started/install-on-clusters/rke2.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/rke2.mdx
@@ -80,16 +80,6 @@ The geeky details of what you get:
        --from-file=.dockerconfigjson=<path/to/pull/secret>
    ```
 
-   For the Prometheus operator, create the pull secret in the `tigera-prometheus` namespace and then patch the deployment.
-
-   ```bash
-   kubectl create secret generic tigera-pull-secret \
-       --type=kubernetes.io/dockerconfigjson -n tigera-prometheus \
-       --from-file=.dockerconfigjson=<path/to/pull/secret>
-   kubectl patch deployment -n tigera-prometheus calico-prometheus-operator \
-       -p '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name": "tigera-pull-secret"}]}}}}'
-   ```
-
 1. Install any extra [Calico resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
 1. Install the Tigera custom resources. For more information on configuration options available, see [the installation reference](../../reference/installation/api.mdx).


### PR DESCRIPTION
With https://github.com/tigera/calico-private/pull/7403 we can stop patching the prometheus operator deployment and the creation of the tigera-prometheus pull secret is already created by the operator so it can be removed too.

In Calico Cloud we have been depending on this behavior (for quite a while) of the operator creating the pull secret in the tigera-prometheus namespace and it has worked quite well. Generally that pull secret is only needed for the prometheus-service image (not part of the prometheus operator deployment) but even if using private images (like in testing) the operator creates the pull secret as soon as the tigera-prometheus namespace is created and prometheus CRDs so it will be present so even if it is needed for the prometheus-operator the pull secret will be there.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
Calico Enterprise

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->