### PR TITLE
Update note on network disruption by enabling BPF.

### DIFF
--- a/calico-cloud/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-cloud/operations/ebpf/enabling-ebpf.mdx
@@ -236,8 +236,7 @@ not be disrupted, but they do not benefit from eBPF mode’s advantages.
 :::note
 
 the operator rolls out the change with a rolling update which means that some nodes will be in eBPF mode
-before others. This can disrupt the flow of traffic through node ports. We plan to improve this in an upcoming release
-by having the operator do the update in two phases.
+before others. This can disrupt the flow of traffic through node ports.
 
 :::
 

--- a/calico-enterprise/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise/operations/ebpf/enabling-ebpf.mdx
@@ -192,8 +192,7 @@ not be disrupted, but they do not benefit from eBPF mode’s advantages.
 :::note
 
 the operator rolls out the change with a rolling update which means that some nodes will be in eBPF mode
-before others. This can disrupt the flow of traffic through node ports. We plan to improve this in an upcoming release
-by having the operator do the update in two phases.
+before others. This can disrupt the flow of traffic through node ports.
 
 :::
 

--- a/calico/operations/ebpf/enabling-ebpf.mdx
+++ b/calico/operations/ebpf/enabling-ebpf.mdx
@@ -324,8 +324,7 @@ To enable eBPF mode, change the `spec.calicoNetwork.linuxDataplane` parameter in
 :::note
 
 the operator rolls out the change with a rolling update which means that some nodes will be in eBPF mode
-before others. This can disrupt the flow of traffic through node ports. We plan to improve this in an upcoming release
-by having the operator do the update in two phases.
+before others. This can disrupt the flow of traffic through node ports.
 
 :::
 


### PR DESCRIPTION
With the operator improvement on enabling eBPF in two phases, we will see less disruptive traffic but we cannot guarantee there’s no disruption at all. However, we probably can remove the last sentence of the note. 
```
We plan to improve this in an upcoming release by having the operator do the update in two phases.
```


<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->