### PR TITLE
Fixes empty breadcrumbs item for use cases

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -483,6 +483,13 @@ const config = {
         id: 'use-cases',
         path: 'use-cases',
         routeBasePath: 'use-cases',
+        editCurrentVersion: true,
+        onlyIncludeVersions: ['current'],
+        versions: {
+          current:{
+            path: '/',
+          },
+        },
         //To see builds for unreleased versions, remove comments in the next line.
         sidebarPath: require.resolve('./sidebars-use-cases.js'),
         editUrl: generateEditUrl,

--- a/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -5,7 +5,7 @@ import { useProductId } from '../../utils/useProductId';
 export default function DocsVersionDropdownNavbarItemWrapper(props) {
   const productId = useProductId();
 
-  if (!productId || productId === 'calico-cloud') {
+  if (!productId || productId === 'calico-cloud' || productId === 'use-cases') {
     return null;
   }
 

--- a/src/theme/NavbarItem/DropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DropdownNavbarItem.js
@@ -10,7 +10,7 @@ function useDropdownLabel(props) {
     return props.label;
   }
 
-  return getProductNameById(productId) || props.label;
+  return productId === 'use-cases' ? props.label : getProductNameById(productId) || props.label;
 }
 
 export default function DropdownNavbarItemWrapper(props) {

--- a/src/utils/getProductNameById.js
+++ b/src/utils/getProductNameById.js
@@ -6,5 +6,8 @@ export function getProductNameById(productId) {
       return 'Calico Cloud';
     case 'calico-enterprise':
       return 'Calico Enterprise';
+    case 'use-cases':
+      return 'All products';
+      o;
   }
 }

--- a/src/utils/useProductId.js
+++ b/src/utils/useProductId.js
@@ -5,11 +5,11 @@ export function useProductId() {
 
   if (pathname.startsWith('/calico/') || pathname === '/calico') {
     return 'calico';
-  } else if (pathname.startsWith('/calico-cloud/') || pathname ===
-    '/calico-cloud') {
+  } else if (pathname.startsWith('/calico-cloud/') || pathname === '/calico-cloud') {
     return 'calico-cloud';
-  } else if (pathname.startsWith('/calico-enterprise/') || pathname ===
-    '/calico-enterprise') {
+  } else if (pathname.startsWith('/calico-enterprise/') || pathname === '/calico-enterprise') {
     return 'calico-enterprise';
+  } else if (pathname.startsWith('/use-cases/') || pathname === '/use-cases') {
+    return 'use-cases';
   }
 }


### PR DESCRIPTION
### Before: 
![image](https://github.com/tigera/docs/assets/39195715/e5a0030b-2897-492d-8ab5-a793797cc03f)
### After:
![image](https://github.com/tigera/docs/assets/39195715/ed0d3526-eec2-485c-868c-a42c9e5126a7)

The breadcrumbs on our use cases pages had an empty section. We swizzled the breadcrumbs component and others to do with doc navbars and version navbars. Adding the use cases plugin broke these because the customizations assumed on the the three products.
