### PR TITLE
DOCS-2206: Changes menu cascade for client credentials

### DIFF
--- a/calico-cloud/get-started/connect/install-automated.mdx
+++ b/calico-cloud/get-started/connect/install-automated.mdx
@@ -21,11 +21,11 @@ Using these credentials with standard kubectl and Helm installations lets you fu
 
 You can create client credentials and generate a Kubernetes secret to use for automated installations.
 
-1. Select the user icon <IconUser width="20"/> > **Client Credentials**, and then click **Add Client Credentials**.
-1. Click the `Add Client Credentials` button
+1. Select the user icon <IconUser width="20"/>** > Settings**.
+1. Under the **Client Credentials** tab, click **Add Client Credential**
 1. In the **Add Client Credential** dialog, enter a name and click **Create**.
-   Your new client credentials will appear in the list on the **Manage Client Credentials** page.
-1. Locate the newly created client credentials in the list and select **Action** > **Manage keys** > **Add Key**
+   Your new client credential will appear in the list on the **Manage Client Credentials** page.
+1. Locate the newly created client credential in the list and select **Action** > **Manage keys** > **Add Key**
 1. Enter a name, choose how long the key will be valid, and click **Create key**.
 1. Click **Download** to download the `<my-key-name>.yaml` secret file and store it in a secure location.
    You will not be able to retrieve this secret again.
@@ -53,14 +53,14 @@ These commands can be added to any automated workflow.
 
 1. Apply the Calico Cloud installer manifests to your cluster.
 
-   <Tabs>
-   <TabItem value="kubectl" label="kubectl">
+<Tabs>
+<TabItem value="kubectl" label="kubectl">
 
-   ```bash
-   kubectl apply -f https://installer.calicocloud.io/manifests/cc-operator/latest/deploy.yaml
-   ```
+  ```bash
+  kubectl apply -f https://installer.calicocloud.io/manifests/cc-operator/latest/deploy.yaml
+  ```
 
-  </TabItem>
+</TabItem>
   <TabItem value="helm" label="Helm">
 
   ```bash
@@ -70,7 +70,7 @@ These commands can be added to any automated workflow.
   --create-namespace
   ```
 
-  </TabItem>
+</TabItem>
   </Tabs>
 
 1. Apply the client credentials secret to your cluster.
@@ -78,39 +78,39 @@ These commands can be added to any automated workflow.
 
    ```bash
    kubectl apply -f <my-key-name.yaml>
-   ```
+  ```
 
-1. Configure and apply the Calico Cloud installer CR.
+  1. Configure and apply the Calico Cloud installer CR.
 
-   <Tabs>
-   <TabItem value="kubectl" label="kubectl">
+  <Tabs>
+    <TabItem value="kubectl" label="kubectl">
 
-   ```shell
-   kubectl apply -f - <<EOF
-   apiVersion: operator.calicocloud.io/v1
-   kind: Installer
-   metadata:
-   name: default
-   namespace: calico-cloud
-   spec:
-     # clusterName is the unique name this cluster will have in Calico Cloud
-     clusterName: my-cluster
-     # calicoCloudVersion is the version to install
-     calicoCloudVersion: v19.1.0
-   EOF
-   ```
+      ```shell
+      kubectl apply -f - <<EOF
+      apiVersion: operator.calicocloud.io/v1
+      kind: Installer
+      metadata:
+      name: default
+      namespace: calico-cloud
+      spec:
+      # clusterName is the unique name this cluster will have in Calico Cloud
+      clusterName: my-cluster
+      # calicoCloudVersion is the version to install
+      calicoCloudVersion: v19.1.0
+      EOF
+      ```
 
-   </TabItem>
-   <TabItem value="helm" label="Helm">
+    </TabItem>
+    <TabItem value="helm" label="Helm">
 
-   ```shell
-   helm upgrade --install calico-cloud calico-cloud/calico-cloud \
-   --namespace calico-cloud \
-   # installer.clusterName is the unique name this cluster will have in Calico Cloud
-   --set installer.clusterName=my-cluster \
-   # installer.calicoCloudVersion is the version to install
-   --set installer.calicoCloudVersion=v19.1.0
-   ```
+      ```shell
+      helm upgrade --install calico-cloud calico-cloud/calico-cloud \
+      --namespace calico-cloud \
+      # installer.clusterName is the unique name this cluster will have in Calico Cloud
+      --set installer.clusterName=my-cluster \
+      # installer.calicoCloudVersion is the version to install
+      --set installer.calicoCloudVersion=v19.1.0
+      ```
 
-   </TabItem>
-   </Tabs>
+    </TabItem>
+  </Tabs>


### PR DESCRIPTION
Changing a step to reflect a new menu cascade for getting to client credentials.

Direct preview link: https://deploy-preview-1494--calico-docs-preview-next.netlify.app/calico-cloud/next/get-started/connect/install-automated#create-client-credentials

For Calico Cloud 19.3