### PR TITLE
- Fix a missed export word on versioned CC docs

### DIFF
--- a/calico-cloud/image-assurance/install-the-admission-controller.mdx
+++ b/calico-cloud/image-assurance/install-the-admission-controller.mdx
@@ -74,7 +74,7 @@ For example, to configure the Kubernetes API server to send admission requests f
 resources created in any namespace with label key `name`, and label values either `prod` or `staging-test`, set the variables as follows:
 
    ```bash
-   export IN_NAMESPACE_SELECTOR_KEY="name" && IN_NAMESPACE_SELECTOR_VALUES="prod staging-test"
+   export IN_NAMESPACE_SELECTOR_KEY="name" && export IN_NAMESPACE_SELECTOR_VALUES="prod staging-test"
    ```
 Here is the namespace manifest with the staging-test label and name key.
 

--- a/calico-cloud_versioned_docs/version-19-1/image-assurance/install-the-admission-controller.mdx
+++ b/calico-cloud_versioned_docs/version-19-1/image-assurance/install-the-admission-controller.mdx
@@ -74,7 +74,7 @@ For example, to configure the Kubernetes API server to send admission requests f
 resources created in any namespace with label key `name`, and label values either `prod` or `staging-test`, set the variables as follows:
 
    ```bash
-   export IN_NAMESPACE_SELECTOR_KEY="name" && IN_NAMESPACE_SELECTOR_VALUES="prod staging-test"
+   export IN_NAMESPACE_SELECTOR_KEY="name" && export IN_NAMESPACE_SELECTOR_VALUES="prod staging-test"
    ```
 Here is the namespace manifest with the staging-test label and name key.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue: a missed "export" word in one of the command in the admission-controller page that it causes a mistake for user
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->