### PR TITLE
Clarify non-support for VXLAN/IPIP on "OpenStack"

### DIFF
--- a/calico-cloud/networking/configuring/vxlan-ipip.mdx
+++ b/calico-cloud/networking/configuring/vxlan-ipip.mdx
@@ -36,7 +36,7 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 **Not supported**
 
-- OpenStack
+- Calico for OpenStack (i.e. when Calico is used as the Neutron plugin)
 
 **Limitations**
 

--- a/calico-cloud_versioned_docs/version-19-1/networking/configuring/vxlan-ipip.mdx
+++ b/calico-cloud_versioned_docs/version-19-1/networking/configuring/vxlan-ipip.mdx
@@ -36,7 +36,7 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 **Not supported**
 
-- OpenStack
+- Calico for OpenStack (i.e. when Calico is used as the Neutron plugin)
 
 **Limitations**
 

--- a/calico-enterprise/networking/configuring/vxlan-ipip.mdx
+++ b/calico-enterprise/networking/configuring/vxlan-ipip.mdx
@@ -36,7 +36,7 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 **Not supported**
 
-- OpenStack
+- Calico for OpenStack (i.e. when Calico is used as the Neutron plugin)
 
 **Limitations**
 

--- a/calico-enterprise_versioned_docs/version-3.16/networking/configuring/vxlan-ipip.mdx
+++ b/calico-enterprise_versioned_docs/version-3.16/networking/configuring/vxlan-ipip.mdx
@@ -36,7 +36,7 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 **Not supported**
 
-- OpenStack
+- Calico for OpenStack (i.e. when Calico is used as the Neutron plugin)
 
 **Limitations**
 

--- a/calico-enterprise_versioned_docs/version-3.17/networking/configuring/vxlan-ipip.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/networking/configuring/vxlan-ipip.mdx
@@ -36,7 +36,7 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 **Not supported**
 
-- OpenStack
+- Calico for OpenStack (i.e. when Calico is used as the Neutron plugin)
 
 **Limitations**
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/networking/configuring/vxlan-ipip.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/networking/configuring/vxlan-ipip.mdx
@@ -36,7 +36,7 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 **Not supported**
 
-- OpenStack
+- Calico for OpenStack (i.e. when Calico is used as the Neutron plugin)
 
 **Limitations**
 

--- a/calico-enterprise_versioned_docs/version-3.18/networking/configuring/vxlan-ipip.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18/networking/configuring/vxlan-ipip.mdx
@@ -36,7 +36,7 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 **Not supported**
 
-- OpenStack
+- Calico for OpenStack (i.e. when Calico is used as the Neutron plugin)
 
 **Limitations**
 

--- a/calico-enterprise_versioned_docs/version-3.19-1/networking/configuring/vxlan-ipip.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-1/networking/configuring/vxlan-ipip.mdx
@@ -36,7 +36,7 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 **Not supported**
 
-- OpenStack
+- Calico for OpenStack (i.e. when Calico is used as the Neutron plugin)
 
 **Limitations**
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/networking/configuring/vxlan-ipip.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/networking/configuring/vxlan-ipip.mdx
@@ -36,7 +36,7 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 **Not supported**
 
-- OpenStack
+- Calico for OpenStack (i.e. when Calico is used as the Neutron plugin)
 
 **Limitations**
 

--- a/calico/networking/configuring/vxlan-ipip.mdx
+++ b/calico/networking/configuring/vxlan-ipip.mdx
@@ -35,7 +35,7 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 **Not supported**
 
-- OpenStack
+- Calico for OpenStack (i.e. when Calico is used as the Neutron plugin)
 
 **Limitations**
 

--- a/calico_versioned_docs/version-3.26/networking/configuring/vxlan-ipip.mdx
+++ b/calico_versioned_docs/version-3.26/networking/configuring/vxlan-ipip.mdx
@@ -35,7 +35,7 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 **Not supported**
 
-- OpenStack
+- Calico for OpenStack (i.e. when Calico is used as the Neutron plugin)
 
 **Limitations**
 

--- a/calico_versioned_docs/version-3.27/networking/configuring/vxlan-ipip.mdx
+++ b/calico_versioned_docs/version-3.27/networking/configuring/vxlan-ipip.mdx
@@ -35,7 +35,7 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 **Not supported**
 
-- OpenStack
+- Calico for OpenStack (i.e. when Calico is used as the Neutron plugin)
 
 **Limitations**
 

--- a/calico_versioned_docs/version-3.28/networking/configuring/vxlan-ipip.mdx
+++ b/calico_versioned_docs/version-3.28/networking/configuring/vxlan-ipip.mdx
@@ -35,7 +35,7 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 **Not supported**
 
-- OpenStack
+- Calico for OpenStack (i.e. when Calico is used as the Neutron plugin)
 
 **Limitations**
 


### PR DESCRIPTION
As discussed in https://github.com/projectcalico/calico/pull/7009, this non-support refers to when Calico is used as the networking plugin at the OpenStack level, but NOT to when Calico is used as the Kubernetes CNI and Kubernetes is running on OpenStack infrastructure.  This change clarifies that.