### PR TITLE
DOCS-2221: Publishes Calico Enterprise 3.19.1 GA

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.18-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/release-notes/index.mdx
@@ -146,11 +146,11 @@ This release is for previewing and testing purposes only.
 It is not supported for use in production.
 This release includes improvements and bug fixes.
 
-### Calico Enterprise 3.18.1 GA
+### Calico Enterprise 3.18.1 general availability 
 
 January 17, 2024
 
-Calico Enterprise 3.18.1 is now available as a GA release.
+Calico Enterprise 3.18.1 is now generally available.
 
 This release is supported for use in production.
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.18-2/variables.js
@@ -5,7 +5,7 @@ const variables = {
   prodname: 'Calico Enterprise',
   prodnamedash: 'calico-enterprise',
   version: 'v3.18',
-  baseUrl: '/calico-enterprise/latest',
+  baseUrl: '/calico-enterprise/3.18',
   filesUrl: 'https://downloads.tigera.io/ee/v3.18.3',
   tutorialFilesURL: 'https://docs.tigera.io/files',
   tmpScriptsURL: 'https://docs.tigera.io/calico-enterprise/3.18',

--- a/calico-enterprise_versioned_docs/version-3.19-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/release-notes/index.mdx
@@ -103,7 +103,7 @@ This release expands our support to clusters with nodes running ARM64-based arch
 ## Bug fixes
 
 * Updates have been made to the Calico API server to ensure that Calico network policies can be sync with GitOps tools such as ArgoCD.
-
+<!--TODO add bug fixes for GA release-->
 
 ## Known issues
 
@@ -115,6 +115,8 @@ This release expands our support to clusters with nodes running ARM64-based arch
 * Calico panics if kube-proxy or other components are using native `nftables` rules instead of the `iptables-nft` compatibility shim. Until Calico supports native nftables mode, we recommend that you continue to use the iptables-nft compatibility layer for all components. (The compatibility layer was the only option before Kubernetes v1.29 added alpha-level `nftables` support.) Do not run Calico in "legacy" iptables mode on a system that is also using `nftables`. Although this combination does not panic or fail (at least on kernels that support both), the interaction between `iptables` "legacy" mode and `nftables` is confusing: both `iptables` and `nftables` rules can be executed on the same packet, leading to policy verdicts being "overturned".
 * When a tier order is set to the maximum float value (1.7976931348623157e+308), this can cause policy re-ordering in the UI not to work properly. Since the `namespace-isolation` tier has this value by default, policy recommendation users are affected. To workaround this issue edit any tier that has this value for the order. For example: use `kubectl edit tier namespace-isolation` and set the order to `10000`.
 * Linseed deployment needs to be manually restarted after an upgrade. Without a restart, Linseed can't ingest data because it can't authenticate with Elastic.
+ <!--TODO add known issues for GA release-->
+
 
 ## Release details
 
@@ -134,4 +136,18 @@ Calico Enterprise 3.19.0-2.0 is now available as an early preview release.
 This release is for previewing and testing purposes only.
 It is not supported for use in production.
 
+#### Updating
+
 To update an existing installation of Calico Enterprise 3.18, see [Install a patch release](../getting-started/manifest-archive.mdx).
+
+### Calico Enterprise 3.19.1 general availability release
+
+June DD, 2024
+
+Calico Enterprise 3.18.1 is now generally available.
+
+This release is supported for use in production.
+
+#### Updating
+
+To update an existing installation of {{prodname}} 3.18, see [Install a patch release](../getting-started/manifest-archive.mdx).

--- a/calico-enterprise_versioned_docs/version-3.19-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.19-2/releases.json
@@ -1,5 +1,256 @@
 [
   {
+    "title": "v3.19.1",
+    "tigera-operator": {
+      "image": "tigera/operator",
+      "version": "v1.34.0",
+      "registry": "quay.io"
+    },
+    "calico": {
+      "minor_version": "v3.28",
+      "archive_path": "archive"
+    },
+    "components": {
+      "cnx-manager": {
+        "image": "tigera/cnx-manager",
+        "version": "v3.19.1"
+      },
+      "voltron": {
+        "image": "tigera/voltron",
+        "version": "v3.19.1"
+      },
+      "guardian": {
+        "image": "tigera/guardian",
+        "version": "v3.19.1"
+      },
+      "cnx-apiserver": {
+        "image": "tigera/cnx-apiserver",
+        "version": "v3.19.1"
+      },
+      "cnx-queryserver": {
+        "image": "tigera/cnx-queryserver",
+        "version": "v3.19.1"
+      },
+      "cnx-kube-controllers": {
+        "image": "tigera/kube-controllers",
+        "version": "v3.19.1"
+      },
+      "calicoq": {
+        "image": "tigera/calicoq",
+        "version": "v3.19.1"
+      },
+      "typha": {
+        "image": "tigera/typha",
+        "version": "v3.19.1"
+      },
+      "calicoctl": {
+        "image": "tigera/calicoctl",
+        "version": "v3.19.1"
+      },
+      "cnx-node": {
+        "image": "tigera/cnx-node",
+        "version": "v3.19.1"
+      },
+      "cnx-node-windows": {
+        "image": "tigera/cnx-node-windows",
+        "version": "v3.19.1"
+      },
+      "dikastes": {
+        "image": "tigera/dikastes",
+        "version": "v3.19.1"
+      },
+      "dex": {
+        "image": "tigera/dex",
+        "version": "v3.19.1"
+      },
+      "fluentd": {
+        "image": "tigera/fluentd",
+        "version": "v3.19.1"
+      },
+      "fluentd-windows": {
+        "image": "tigera/fluentd-windows",
+        "version": "v3.19.1"
+      },
+      "es-proxy": {
+        "image": "tigera/es-proxy",
+        "version": "v3.19.1"
+      },
+      "eck-kibana": {
+        "version": "7.17.18"
+      },
+      "kibana": {
+        "image": "tigera/kibana",
+        "version": "v3.19.1"
+      },
+      "eck-elasticsearch": {
+        "version": "7.17.18"
+      },
+      "elasticsearch": {
+        "image": "tigera/elasticsearch",
+        "version": "v3.19.1"
+      },
+      "elastic-tsee-installer": {
+        "image": "tigera/intrusion-detection-job-installer",
+        "version": "v3.19.1"
+      },
+      "es-curator": {
+        "image": "tigera/es-curator",
+        "version": "v3.19.1"
+      },
+      "intrusion-detection-controller": {
+        "image": "tigera/intrusion-detection-controller",
+        "version": "v3.19.1"
+      },
+      "compliance-controller": {
+        "image": "tigera/compliance-controller",
+        "version": "v3.19.1"
+      },
+      "compliance-reporter": {
+        "image": "tigera/compliance-reporter",
+        "version": "v3.19.1"
+      },
+      "compliance-snapshotter": {
+        "image": "tigera/compliance-snapshotter",
+        "version": "v3.19.1"
+      },
+      "compliance-server": {
+        "image": "tigera/compliance-server",
+        "version": "v3.19.1"
+      },
+      "compliance-benchmarker": {
+        "image": "tigera/compliance-benchmarker",
+        "version": "v3.19.1"
+      },
+      "ingress-collector": {
+        "image": "tigera/ingress-collector",
+        "version": "v3.19.1"
+      },
+      "l7-collector": {
+        "image": "tigera/l7-collector",
+        "version": "v3.19.1"
+      },
+      "license-agent": {
+        "image": "tigera/license-agent",
+        "version": "v3.19.1"
+      },
+      "tigera-cni": {
+        "image": "tigera/cni",
+        "version": "v3.19.1"
+      },
+      "tigera-cni-windows": {
+        "image": "tigera/cni-windows",
+        "version": "v3.19.1"
+      },
+      "firewall-integration": {
+        "image": "tigera/firewall-integration",
+        "version": "v3.19.1"
+      },
+      "egress-gateway": {
+        "image": "tigera/egress-gateway",
+        "version": "v3.19.1"
+      },
+      "honeypod": {
+        "image": "tigera/honeypod",
+        "version": "v3.19.1"
+      },
+      "honeypod-exp-service": {
+        "image": "tigera/honeypod-exp-service",
+        "version": "v3.19.1"
+      },
+      "honeypod-controller": {
+        "image": "tigera/honeypod-controller",
+        "version": "v3.19.1"
+      },
+      "key-cert-provisioner": {
+        "image": "tigera/key-cert-provisioner",
+        "version": "v3.19.1"
+      },
+      "elasticsearch-metrics": {
+        "image": "tigera/elasticsearch-metrics",
+        "version": "v3.19.1"
+      },
+      "packetcapture": {
+        "image": "tigera/packetcapture",
+        "version": "v3.19.1"
+      },
+      "policy-recommendation": {
+        "image": "tigera/policy-recommendation",
+        "version": "v3.19.1"
+      },
+      "prometheus": {
+        "image": "tigera/prometheus",
+        "version": "v3.19.1"
+      },
+      "coreos-prometheus": {
+        "version": "v2.48.1"
+      },
+      "coreos-prometheus-operator": {
+        "version": "v0.70.0"
+      },
+      "coreos-config-reloader": {
+        "version": "v0.70.0"
+      },
+      "prometheus-operator": {
+        "image": "tigera/prometheus-operator",
+        "version": "v3.19.1"
+      },
+      "prometheus-config-reloader": {
+        "image": "tigera/prometheus-config-reloader",
+        "version": "v3.19.1"
+      },
+      "tigera-prometheus-service": {
+        "image": "tigera/prometheus-service",
+        "version": "v3.19.1"
+      },
+      "es-gateway": {
+        "image": "tigera/es-gateway",
+        "version": "v3.19.1"
+      },
+      "linseed": {
+        "image": "tigera/linseed",
+        "version": "v3.19.1"
+      },
+      "deep-packet-inspection": {
+        "image": "tigera/deep-packet-inspection",
+        "version": "v3.19.1"
+      },
+      "eck-elasticsearch-operator": {
+        "version": "2.6.1"
+      },
+      "elasticsearch-operator": {
+        "image": "tigera/eck-operator",
+        "version": "v3.19.1"
+      },
+      "coreos-alertmanager": {
+        "version": "v0.25.1"
+      },
+      "alertmanager": {
+        "image": "tigera/alertmanager",
+        "version": "v3.19.1"
+      },
+      "envoy": {
+        "image": "tigera/envoy",
+        "version": "v3.19.1"
+      },
+      "envoy-init": {
+        "image": "tigera/envoy-init",
+        "version": "v3.19.1"
+      },
+      "flexvol": {
+        "image": "tigera/pod2daemon-flexvol",
+        "version": "v3.19.1"
+      },
+      "csi": {
+        "image": "tigera/csi",
+        "version": "v3.19.1"
+      },
+      "csi-node-driver-registrar": {
+        "image": "tigera/node-driver-registrar",
+        "version": "v3.19.1"
+      }
+    }
+  },
+  {
     "title": "v3.19.0-2.0",
     "tigera-operator": {
       "image": "tigera/operator",

--- a/calico-enterprise_versioned_docs/version-3.19-2/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.19-2/variables.js
@@ -1,12 +1,12 @@
 const releases = require('./releases.json');
 
 const variables = {
-  releaseTitle: 'v3.19.0-2.0',
+  releaseTitle: 'v3.19.1',
   prodname: 'Calico Enterprise',
   prodnamedash: 'calico-enterprise',
   version: 'v3.19',
-  baseUrl: '/calico-enterprise/3.19',
-  filesUrl: 'https://downloads.tigera.io/ee/v3.19.0-2.0',
+  baseUrl: '/calico-enterprise/latest',
+  filesUrl: 'https://downloads.tigera.io/ee/v3.19.1',
   tutorialFilesURL: 'https://docs.tigera.io/files',
   tmpScriptsURL: 'https://docs.tigera.io/calico-enterprise/3.19',
   windowsScriptsURL: 'https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess',
@@ -16,7 +16,7 @@ const variables = {
   noderunning: 'calico-node',
   rootDirWindows: 'C:\\TigeraCalico',
   registry: 'quay.io/',
-  chart_version_name: 'v3.19.0-2.0-0',
+  chart_version_name: 'v3.19.1-0',
   tigeraOperator: releases[0]['tigera-operator'],
   releases,
   imageNames: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -418,17 +418,12 @@ const config = {
             banner: 'unreleased',
           },
           '3.19-2': {
-            label: '3.19 (early preview)',
+            label: '3.19 (latest)',
             path: '3.19',
-            banner: 'unreleased',
-          },
-          '3.19-1': {
-            label: '3.19 (early preview)',
-            path: '3.19',
-            banner: 'unreleased',
+            banner: 'none',
           },
           '3.18-2': {
-            label: '3.18 (latest)',
+            label: '3.18',
             path: 'latest',
             banner: 'none',
           },

--- a/static/_redirects
+++ b/static/_redirects
@@ -11,7 +11,7 @@
 # Splat rule for 'latest' X.Y to 'latest' URL
 
 /calico/3.28/* /calico/latest/:splat 302
-/calico-enterprise/3.18/* /calico-enterprise/latest/:splat 302
+/calico-enterprise/3.19/* /calico-enterprise/latest/:splat 302
 
 # Calico OSS pages moved
 /calico/:version/about/about-calico /calico/:version/about 301


### PR DESCRIPTION
@rene-dekker @radTuti This PR still needs:
* RN updates (any relevant bug fixes from EP1 to 3.19.1)
* updates to `releases.json` (Tuti's makefile being the best way)