### PR TITLE
Update IA API reference to latest release 1.17.7 and fix api generation

### DIFF
--- a/calico-cloud/reference/installation/_ia-api.mdx
+++ b/calico-cloud/reference/installation/_ia-api.mdx
@@ -7,702 +7,13 @@ Packages:
 </li>
 </ul>
 <h2 id="image-assurance.operator.tigera.io/v1">image-assurance.operator.tigera.io/v1</h2>
+<div>
 <p>
 API Schema definitions for configuring the installation of Image Assurance
 </p>
+</div>
 Resource Types:
-<ul><li>
-<a href="#image-assurance.operator.tigera.io/v1.ImageAssurance">ImageAssurance</a>
-</li><li>
-<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceCentral">ImageAssuranceCentral</a>
-</li></ul>
-<h3 id="image-assurance.operator.tigera.io/v1.ImageAssurance">ImageAssurance</h3>
-<p>
-ImageAssurance is the Schema for the imageassurances API
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-
-<code>apiVersion</code><br/>
-string
-</td>
-<td>
-
-<code>
-image-assurance.operator.tigera.io/v1
-</code>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>kind</code><br/>
-string
-
-</td>
-<td>
-<code>ImageAssurance</code>
-</td>
-</tr>
-<tr>
-<td>
-
-<code>metadata</code><br/>
-<em>
-<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-
-</td>
-<td>
-
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>spec</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceSpec">
-ImageAssuranceSpec
-</a>
-</em>
-
-</td>
-<td>
-
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>criSocketPath</code><br/>
-<em>
-string
-</em>
-
-</td>
-<td>
-
-<p>
-CRISocketPath is the path to the CRI socket on the nodes. Defaults to /run/containerd/containerd.sock.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>containerdVolumeMountPath</code><br/>
-<em>
-string
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-ContainerdVolumeMountPath is the path to the root of containerd file system. Defaults to /var/lib/containerd/.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>clusterScanner</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.ClusterScannerStatusType">
-ClusterScannerStatusType
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-This setting enables or disables the cluster scanner.
-Allowed values are Enabled or Disabled. Defaults to Disabled.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>crawdadDaemonset</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.CrawdadDaemonSet">
-CrawdadDaemonSet
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-CrawdadDaemonSet is the specification of the Crawdad Daemonset.
-</p>
-
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-
-<code>status</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceStatus">
-ImageAssuranceStatus
-</a>
-</em>
-
-</td>
-<td>
-
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="image-assurance.operator.tigera.io/v1.ImageAssuranceCentral">ImageAssuranceCentral</h3>
-<p>
-ImageAssuranceCentral is the Schema for the imageassurancecentrals API.
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-
-<code>apiVersion</code><br/>
-string
-</td>
-<td>
-
-<code>
-image-assurance.operator.tigera.io/v1
-</code>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>kind</code><br/>
-string
-
-</td>
-<td>
-<code>ImageAssuranceCentral</code>
-</td>
-</tr>
-<tr>
-<td>
-
-<code>metadata</code><br/>
-<em>
-<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-
-</td>
-<td>
-
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>spec</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceCentralSpec">
-ImageAssuranceCentralSpec
-</a>
-</em>
-
-</td>
-<td>
-
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>apiProxyURL</code><br/>
-<em>
-string
-</em>
-
-</td>
-<td>
-
-<p>
-APIProxyURL is the url the api proxy should proxy to.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>apiProxyDeployment</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeployment">
-APIProxyDeployment
-</a>
-</em>
-
-</td>
-<td>
-
-<p>
-APIProxyDeployment configures the api proxy Deployment.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>scannerWorkerDeployment</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeployment">
-ScannerWorkerDeployment
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-ScannerWorkerDeployment is the specification of the Scanner Worker Deployment.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>runtimeCleanerDeployment</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeployment">
-RuntimeCleanerDeployment
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-RuntimeCleanerDeployment is the specification of the Runtime Cleaner Deployment.
-</p>
-
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-
-<code>status</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceCentralStatus">
-ImageAssuranceCentralStatus
-</a>
-</em>
-
-</td>
-<td>
-
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="image-assurance.operator.tigera.io/v1.APIProxyDeployment">APIProxyDeployment</h3>
-<p>
-
-(<em>Appears on:</em>
-<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceCentralSpec">ImageAssuranceCentralSpec</a>)
-
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-
-<code>metadata</code><br/>
-<em>
-github.com/tigera/operator/api/v1.Metadata
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the Deployment.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>spec</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeploymentSpec">
-APIProxyDeploymentSpec
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Spec is the specification of the api-proxy Deployment.
-</p>
-<br/>
-<br/>
-<table>
-</table>
-
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="image-assurance.operator.tigera.io/v1.APIProxyDeploymentContainer">APIProxyDeploymentContainer</h3>
-<p>
-
-(<em>Appears on:</em>
-<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeploymentPodSpec">APIProxyDeploymentPodSpec</a>)
-
-</p>
-<p>
-APIProxyDeploymentContainer is a api-proxy Deployment container.
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-
-<code>name</code><br/>
-<em>
-string
-</em>
-
-</td>
-<td>
-
-<p>
-Name is an enum which identifies the api-proxy Deployment container by name.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>resources</code><br/>
-<em>
-<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Resources allows customization of limits and requests for compute resources such as cpu and memory.
-If specified, this overrides the named api-proxy Deployment container&rsquo;s resources.
-If omitted, the api-proxy Deployment will use its default value for this container&rsquo;s resources.
-If used in conjunction with the deprecated ComponentResources, then this value takes precedence.
-</p>
-
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="image-assurance.operator.tigera.io/v1.APIProxyDeploymentPodSpec">APIProxyDeploymentPodSpec</h3>
-<p>
-
-(<em>Appears on:</em>
-<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeploymentPodTemplateSpec">APIProxyDeploymentPodTemplateSpec</a>)
-
-</p>
-<p>
-APIProxyDeploymentPodSpec is the api-proxy Deployment&rsquo;s PodSpec.
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-
-<code>containers</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeploymentContainer">
-[]APIProxyDeploymentContainer
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Containers is a list of api-proxy containers.
-If specified, this overrides the specified api-proxy Deployment containers.
-If omitted, the api-proxy Deployment will use its default values for its containers.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>affinity</code><br/>
-<em>
-<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
-Kubernetes core/v1.Affinity
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Affinity is a group of affinity scheduling rules for the api-proxy pods.
-If specified, this overrides any affinity that may be set on the api-proxy Deployment.
-If omitted, the api-proxy Deployment will use its default value for affinity.
-WARNING: Please note that this field will override the default api-proxy Deployment affinity.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>nodeSelector</code><br/>
-<em>
-map[string]string
-</em>
-
-</td>
-<td>
-
-<p>
-NodeSelector is the api-proxy pod&rsquo;s scheduling constraints.
-If specified, each of the key/value pairs are added to the api-proxy Deployment nodeSelector provided
-the key does not already exist in the object&rsquo;s nodeSelector.
-If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on the api-proxy Deployment
-and each of this field&rsquo;s key/value pairs are added to the api-proxy Deployment nodeSelector provided
-the key does not already exist in the object&rsquo;s nodeSelector.
-If omitted, the api-proxy Deployment will use its default value for nodeSelector.
-WARNING: Please note that this field will modify the default api-proxy Deployment nodeSelector.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>tolerations</code><br/>
-<em>
-<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
-[]Kubernetes core/v1.Toleration
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Tolerations is the api-proxy pod&rsquo;s tolerations.
-If specified, this overrides any tolerations that may be set on the api-proxy Deployment.
-If omitted, the api-proxy Deployment will use its default value for tolerations.
-WARNING: Please note that this field will override the default api-proxy Deployment tolerations.
-</p>
-
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="image-assurance.operator.tigera.io/v1.APIProxyDeploymentPodTemplateSpec">APIProxyDeploymentPodTemplateSpec</h3>
-<p>
-
-(<em>Appears on:</em>
-<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeploymentSpec">APIProxyDeploymentSpec</a>)
-
-</p>
-<p>
-APIProxyDeploymentPodTemplateSpec is the api-proxy Deployment&rsquo;s PodTemplateSpec
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-
-<code>metadata</code><br/>
-<em>
-github.com/tigera/operator/api/v1.Metadata
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
-the pod&rsquo;s metadata.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>spec</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeploymentPodSpec">
-APIProxyDeploymentPodSpec
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Spec is the api-proxy Deployment&rsquo;s PodSpec.
-</p>
-<br/>
-<br/>
-<table>
-</table>
-
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="image-assurance.operator.tigera.io/v1.APIProxyDeploymentSpec">APIProxyDeploymentSpec</h3>
-<p>
-
-(<em>Appears on:</em>
-<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeployment">APIProxyDeployment</a>)
-
-</p>
-<p>
-APIProxyDeploymentSpec defines configuration for the api-proxy Deployment.
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-
-<code>minReadySeconds</code><br/>
-<em>
-int32
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should
-be ready without any of its container crashing, for it to be considered available.
-If specified, this overrides any minReadySeconds value that may be set on the api-proxy Deployment.
-If omitted, the api-proxy Deployment will use its default value for minReadySeconds.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>template</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeploymentPodTemplateSpec">
-APIProxyDeploymentPodTemplateSpec
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Template describes the api-proxy Deployment pod that will be created.
-</p>
-
-</td>
-</tr>
-</tbody>
-</table>
+<ul></ul>
 <h3 id="image-assurance.operator.tigera.io/v1.ClusterScannerStatusType">ClusterScannerStatusType
 (<code>string</code> alias)</h3>
 <p>
@@ -1066,15 +377,26 @@ Template describes the crawdad DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="image-assurance.operator.tigera.io/v1.ImageAssuranceCentralSpec">ImageAssuranceCentralSpec</h3>
+<h3 id="image-assurance.operator.tigera.io/v1.ExcludedNamespace">ExcludedNamespace
+(<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceCentral">ImageAssuranceCentral</a>)
+<a href="#image-assurance.operator.tigera.io/v1.Exclusions">Exclusions</a>)
 
 </p>
 <p>
-ImageAssuranceCentralSpec defines the desired state of ImageAssuranceCentral.
+ExcludedNamespace is a namespace name to be excluded from image scanning.
+</p>
+<h3 id="image-assurance.operator.tigera.io/v1.Exclusions">Exclusions</h3>
+<p>
+
+(<em>Appears on:</em>
+<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceSpec">ImageAssuranceSpec</a>)
+
+</p>
+<p>
+Exclusions specifies the criteria for what to exclude from image scanning.
 </p>
 <table>
 <thead>
@@ -1087,46 +409,10 @@ ImageAssuranceCentralSpec defines the desired state of ImageAssuranceCentral.
 <tr>
 <td>
 
-<code>apiProxyURL</code><br/>
+<code>namespaces</code><br/>
 <em>
-string
-</em>
-
-</td>
-<td>
-
-<p>
-APIProxyURL is the url the api proxy should proxy to.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>apiProxyDeployment</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.APIProxyDeployment">
-APIProxyDeployment
-</a>
-</em>
-
-</td>
-<td>
-
-<p>
-APIProxyDeployment configures the api proxy Deployment.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>scannerWorkerDeployment</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeployment">
-ScannerWorkerDeployment
+<a href="#image-assurance.operator.tigera.io/v1.ExcludedNamespace">
+[]ExcludedNamespace
 </a>
 </em>
 
@@ -1135,42 +421,16 @@ ScannerWorkerDeployment
 
 <em>(Optional)</em>
 <p>
-ScannerWorkerDeployment is the specification of the Scanner Worker Deployment.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>runtimeCleanerDeployment</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeployment">
-RuntimeCleanerDeployment
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-RuntimeCleanerDeployment is the specification of the Runtime Cleaner Deployment.
+Namespaces is an array of namespace names to be excluded from image scanning.
 </p>
 
 </td>
 </tr>
 </tbody>
 </table>
-<h3 id="image-assurance.operator.tigera.io/v1.ImageAssuranceCentralStatus">ImageAssuranceCentralStatus</h3>
+<h3 id="image-assurance.operator.tigera.io/v1.ImageAssurance">ImageAssurance</h3>
 <p>
-
-(<em>Appears on:</em>
-<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceCentral">ImageAssuranceCentral</a>)
-
-</p>
-<p>
-ImageAssuranceCentralStatus defines the observed state of ImageAssuranceCentral.
+ImageAssurance is the Schema for the imageassurances API
 </p>
 <table>
 <thead>
@@ -1183,7 +443,40 @@ ImageAssuranceCentralStatus defines the observed state of ImageAssuranceCentral.
 <tr>
 <td>
 
-<code>state</code><br/>
+<code>metadata</code><br/>
+<em>
+<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+
+</td>
+<td>
+
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+
+</td>
+</tr>
+<tr>
+<td>
+
+<code>spec</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceSpec">
+ImageAssuranceSpec
+</a>
+</em>
+
+</td>
+<td>
+
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>criSocketPath</code><br/>
 <em>
 string
 </em>
@@ -1192,8 +485,107 @@ string
 <td>
 
 <p>
-State provides user-readable status.
+CRISocketPath is the path to the CRI socket on the nodes. Defaults to /run/containerd/containerd.sock.
 </p>
+
+</td>
+</tr>
+<tr>
+<td>
+
+<code>containerdVolumeMountPath</code><br/>
+<em>
+string
+</em>
+
+</td>
+<td>
+
+<em>(Optional)</em>
+<p>
+ContainerdVolumeMountPath is the path to the root of containerd file system. Defaults to /var/lib/containerd/.
+</p>
+
+</td>
+</tr>
+<tr>
+<td>
+
+<code>clusterScanner</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.ClusterScannerStatusType">
+ClusterScannerStatusType
+</a>
+</em>
+
+</td>
+<td>
+
+<em>(Optional)</em>
+<p>
+This setting enables or disables the cluster scanner.
+Allowed values are Enabled or Disabled. Defaults to Disabled.
+</p>
+
+</td>
+</tr>
+<tr>
+<td>
+
+<code>crawdadDaemonset</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.CrawdadDaemonSet">
+CrawdadDaemonSet
+</a>
+</em>
+
+</td>
+<td>
+
+<em>(Optional)</em>
+<p>
+CrawdadDaemonSet is the specification of the Crawdad Daemonset.
+</p>
+
+</td>
+</tr>
+<tr>
+<td>
+
+<code>exclusions</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.Exclusions">
+Exclusions
+</a>
+</em>
+
+</td>
+<td>
+
+<em>(Optional)</em>
+<p>
+Exclusions define the exclusion criteria for image scanning.
+Note: Exclusions are applied to future scans and do not affect past scan results.
+</p>
+
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+
+<code>status</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceStatus">
+ImageAssuranceStatus
+</a>
+</em>
+
+</td>
+<td>
+
 
 </td>
 </tr>
@@ -1293,6 +685,27 @@ CrawdadDaemonSet is the specification of the Crawdad Daemonset.
 
 </td>
 </tr>
+<tr>
+<td>
+
+<code>exclusions</code><br/>
+<em>
+<a href="#image-assurance.operator.tigera.io/v1.Exclusions">
+Exclusions
+</a>
+</em>
+
+</td>
+<td>
+
+<em>(Optional)</em>
+<p>
+Exclusions define the exclusion criteria for image scanning.
+Note: Exclusions are applied to future scans and do not affect past scan results.
+</p>
+
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="image-assurance.operator.tigera.io/v1.ImageAssuranceStatus">ImageAssuranceStatus</h3>
@@ -1305,714 +718,4 @@ CrawdadDaemonSet is the specification of the Crawdad Daemonset.
 <p>
 ImageAssuranceStatus defines the observed state of ImageAssurance
 </p>
-<h3 id="image-assurance.operator.tigera.io/v1.RuntimeCleanerDeployment">RuntimeCleanerDeployment</h3>
-<p>
-
-(<em>Appears on:</em>
-<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceCentralSpec">ImageAssuranceCentralSpec</a>)
-
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-
-<code>metadata</code><br/>
-<em>
-github.com/tigera/operator/api/v1.Metadata
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the Deployment.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>spec</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentSpec">
-RuntimeCleanerDeploymentSpec
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Spec is the specification of the runtime-cleaner Deployment.
-</p>
-<br/>
-<br/>
-<table>
-</table>
-
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentContainer">RuntimeCleanerDeploymentContainer</h3>
-<p>
-
-(<em>Appears on:</em>
-<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentPodSpec">RuntimeCleanerDeploymentPodSpec</a>)
-
-</p>
-<p>
-RuntimeCleanerDeploymentContainer is a runtime-cleaner Deployment container.
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-
-<code>name</code><br/>
-<em>
-string
-</em>
-
-</td>
-<td>
-
-<p>
-Name is an enum which identifies the runtime-cleaner Deployment container by name.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>resources</code><br/>
-<em>
-<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Resources allows customization of limits and requests for compute resources such as cpu and memory.
-If specified, this overrides the named runtime-cleaner Deployment container&rsquo;s resources.
-If omitted, the runtime-cleaner Deployment will use its default value for this container&rsquo;s resources.
-If used in conjunction with the deprecated ComponentResources, then this value takes precedence.
-</p>
-
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentPodSpec">RuntimeCleanerDeploymentPodSpec</h3>
-<p>
-
-(<em>Appears on:</em>
-<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentPodTemplateSpec">RuntimeCleanerDeploymentPodTemplateSpec</a>)
-
-</p>
-<p>
-RuntimeCleanerDeploymentPodSpec is the runtime-cleaner Deployment&rsquo;s PodSpec.
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-
-<code>containers</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentContainer">
-[]RuntimeCleanerDeploymentContainer
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Containers is a list of runtime-cleaner containers.
-If specified, this overrides the specified runtime-cleaner Deployment containers.
-If omitted, the runtime-cleaner Deployment will use its default values for its containers.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>affinity</code><br/>
-<em>
-<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
-Kubernetes core/v1.Affinity
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Affinity is a group of affinity scheduling rules for the runtime-cleaner pods.
-If specified, this overrides any affinity that may be set on the runtime-cleaner Deployment.
-If omitted, the runtime-cleaner Deployment will use its default value for affinity.
-WARNING: Please note that this field will override the default runtime-cleaner Deployment affinity.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>nodeSelector</code><br/>
-<em>
-map[string]string
-</em>
-
-</td>
-<td>
-
-<p>
-NodeSelector is the runtime-cleaner pod&rsquo;s scheduling constraints.
-If specified, each of the key/value pairs are added to the runtime-cleaner Deployment nodeSelector provided
-the key does not already exist in the object&rsquo;s nodeSelector.
-If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on the runtime-cleaner Deployment
-and each of this field&rsquo;s key/value pairs are added to the runtime-cleaner Deployment nodeSelector provided
-the key does not already exist in the object&rsquo;s nodeSelector.
-If omitted, the runtime-cleaner Deployment will use its default value for nodeSelector.
-WARNING: Please note that this field will modify the default runtime-cleaner Deployment nodeSelector.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>tolerations</code><br/>
-<em>
-<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
-[]Kubernetes core/v1.Toleration
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Tolerations is the runtime-cleaner pod&rsquo;s tolerations.
-If specified, this overrides any tolerations that may be set on the runtime-cleaner Deployment.
-If omitted, the runtime-cleaner Deployment will use its default value for tolerations.
-WARNING: Please note that this field will override the default runtime-cleaner Deployment tolerations.
-</p>
-
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentPodTemplateSpec">RuntimeCleanerDeploymentPodTemplateSpec</h3>
-<p>
-
-(<em>Appears on:</em>
-<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentSpec">RuntimeCleanerDeploymentSpec</a>)
-
-</p>
-<p>
-RuntimeCleanerDeploymentPodTemplateSpec is the runtime-cleaner Deployment&rsquo;s PodTemplateSpec
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-
-<code>metadata</code><br/>
-<em>
-github.com/tigera/operator/api/v1.Metadata
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
-the pod&rsquo;s metadata.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>spec</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentPodSpec">
-RuntimeCleanerDeploymentPodSpec
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Spec is the runtime-cleaner Deployment&rsquo;s PodSpec.
-</p>
-<br/>
-<br/>
-<table>
-</table>
-
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentSpec">RuntimeCleanerDeploymentSpec</h3>
-<p>
-
-(<em>Appears on:</em>
-<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeployment">RuntimeCleanerDeployment</a>)
-
-</p>
-<p>
-RuntimeCleanerDeploymentSpec defines configuration for the runtime-cleaner Deployment.
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-
-<code>minReadySeconds</code><br/>
-<em>
-int32
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should
-be ready without any of its container crashing, for it to be considered available.
-If specified, this overrides any minReadySeconds value that may be set on the runtime-cleaner Deployment.
-If omitted, the runtime-cleaner Deployment will use its default value for minReadySeconds.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>template</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.RuntimeCleanerDeploymentPodTemplateSpec">
-RuntimeCleanerDeploymentPodTemplateSpec
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Template describes the runtime-cleaner Deployment pod that will be created.
-</p>
-
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="image-assurance.operator.tigera.io/v1.ScannerWorkerDeployment">ScannerWorkerDeployment</h3>
-<p>
-
-(<em>Appears on:</em>
-<a href="#image-assurance.operator.tigera.io/v1.ImageAssuranceCentralSpec">ImageAssuranceCentralSpec</a>)
-
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-
-<code>metadata</code><br/>
-<em>
-github.com/tigera/operator/api/v1.Metadata
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to the Deployment.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>spec</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentSpec">
-ScannerWorkerDeploymentSpec
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Spec is the specification of the scanner worker Deployment.
-</p>
-<br/>
-<br/>
-<table>
-</table>
-
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentContainer">ScannerWorkerDeploymentContainer</h3>
-<p>
-
-(<em>Appears on:</em>
-<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentPodSpec">ScannerWorkerDeploymentPodSpec</a>)
-
-</p>
-<p>
-ScannerWorkerDeploymentContainer is a scanner worker Deployment container.
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-
-<code>name</code><br/>
-<em>
-string
-</em>
-
-</td>
-<td>
-
-<p>
-Name is an enum which identifies the scanner worker Deployment container by name.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>resources</code><br/>
-<em>
-<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#resourcerequirements-v1-core">
-Kubernetes core/v1.ResourceRequirements
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Resources allows customization of limits and requests for compute resources such as cpu and memory.
-If specified, this overrides the named scanner worker Deployment container&rsquo;s resources.
-If omitted, the scanner worker Deployment will use its default value for this container&rsquo;s resources.
-If used in conjunction with the deprecated ComponentResources, then this value takes precedence.
-</p>
-
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentPodSpec">ScannerWorkerDeploymentPodSpec</h3>
-<p>
-
-(<em>Appears on:</em>
-<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentPodTemplateSpec">ScannerWorkerDeploymentPodTemplateSpec</a>)
-
-</p>
-<p>
-ScannerWorkerDeploymentPodSpec is the scanner worker Deployment&rsquo;s PodSpec.
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-
-<code>containers</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentContainer">
-[]ScannerWorkerDeploymentContainer
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Containers is a list of scanner worker containers.
-If specified, this overrides the specified scanner worker Deployment containers.
-If omitted, the scanner worker Deployment will use its default values for its containers.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>affinity</code><br/>
-<em>
-<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#affinity-v1-core">
-Kubernetes core/v1.Affinity
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Affinity is a group of affinity scheduling rules for the scanner worker pods.
-If specified, this overrides any affinity that may be set on the scanner worker Deployment.
-If omitted, the scanner worker Deployment will use its default value for affinity.
-WARNING: Please note that this field will override the default scanner worker Deployment affinity.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>nodeSelector</code><br/>
-<em>
-map[string]string
-</em>
-
-</td>
-<td>
-
-<p>
-NodeSelector is the scanner worker pod&rsquo;s scheduling constraints.
-If specified, each of the key/value pairs are added to the scanner worker Deployment nodeSelector provided
-the key does not already exist in the object&rsquo;s nodeSelector.
-If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on the scanner worker Deployment
-and each of this field&rsquo;s key/value pairs are added to the scanner worker Deployment nodeSelector provided
-the key does not already exist in the object&rsquo;s nodeSelector.
-If omitted, the scanner worker Deployment will use its default value for nodeSelector.
-WARNING: Please note that this field will modify the default scanner worker Deployment nodeSelector.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>tolerations</code><br/>
-<em>
-<a href="https://v1-21.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#toleration-v1-core">
-[]Kubernetes core/v1.Toleration
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Tolerations is the scanner worker pod&rsquo;s tolerations.
-If specified, this overrides any tolerations that may be set on the scanner worker Deployment.
-If omitted, the scanner worker Deployment will use its default value for tolerations.
-WARNING: Please note that this field will override the default scanner worker Deployment tolerations.
-</p>
-
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentPodTemplateSpec">ScannerWorkerDeploymentPodTemplateSpec</h3>
-<p>
-
-(<em>Appears on:</em>
-<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentSpec">ScannerWorkerDeploymentSpec</a>)
-
-</p>
-<p>
-ScannerWorkerDeploymentPodTemplateSpec is the scanner worker Deployment&rsquo;s PodTemplateSpec
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-
-<code>metadata</code><br/>
-<em>
-github.com/tigera/operator/api/v1.Metadata
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to
-the pod&rsquo;s metadata.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>spec</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentPodSpec">
-ScannerWorkerDeploymentPodSpec
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Spec is the scanner worker Deployment&rsquo;s PodSpec.
-</p>
-<br/>
-<br/>
-<table>
-</table>
-
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentSpec">ScannerWorkerDeploymentSpec</h3>
-<p>
-
-(<em>Appears on:</em>
-<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeployment">ScannerWorkerDeployment</a>)
-
-</p>
-<p>
-ScannerWorkerDeploymentSpec defines configuration for the scanner worker Deployment.
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-
-<code>minReadySeconds</code><br/>
-<em>
-int32
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should
-be ready without any of its container crashing, for it to be considered available.
-If specified, this overrides any minReadySeconds value that may be set on the scanner worker Deployment.
-If omitted, the scanner worker Deployment will use its default value for minReadySeconds.
-</p>
-
-</td>
-</tr>
-<tr>
-<td>
-
-<code>template</code><br/>
-<em>
-<a href="#image-assurance.operator.tigera.io/v1.ScannerWorkerDeploymentPodTemplateSpec">
-ScannerWorkerDeploymentPodTemplateSpec
-</a>
-</em>
-
-</td>
-<td>
-
-<em>(Optional)</em>
-<p>
-Template describes the scanner worker Deployment pod that will be created.
-</p>
-
-</td>
-</tr>
-</tbody>
-</table>
 <hr/>

--- a/calico-cloud/reference/installation/config.json
+++ b/calico-cloud/reference/installation/config.json
@@ -4,7 +4,15 @@
     ],
     "hideTypePatterns": [
         "ParseError$",
-        "List$"
+        "List$",
+        "ImageAssuranceCentral$",
+        "ImageAssuranceCentralSpec$",
+        "ImageAssuranceCentralStatus$",
+        "APIProxyDeployment",
+        "ManagedClusterControllerDeployment",
+        "RuntimeCleanerDeployment",
+        "ScannerWorkerDeployment",
+        "WaiterDeployment"
     ],
     "externalPackages": [
         {

--- a/crd-gen-template/members.tpl
+++ b/crd-gen-template/members.tpl
@@ -1,0 +1,48 @@
+{{ define "members" }}
+
+{{ range .Members }}
+{{ if not (hiddenMember .)}}
+<tr>
+    <td>
+        <code>{{ fieldName . }}</code><br/>
+        <em>
+            {{ if linkForType .Type }}
+                <a href="{{ linkForType .Type}}">
+                    {{ typeDisplayName .Type }}
+                </a>
+            {{ else }}
+                {{ typeDisplayName .Type }}
+            {{ end }}
+        </em>
+    </td>
+    <td>
+        {{ if fieldEmbedded . }}
+            <p>
+                (Members of <code>{{ fieldName . }}</code> are embedded into this type.)
+            </p>
+        {{ end}}
+
+        {{ if isOptionalMember .}}
+            <em>(Optional)</em>
+        {{ end }}
+
+        {{ safe (renderComments .CommentLines) }}
+
+    {{ if and (eq (.Type.Name.Name) "ObjectMeta") }}
+        Refer to the Kubernetes API documentation for the fields of the
+        <code>metadata</code> field.
+    {{ end }}
+
+    {{ if or (eq (fieldName .) "spec") }}
+        <br/>
+        <br/>
+        <table>
+            {{ template "members" .Type }}
+        </table>
+    {{ end }}
+    </td>
+</tr>
+{{ end }}
+{{ end }}
+
+{{ end }}

--- a/crd-gen-template/pkg.tpl
+++ b/crd-gen-template/pkg.tpl
@@ -1,0 +1,44 @@
+{{ define "packages" }}
+
+{{ with .packages}}
+<p>Packages:</p>
+<ul>
+    {{ range . }}
+    <li>
+        <a href="#{{- packageAnchorID . -}}">{{ packageDisplayName . }}</a>
+    </li>
+    {{ end }}
+</ul>
+{{ end}}
+
+{{ range .packages }}
+    <h2 id="{{- packageAnchorID . -}}">
+        {{- packageDisplayName . -}}
+    </h2>
+
+    {{ with (index .GoPackages 0 )}}
+        {{ with .DocComments }}
+        <div>
+            {{ safe (renderComments .) }}
+        </div>
+        {{ end }}
+    {{ end }}
+
+    Resource Types:
+    <ul>
+    {{- range (visibleTypes (sortedTypes .Types)) -}}
+        {{ if isExportedType . -}}
+        <li>
+            <a href="{{ linkForType . }}">{{ typeDisplayName . }}</a>
+        </li>
+        {{- end }}
+    {{- end -}}
+    </ul>
+
+    {{ range (visibleTypes (sortedTypes .Types))}}
+        {{ template "type" .  }}
+    {{ end }}
+    <hr/>
+{{ end }}
+
+{{ end }}

--- a/crd-gen-template/placeholder.go
+++ b/crd-gen-template/placeholder.go
@@ -1,0 +1,2 @@
+// Placeholder file to make Go vendor this directory properly.
+package template

--- a/crd-gen-template/type.tpl
+++ b/crd-gen-template/type.tpl
@@ -1,0 +1,56 @@
+{{ define "type" }}
+
+<h3 id="{{ anchorIDForType . }}">
+    {{- .Name.Name }}
+    {{ if eq .Kind "Alias" }}(<code>{{.Underlying}}</code> alias){{ end -}}
+</h3>
+{{ with (typeReferences .) }}
+    <p>
+        (<em>Appears on:</em>
+        {{- $prev := "" -}}
+        {{- range . -}}
+            {{- if $prev -}}, {{ end -}}
+            {{ $prev = . }}
+            <a href="{{ linkForType . }}">{{ typeDisplayName . }}</a>
+        {{- end -}}
+        )
+    </p>
+{{ end }}
+
+
+    {{ safe (renderComments .CommentLines) }}
+
+{{ if .Members }}
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{ if isExportedType . }}
+        <tr>
+            <td>
+                <code>apiVersion</code><br/>
+                string</td>
+            <td>
+                <code>
+                    {{apiGroup .}}
+                </code>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <code>kind</code><br/>
+                string
+            </td>
+            <td><code>{{.Name.Name}}</code></td>
+        </tr>
+        {{ end }}
+        {{ template "members" .}}
+    </tbody>
+</table>
+{{ end }}
+
+{{ end }}


### PR DESCRIPTION
IA API reference docs are quite out of date, mainly because generating the API docs has been broken.

I've changed the generation logic to not use custom forks anymore, and to use a much newer version of github.com/ahmetb/gen-crd-api-reference-docs The latest one is compatible with the latest go versions, and this new process (well the process outlined in the repo itself) doesn't require modifying the go.mod file.

We now check out the gen repo, build it, check out the ia repo, then run the gen tool in the operator repo.

This commit also omits internal packages from IA using the config.json in this repo. The template is also stored in this repo in the crd-gen-template, so any modifications to the generated code structure can be handled there.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->