### PR TITLE
Introduce helm --reuse-values flag during helm upgrade

### DIFF
--- a/calico-enterprise/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
@@ -115,12 +115,12 @@ These steps differ based on your cluster type. If you are unsure of your cluster
   <CodeBlock language='bash'>
     {'{{version}}' === 'master'
       ? (
-        `helm upgrade calico-enterprise --values=<path-to-values-yaml> tigera-operator-v0.0.tgz \\
+        `helm upgrade calico-enterprise --reuse-values --values=<path-to-values-yaml> tigera-operator-v0.0.tgz \\
   --set-file imagePullSecrets.tigera-pull-secret=<path-to-pull-secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path-to-pull-secret> \\
   --namespace tigera-operator`
       )
       : (
-        `helm upgrade calico-enterprise --values=<path-to-values-yaml> tigera-operator-{{chart_version_name}}.tgz \\
+        `helm upgrade calico-enterprise --reuse-values --values=<path-to-values-yaml> tigera-operator-{{chart_version_name}}.tgz \\
   --set-file imagePullSecrets.tigera-pull-secret=<path-to-pull-secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path-to-pull-secret> \\
   --namespace tigera-operator`
         )


### PR DESCRIPTION
reuse-values helps to retain the existing flag/features in the cluster if not mentioned in the upgrade charts

https://tigera.atlassian.net/browse/EV-4894

![image](https://github.com/tigera/docs/assets/102720382/a1338efc-8292-4855-80e6-66f59fd25ed2)


<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->