### PR TITLE
add id to the code-block for openshift manifests install instruction

### DIFF
--- a/calico-enterprise/_includes/components/InstallOpenShiftManifests.js
+++ b/calico-enterprise/_includes/components/InstallOpenShiftManifests.js
@@ -14,7 +14,7 @@ export default function InstallOpenShiftManifests(props) {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock id='installOCPManifests' language='bash'>
+      <CodeBlock id='data-install-openshift-manifests' language='bash'>
         {`mkdir calico
 wget -qO- ${filesUrl}/manifests/ocp.tgz | tar xvz --strip-components=1 -C calico ${flag1}${flag2}
 cp calico/* manifests/`}

--- a/calico-enterprise/_includes/components/InstallOpenShiftManifests.js
+++ b/calico-enterprise/_includes/components/InstallOpenShiftManifests.js
@@ -14,7 +14,7 @@ export default function InstallOpenShiftManifests(props) {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock language='bash'>
+      <CodeBlock id='installOCPManifests' language='bash'>
         {`mkdir calico
 wget -qO- ${filesUrl}/manifests/ocp.tgz | tar xvz --strip-components=1 -C calico ${flag1}${flag2}
 cp calico/* manifests/`}

--- a/calico-enterprise_versioned_docs/version-3.16/_includes/components/InstallOpenShiftManifests.js
+++ b/calico-enterprise_versioned_docs/version-3.16/_includes/components/InstallOpenShiftManifests.js
@@ -14,7 +14,7 @@ export default function InstallOpenShiftManifests(props) {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock id='installOCPManifests' language='bash'>
+      <CodeBlock id='data-install-openshift-manifests' language='bash'>
         {`mkdir calico
 wget -qO- ${filesUrl}/manifests/ocp.tgz | tar xvz --strip-components=1 -C calico ${flag1}${flag2}
 cp calico/* manifests/`}

--- a/calico-enterprise_versioned_docs/version-3.16/_includes/components/InstallOpenShiftManifests.js
+++ b/calico-enterprise_versioned_docs/version-3.16/_includes/components/InstallOpenShiftManifests.js
@@ -14,7 +14,7 @@ export default function InstallOpenShiftManifests(props) {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock language='bash'>
+      <CodeBlock id='installOCPManifests' language='bash'>
         {`mkdir calico
 wget -qO- ${filesUrl}/manifests/ocp.tgz | tar xvz --strip-components=1 -C calico ${flag1}${flag2}
 cp calico/* manifests/`}

--- a/calico-enterprise_versioned_docs/version-3.17/_includes/components/InstallOpenShiftManifests.js
+++ b/calico-enterprise_versioned_docs/version-3.17/_includes/components/InstallOpenShiftManifests.js
@@ -14,7 +14,7 @@ export default function InstallOpenShiftManifests(props) {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock id='installOCPManifests' language='bash'>
+      <CodeBlock id='data-install-openshift-manifests' language='bash'>
         {`mkdir calico
 wget -qO- ${filesUrl}/manifests/ocp.tgz | tar xvz --strip-components=1 -C calico ${flag1}${flag2}
 cp calico/* manifests/`}

--- a/calico-enterprise_versioned_docs/version-3.17/_includes/components/InstallOpenShiftManifests.js
+++ b/calico-enterprise_versioned_docs/version-3.17/_includes/components/InstallOpenShiftManifests.js
@@ -14,7 +14,7 @@ export default function InstallOpenShiftManifests(props) {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock language='bash'>
+      <CodeBlock id='installOCPManifests' language='bash'>
         {`mkdir calico
 wget -qO- ${filesUrl}/manifests/ocp.tgz | tar xvz --strip-components=1 -C calico ${flag1}${flag2}
 cp calico/* manifests/`}

--- a/calico-enterprise_versioned_docs/version-3.18-2/_includes/components/InstallOpenShiftManifests.js
+++ b/calico-enterprise_versioned_docs/version-3.18-2/_includes/components/InstallOpenShiftManifests.js
@@ -14,7 +14,7 @@ export default function InstallOpenShiftManifests(props) {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock id='installOCPManifests' language='bash'>
+      <CodeBlock id='data-install-openshift-manifests' language='bash'>
         {`mkdir calico
 wget -qO- ${filesUrl}/manifests/ocp.tgz | tar xvz --strip-components=1 -C calico ${flag1}${flag2}
 cp calico/* manifests/`}

--- a/calico-enterprise_versioned_docs/version-3.18-2/_includes/components/InstallOpenShiftManifests.js
+++ b/calico-enterprise_versioned_docs/version-3.18-2/_includes/components/InstallOpenShiftManifests.js
@@ -14,7 +14,7 @@ export default function InstallOpenShiftManifests(props) {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock language='bash'>
+      <CodeBlock id='installOCPManifests' language='bash'>
         {`mkdir calico
 wget -qO- ${filesUrl}/manifests/ocp.tgz | tar xvz --strip-components=1 -C calico ${flag1}${flag2}
 cp calico/* manifests/`}

--- a/calico-enterprise_versioned_docs/version-3.18/_includes/components/InstallOpenShiftManifests.js
+++ b/calico-enterprise_versioned_docs/version-3.18/_includes/components/InstallOpenShiftManifests.js
@@ -14,7 +14,7 @@ export default function InstallOpenShiftManifests(props) {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock id='installOCPManifests' language='bash'>
+      <CodeBlock id='data-install-openshift-manifests' language='bash'>
         {`mkdir calico
 wget -qO- ${filesUrl}/manifests/ocp.tgz | tar xvz --strip-components=1 -C calico ${flag1}${flag2}
 cp calico/* manifests/`}

--- a/calico-enterprise_versioned_docs/version-3.18/_includes/components/InstallOpenShiftManifests.js
+++ b/calico-enterprise_versioned_docs/version-3.18/_includes/components/InstallOpenShiftManifests.js
@@ -14,7 +14,7 @@ export default function InstallOpenShiftManifests(props) {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock language='bash'>
+      <CodeBlock id='installOCPManifests' language='bash'>
         {`mkdir calico
 wget -qO- ${filesUrl}/manifests/ocp.tgz | tar xvz --strip-components=1 -C calico ${flag1}${flag2}
 cp calico/* manifests/`}

--- a/calico-enterprise_versioned_docs/version-3.19-1/_includes/components/InstallOpenShiftManifests.js
+++ b/calico-enterprise_versioned_docs/version-3.19-1/_includes/components/InstallOpenShiftManifests.js
@@ -14,7 +14,7 @@ export default function InstallOpenShiftManifests(props) {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock id='installOCPManifests' language='bash'>
+      <CodeBlock id='data-install-openshift-manifests' language='bash'>
         {`mkdir calico
 wget -qO- ${filesUrl}/manifests/ocp.tgz | tar xvz --strip-components=1 -C calico ${flag1}${flag2}
 cp calico/* manifests/`}

--- a/calico-enterprise_versioned_docs/version-3.19-1/_includes/components/InstallOpenShiftManifests.js
+++ b/calico-enterprise_versioned_docs/version-3.19-1/_includes/components/InstallOpenShiftManifests.js
@@ -14,7 +14,7 @@ export default function InstallOpenShiftManifests(props) {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock language='bash'>
+      <CodeBlock id='installOCPManifests' language='bash'>
         {`mkdir calico
 wget -qO- ${filesUrl}/manifests/ocp.tgz | tar xvz --strip-components=1 -C calico ${flag1}${flag2}
 cp calico/* manifests/`}

--- a/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/InstallOpenShiftManifests.js
+++ b/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/InstallOpenShiftManifests.js
@@ -14,7 +14,7 @@ export default function InstallOpenShiftManifests(props) {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock id='installOCPManifests' language='bash'>
+      <CodeBlock id='data-install-openshift-manifests' language='bash'>
         {`mkdir calico
 wget -qO- ${filesUrl}/manifests/ocp.tgz | tar xvz --strip-components=1 -C calico ${flag1}${flag2}
 cp calico/* manifests/`}

--- a/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/InstallOpenShiftManifests.js
+++ b/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/InstallOpenShiftManifests.js
@@ -14,7 +14,7 @@ export default function InstallOpenShiftManifests(props) {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock language='bash'>
+      <CodeBlock id='installOCPManifests' language='bash'>
         {`mkdir calico
 wget -qO- ${filesUrl}/manifests/ocp.tgz | tar xvz --strip-components=1 -C calico ${flag1}${flag2}
 cp calico/* manifests/`}

--- a/calico/_includes/components/InstallOpenShiftManifests.js
+++ b/calico/_includes/components/InstallOpenShiftManifests.js
@@ -8,7 +8,7 @@ export default function InstallOpenShiftManifests() {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock language='bash'>
+      <CodeBlock id='installOCPManifests' language='bash'>
         {`mkdir calico
 wget -qO- ${calicoReleasesURL}/${releaseTitle}/ocp.tgz | tar xvz --strip-components=1 -C calico
 cp calico/* manifests/`}

--- a/calico/_includes/components/InstallOpenShiftManifests.js
+++ b/calico/_includes/components/InstallOpenShiftManifests.js
@@ -8,7 +8,7 @@ export default function InstallOpenShiftManifests() {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock id='installOCPManifests' language='bash'>
+      <CodeBlock id='data-install-openshift-manifests' language='bash'>
         {`mkdir calico
 wget -qO- ${calicoReleasesURL}/${releaseTitle}/ocp.tgz | tar xvz --strip-components=1 -C calico
 cp calico/* manifests/`}

--- a/calico_versioned_docs/version-3.26/_includes/components/InstallOpenShiftManifests.js
+++ b/calico_versioned_docs/version-3.26/_includes/components/InstallOpenShiftManifests.js
@@ -8,7 +8,7 @@ export default function InstallOpenShiftManifests() {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock language='bash'>
+      <CodeBlock id='installOCPManifests' language='bash'>
         {`mkdir calico
 wget -qO- ${calicoReleasesURL}/${releaseTitle}/ocp.tgz | tar xvz --strip-components=1 -C calico
 cp calico/* manifests/`}

--- a/calico_versioned_docs/version-3.26/_includes/components/InstallOpenShiftManifests.js
+++ b/calico_versioned_docs/version-3.26/_includes/components/InstallOpenShiftManifests.js
@@ -8,7 +8,7 @@ export default function InstallOpenShiftManifests() {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock id='installOCPManifests' language='bash'>
+      <CodeBlock id='data-install-openshift-manifests' language='bash'>
         {`mkdir calico
 wget -qO- ${calicoReleasesURL}/${releaseTitle}/ocp.tgz | tar xvz --strip-components=1 -C calico
 cp calico/* manifests/`}

--- a/calico_versioned_docs/version-3.27/_includes/components/InstallOpenShiftManifests.js
+++ b/calico_versioned_docs/version-3.27/_includes/components/InstallOpenShiftManifests.js
@@ -8,7 +8,7 @@ export default function InstallOpenShiftManifests() {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock language='bash'>
+      <CodeBlock id='installOCPManifests' language='bash'>
         {`mkdir calico
 wget -qO- ${calicoReleasesURL}/${releaseTitle}/ocp.tgz | tar xvz --strip-components=1 -C calico
 cp calico/* manifests/`}

--- a/calico_versioned_docs/version-3.27/_includes/components/InstallOpenShiftManifests.js
+++ b/calico_versioned_docs/version-3.27/_includes/components/InstallOpenShiftManifests.js
@@ -8,7 +8,7 @@ export default function InstallOpenShiftManifests() {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock id='installOCPManifests' language='bash'>
+      <CodeBlock id='data-install-openshift-manifests' language='bash'>
         {`mkdir calico
 wget -qO- ${calicoReleasesURL}/${releaseTitle}/ocp.tgz | tar xvz --strip-components=1 -C calico
 cp calico/* manifests/`}

--- a/calico_versioned_docs/version-3.28/_includes/components/InstallOpenShiftManifests.js
+++ b/calico_versioned_docs/version-3.28/_includes/components/InstallOpenShiftManifests.js
@@ -8,7 +8,7 @@ export default function InstallOpenShiftManifests() {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock language='bash'>
+      <CodeBlock id='installOCPManifests' language='bash'>
         {`mkdir calico
 wget -qO- ${calicoReleasesURL}/${releaseTitle}/ocp.tgz | tar xvz --strip-components=1 -C calico
 cp calico/* manifests/`}

--- a/calico_versioned_docs/version-3.28/_includes/components/InstallOpenShiftManifests.js
+++ b/calico_versioned_docs/version-3.28/_includes/components/InstallOpenShiftManifests.js
@@ -8,7 +8,7 @@ export default function InstallOpenShiftManifests() {
   return (
     <>
       <p>Download the {prodname} manifests for OpenShift and add them to the generated manifests directory:</p>
-      <CodeBlock id='installOCPManifests' language='bash'>
+      <CodeBlock id='data-install-openshift-manifests' language='bash'>
         {`mkdir calico
 wget -qO- ${calicoReleasesURL}/${releaseTitle}/ocp.tgz | tar xvz --strip-components=1 -C calico
 cp calico/* manifests/`}


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
The `code` block for OCP manifests need a uniquely identifiable `attr` in the page for installation automation to work. We used to use the `text` earlier but because of the change in the formatting of the line above the codeblock (adding `<!---`) RegEx does not work and does not successfully search the line in the HTML. This change adds an id to the `code` tag.


Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->