### PR TITLE
DOCS-2252: Edits to compatibility page to maintain only supported versions of CE

### DIFF
--- a/calico-enterprise/getting-started/compatibility.mdx
+++ b/calico-enterprise/getting-started/compatibility.mdx
@@ -6,7 +6,7 @@ description: Lists versions of Calico Enterprise and Kubernetes for each platfor
 
 ## Supported platforms
 
-The following list shows the platforms supported in this release. The tables provide a platform version history, starting with {{prodname}} 3.5. If you need an earlier version, contact Support.
+The following list shows the platforms supported in this release.  If you're working with a version older than these, consult the [documentation archive](https://docs.tigera.io/archive) or contact Support.
 
 - [AKS](#aks)
 - [EKS](#eks)
@@ -161,7 +161,9 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | {{prodname}} version | TKG version | {{prodname}} support                 | Kubernetes versions    |
 | -------------------- | ----------- | ------------------------------------ | ---------------------- |
+| 3.19                 | 2.4         | {{prodname}} CNI with network policy | 1.27                    |
 | 3.18                 | 2.4         | {{prodname}} CNI with network policy | 1.27                   |
+| 3.17                 | 1.6         | {{prodname}} CNI with network policy | 1.23                   |
 | 3.16                 | 1.6         | {{prodname}} CNI with network policy | 1.23                   |
 | 3.15                 | 1.5         | {{prodname}} CNI with network policy | 1.22                   |
 | 3.14                 | 1.5         | {{prodname}} CNI with network policy | 1.21                   |

--- a/calico-enterprise_versioned_docs/version-3.17/getting-started/compatibility.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/getting-started/compatibility.mdx
@@ -6,7 +6,7 @@ description: Lists versions of Calico Enterprise and Kubernetes for each platfor
 
 ## Supported platforms
 
-The following list shows the platforms supported in this release. The tables provide a platform version history, starting with {{prodname}} 3.5. If you need an earlier version, contact Support.
+The following list shows the platforms supported in this release.  If you're working with a version older than these, consult the [documentation archive](https://docs.tigera.io/archive) or contact Support.
 
 - [AKS](#aks)
 - [EKS](#eks)
@@ -31,8 +31,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | {{prodname}} version | {{prodname}} support                                         |
 | ---------------------------- | ------------------------------------------------------------ |
-| 3.14 through current release | - {{prodname}} CNI with network policy<br />- Azure CNI with {{prodname}} network policy |
-| 3.13 through current release | Azure CNI with {{prodname}} network policy                   |
+| 3.15 to current release  | - {{prodname}} CNI with network policy<br />- Azure CNI with {{prodname}} network policy <br />- Azure CNI with {{prodname}} network policy|
 
 ## EKS
 
@@ -40,7 +39,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | {{prodname}} version   | {{prodname}} support                                         |
 | ---------------------- | ------------------------------------------------------------ |
-| 3.5 through current release | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
+| 3.15 to current release  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
 
 ## GKE
 
@@ -48,7 +47,9 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | {{prodname}} version | {{prodname}} support                       |
 | -------------------- | ------------------------------------------ |
-| 3.5 through current release                  | - GKE CNI with {{prodname}} network policy |
+| 3.15 to current release                  | - GKE CNI with {{prodname}} network policy |
+
+
 
 ## kOps on AWS
 
@@ -57,12 +58,6 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | 3.17                 | 1.25 - 1.26                  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
 | 3.16                 | 1.24 - 1.25                  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
 | 3.15                 | 1.23 - 1.25                  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
-| 3.14                 | 1.21 - 1.23                  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
-| 3.13                 | 1.21 - 1.23                  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
-| 3.12                 | 1.21, 1.22                   | - {{prodname}} CNI with network policy<br />- AWS CNI with{{prodname}} network policy |
-| 3.11                 | 1.20, 1.21                   | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
-| 3.10                 | 1.19, 1.20                   | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
-| 3.6 - 3.9            | 1.20                         | - {{prodname}} CNI with network policy<br />- AWS CNI with{{prodname}} network policy |
 
 ## Kubernetes-kubeadm
 
@@ -71,16 +66,6 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | 3.17                 | 1.25 - 1.27                 | {{prodname}} CNI with network policy |
 | 3.16                 | 1.24 - 1.26                 | {{prodname}} CNI with network policy |
 | 3.15                 | 1.23 - 1.25                 | {{prodname}} CNI with network policy |
-| 3.14                 | 1.21 - 1.23                 | {{prodname}} CNI with network policy |
-| 3.13                 | 1.21 - 1.23                 | {{prodname}} CNI with network policy |
-| 3.12                 | 1.20 - 1.23                 | {{prodname}} CNI with network policy |
-| 3.11                 | 1.20 - 1.22                 | {{prodname}} CNI with network policy |
-| 3.10                 | 1.20 - 1.22                 | {{prodname}} CNI with network policy |
-| 3.9                  | 1.19 - 1.21                 | {{prodname}} CNI with network policy |
-| 3.8                  | 1.19 - 1.21                 | {{prodname}} CNI with network policy |
-| 3.7                  | 1.19 - 1.21                 | {{prodname}} CNI with network policy |
-| 3.6                  | 1.18 - 1.20                 | {{prodname}} CNI with network policy |
-| 3.5                  | 1.18 - 1.20                 | {{prodname}} CNI with network policy |
 
 ## MKE
 
@@ -89,16 +74,6 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | 3.17                 | MKE 3.7.1                            | {{prodname}} CNI with network policy | 1.27                |
 | 3.16                 | MKE 3.6                              | {{prodname}} CNI with network policy | 1.24                |
 | 3.15                 | MKE 3.6                              | {{prodname}} CNI with network policy | 1.24                |
-| 3.14                 | MKE 3.5                              | {{prodname}} CNI with network policy | 1.21                |
-| 3.13                 | MKE 3.5                              | {{prodname}} CNI with network policy | 1.21                |
-| 3.12                 | MKE 3.5                              | {{prodname}} CNI with network policy | 1.21                |
-| 3.11                 | MKE 3.5                              | {{prodname}} CNI with network policy | 1.20                |
-| 3.10                 | MKE 3.4                              | {{prodname}} CNI with network policy | 1.20                |
-| 3.9                  | MKE 3.4                              | {{prodname}} CNI with network policy | 1.19                |
-| 3.8                  | MKE 3.4                              | {{prodname}} CNI with network policy | 1.19                |
-| 3.7                  | Docker Enterprise 3.1 with UCP 3.3.5 | {{prodname}} CNI with network policy | 1.19                |
-| 3.6                  | Docker Enterprise 3.1 with UCP 3.3.5 | {{prodname}} CNI with network policy | 1.18                |
-| 3.5                  | Docker Enterprise 3.1 with UCP 3.3.5 | {{prodname}} CNI with network policy | 1.18                |
 
 ## OpenShift
 
@@ -107,16 +82,6 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | 3.17                 | 4.12 - 4.13                       | {{prodname}} CNI with network policy |
 | 3.16                 | 4.10 - 4.12                       | {{prodname}} CNI with network policy |
 | 3.15                 | 4.9 - 4.11                        | {{prodname}} CNI with network policy |
-| 3.14                 | 4.8 - 4.10                        | {{prodname}} CNI with network policy |
-| 3.13                 | 4.8 - 4.10                        | {{prodname}} CNI with network policy |
-| 3.12                 | 4.8, 4.9                          | {{prodname}} CNI with network policy |
-| 3.11                 | 4.8, 4.9                          | {{prodname}} CNI with network policy |
-| 3.10                 | 4.6 and 4.8                       | {{prodname}} CNI with network policy |
-| 3.9                  | 4.6 and 4.8                       | {{prodname}} CNI with network policy |
-| 3.8                  | 4.6, 4.7                          | {{prodname}} CNI with network policy |
-| 3.7                  | 4.6, 4.7                          | {{prodname}} CNI with network policy |
-| 3.6                  | 4.6, 4.7                          | {{prodname}} CNI with network policy |
-| 3.5                  | 4.5 - 4.7                         | {{prodname}} CNI with network policy |
 
 ## RKE
 
@@ -125,16 +90,6 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | 3.17                 | 1.4         | {{prodname}} CNI with network policy | 1.25                |
 | 3.16                 | 1.4         | {{prodname}} CNI with network policy | 1.23                |
 | 3.15                 | 1.3         | {{prodname}} CNI with network policy | 1.23                |
-| 3.14                 | 1.3         | {{prodname}} CNI with network policy | 1.22                |
-| 3.13                 | 1.3         | {{prodname}} CNI with network policy | 1.21                |
-| 3.12                 | 1.3         | {{prodname}} CNI with network policy | 1.21                |
-| 3.11                 | 1.3         | {{prodname}} CNI with network policy | 1.20                |
-| 3.10                 | 1.2         | {{prodname}} CNI with network policy | 1.20                |
-| 3.9                  | 1.2         | {{prodname}} CNI with network policy | 1.19                |
-| 3.8                  | 1.2         | {{prodname}} CNI with network policy | 1.19                |
-| 3.7                  | 1.2         | {{prodname}} CNI with network policy | 1.19                |
-| 3.6                  | 1.2         | {{prodname}} CNI with network policy | 1.18                |
-| 3.5                  | 1.2         | {{prodname}} CNI with network policy | 1.18                |
 
 ## RKE2
 
@@ -143,16 +98,11 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | 3.17                 | {{prodname}} CNI with network policy | 1.25 - 1.26         |
 | 3.16                 | {{prodname}} CNI with network policy | 1.24 - 1.25         |
 | 3.15                 | {{prodname}} CNI with network policy | 1.24                |
-| 3.14                 | {{prodname}} CNI with network policy | 1.22                |
 
 ## TKG
 
 | {{prodname}} version | TKG version | {{prodname}} support                 | Kubernetes versions    |
 | -------------------- | ----------- | ------------------------------------ | ---------------------- |
-| 3.17                 | 1.6         | {{prodname}} CNI with network policy | 1.23                   |
+| 3.17                 | N/A        | {{prodname}} 3.17 does not support TKG | N/A                   |
 | 3.16                 | 1.6         | {{prodname}} CNI with network policy | 1.23                   |
 | 3.15                 | 1.5         | {{prodname}} CNI with network policy | 1.22                   |
-| 3.14                 | 1.5         | {{prodname}} CNI with network policy | 1.21                   |
-| 3.13                 | 1.5         | {{prodname}} CNI with network policy | 1.21                   |
-| 3.12                 | 1.4, 1.5    | {{prodname}} CNI with network policy | 1.20 (1.4), 1.21 (1.5) |
-| 3.11                 | 1.3         | {{prodname}} CNI with network policy | 1.20                   |

--- a/calico-enterprise_versioned_docs/version-3.18-2/getting-started/compatibility.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/getting-started/compatibility.mdx
@@ -6,7 +6,7 @@ description: Lists versions of Calico Enterprise and Kubernetes for each platfor
 
 ## Supported platforms
 
-The following list shows the platforms supported in this release. The tables provide a platform version history, starting with {{prodname}} 3.5. If you need an earlier version, contact Support.
+The following list shows the platforms supported in this release.  If you're working with a version older than these, consult the [documentation archive](https://docs.tigera.io/archive) or contact Support.
 
 - [AKS](#aks)
 - [EKS](#eks)
@@ -31,8 +31,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | {{prodname}} version | {{prodname}} support                                         |
 | ---------------------------- | ------------------------------------------------------------ |
-| 3.14 through current release | - {{prodname}} CNI with network policy<br />- Azure CNI with {{prodname}} network policy |
-| 3.13 through current release | Azure CNI with {{prodname}} network policy                   |
+| 3.16 to current release  | - {{prodname}} CNI with network policy<br />- Azure CNI with {{prodname}} network policy <br />- Azure CNI with {{prodname}} network policy|
 
 ## EKS
 
@@ -40,7 +39,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | {{prodname}} version   | {{prodname}} support                                         |
 | ---------------------- | ------------------------------------------------------------ |
-| 3.5 through current release | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
+| 3.16 to current release  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
 
 ## GKE
 
@@ -48,7 +47,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | {{prodname}} version | {{prodname}} support                       |
 | -------------------- | ------------------------------------------ |
-| 3.5 through current release                  | - GKE CNI with {{prodname}} network policy |
+| 3.16 to current release                  | - GKE CNI with {{prodname}} network policy |
 
 ## kOps on AWS
 
@@ -57,13 +56,6 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | 3.18                 | 1.26 - 1.28                  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
 | 3.17                 | 1.25 - 1.26                  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
 | 3.16                 | 1.24 - 1.25                  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
-| 3.15                 | 1.23 - 1.25                  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
-| 3.14                 | 1.21 - 1.23                  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
-| 3.13                 | 1.21 - 1.23                  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
-| 3.12                 | 1.21, 1.22                   | - {{prodname}} CNI with network policy<br />- AWS CNI with{{prodname}} network policy |
-| 3.11                 | 1.20, 1.21                   | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
-| 3.10                 | 1.19, 1.20                   | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
-| 3.6 - 3.9            | 1.20                         | - {{prodname}} CNI with network policy<br />- AWS CNI with{{prodname}} network policy |
 
 ## Kubernetes-kubeadm
 
@@ -72,17 +64,6 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | 3.18                 | 1.26 - 1.28                 | {{prodname}} CNI with network policy |
 | 3.17                 | 1.25 - 1.27                 | {{prodname}} CNI with network policy |
 | 3.16                 | 1.24 - 1.26                 | {{prodname}} CNI with network policy |
-| 3.15                 | 1.23 - 1.25                 | {{prodname}} CNI with network policy |
-| 3.14                 | 1.21 - 1.23                 | {{prodname}} CNI with network policy |
-| 3.13                 | 1.21 - 1.23                 | {{prodname}} CNI with network policy |
-| 3.12                 | 1.20 - 1.23                 | {{prodname}} CNI with network policy |
-| 3.11                 | 1.20 - 1.22                 | {{prodname}} CNI with network policy |
-| 3.10                 | 1.20 - 1.22                 | {{prodname}} CNI with network policy |
-| 3.9                  | 1.19 - 1.21                 | {{prodname}} CNI with network policy |
-| 3.8                  | 1.19 - 1.21                 | {{prodname}} CNI with network policy |
-| 3.7                  | 1.19 - 1.21                 | {{prodname}} CNI with network policy |
-| 3.6                  | 1.18 - 1.20                 | {{prodname}} CNI with network policy |
-| 3.5                  | 1.18 - 1.20                 | {{prodname}} CNI with network policy |
 
 ## MKE
 
@@ -91,17 +72,6 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | 3.18                 | MKE 3.7.1                            | {{prodname}} CNI with network policy | 1.27                |
 | 3.17                 | MKE 3.7.1                            | {{prodname}} CNI with network policy | 1.27                |
 | 3.16                 | MKE 3.6                              | {{prodname}} CNI with network policy | 1.24                |
-| 3.15                 | MKE 3.6                              | {{prodname}} CNI with network policy | 1.24                |
-| 3.14                 | MKE 3.5                              | {{prodname}} CNI with network policy | 1.21                |
-| 3.13                 | MKE 3.5                              | {{prodname}} CNI with network policy | 1.21                |
-| 3.12                 | MKE 3.5                              | {{prodname}} CNI with network policy | 1.21                |
-| 3.11                 | MKE 3.5                              | {{prodname}} CNI with network policy | 1.20                |
-| 3.10                 | MKE 3.4                              | {{prodname}} CNI with network policy | 1.20                |
-| 3.9                  | MKE 3.4                              | {{prodname}} CNI with network policy | 1.19                |
-| 3.8                  | MKE 3.4                              | {{prodname}} CNI with network policy | 1.19                |
-| 3.7                  | Docker Enterprise 3.1 with UCP 3.3.5 | {{prodname}} CNI with network policy | 1.19                |
-| 3.6                  | Docker Enterprise 3.1 with UCP 3.3.5 | {{prodname}} CNI with network policy | 1.18                |
-| 3.5                  | Docker Enterprise 3.1 with UCP 3.3.5 | {{prodname}} CNI with network policy | 1.18                |
 
 ## OpenShift
 
@@ -110,17 +80,6 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | 3.18                 | 4.12 - 4.14                       | {{prodname}} CNI with network policy |
 | 3.17                 | 4.12 - 4.13                       | {{prodname}} CNI with network policy |
 | 3.16                 | 4.10 - 4.12                       | {{prodname}} CNI with network policy |
-| 3.15                 | 4.9 - 4.11                        | {{prodname}} CNI with network policy |
-| 3.14                 | 4.8 - 4.10                        | {{prodname}} CNI with network policy |
-| 3.13                 | 4.8 - 4.10                        | {{prodname}} CNI with network policy |
-| 3.12                 | 4.8, 4.9                          | {{prodname}} CNI with network policy |
-| 3.11                 | 4.8, 4.9                          | {{prodname}} CNI with network policy |
-| 3.10                 | 4.6 and 4.8                       | {{prodname}} CNI with network policy |
-| 3.9                  | 4.6 and 4.8                       | {{prodname}} CNI with network policy |
-| 3.8                  | 4.6, 4.7                          | {{prodname}} CNI with network policy |
-| 3.7                  | 4.6, 4.7                          | {{prodname}} CNI with network policy |
-| 3.6                  | 4.6, 4.7                          | {{prodname}} CNI with network policy |
-| 3.5                  | 4.5 - 4.7                         | {{prodname}} CNI with network policy |
 
 ## RKE
 
@@ -129,17 +88,6 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | 3.18                 | 1.4         | {{prodname}} CNI with network policy | 1.26                |
 | 3.17                 | 1.4         | {{prodname}} CNI with network policy | 1.25                |
 | 3.16                 | 1.4         | {{prodname}} CNI with network policy | 1.23                |
-| 3.15                 | 1.3         | {{prodname}} CNI with network policy | 1.23                |
-| 3.14                 | 1.3         | {{prodname}} CNI with network policy | 1.22                |
-| 3.13                 | 1.3         | {{prodname}} CNI with network policy | 1.21                |
-| 3.12                 | 1.3         | {{prodname}} CNI with network policy | 1.21                |
-| 3.11                 | 1.3         | {{prodname}} CNI with network policy | 1.20                |
-| 3.10                 | 1.2         | {{prodname}} CNI with network policy | 1.20                |
-| 3.9                  | 1.2         | {{prodname}} CNI with network policy | 1.19                |
-| 3.8                  | 1.2         | {{prodname}} CNI with network policy | 1.19                |
-| 3.7                  | 1.2         | {{prodname}} CNI with network policy | 1.19                |
-| 3.6                  | 1.2         | {{prodname}} CNI with network policy | 1.18                |
-| 3.5                  | 1.2         | {{prodname}} CNI with network policy | 1.18                |
 
 ## RKE2
 
@@ -148,17 +96,11 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | 3.18                 | {{prodname}} CNI with network policy | 1.26 - 1.28         |
 | 3.17                 | {{prodname}} CNI with network policy | 1.25 - 1.26         |
 | 3.16                 | {{prodname}} CNI with network policy | 1.24 - 1.25         |
-| 3.15                 | {{prodname}} CNI with network policy | 1.24                |
-| 3.14                 | {{prodname}} CNI with network policy | 1.22                |
 
 ## TKG
 
 | {{prodname}} version | TKG version | {{prodname}} support                 | Kubernetes versions    |
 | -------------------- | ----------- | ------------------------------------ | ---------------------- |
 | 3.18                 | 2.4         | {{prodname}} CNI with network policy | 1.27                   |
+| 3.17                 | N/A        | {{prodname}} 3.17 does not support TKG | N/A                   |
 | 3.16                 | 1.6         | {{prodname}} CNI with network policy | 1.23                   |
-| 3.15                 | 1.5         | {{prodname}} CNI with network policy | 1.22                   |
-| 3.14                 | 1.5         | {{prodname}} CNI with network policy | 1.21                   |
-| 3.13                 | 1.5         | {{prodname}} CNI with network policy | 1.21                   |
-| 3.12                 | 1.4, 1.5    | {{prodname}} CNI with network policy | 1.20 (1.4), 1.21 (1.5) |
-| 3.11                 | 1.3         | {{prodname}} CNI with network policy | 1.20                   |

--- a/calico-enterprise_versioned_docs/version-3.18/getting-started/compatibility.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18/getting-started/compatibility.mdx
@@ -6,7 +6,7 @@ description: Lists versions of Calico Enterprise and Kubernetes for each platfor
 
 ## Supported platforms
 
-The following list shows the platforms supported in this release. The tables provide a platform version history, starting with {{prodname}} 3.5. If you need an earlier version, contact Support.
+The following list shows the platforms supported in this release.  If you're working with a version older than these, consult the [documentation archive](https://docs.tigera.io/archive) or contact Support.
 
 - [AKS](#aks)
 - [EKS](#eks)

--- a/calico-enterprise_versioned_docs/version-3.19-1/getting-started/compatibility.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-1/getting-started/compatibility.mdx
@@ -6,7 +6,7 @@ description: Lists versions of Calico Enterprise and Kubernetes for each platfor
 
 ## Supported platforms
 
-The following list shows the platforms supported in this release. The tables provide a platform version history, starting with {{prodname}} 3.5. If you need an earlier version, contact Support.
+The following list shows the platforms supported in this release.  If you're working with a version older than these, consult the [documentation archive](https://docs.tigera.io/archive) or contact Support.
 
 - [AKS](#aks)
 - [EKS](#eks)

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/compatibility.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/compatibility.mdx
@@ -6,7 +6,7 @@ description: Lists versions of Calico Enterprise and Kubernetes for each platfor
 
 ## Supported platforms
 
-The following list shows the platforms supported in this release. The tables provide a platform version history, starting with {{prodname}} 3.5. If you need an earlier version, contact Support.
+The following list shows the platforms supported in this release.  If you're working with a version older than these, consult the [documentation archive](https://docs.tigera.io/archive) or contact Support.
 
 - [AKS](#aks)
 - [EKS](#eks)
@@ -31,8 +31,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | {{prodname}} version | {{prodname}} support                                         |
 | ---------------------------- | ------------------------------------------------------------ |
-| 3.14 through current release | - {{prodname}} CNI with network policy<br />- Azure CNI with {{prodname}} network policy |
-| 3.13 through current release | Azure CNI with {{prodname}} network policy                   |
+| 3.17 to current release  | - {{prodname}} CNI with network policy<br />- Azure CNI with {{prodname}} network policy <br />- Azure CNI with {{prodname}} network policy|
 
 ## EKS
 
@@ -40,7 +39,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | {{prodname}} version   | {{prodname}} support                                         |
 | ---------------------- | ------------------------------------------------------------ |
-| 3.5 through current release | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
+| 3.17 to current release  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
 
 ## GKE
 
@@ -48,7 +47,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | {{prodname}} version | {{prodname}} support                       |
 | -------------------- | ------------------------------------------ |
-| 3.5 through current release                  | - GKE CNI with {{prodname}} network policy |
+| 3.17 to current release                  | - GKE CNI with {{prodname}} network policy |
 
 ## kOps on AWS
 
@@ -57,14 +56,6 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | 3.19                 | 1.27 - 1.29                  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
 | 3.18                 | 1.26 - 1.28                  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
 | 3.17                 | 1.25 - 1.26                  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
-| 3.16                 | 1.24 - 1.25                  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
-| 3.15                 | 1.23 - 1.25                  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
-| 3.14                 | 1.21 - 1.23                  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
-| 3.13                 | 1.21 - 1.23                  | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
-| 3.12                 | 1.21, 1.22                   | - {{prodname}} CNI with network policy<br />- AWS CNI with{{prodname}} network policy |
-| 3.11                 | 1.20, 1.21                   | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
-| 3.10                 | 1.19, 1.20                   | - {{prodname}} CNI with network policy<br />- AWS CNI with {{prodname}} network policy |
-| 3.6 - 3.9            | 1.20                         | - {{prodname}} CNI with network policy<br />- AWS CNI with{{prodname}} network policy |
 
 ## Kubernetes-kubeadm
 
@@ -73,18 +64,6 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | 3.19                 | 1.28 - 1.30                 | {{prodname}} CNI with network policy |
 | 3.18                 | 1.26 - 1.28                 | {{prodname}} CNI with network policy |
 | 3.17                 | 1.25 - 1.27                 | {{prodname}} CNI with network policy |
-| 3.16                 | 1.24 - 1.26                 | {{prodname}} CNI with network policy |
-| 3.15                 | 1.23 - 1.25                 | {{prodname}} CNI with network policy |
-| 3.14                 | 1.21 - 1.23                 | {{prodname}} CNI with network policy |
-| 3.13                 | 1.21 - 1.23                 | {{prodname}} CNI with network policy |
-| 3.12                 | 1.20 - 1.23                 | {{prodname}} CNI with network policy |
-| 3.11                 | 1.20 - 1.22                 | {{prodname}} CNI with network policy |
-| 3.10                 | 1.20 - 1.22                 | {{prodname}} CNI with network policy |
-| 3.9                  | 1.19 - 1.21                 | {{prodname}} CNI with network policy |
-| 3.8                  | 1.19 - 1.21                 | {{prodname}} CNI with network policy |
-| 3.7                  | 1.19 - 1.21                 | {{prodname}} CNI with network policy |
-| 3.6                  | 1.18 - 1.20                 | {{prodname}} CNI with network policy |
-| 3.5                  | 1.18 - 1.20                 | {{prodname}} CNI with network policy |
 
 ## MKE
 
@@ -93,18 +72,6 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | 3.19                 | MKE 3.7                              | {{prodname}} CNI with network policy | 1.27                |
 | 3.18                 | MKE 3.7                              | {{prodname}} CNI with network policy | 1.27                |
 | 3.17                 | MKE 3.7                              | {{prodname}} CNI with network policy | 1.27                |
-| 3.16                 | MKE 3.6                              | {{prodname}} CNI with network policy | 1.24                |
-| 3.15                 | MKE 3.6                              | {{prodname}} CNI with network policy | 1.24                |
-| 3.14                 | MKE 3.5                              | {{prodname}} CNI with network policy | 1.21                |
-| 3.13                 | MKE 3.5                              | {{prodname}} CNI with network policy | 1.21                |
-| 3.12                 | MKE 3.5                              | {{prodname}} CNI with network policy | 1.21                |
-| 3.11                 | MKE 3.5                              | {{prodname}} CNI with network policy | 1.20                |
-| 3.10                 | MKE 3.4                              | {{prodname}} CNI with network policy | 1.20                |
-| 3.9                  | MKE 3.4                              | {{prodname}} CNI with network policy | 1.19                |
-| 3.8                  | MKE 3.4                              | {{prodname}} CNI with network policy | 1.19                |
-| 3.7                  | Docker Enterprise 3.1 with UCP 3.3.5 | {{prodname}} CNI with network policy | 1.19                |
-| 3.6                  | Docker Enterprise 3.1 with UCP 3.3.5 | {{prodname}} CNI with network policy | 1.18                |
-| 3.5                  | Docker Enterprise 3.1 with UCP 3.3.5 | {{prodname}} CNI with network policy | 1.18                |
 
 ## OpenShift
 
@@ -113,18 +80,6 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | 3.19                 | 4.14 - 4.15                       | {{prodname}} CNI with network policy |
 | 3.18                 | 4.12 - 4.14                       | {{prodname}} CNI with network policy |
 | 3.17                 | 4.12 - 4.13                       | {{prodname}} CNI with network policy |
-| 3.16                 | 4.10 - 4.12                       | {{prodname}} CNI with network policy |
-| 3.15                 | 4.9 - 4.11                        | {{prodname}} CNI with network policy |
-| 3.14                 | 4.8 - 4.10                        | {{prodname}} CNI with network policy |
-| 3.13                 | 4.8 - 4.10                        | {{prodname}} CNI with network policy |
-| 3.12                 | 4.8, 4.9                          | {{prodname}} CNI with network policy |
-| 3.11                 | 4.8, 4.9                          | {{prodname}} CNI with network policy |
-| 3.10                 | 4.6 and 4.8                       | {{prodname}} CNI with network policy |
-| 3.9                  | 4.6 and 4.8                       | {{prodname}} CNI with network policy |
-| 3.8                  | 4.6, 4.7                          | {{prodname}} CNI with network policy |
-| 3.7                  | 4.6, 4.7                          | {{prodname}} CNI with network policy |
-| 3.6                  | 4.6, 4.7                          | {{prodname}} CNI with network policy |
-| 3.5                  | 4.5 - 4.7                         | {{prodname}} CNI with network policy |
 
 ## RKE
 
@@ -133,18 +88,6 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | 3.19                 | 1.5         | {{prodname}} CNI with network policy | 1.28                |
 | 3.18                 | 1.4         | {{prodname}} CNI with network policy | 1.26                |
 | 3.17                 | 1.4         | {{prodname}} CNI with network policy | 1.25                |
-| 3.16                 | 1.4         | {{prodname}} CNI with network policy | 1.23                |
-| 3.15                 | 1.3         | {{prodname}} CNI with network policy | 1.23                |
-| 3.14                 | 1.3         | {{prodname}} CNI with network policy | 1.22                |
-| 3.13                 | 1.3         | {{prodname}} CNI with network policy | 1.21                |
-| 3.12                 | 1.3         | {{prodname}} CNI with network policy | 1.21                |
-| 3.11                 | 1.3         | {{prodname}} CNI with network policy | 1.20                |
-| 3.10                 | 1.2         | {{prodname}} CNI with network policy | 1.20                |
-| 3.9                  | 1.2         | {{prodname}} CNI with network policy | 1.19                |
-| 3.8                  | 1.2         | {{prodname}} CNI with network policy | 1.19                |
-| 3.7                  | 1.2         | {{prodname}} CNI with network policy | 1.19                |
-| 3.6                  | 1.2         | {{prodname}} CNI with network policy | 1.18                |
-| 3.5                  | 1.2         | {{prodname}} CNI with network policy | 1.18                |
 
 ## RKE2
 
@@ -153,21 +96,14 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | 3.19                 | {{prodname}} CNI with network policy | 1.28 - 1.30         |
 | 3.18                 | {{prodname}} CNI with network policy | 1.26 - 1.28         |
 | 3.17                 | {{prodname}} CNI with network policy | 1.25 - 1.26         |
-| 3.16                 | {{prodname}} CNI with network policy | 1.24 - 1.25         |
-| 3.15                 | {{prodname}} CNI with network policy | 1.24                |
-| 3.14                 | {{prodname}} CNI with network policy | 1.22                |
 
 ## TKG
 
 | {{prodname}} version | TKG version | {{prodname}} support                 | Kubernetes versions    |
 | -------------------- | ----------- | ------------------------------------ | ---------------------- |
+| 3.19                 | 2.4         | {{prodname}} CNI with network policy | 1.27                    |
 | 3.18                 | 2.4         | {{prodname}} CNI with network policy | 1.27                   |
-| 3.16                 | 1.6         | {{prodname}} CNI with network policy | 1.23                   |
-| 3.15                 | 1.5         | {{prodname}} CNI with network policy | 1.22                   |
-| 3.14                 | 1.5         | {{prodname}} CNI with network policy | 1.21                   |
-| 3.13                 | 1.5         | {{prodname}} CNI with network policy | 1.21                   |
-| 3.12                 | 1.4, 1.5    | {{prodname}} CNI with network policy | 1.20 (1.4), 1.21 (1.5) |
-| 3.11                 | 1.3         | {{prodname}} CNI with network policy | 1.20                   |
+| 3.17                 | N/A        | {{prodname}} 3.17 does not support TKG | N/A                   |
 
 ## Supported browsers
 


### PR DESCRIPTION
I'm removing old versions from the support and compatibility page. 

We generally support N-2 versions, so it really doesn't make sense to list the historical compatibility records for current releases. If people want that information, they can find it in the [Documentation archive](https://docs.tigera.io/archive).

The idea here is to make each page with the correct N-2 versions for the time when that version was released. It may be worth revisiting this to have a single evergreen page. But for now, I just want the versions to be correct for when each version was latest.


Deploy previews

| CE version | Current | Proposed |
| -- | -- | -- |
| v3.19 |  [Support and compatibility](https://docs.tigera.io/calico-enterprise/latest/getting-started/compatibility) | [Support and compatibility](https://deploy-preview-1558--tigera.netlify.app/calico-enterprise/latest/getting-started/compatibility) |
| v3.18 |[Support and compatibility](https://docs.tigera.io/calico-enterprise/3.18/getting-started/compatibility)  | [Support and compatibility](https://deploy-preview-1558--tigera.netlify.app/calico-enterprise/3.18/getting-started/compatibility) |
| v3.17 |[Support and compatibility](https://docs.tigera.io/calico-enterprise/3.17/getting-started/compatibility)  | [Support and compatibility](https://deploy-preview-1558--tigera.netlify.app/calico-enterprise/3.17/getting-started/compatibility) |