### PR TITLE
DOCS-2265: Fixes bug with attributions page for OSS 3.28. Updates attributions."

### DIFF
--- a/calico_versioned_sidebars/version-3.28-sidebars.json
+++ b/calico_versioned_sidebars/version-3.28-sidebars.json
@@ -815,7 +815,7 @@
         {
           "type": "link",
           "label": "Attributions",
-          "href": "pathname:///calico/next/licenses/third-party-attributions.html"
+          "href": "pathname:///calico/3.28/licenses/third-party-attributions.html"
         }
       ]
     },


### PR DESCRIPTION
The attributions link from the sidebar went to the vNext placeholder rather than to the correct OSS 3.28 attributions page. 