### PR TITLE
DOCS-2277: Fixes dikastes image path with dynamic version number

### DIFF
--- a/calico-cloud/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-cloud/threat/deploying-waf-ingress-gateway.mdx
@@ -59,7 +59,7 @@ spec:
           spec:
             containers:
             - name: dikastes
-              image: gcr.io/unique-caldron-775/cnx/tigera/dikastes:master-amd64
+              image: quay.io/tigera/dikastes:{{dikastesVersion}}-amd64
               args:
               - -waf-enabled
               - -waf-directive

--- a/calico-cloud/variables.js
+++ b/calico-cloud/variables.js
@@ -18,6 +18,7 @@ const variables = {
   cloudoperatorimage: 'quay.io/tigera/cc-operator',
   imageassuranceversion: 'v1.14.1',
   tigeraOperator: releases[0]['tigera-operator'],
+  dikastesVersion: releases[0].components.dikastes.version,
   releases,
   registry: 'quay.io/',
   imageNames: {

--- a/calico-cloud_versioned_docs/version-19-2/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-cloud_versioned_docs/version-19-2/threat/deploying-waf-ingress-gateway.mdx
@@ -59,7 +59,7 @@ spec:
           spec:
             containers:
             - name: dikastes
-              image: gcr.io/unique-caldron-775/cnx/tigera/dikastes:master-amd64
+              image: quay.io/tigera/dikastes:{{dikastesVersion}}-amd64
               args:
               - -waf-enabled
               - -waf-directive

--- a/calico-cloud_versioned_docs/version-19-2/variables.js
+++ b/calico-cloud_versioned_docs/version-19-2/variables.js
@@ -18,6 +18,7 @@ const variables = {
   cloudoperatorimage: 'quay.io/tigera/cc-operator',
   imageassuranceversion: 'v1.18.3',
   tigeraOperator: releases[0]['tigera-operator'],
+  dikastesVersion: releases[0].components.dikastes.version,
   releases,
   registry: 'quay.io/',
   imageNames: {

--- a/calico-enterprise/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-enterprise/threat/deploying-waf-ingress-gateway.mdx
@@ -59,7 +59,7 @@ spec:
           spec:
             containers:
             - name: dikastes
-              image: gcr.io/unique-caldron-775/cnx/tigera/dikastes:master-amd64
+              image: quay.io/tigera/dikastes:{{dikastesVersion}}-amd64
               args:
               - -waf-enabled
               - -waf-directive

--- a/calico-enterprise/variables.js
+++ b/calico-enterprise/variables.js
@@ -19,6 +19,7 @@ const variables = {
   registry: 'gcr.io/unique-caldron-775/cnx/', // Change to 'quay.io/' for new release
   chart_version_name: 'master',
   tigeraOperator: releases[0]['tigera-operator'],
+  dikastesVersion: releases[0].components.dikastes.version,
   manifestsUrl: 'https://docs.tigera.io/master',
   releases,
   imageNames: {

--- a/calico-enterprise_versioned_docs/version-3.19-2/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/threat/deploying-waf-ingress-gateway.mdx
@@ -59,7 +59,7 @@ spec:
           spec:
             containers:
             - name: dikastes
-              image: gcr.io/unique-caldron-775/cnx/tigera/dikastes:master-amd64
+              image: quay.io/tigera/dikastes:{{dikastesVersion}}-amd64
               args:
               - -waf-enabled
               - -waf-directive

--- a/calico-enterprise_versioned_docs/version-3.19-2/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.19-2/variables.js
@@ -18,6 +18,7 @@ const variables = {
   registry: 'quay.io/',
   chart_version_name: 'v3.19.1-1',
   tigeraOperator: releases[0]['tigera-operator'],
+  dikastesVersion: releases[0].components.dikastes.version,
   releases,
   imageNames: {
     node: 'tigera/cnx-node',

--- a/calico-enterprise_versioned_docs/version-3.20-1/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/threat/deploying-waf-ingress-gateway.mdx
@@ -59,7 +59,7 @@ spec:
           spec:
             containers:
             - name: dikastes
-              image: gcr.io/unique-caldron-775/cnx/tigera/dikastes:master-amd64
+              image: quay.io/tigera/dikastes:{{dikastesVersion}}-amd64
               args:
               - -waf-enabled
               - -waf-directive

--- a/calico-enterprise_versioned_docs/version-3.20-1/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.20-1/variables.js
@@ -18,6 +18,7 @@ const variables = {
   registry: 'quay.io/',
   chart_version_name: 'v3.20.0-1.0-0',
   tigeraOperator: releases[0]['tigera-operator'],
+  dikastesVersion: releases[0].components.dikastes.version,
   releases,
   imageNames: {
     node: 'tigera/cnx-node',


### PR DESCRIPTION
Deploy preview: https://deploy-preview-1588--tigera.netlify.app/calico-enterprise/latest/threat/deploying-waf-ingress-gateway#2-deploy-istiooperator-custom-resource-for-custom-sidecar-injection

