### PR TITLE
Note that ENABLE_V4_EGRESS pods are not supported.

### DIFF
--- a/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -38,6 +38,12 @@ The geeky details of what you get:
   details='Policy:Calico,IPAM:AWS,CNI:AWS,Overlay:No,Routing:VPC Native,Datastore:Kubernetes'
 />
 
+:::note
+
+When using the Amazon VPC CNI plugin, {{prodname}} does not support enforcement of network policy on IPv6 pods with `ENABLE_V4_EGRESS` set to `true`.
+
+:::
+
 
 1. First, create an Amazon EKS cluster.
 
@@ -68,14 +74,14 @@ The geeky details of what you get:
    EOF
    ```
 
-1. Confirm installation by checking the `STATUS`, your cluster nodes should have a `Ready` status. 
+1. Confirm installation by checking the `STATUS`, your cluster nodes should have a `Ready` status.
 
    ```
    kubectl get nodes -o wide
    ```
-   
+
    It should return something like the following.
-   
+
    ```
    NAME              STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION    CONTAINER-RUNTIME
    <your-hostname>   Ready    master   52m   v1.12.2   10.128.0.28   <none>        Ubuntu 18.04.1 LTS   4.15.0-1023-gcp   docker://18.6.1

--- a/calico_versioned_docs/version-3.26/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico_versioned_docs/version-3.26/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -38,6 +38,11 @@ The geeky details of what you get:
   details='Policy:Calico,IPAM:AWS,CNI:AWS,Overlay:No,Routing:VPC Native,Datastore:Kubernetes'
 />
 
+:::note
+
+When using the Amazon VPC CNI plugin, {{prodname}} does not support enforcement of network policy on IPv6 pods with `ENABLE_V4_EGRESS` set to `true`.
+
+:::
 
 1. First, create an Amazon EKS cluster.
 
@@ -68,14 +73,14 @@ The geeky details of what you get:
    EOF
    ```
 
-1. Confirm installation by checking the `STATUS`, your cluster nodes should have a `Ready` status. 
+1. Confirm installation by checking the `STATUS`, your cluster nodes should have a `Ready` status.
 
    ```
    kubectl get nodes -o wide
    ```
-   
+
    It should return something like the following.
-   
+
    ```
    NAME              STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION    CONTAINER-RUNTIME
    <your-hostname>   Ready    master   52m   v1.12.2   10.128.0.28   <none>        Ubuntu 18.04.1 LTS   4.15.0-1023-gcp   docker://18.6.1

--- a/calico_versioned_docs/version-3.27/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico_versioned_docs/version-3.27/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -40,6 +40,11 @@ The geeky details of what you get:
 
 To enable {{prodname}} network policy enforcement on an EKS cluster using the AWS VPC CNI plugin, follow these step-by-step instructions: [Installing Calico on Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/calico.html)
 
+:::note
+
+When using the Amazon VPC CNI plugin, {{prodname}} does not support enforcement of network policy on IPv6 pods with `ENABLE_V4_EGRESS` set to `true`.
+
+:::
 
 1. First, create an Amazon EKS cluster.
 
@@ -70,14 +75,14 @@ To enable {{prodname}} network policy enforcement on an EKS cluster using the AW
    EOF
    ```
 
-1. Confirm installation by checking the `STATUS`, your cluster nodes should have a `Ready` status. 
+1. Confirm installation by checking the `STATUS`, your cluster nodes should have a `Ready` status.
 
    ```
    kubectl get nodes -o wide
    ```
-   
+
    It should return something like the following.
-   
+
    ```
    NAME              STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION    CONTAINER-RUNTIME
    <your-hostname>   Ready    master   52m   v1.12.2   10.128.0.28   <none>        Ubuntu 18.04.1 LTS   4.15.0-1023-gcp   docker://18.6.1

--- a/calico_versioned_docs/version-3.28/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico_versioned_docs/version-3.28/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -38,6 +38,11 @@ The geeky details of what you get:
   details='Policy:Calico,IPAM:AWS,CNI:AWS,Overlay:No,Routing:VPC Native,Datastore:Kubernetes'
 />
 
+:::note
+
+When using the Amazon VPC CNI plugin, {{prodname}} does not support enforcement of network policy on IPv6 pods with `ENABLE_V4_EGRESS` set to `true`.
+
+:::
 
 1. First, create an Amazon EKS cluster.
 
@@ -68,14 +73,14 @@ The geeky details of what you get:
    EOF
    ```
 
-1. Confirm installation by checking the `STATUS`, your cluster nodes should have a `Ready` status. 
+1. Confirm installation by checking the `STATUS`, your cluster nodes should have a `Ready` status.
 
    ```
    kubectl get nodes -o wide
    ```
-   
+
    It should return something like the following.
-   
+
    ```
    NAME              STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION    CONTAINER-RUNTIME
    <your-hostname>   Ready    master   52m   v1.12.2   10.128.0.28   <none>        Ubuntu 18.04.1 LTS   4.15.0-1023-gcp   docker://18.6.1


### PR DESCRIPTION
See:

- https://github.com/projectcalico/calico/issues/9099#issuecomment-2297203663
- https://docs.aws.amazon.com/eks/latest/userguide/cni-network-policy.html#cni-network-policy-considerations

This same limitation exists for the Amazon network policy engine:

```
The Amazon VPC CNI plugin for Kubernetes doesn't apply network policies to additional network interfaces for each pod, only the primary interface for each pod (eth0). This affects the following architectures:

IPv6 pods with the ENABLE_V4_EGRESS variable set to true. This variable enables the IPv4 egress feature to connect the IPv6 pods to IPv4 endpoints such as those outside the cluster. The IPv4 egress feature works by creating an additional network interface with a local loopback IPv4 address.
```

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->