### PR TITLE
Fix openshift upgrade from v3.18 and earlier due to manager.spec.authn

### DIFF
--- a/calico-enterprise/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
@@ -148,13 +148,13 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
 
 1. If your cluster was at one time v3.18 or older, remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#operator.tigera.io/v1.Manager).
 
-```bash
-oc apply -f - <<EOF
-apiVersion: operator.tigera.io/v1
-kind: Manager
-metadata:
-  name: tigera-secure
-EOF
+   ```bash
+   oc apply -f - <<EOF
+   apiVersion: operator.tigera.io/v1
+   kind: Manager
+   metadata:
+     name: tigera-secure
+   EOF
    ```
 
 1. If your cluster is v3.19 or older, apply a new [PacketCaptureAPI](../../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI)

--- a/calico-enterprise/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
@@ -146,6 +146,17 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
+1. If your cluster was at one time v3.18 or older, remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#operator.tigera.io/v1.Manager).
+
+```bash
+oc apply -f - <<EOF
+apiVersion: operator.tigera.io/v1
+kind: Manager
+metadata:
+  name: tigera-secure
+EOF
+   ```
+
 1. If your cluster is v3.19 or older, apply a new [PacketCaptureAPI](../../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI)
     CR to your cluster.
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
@@ -149,6 +149,18 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
+1. Remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#operator.tigera.io/v1.Manager).
+
+```bash
+oc apply -f - <<EOF
+apiVersion: operator.tigera.io/v1
+kind: Manager
+metadata:
+  name: tigera-secure
+EOF
+   ```
+
+
 1. You can now monitor the upgrade progress with the following command:
 
    ```bash

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
@@ -151,15 +151,14 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
 
 1. Remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#operator.tigera.io/v1.Manager).
 
-```bash
-oc apply -f - <<EOF
-apiVersion: operator.tigera.io/v1
-kind: Manager
-metadata:
-  name: tigera-secure
-EOF
+   ```bash
+   oc apply -f - <<EOF
+   apiVersion: operator.tigera.io/v1
+   kind: Manager
+   metadata:
+     name: tigera-secure
+   EOF
    ```
-
 
 1. You can now monitor the upgrade progress with the following command:
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
@@ -131,6 +131,17 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
+1. If your cluster was at one time v3.18 or older, remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#operator.tigera.io/v1.Manager).
+
+```bash
+oc apply -f - <<EOF
+apiVersion: operator.tigera.io/v1
+kind: Manager
+metadata:
+  name: tigera-secure
+EOF
+   ```
+
 1. If your cluster is v3.19 or older, apply a new [PacketCaptureAPI](../../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI)
     CR to your cluster.
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
@@ -133,13 +133,13 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
 
 1. If your cluster was at one time v3.18 or older, remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#operator.tigera.io/v1.Manager).
 
-```bash
-oc apply -f - <<EOF
-apiVersion: operator.tigera.io/v1
-kind: Manager
-metadata:
-  name: tigera-secure
-EOF
+   ```bash
+   oc apply -f - <<EOF
+   apiVersion: operator.tigera.io/v1
+   kind: Manager
+   metadata:
+     name: tigera-secure
+   EOF
    ```
 
 1. If your cluster is v3.19 or older, apply a new [PacketCaptureAPI](../../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI)


### PR DESCRIPTION
Fix openshift upgrade from v3.18 and earlier due to manager.spec.authn

The spec.authn field has been removed. It was deprecated in 2020, but until v3.18 for OCP only, we would set the field to the default in the Manager CR. This can break upgrades.