### PR TITLE
DOCS-2243: Publishes OSS 3.26.5 documentation

### DIFF
--- a/calico_versioned_docs/version-3.26/_includes/release-notes/_v3.26.5-release-notes.mdx
+++ b/calico_versioned_docs/version-3.26/_includes/release-notes/_v3.26.5-release-notes.mdx
@@ -1,0 +1,5 @@
+29 August 2024
+
+#### Bug fixes
+
+TODO

--- a/calico_versioned_docs/version-3.26/_includes/release-notes/_v3.26.5-release-notes.mdx
+++ b/calico_versioned_docs/version-3.26/_includes/release-notes/_v3.26.5-release-notes.mdx
@@ -1,5 +1,17 @@
 29 August 2024
 
+#### Security updates
+
+This release contains the following change to resolve [CVE-2024-33522](https://www.tigera.io/security-bulletins-tta-2024-001/):
+ - Improve cni-plugin binary install verification. [calico #8842](https://github.com/projectcalico/calico/pull/8842) (@ialidzhikov)
+
 #### Bug fixes
 
-TODO
+ - Fix that Felix would not recognise HyperV containers as ready. [calico #9027](https://github.com/projectcalico/calico/pull/9027) (@coutinhop)
+ - ebpf: Update map definition in sockops program to let libbpf v1.0+ load them successfully. [calico #8703](https://github.com/projectcalico/calico/pull/8703) (@mazdakn)
+ - ebpf: Update map definitions in programs used in iptables mode to let libbpf v1.0+ load them successfully. [calico #8623](https://github.com/projectcalico/calico/pull/8623) (@mazdakn)
+ - ebpf: ClusterIP reflects InternalTrafficPolicy=Local [calico #8264](https://github.com/projectcalico/calico/pull/8264) (@tomastigera)
+
+#### Other changes
+
+ - Update various dependency versions

--- a/calico_versioned_docs/version-3.26/releases.json
+++ b/calico_versioned_docs/version-3.26/releases.json
@@ -4,7 +4,7 @@
     "tigera-operator": {
       "image": "tigera/operator",
       "registry": "quay.io",
-      "version": "v1.30.9"
+      "version": "v1.30.11"
     },
     "components": {
       "typha": {

--- a/calico_versioned_docs/version-3.26/releases.json
+++ b/calico_versioned_docs/version-3.26/releases.json
@@ -1,5 +1,57 @@
 [
   {
+    "title": "v3.26.5",
+    "tigera-operator": {
+      "image": "tigera/operator",
+      "registry": "quay.io",
+      "version": "v1.30.9"
+    },
+    "components": {
+      "typha": {
+        "version": "v3.26.5"
+      },
+      "calicoctl": {
+        "version": "v3.26.5"
+      },
+      "calico/node": {
+        "version": "v3.26.5"
+      },
+      "calico/cni": {
+        "version": "v3.26.5"
+      },
+      "calico/apiserver": {
+        "version": "v3.26.5"
+      },
+      "calico/kube-controllers": {
+        "version": "v3.26.5"
+      },
+      "calico/flannel-migration-controller": {
+        "version": "v3.26.5"
+      },
+      "calico/windows": {
+        "version": "v3.26.5"
+      },
+      "networking-calico": {
+        "version": "v3.26.5"
+      },
+      "flannel": {
+        "version": "v0.16.3"
+      },
+      "calico/dikastes": {
+        "version": "v3.26.5"
+      },
+      "flexvol": {
+        "version": "v3.26.5"
+      },
+      "csi-driver": {
+        "version": "v3.26.5"
+      },
+      "csi-node-driver-registrar": {
+        "version": "v3.26.5"
+      }
+    }
+  },
+  {
     "title": "v3.26.4",
     "tigera-operator": {
       "image": "tigera/operator",

--- a/calico_versioned_docs/version-3.26/variables.js
+++ b/calico_versioned_docs/version-3.26/variables.js
@@ -1,7 +1,7 @@
 const releases = require('./releases.json');
 
 const variables = {
-  releaseTitle: 'v3.26.4',
+  releaseTitle: 'v3.26.5',
   prodname: 'Calico',
   prodnamedash: 'calico',
   version: 'v3.26',
@@ -15,7 +15,7 @@ const variables = {
   noderunning: 'calico-node',
   rootDirWindows: 'C:\\CalicoWindows',
   ppa_repo_name: 'calico-3.26',
-  manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.26.4',
+  manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.26.5',
   releases,
   registry: '',
   vppbranch: 'v3.26.0',


### PR DESCRIPTION
FYI @coutinhop @lwr20

Still needs:
* operator and other version updates: `calico_versioned_docs/version-3.26/releases.json`
* generated release notes: `calico_versioned_docs/version-3.26/_includes/release-notes/_v3.26.5-release-notes.mdx` (This is still the old release notes in 3.26).

