### PR TITLE
DOCS-2244: Publishes Calico Enterprise 3.19.2

### DIFF
--- a/calico-enterprise/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise/operations/ebpf/enabling-ebpf.mdx
@@ -89,6 +89,8 @@ The best way to do that varies by Kubernetes distribution:
   `api-int.<cluster_name>.<base_domain>` should point to the API server or to the load balancer in front of the
   API server. Use that (filling in the `<cluster_name>` and `<base_domain>` as appropriate for your cluster) for the
   `KUBERNETES_SERVICE_HOST` below. Openshift uses 6443 for the `KUBERNETES_SERVICE_PORT`.
+- MKE runs a reverse proxy in each node that can be used to reach the API server. You should use `proxy.local`
+  as the `KUBERNETES_SERVICE_HOST` and `6444` as the `KUBERNETES_SERVICE_PORT`.
 - For AKS and EKS clusters you should use the FQDN of the API server's load balancer. This can be found with
   ```
   kubectl cluster-info
@@ -160,6 +162,13 @@ To re-enable it:
 kubectl patch networks.operator.openshift.io cluster --type merge -p '{"spec":{"deployKubeProxy": true}}'
 ```
 
+#### MKE
+
+If you are running MKE, you can disable `kube-proxy` as follows:
+
+Follow the step procedure in [Modify an existing MKE configuration](https://docs.mirantis.com/mke/current/ops/administer-cluster/configure-an-mke-cluster/use-an-mke-configuration-file.html#modify-an-existing-mke-configuration) to download, edit, and upload your MKE configuration. During the editing step, add the following configuration:
+`kube_proxy_mode=disabled` and `kube_default_drop_masq_bits=true`.
+
 ### Avoiding conflicts with kube-proxy
 
 If you cannot disable `kube-proxy` (for example, because it is managed by your Kubernetes distribution), then you _must_ change Felix configuration parameter `BPFKubeProxyIptablesCleanupEnabled` to `false`. This can be done with `kubectl` as follows:
@@ -221,5 +230,7 @@ To revert to standard Linux networking:
    ```bash
    kubectl patch ds -n kube-system kube-proxy --type merge -p '{"spec":{"template":{"spec":{"nodeSelector":{"non-calico": null}}}}}'
    ```
+2. If you are running MKE, follow the step procedure in [Modify an existing MKE configuration](https://docs.mirantis.com/mke/current/ops/administer-cluster/configure-an-mke-cluster/use-an-mke-configuration-file.html#modify-an-existing-mke-configuration) to download, edit, and upload your MKE configuration. During the editing step, add the following configuration:
+`kube_proxy_mode` to `iptables`.
 
 1. Since disabling eBPF mode is disruptive to existing connections, monitor existing workloads to make sure they re-establish any connections that were disrupted by the switch.

--- a/calico-enterprise/operations/ebpf/install.mdx
+++ b/calico-enterprise/operations/ebpf/install.mdx
@@ -42,7 +42,6 @@ and in particular, pushing the networking capabilities of the latest Linux kerne
 **Unsupported platforms**
 
 - GKE
-- MKE
 - TKG
 - RKE
 
@@ -111,7 +110,7 @@ Select the appropriate tab below for distribution-specific instructions:
 `kubeadm` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 20.04) meets the kernel
 requirements, `kubeadm`-provisioned clusters are supported.
 
-Since `kube-proxy` is not required in eBPF mode, you may wish to disable `kube-proxy` at install time. With `kubeadm`
+Since `kube-proxy` is not required in eBPF mode, you must disable `kube-proxy` at install time. With `kubeadm`
 you can do that by passing the ` --skip-phases=addon/kube-proxy` flag to `kubeadm init`:
 
 ```
@@ -124,7 +123,7 @@ kubeadm init --skip-phases=addon/kube-proxy
 `kops` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 20.04 or RHEL 8.2) meets the kernel
 requirements, `kops`-provisioned clusters are supported.
 
-Since `kube-proxy` is not required in eBPF mode, you may wish to disable `kube-proxy` at install time. With `kops` you
+Since `kube-proxy` is not required in eBPF mode, you must disable `kube-proxy` at install time. With `kops` you
 can do that by setting the following in your `kops` configuration:
 
 ```yaml
@@ -156,6 +155,17 @@ default kernel used by Amazon Linux is recent enough to run eBPF mode, as is the
 18.04 image did not have a recent-enough kernel (but that may have changed by the time you read this).
 
 </TabItem>
+<TabItem label="MKE" value="MKE-5">
+
+The eBPF data plane is supported on MKE with any Linux operating system that meets the minimum kernel requirements.
+
+Since `kube-proxy` is not required in eBPF mode, you must disable `kube-proxy` at install time. With `MKE` you
+can do that by setting `--kube-proxy-mode=disabled` and `--kube-default-drop-masq-bits` when installing the cluster.
+
+More details can be found in [the MKE documentation](https://docs.mirantis.com/mke/current/install/predeployment/configure-networking/cluster-service-networking-options.html)
+
+</TabItem>
+
 </Tabs>
 
 ### Create kubernetes-service-endpoint config map
@@ -172,7 +182,7 @@ scaled up/down. If you have multiple API servers, with DNS or other load balanci
 the address of the load balancer. This prevents {{prodname}} from being disconnected if the API servers IP changes.
 
 <Tabs>
-<TabItem label="Generic or kubeadm" value="Generic or kubeadm-5">
+<TabItem label="Generic or kubeadm" value="Generic or kubeadm-6">
 
 If you created a cluster manually (for example by using `kubeadm`) then the right address to use depends on whether you
 opted for a high-availability cluster with multiple API servers or a simple one-node API server.
@@ -186,13 +196,13 @@ opted for a high-availability cluster with multiple API servers or a simple one-
   causing {{prodname}} to lose connectivity to the API server.
 
 </TabItem>
-<TabItem label="kOps" value="kOps-6">
+<TabItem label="kOps" value="kOps-7">
 
 When using `kops`, `kops` typically sets up a load balancer of some sort in front of the API server. You should use
 the FQDN and port of the API load balancer: `api.internal.<clustername>`.
 
 </TabItem>
-<TabItem label="OpenShift" value="OpenShift-7">
+<TabItem label="OpenShift" value="OpenShift-8">
 
 OpenShift requires various DNS records to be created for the cluster; one of these is exactly what we need:
 `api.<cluster_name>.<base_domain>` should point to the API server or to the load balancer in front of the
@@ -200,7 +210,7 @@ API server. Use that (filling in the `<cluster_name>` and `<base_domain>` as app
 `KUBERNETES_SERVICE_HOST` below. Openshift uses 6443 for the `KUBERNETES_SERVICE_PORT`.
 
 </TabItem>
-<TabItem label="AKS" value="AKS-8">
+<TabItem label="AKS" value="AKS-9">
 
 For AKS clusters, you should use the FQDN of your API server. This can be found by running the following command:
 
@@ -218,7 +228,7 @@ In this example, you would use `mycalicocl-calicodemorg-03a087-36558dbb.hcp.cana
 `KUBERNETES_SERVICE_HOST` and `443` for `KUBERNETES_SERVICE_PORT` when creating the config map.
 
 </TabItem>
-<TabItem label="EKS" value="EKS-9">
+<TabItem label="EKS" value="EKS-10">
 
 For an EKS cluster, it's important to use the domain name of the EKS-provided load balancer that is in front of the API
 server. This can be found by running the following command:
@@ -236,6 +246,12 @@ Kubernetes master is running at https://60F939227672BC3D5A1B3EC9744B2B21.gr7.us-
 
 In this example, you would use `60F939227672BC3D5A1B3EC9744B2B21.gr7.us-west-2.eks.amazonaws.com` for
 `KUBERNETES_SERVICE_HOST` and `443` for `KUBERNETES_SERVICE_PORT` when creating the config map.
+
+</TabItem>
+<TabItem label="MKE" value="MKE-11">
+
+MKE runs a reverse proxy in each node which can be used to reach the api-server. `KUBERNETES_SERVICE_HOST` must be set to
+`proxy.local` and `KUBERNETES_SERVICE_PORT` must be set to `6444`.
 
 </TabItem>
 </Tabs>
@@ -348,7 +364,7 @@ kubectl patch ds -n kube-system kube-proxy -p '{"spec":{"template":{"spec":{"nod
 Then, should you want to start `kube-proxy` again, you can simply remove the node selector.
 
 </TabItem>
-<TabItem label="kOps" value="kOps-11">
+<TabItem label="kOps" value="kOps-12">
 
 `kops` allows `kube-proxy` to be disabled by setting
 
@@ -360,7 +376,7 @@ kubeProxy:
 in its configuration. You will need to do `kops update cluster` to roll out the change.
 
 </TabItem>
-<TabItem label="OpenShift" value="OpenShift-12">
+<TabItem label="OpenShift" value="OpenShift-13">
 
 In OpenShift, you can disable `kube-proxy` as follows:
 
@@ -375,7 +391,7 @@ kubectl patch networks.operator.openshift.io cluster --type merge -p '{"spec":{"
 ```
 
 </TabItem>
-<TabItem label="AKS" value="AKS-13">
+<TabItem label="AKS" value="AKS-14">
 
 AKS with Azure CNI does not allow `kube-proxy` to be disabled, `kube-proxy` is deployed by the add-on manager, which will reconcile
 away any manual changes made to its configuration. To ensure `kube-proxy` and {{prodname}} don't fight, set
@@ -387,7 +403,7 @@ kubectl patch felixconfiguration default --type merge --patch='{"spec": {"bpfKub
 ```
 
 </TabItem>
-<TabItem label="EKS" value="EKS-14">
+<TabItem label="EKS" value="EKS-15">
 
 In EKS, you can disable `kube-proxy`, reversibly, by adding a node selector that doesn't match and nodes to
 `kube-proxy`'s `DaemonSet`, for example:

--- a/calico-enterprise_versioned_docs/version-3.19-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/operations/ebpf/enabling-ebpf.mdx
@@ -89,6 +89,8 @@ The best way to do that varies by Kubernetes distribution:
   `api-int.<cluster_name>.<base_domain>` should point to the API server or to the load balancer in front of the
   API server. Use that (filling in the `<cluster_name>` and `<base_domain>` as appropriate for your cluster) for the
   `KUBERNETES_SERVICE_HOST` below. Openshift uses 6443 for the `KUBERNETES_SERVICE_PORT`.
+- MKE runs a reverse proxy in each node that can be used to reach the API server. You should use `proxy.local`
+  as the `KUBERNETES_SERVICE_HOST` and `6444` as the `KUBERNETES_SERVICE_PORT`.
 - For AKS and EKS clusters you should use the FQDN of the API server's load balancer. This can be found with
   ```
   kubectl cluster-info
@@ -160,6 +162,13 @@ To re-enable it:
 kubectl patch networks.operator.openshift.io cluster --type merge -p '{"spec":{"deployKubeProxy": true}}'
 ```
 
+#### MKE
+
+If you are running MKE, you can disable `kube-proxy` as follows:
+
+Follow the step procedure in [Modify an existing MKE configuration](https://docs.mirantis.com/mke/current/ops/administer-cluster/configure-an-mke-cluster/use-an-mke-configuration-file.html#modify-an-existing-mke-configuration) to download, edit, and upload your MKE configuration. During the editing step, add the following configuration:
+`kube_proxy_mode=disabled` and `kube_default_drop_masq_bits=true`.
+
 ### Avoiding conflicts with kube-proxy
 
 If you cannot disable `kube-proxy` (for example, because it is managed by your Kubernetes distribution), then you _must_ change Felix configuration parameter `BPFKubeProxyIptablesCleanupEnabled` to `false`. This can be done with `kubectl` as follows:
@@ -221,5 +230,7 @@ To revert to standard Linux networking:
    ```bash
    kubectl patch ds -n kube-system kube-proxy --type merge -p '{"spec":{"template":{"spec":{"nodeSelector":{"non-calico": null}}}}}'
    ```
+2. If you are running MKE, follow the step procedure in [Modify an existing MKE configuration](https://docs.mirantis.com/mke/current/ops/administer-cluster/configure-an-mke-cluster/use-an-mke-configuration-file.html#modify-an-existing-mke-configuration) to download, edit, and upload your MKE configuration. During the editing step, add the following configuration:
+`kube_proxy_mode` to `iptables`.
 
 1. Since disabling eBPF mode is disruptive to existing connections, monitor existing workloads to make sure they re-establish any connections that were disrupted by the switch.

--- a/calico-enterprise_versioned_docs/version-3.19-2/operations/ebpf/install.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/operations/ebpf/install.mdx
@@ -111,7 +111,7 @@ Select the appropriate tab below for distribution-specific instructions:
 `kubeadm` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 20.04) meets the kernel
 requirements, `kubeadm`-provisioned clusters are supported.
 
-Since `kube-proxy` is not required in eBPF mode, you may wish to disable `kube-proxy` at install time. With `kubeadm`
+Since `kube-proxy` is not required in eBPF mode, you must disable `kube-proxy` at install time. With `kubeadm`
 you can do that by passing the ` --skip-phases=addon/kube-proxy` flag to `kubeadm init`:
 
 ```
@@ -124,7 +124,7 @@ kubeadm init --skip-phases=addon/kube-proxy
 `kops` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 20.04 or RHEL 8.2) meets the kernel
 requirements, `kops`-provisioned clusters are supported.
 
-Since `kube-proxy` is not required in eBPF mode, you may wish to disable `kube-proxy` at install time. With `kops` you
+Since `kube-proxy` is not required in eBPF mode, you must disable `kube-proxy` at install time. With `kops` you
 can do that by setting the following in your `kops` configuration:
 
 ```yaml
@@ -156,6 +156,17 @@ default kernel used by Amazon Linux is recent enough to run eBPF mode, as is the
 18.04 image did not have a recent-enough kernel (but that may have changed by the time you read this).
 
 </TabItem>
+<TabItem label="MKE" value="MKE-5">
+
+The eBPF data plane is supported on MKE with any Linux operating system that meets the minimum kernel requirements.
+
+Since `kube-proxy` is not required in eBPF mode, you must disable `kube-proxy` at install time. With `MKE` you
+can do that by setting `--kube-proxy-mode=disabled` and `--kube-default-drop-masq-bits` when installing the cluster.
+
+More details can be found in [the MKE documentation](https://docs.mirantis.com/mke/current/install/predeployment/configure-networking/cluster-service-networking-options.html)
+
+</TabItem>
+
 </Tabs>
 
 ### Create kubernetes-service-endpoint config map
@@ -172,7 +183,7 @@ scaled up/down. If you have multiple API servers, with DNS or other load balanci
 the address of the load balancer. This prevents {{prodname}} from being disconnected if the API servers IP changes.
 
 <Tabs>
-<TabItem label="Generic or kubeadm" value="Generic or kubeadm-5">
+<TabItem label="Generic or kubeadm" value="Generic or kubeadm-6">
 
 If you created a cluster manually (for example by using `kubeadm`) then the right address to use depends on whether you
 opted for a high-availability cluster with multiple API servers or a simple one-node API server.
@@ -186,13 +197,13 @@ opted for a high-availability cluster with multiple API servers or a simple one-
   causing {{prodname}} to lose connectivity to the API server.
 
 </TabItem>
-<TabItem label="kOps" value="kOps-6">
+<TabItem label="kOps" value="kOps-7">
 
 When using `kops`, `kops` typically sets up a load balancer of some sort in front of the API server. You should use
 the FQDN and port of the API load balancer: `api.internal.<clustername>`.
 
 </TabItem>
-<TabItem label="OpenShift" value="OpenShift-7">
+<TabItem label="OpenShift" value="OpenShift-8">
 
 OpenShift requires various DNS records to be created for the cluster; one of these is exactly what we need:
 `api.<cluster_name>.<base_domain>` should point to the API server or to the load balancer in front of the
@@ -200,7 +211,7 @@ API server. Use that (filling in the `<cluster_name>` and `<base_domain>` as app
 `KUBERNETES_SERVICE_HOST` below. Openshift uses 6443 for the `KUBERNETES_SERVICE_PORT`.
 
 </TabItem>
-<TabItem label="AKS" value="AKS-8">
+<TabItem label="AKS" value="AKS-9">
 
 For AKS clusters, you should use the FQDN of your API server. This can be found by running the following command:
 
@@ -218,7 +229,7 @@ In this example, you would use `mycalicocl-calicodemorg-03a087-36558dbb.hcp.cana
 `KUBERNETES_SERVICE_HOST` and `443` for `KUBERNETES_SERVICE_PORT` when creating the config map.
 
 </TabItem>
-<TabItem label="EKS" value="EKS-9">
+<TabItem label="EKS" value="EKS-10">
 
 For an EKS cluster, it's important to use the domain name of the EKS-provided load balancer that is in front of the API
 server. This can be found by running the following command:
@@ -236,6 +247,12 @@ Kubernetes master is running at https://60F939227672BC3D5A1B3EC9744B2B21.gr7.us-
 
 In this example, you would use `60F939227672BC3D5A1B3EC9744B2B21.gr7.us-west-2.eks.amazonaws.com` for
 `KUBERNETES_SERVICE_HOST` and `443` for `KUBERNETES_SERVICE_PORT` when creating the config map.
+
+</TabItem>
+<TabItem label="MKE" value="MKE-11">
+
+MKE runs a reverse proxy in each node which can be used to reach the api-server. `KUBERNETES_SERVICE_HOST` must be set to
+`proxy.local` and `KUBERNETES_SERVICE_PORT` must be set to `6444`.
 
 </TabItem>
 </Tabs>
@@ -348,7 +365,7 @@ kubectl patch ds -n kube-system kube-proxy -p '{"spec":{"template":{"spec":{"nod
 Then, should you want to start `kube-proxy` again, you can simply remove the node selector.
 
 </TabItem>
-<TabItem label="kOps" value="kOps-11">
+<TabItem label="kOps" value="kOps-12">
 
 `kops` allows `kube-proxy` to be disabled by setting
 
@@ -360,7 +377,7 @@ kubeProxy:
 in its configuration. You will need to do `kops update cluster` to roll out the change.
 
 </TabItem>
-<TabItem label="OpenShift" value="OpenShift-12">
+<TabItem label="OpenShift" value="OpenShift-13">
 
 In OpenShift, you can disable `kube-proxy` as follows:
 
@@ -375,7 +392,7 @@ kubectl patch networks.operator.openshift.io cluster --type merge -p '{"spec":{"
 ```
 
 </TabItem>
-<TabItem label="AKS" value="AKS-13">
+<TabItem label="AKS" value="AKS-14">
 
 AKS with Azure CNI does not allow `kube-proxy` to be disabled, `kube-proxy` is deployed by the add-on manager, which will reconcile
 away any manual changes made to its configuration. To ensure `kube-proxy` and {{prodname}} don't fight, set
@@ -387,7 +404,7 @@ kubectl patch felixconfiguration default --type merge --patch='{"spec": {"bpfKub
 ```
 
 </TabItem>
-<TabItem label="EKS" value="EKS-14">
+<TabItem label="EKS" value="EKS-15">
 
 In EKS, you can disable `kube-proxy`, reversibly, by adding a node selector that doesn't match and nodes to
 `kube-proxy`'s `DaemonSet`, for example:

--- a/calico-enterprise_versioned_docs/version-3.19-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/release-notes/index.mdx
@@ -174,3 +174,22 @@ No other components have been changed.
   AKS began applying an image set to clusters with Kubernetes 1.29, and this change conflicted with operations performed by the Tigera Operator during migration.
   We fixed the issue by modifying how the Tigera Operator checks for image sets during migrations to Calico Enterprise.
 * Removed a mutual dependency between logstorage and other components that could result in a degraded TigeraStatus if certificates are missing required key usages.
+
+### Calico Enterprise 3.19.2 bug fix release
+
+August 30, 2024
+
+Calico Enterprise 3.19.2 is now available.
+This release includes bug fixes and improvements.
+
+#### Bug fixes
+
+* Fix that Felix would panic when trying to resync a temporary IP set.  Temporary IP sets are created in certain scenarios after previous failures.
+* Reduce lock contention between the process info cache and the flow logs collector.  Avoids slowing down the collector when the info cache is under update load.
+* Fix excessive CPU usage in the process name lookup cache if a PID was unknown.
+* Updates the default behaviour of list request without tier field selector or label selector on globalnetworkpolicy, stagedglobalnetworkpolicy, networkpolicy and staged network policy to return all policies available to user, instead of returning only the policies in the default tier. This change allows to manage policies with GitOps tools like ArgoCD.
+* Fix Felix panic when using non-default BPF map sizes. Size was not updated in all places resulting in failure to attach programs.
+* Fix dual ToR startup when using bgp-layout ConfigMap to assign AS numbers.
+* Security updates.
+
+To update an existing installation of Calico Enterprise 3.19, see [Install a patch release](../getting-started/manifest-archive.mdx).

--- a/calico-enterprise_versioned_docs/version-3.19-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/release-notes/index.mdx
@@ -190,6 +190,7 @@ This release includes bug fixes and improvements.
 * Updates the default behaviour of list request without tier field selector or label selector on globalnetworkpolicy, stagedglobalnetworkpolicy, networkpolicy and staged network policy to return all policies available to user, instead of returning only the policies in the default tier. This change allows to manage policies with GitOps tools like ArgoCD.
 * Fix Felix panic when using non-default BPF map sizes. Size was not updated in all places resulting in failure to attach programs.
 * Fix dual ToR startup when using bgp-layout ConfigMap to assign AS numbers.
+* Added support for eBPF on MKE.
 * Security updates.
 
 To update an existing installation of Calico Enterprise 3.19, see [Install a patch release](../getting-started/manifest-archive.mdx).

--- a/calico-enterprise_versioned_docs/version-3.19-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.19-2/releases.json
@@ -1,5 +1,256 @@
 [
   {
+    "title": "v3.19.2",
+    "tigera-operator": {
+      "image": "tigera/operator",
+      "version": "v1.34.2",
+      "registry": "quay.io"
+    },
+    "calico": {
+      "minor_version": "v3.28",
+      "archive_path": "archive"
+    },
+    "components": {
+      "cnx-manager": {
+        "image": "tigera/cnx-manager",
+        "version": "v3.19.2"
+      },
+      "voltron": {
+        "image": "tigera/voltron",
+        "version": "v3.19.2"
+      },
+      "guardian": {
+        "image": "tigera/guardian",
+        "version": "v3.19.2"
+      },
+      "cnx-apiserver": {
+        "image": "tigera/cnx-apiserver",
+        "version": "v3.19.2"
+      },
+      "cnx-queryserver": {
+        "image": "tigera/cnx-queryserver",
+        "version": "v3.19.2"
+      },
+      "cnx-kube-controllers": {
+        "image": "tigera/kube-controllers",
+        "version": "v3.19.2"
+      },
+      "calicoq": {
+        "image": "tigera/calicoq",
+        "version": "v3.19.2"
+      },
+      "typha": {
+        "image": "tigera/typha",
+        "version": "v3.19.2"
+      },
+      "calicoctl": {
+        "image": "tigera/calicoctl",
+        "version": "v3.19.2"
+      },
+      "cnx-node": {
+        "image": "tigera/cnx-node",
+        "version": "v3.19.2"
+      },
+      "cnx-node-windows": {
+        "image": "tigera/cnx-node-windows",
+        "version": "v3.19.2"
+      },
+      "dikastes": {
+        "image": "tigera/dikastes",
+        "version": "v3.19.2"
+      },
+      "dex": {
+        "image": "tigera/dex",
+        "version": "v3.19.2"
+      },
+      "fluentd": {
+        "image": "tigera/fluentd",
+        "version": "v3.19.2"
+      },
+      "fluentd-windows": {
+        "image": "tigera/fluentd-windows",
+        "version": "v3.19.2"
+      },
+      "es-proxy": {
+        "image": "tigera/es-proxy",
+        "version": "v3.19.2"
+      },
+      "eck-kibana": {
+        "version": "7.17.21"
+      },
+      "kibana": {
+        "image": "tigera/kibana",
+        "version": "v3.19.2"
+      },
+      "eck-elasticsearch": {
+        "version": "7.17.21"
+      },
+      "elasticsearch": {
+        "image": "tigera/elasticsearch",
+        "version": "v3.19.2"
+      },
+      "elastic-tsee-installer": {
+        "image": "tigera/intrusion-detection-job-installer",
+        "version": "v3.19.2"
+      },
+      "intrusion-detection-controller": {
+        "image": "tigera/intrusion-detection-controller",
+        "version": "v3.19.2"
+      },
+      "compliance-controller": {
+        "image": "tigera/compliance-controller",
+        "version": "v3.19.2"
+      },
+      "compliance-reporter": {
+        "image": "tigera/compliance-reporter",
+        "version": "v3.19.2"
+      },
+      "compliance-snapshotter": {
+        "image": "tigera/compliance-snapshotter",
+        "version": "v3.19.2"
+      },
+      "compliance-server": {
+        "image": "tigera/compliance-server",
+        "version": "v3.19.2"
+      },
+      "compliance-benchmarker": {
+        "image": "tigera/compliance-benchmarker",
+        "version": "v3.19.2"
+      },
+      "ingress-collector": {
+        "image": "tigera/ingress-collector",
+        "version": "v3.19.2"
+      },
+      "l7-collector": {
+        "image": "tigera/l7-collector",
+        "version": "v3.19.2"
+      },
+      "license-agent": {
+        "image": "tigera/license-agent",
+        "version": "v3.19.2"
+      },
+      "tigera-cni": {
+        "image": "tigera/cni",
+        "version": "v3.19.2"
+      },
+      "tigera-cni-windows": {
+        "image": "tigera/cni-windows",
+        "version": "v3.19.2"
+      },
+      "firewall-integration": {
+        "image": "tigera/firewall-integration",
+        "version": "v3.19.2"
+      },
+      "egress-gateway": {
+        "image": "tigera/egress-gateway",
+        "version": "v3.19.2"
+      },
+      "honeypod": {
+        "image": "tigera/honeypod",
+        "version": "v3.19.2"
+      },
+      "honeypod-exp-service": {
+        "image": "tigera/honeypod-exp-service",
+        "version": "v3.19.2"
+      },
+      "honeypod-controller": {
+        "image": "tigera/honeypod-controller",
+        "version": "v3.19.2"
+      },
+      "key-cert-provisioner": {
+        "image": "tigera/key-cert-provisioner",
+        "version": "v3.19.2"
+      },
+      "elasticsearch-metrics": {
+        "image": "tigera/elasticsearch-metrics",
+        "version": "v3.19.2"
+      },
+      "packetcapture": {
+        "image": "tigera/packetcapture",
+        "version": "v3.19.2"
+      },
+      "policy-recommendation": {
+        "image": "tigera/policy-recommendation",
+        "version": "v3.19.2"
+      },
+      "prometheus": {
+        "image": "tigera/prometheus",
+        "version": "v3.19.2"
+      },
+      "coreos-prometheus": {
+        "version": "v2.48.1"
+      },
+      "coreos-prometheus-operator": {
+        "version": "v0.70.0"
+      },
+      "coreos-config-reloader": {
+        "version": "v0.70.0"
+      },
+      "prometheus-operator": {
+        "image": "tigera/prometheus-operator",
+        "version": "v3.19.2"
+      },
+      "prometheus-config-reloader": {
+        "image": "tigera/prometheus-config-reloader",
+        "version": "v3.19.2"
+      },
+      "tigera-prometheus-service": {
+        "image": "tigera/prometheus-service",
+        "version": "v3.19.2"
+      },
+      "es-gateway": {
+        "image": "tigera/es-gateway",
+        "version": "v3.19.2"
+      },
+      "linseed": {
+        "image": "tigera/linseed",
+        "version": "v3.19.2"
+      },
+      "deep-packet-inspection": {
+        "image": "tigera/deep-packet-inspection",
+        "version": "v3.19.2"
+      },
+      "eck-elasticsearch-operator": {
+        "version": "2.6.1"
+      },
+      "elasticsearch-operator": {
+        "image": "tigera/eck-operator",
+        "version": "v3.19.2"
+      },
+      "coreos-alertmanager": {
+        "version": "v0.25.1"
+      },
+      "alertmanager": {
+        "image": "tigera/alertmanager",
+        "version": "v3.19.2"
+      },
+      "envoy": {
+        "image": "tigera/envoy",
+        "version": "v3.19.2"
+      },
+      "envoy-init": {
+        "image": "tigera/envoy-init",
+        "version": "v3.19.2"
+      },
+      "webhooks-processor": {
+        "image": "tigera/webhooks-processor",
+        "version": "v3.19.2"
+      },
+      "flexvol": {
+        "image": "tigera/pod2daemon-flexvol",
+        "version": "v3.19.2"
+      },
+      "csi": {
+        "image": "tigera/csi",
+        "version": "v3.19.2"
+      },
+      "csi-node-driver-registrar": {
+        "image": "tigera/node-driver-registrar",
+        "version": "v3.19.2"
+      }
+    }
+  },
+  {
     "title": "v3.19.1",
     "tigera-operator": {
       "image": "tigera/operator",

--- a/calico-enterprise_versioned_docs/version-3.19-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.19-2/releases.json
@@ -3,7 +3,7 @@
     "title": "v3.19.2",
     "tigera-operator": {
       "image": "tigera/operator",
-      "version": "v1.34.2",
+      "version": "v1.34.4",
       "registry": "quay.io"
     },
     "calico": {

--- a/calico-enterprise_versioned_docs/version-3.19-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.19-2/releases.json
@@ -76,14 +76,14 @@
         "version": "v3.19.2"
       },
       "eck-kibana": {
-        "version": "7.17.21"
+        "version": "7.17.22"
       },
       "kibana": {
         "image": "tigera/kibana",
         "version": "v3.19.2"
       },
       "eck-elasticsearch": {
-        "version": "7.17.21"
+        "version": "7.17.22"
       },
       "elasticsearch": {
         "image": "tigera/elasticsearch",
@@ -181,10 +181,10 @@
         "version": "v2.48.1"
       },
       "coreos-prometheus-operator": {
-        "version": "v0.70.0"
+        "version": "v0.73.2"
       },
       "coreos-config-reloader": {
-        "version": "v0.70.0"
+        "version": "v0.73.2"
       },
       "prometheus-operator": {
         "image": "tigera/prometheus-operator",

--- a/calico-enterprise_versioned_docs/version-3.19-2/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.19-2/variables.js
@@ -1,12 +1,12 @@
 const releases = require('./releases.json');
 
 const variables = {
-  releaseTitle: 'v3.19.1',
+  releaseTitle: 'v3.19.2',
   prodname: 'Calico Enterprise',
   prodnamedash: 'calico-enterprise',
   version: 'v3.19',
   baseUrl: '/calico-enterprise/latest',
-  filesUrl: 'https://downloads.tigera.io/ee/v3.19.1',
+  filesUrl: 'https://downloads.tigera.io/ee/v3.19.2',
   tutorialFilesURL: 'https://docs.tigera.io/files',
   tmpScriptsURL: 'https://docs.tigera.io/calico-enterprise/3.19',
   windowsScriptsURL: 'https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess',
@@ -16,7 +16,7 @@ const variables = {
   noderunning: 'calico-node',
   rootDirWindows: 'C:\\TigeraCalico',
   registry: 'quay.io/',
-  chart_version_name: 'v3.19.1-1',
+  chart_version_name: 'v3.19.2-0',
   tigeraOperator: releases[0]['tigera-operator'],
   dikastesVersion: releases[0].components.dikastes.version,
   releases,

--- a/calico/operations/ebpf/enabling-ebpf.mdx
+++ b/calico/operations/ebpf/enabling-ebpf.mdx
@@ -40,6 +40,7 @@ eBPF (or "extended Berkeley Packet Filter"), is a technology that allows safe mi
     - [AKS with Azure CNI and Calico network policy](../../getting-started/kubernetes/managed-public-cloud/aks.mdx#install-aks-with-calico-for-network-policy) works, but it is not possible to disable kube-proxy resulting in wasted resources and suboptimal performance.
     - [AKS with {{prodname}} networking](../../getting-started/kubernetes/managed-public-cloud/aks.mdx#install-aks-with-calico-networking) is in testing with the eBPF dataplane. This should be a better solution overall but, at time of writing, the testing was not complete.
   - RKE (RKE2 recommended because it supports disabling `kube-proxy`)
+  - MKE
 
 - Linux distribution/kernel:
 
@@ -145,6 +146,8 @@ The best way to do that varies by Kubernetes distribution:
   `api-int.<cluster_name>.<base_domain>` should point to the API server or to the load balancer in front of the
   API server. Use that (filling in the `<cluster_name>` and `<base_domain>` as appropriate for your cluster) for the
   `KUBERNETES_SERVICE_HOST` below. Openshift uses 6443 for the `KUBERNETES_SERVICE_PORT`.
+- MKE runs a reverse proxy in each node that can be used to reach the API server. You should use `proxy.local`
+  as the `KUBERNETES_SERVICE_HOST` and `6444` as the `KUBERNETES_SERVICE_PORT`.
 - For AKS and EKS clusters you should use the FQDN of the API server's load balancer. This can be found with
   ```
   kubectl cluster-info
@@ -285,6 +288,13 @@ To re-enable it:
 kubectl patch networks.operator.openshift.io cluster --type merge -p '{"spec":{"deployKubeProxy": true}}'
 ```
 
+#### MKE
+
+If you are running MKE, you can disable `kube-proxy` as follows:
+
+Follow the step procedure in [Modify an existing MKE configuration](https://docs.mirantis.com/mke/current/ops/administer-cluster/configure-an-mke-cluster/use-an-mke-configuration-file.html#modify-an-existing-mke-configuration) to download, edit, and upload your MKE configuration. During the editing step, add the following configuration:
+`kube_proxy_mode=disabled` and `kube_default_drop_masq_bits=true`.
+ 
 ### Avoiding conflicts with kube-proxy
 
 If you cannot disable `kube-proxy` (for example, because it is managed by your Kubernetes distribution), then you _must_ change Felix configuration parameter `BPFKubeProxyIptablesCleanupEnabled` to `false`. This can be done with `kubectl` as follows:
@@ -376,6 +386,8 @@ To revert to standard Linux networking:
 
    ```
    kubectl patch ds -n kube-system kube-proxy --type merge -p '{"spec":{"template":{"spec":{"nodeSelector":{"non-calico": null}}}}}'
-   ```
+
+2. If you are running MKE, follow the step procedure in [Modify an existing MKE configuration](https://docs.mirantis.com/mke/current/ops/administer-cluster/configure-an-mke-cluster/use-an-mke-configuration-file.html#modify-an-existing-mke-configuration) to download, edit, and upload your MKE configuration. During the editing step, add the following configuration:
+`kube_proxy_mode` to `iptables`.
 
 1. Since disabling eBPF mode is disruptive to existing connections, monitor existing workloads to make sure they re-establish any connections that were disrupted by the switch.

--- a/calico/operations/ebpf/install.mdx
+++ b/calico/operations/ebpf/install.mdx
@@ -40,6 +40,7 @@ and in particular, pushing the networking capabilities of the latest Linux kerne
   - OpenShift
   - EKS
   - AKS
+  - MKE
 
 - Linux distribution/kernel:
 
@@ -123,7 +124,7 @@ Select the appropriate tab below for distribution-specific instructions:
 `kubeadm` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 20.04) meets the kernel
 requirements, `kubeadm`-provisioned clusters are supported.
 
-Since `kube-proxy` is not required in eBPF mode, you may wish to disable `kube-proxy` at install time. With `kubeadm`
+Since `kube-proxy` is not required in eBPF mode, you must disable `kube-proxy` at install time. With `kubeadm`
 you can do that by passing the ` --skip-phases=addon/kube-proxy` flag to `kubeadm init`:
 
 ```bash
@@ -136,7 +137,7 @@ kubeadm init --skip-phases=addon/kube-proxy
 `kops` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 20.04 or RHEL 8.2) meets the kernel
 requirements, `kops`-provisioned clusters are supported.
 
-Since `kube-proxy` is not required in eBPF mode, you may wish to disable `kube-proxy` at install time. With `kops` you
+Since `kube-proxy` is not required in eBPF mode, you must disable `kube-proxy` at install time. With `kops` you
 can do that by setting the following in your `kops` configuration:
 
 ```yaml
@@ -168,6 +169,17 @@ default kernel used by Amazon Linux is recent enough to run eBPF mode, as is the
 18.04 image did not have a recent-enough kernel (but that may have changed by the time you read this).
 
 </TabItem>
+<TabItem label="MKE" value="MKE-5">
+
+The eBPF data plane is supported on MKE with any Linux operating system that meets the minimum kernel requirements.
+
+Since `kube-proxy` is not required in eBPF mode, you must disable `kube-proxy` at install time. With `MKE` you
+can do that by setting `--kube-proxy-mode=disabled` and `--kube-default-drop-masq-bits` when installing the cluster.
+
+More details can be found in [the MKE documentation](https://docs.mirantis.com/mke/current/install/predeployment/configure-networking/cluster-service-networking-options.html)
+
+</TabItem>
+
 </Tabs>
 
 ### Create kubernetes-service-endpoint config map
@@ -184,7 +196,7 @@ scaled up/down. If you have multiple API servers, with DNS or other load balanci
 the address of the load balancer. This prevents {{prodname}} from being disconnected if the API servers IP changes.
 
 <Tabs>
-<TabItem label="Generic or kubeadm" value="Generic or kubeadm-5">
+<TabItem label="Generic or kubeadm" value="Generic or kubeadm-6">
 
 If you created a cluster manually (for example by using `kubeadm`) then the right address to use depends on whether you
 opted for a high-availability cluster with multiple API servers or a simple one-node API server.
@@ -198,13 +210,13 @@ opted for a high-availability cluster with multiple API servers or a simple one-
   causing {{prodname}} to lose connectivity to the API server.
 
 </TabItem>
-<TabItem label="kOps" value="kOps-6">
+<TabItem label="kOps" value="kOps-7">
 
 When using `kops`, `kops` typically sets up a load balancer of some sort in front of the API server. You should use
 the FQDN and port of the API load balancer: `api.internal.<clustername>`.
 
 </TabItem>
-<TabItem label="OpenShift" value="OpenShift-7">
+<TabItem label="OpenShift" value="OpenShift-8">
 
 OpenShift requires various DNS records to be created for the cluster; one of these is exactly what we need:
 `api.<cluster_name>.<base_domain>` should point to the API server or to the load balancer in front of the
@@ -212,7 +224,7 @@ API server. Use that (filling in the `<cluster_name>` and `<base_domain>` as app
 `KUBERNETES_SERVICE_HOST` below. Openshift uses 6443 for the `KUBERNETES_SERVICE_PORT`.
 
 </TabItem>
-<TabItem label="AKS" value="AKS-8">
+<TabItem label="AKS" value="AKS-9">
 
 For AKS clusters, you should use the FQDN of your API server. This can be found by running the following command:
 
@@ -230,7 +242,7 @@ In this example, you would use `mycalicocl-calicodemorg-03a087-36558dbb.hcp.cana
 `KUBERNETES_SERVICE_HOST` and `443` for `KUBERNETES_SERVICE_PORT` when creating the config map.
 
 </TabItem>
-<TabItem label="EKS" value="EKS-9">
+<TabItem label="EKS" value="EKS-10">
 
 For an EKS cluster, it's important to use the domain name of the EKS-provided load balancer that is in front of the API
 server. This can be found by running the following command:
@@ -248,6 +260,12 @@ Kubernetes master is running at https://60F939227672BC3D5A1B3EC9744B2B21.gr7.us-
 
 In this example, you would use `60F939227672BC3D5A1B3EC9744B2B21.gr7.us-west-2.eks.amazonaws.com` for
 `KUBERNETES_SERVICE_HOST` and `443` for `KUBERNETES_SERVICE_PORT` when creating the config map.
+
+</TabItem>
+<TabItem label="MKE" value="MKE-11">
+
+MKE runs a reverse proxy in each node which can be used to reach the api-server. `KUBERNETES_SERVICE_HOST` must be set to
+`proxy.local` and `KUBERNETES_SERVICE_PORT` must be set to `6444`.
 
 </TabItem>
 </Tabs>
@@ -367,7 +385,7 @@ kubectl patch ds -n kube-system kube-proxy -p '{"spec":{"template":{"spec":{"nod
 Then, should you want to start `kube-proxy` again, you can simply remove the node selector.
 
 </TabItem>
-<TabItem label="kOps" value="kOps-11">
+<TabItem label="kOps" value="kOps-12">
 
 `kops` allows `kube-proxy` to be disabled by setting
 
@@ -379,7 +397,7 @@ kubeProxy:
 in its configuration. You will need to do `kops update cluster` to roll out the change.
 
 </TabItem>
-<TabItem label="OpenShift" value="OpenShift-12">
+<TabItem label="OpenShift" value="OpenShift-13">
 
 In OpenShift, you can disable `kube-proxy` as follows:
 
@@ -394,7 +412,7 @@ kubectl patch networks.operator.openshift.io cluster --type merge -p '{"spec":{"
 ```
 
 </TabItem>
-<TabItem label="AKS" value="AKS-13">
+<TabItem label="AKS" value="AKS-14">
 
 AKS with Azure CNI does not allow `kube-proxy` to be disabled, `kube-proxy` is deployed by the add-on manager, which will reconcile
 away any manual changes made to its configuration. To ensure `kube-proxy` and {{prodname}} don't fight, set
@@ -406,7 +424,7 @@ kubectl patch felixconfiguration default --type merge --patch='{"spec": {"bpfKub
 ```
 
 </TabItem>
-<TabItem label="EKS" value="EKS-14">
+<TabItem label="EKS" value="EKS-15">
 
 In EKS, you can disable `kube-proxy`, reversibly, by adding a node selector that doesn't match and nodes to
 `kube-proxy`'s `DaemonSet`, for example:


### PR DESCRIPTION
Still needs:
* ~version updates~
* ~merge #1556 to this branch. @sridhartigera is going to:~
  * ~port changes to 3.19 docs~
  * ~fetch `publish/ce-3.19.2` change tracking branch to `publish/ce-3.19.2`, squash commits with git rebase -i~
  * ~confirm build passes (yarn build)~
  * ~change PR target branch to `publish/ce-3.19.2`~
  * ~tag @rene-dekker for review and merge~ @ctauchen reviewed
  * ~merge~
  * There won't be a deploy preview, so we'll just rely on the report of a clean build 