### PR TITLE
Adds component for image captions

### DIFF
--- a/src/___new___/components/ImageCaption/index.tsx
+++ b/src/___new___/components/ImageCaption/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { ChakraProvider, Text } from '@chakra-ui/react';
+import { imageCaptionStyles } from './styles';
+import { theme } from '../../theme';
+
+const ImageCaption: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <ChakraProvider theme={theme}>
+    <Text sx={imageCaptionStyles}>{children}</Text>
+  </ChakraProvider>
+);
+
+export default ImageCaption;

--- a/src/___new___/components/ImageCaption/styles.ts
+++ b/src/___new___/components/ImageCaption/styles.ts
@@ -1,0 +1,6 @@
+export const imageCaptionStyles = {
+  fontSize: 'sm',
+  color: 'tigeraGrey.600',
+  fontStyle: 'italic',
+  textAlign: 'center',
+};

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -2,9 +2,11 @@ import React from 'react';
 import MDXComponents from '@theme-original/MDXComponents';
 import GeekDetails from '@site/src/components/partials/GeekDetails';
 import Callouts from '@site/src/components/Callouts';
+import ImageCaption from '@site/src/___new___/components/ImageCaption';
 
 export default {
   ...MDXComponents,
   GeekDetails,
   Callouts,
+  ImageCaption,
 };


### PR DESCRIPTION
This adds a new global component, `ImageCaption`, which defines styles for image captions. We haven't been at all consistent in using captions, let alone styling them consistently. This is a first step toward fixing this in the docs.

Demonstration: 
![image](https://github.com/user-attachments/assets/f84fee7e-0fb5-40cf-b173-bd54dccae89b)
-----