### PR TITLE
Update Prometheus to v2.54.1 and AlertManager to v0.27.0

### DIFF
--- a/calico-enterprise/releases.json
+++ b/calico-enterprise/releases.json
@@ -171,7 +171,7 @@
         "version": "master"
       },
       "coreos-prometheus": {
-        "version": "v2.48.1"
+        "version": "v2.54.1"
       },
       "prometheus-operator": {
         "image": "tigera/prometheus-operator",
@@ -201,7 +201,7 @@
         "version": "master"
       },
       "coreos-alertmanager": {
-        "version": "v0.25.1"
+        "version": "v0.27.0"
       },
       "alertmanager": {
         "image": "tigera/alertmanager",


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Update Prometheus to v2.54.1 and AlertManager to v0.27.0

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->
https://tigera.atlassian.net/browse/EV-5181
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->