### PR TITLE
DOCS-2309: Publishes Calico Open Source 3.28.2

### DIFF
--- a/calico_versioned_docs/version-3.28/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.28/release-notes/index.mdx
@@ -193,7 +193,7 @@ To update an existing installation of Calico Open Source 3.28, see [the upgrade 
 
 ### Calico Open Source 3.28.2 bug fix update
 
-September 18, 2024
+September 19, 2024
 
 #### Bug fixes
 

--- a/calico_versioned_docs/version-3.28/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.28/release-notes/index.mdx
@@ -195,10 +195,18 @@ To update an existing installation of Calico Open Source 3.28, see [the upgrade 
 
 September 18, 2024
 
-#### Enhancements
-
 #### Bug fixes
 
-#### How to update
+ - Don't run pprof on prometheus metrics port [calico #9224](https://github.com/projectcalico/calico/pull/9224) (@coutinhop)
+ - ebpf: Fix for Istio ambient mode - traffic that arrives from host should go back through host and not skip iptables [calico #9199](https://github.com/projectcalico/calico/pull/9199) (@tomastigera)
+ - [etcd mode] Fix issue where Calico nodes failed to decommission if calico-kube-controllers was running on the terminated node. [calico #9197](https://github.com/projectcalico/calico/pull/9197) (@caseydavenport)
+ - ebpf: Attach XDP to bond slave devices. [calico #9143](https://github.com/projectcalico/calico/pull/9143) (@sridhartigera)
+ - BGP: Prevent the advertisement of local kernel routes learned from eBPF interfaces (bpf*.cali) to peers. [calico #9127](https://github.com/projectcalico/calico/pull/9127) (@mazdakn)
+ - Fix Felix panic when using non-default BPF map sizes.  Size was not updated in all places resulting in failure to attach programs. [calico #9118](https://github.com/projectcalico/calico/pull/9118) (@sridhartigera)
+ - Fix interaction between kube-proxy and Calico's SNAT rules that could cause corrupted VXLAN packets when checksum offload was enabled.  Move Calico's rules after kube-proxy's to make sure kube-proxy's mark bit is cleared if both would have done SNAT. [calico #9102](https://github.com/projectcalico/calico/pull/9102) (@tomastigera)
+ - Fix missing resources in calioctl command help text [calico #9095](https://github.com/projectcalico/calico/pull/9095) (@caseydavenport)
+ - ebpf: Fix parsing host IP update and re-attach program on all interfaces when there is a host IP update; fix frequently attaching BPF programs when pods annotations/labels change and eventually failing due ro running out of tc priority. [calico #9094](https://github.com/projectcalico/calico/pull/9094) (@sridhartigera)
+ - Fix Felix panicing when trying to resync a temporary IP set. Temporary IP sets are created in certain scenarios after previous failures. [calico #9078](https://github.com/projectcalico/calico/pull/9078) (@fasaxc)
+ - Helm: Fix error parsing kubernetesServiceEndpoint.host and kubernetesServiceEndpoint.port as an integer [calico #9068](https://github.com/projectcalico/calico/pull/9068) (@MichalFupso)
 
 To update an existing installation of Calico Open Source 3.28, see [the upgrade guides](../operations/upgrading/index.mdx).

--- a/calico_versioned_docs/version-3.28/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.28/release-notes/index.mdx
@@ -190,3 +190,15 @@ July 30, 2024
 #### How to update
 
 To update an existing installation of Calico Open Source 3.28, see [the upgrade guides](../operations/upgrading/index.mdx).
+
+### Calico Open Source 3.28.2 bug fix update
+
+September 18, 2024
+
+#### Enhancements
+
+#### Bug fixes
+
+#### How to update
+
+To update an existing installation of Calico Open Source 3.28, see [the upgrade guides](../operations/upgrading/index.mdx).

--- a/calico_versioned_docs/version-3.28/releases.json
+++ b/calico_versioned_docs/version-3.28/releases.json
@@ -1,5 +1,57 @@
 [
   {
+    "title": "v3.28.2",
+    "tigera-operator": {
+      "image": "tigera/operator",
+      "registry": "quay.io",
+      "version": "v1.34.3"
+    },
+    "components": {
+      "typha": {
+        "version": "v3.28.2"
+      },
+      "calicoctl": {
+        "version": "v3.28.2"
+      },
+      "calico/node": {
+        "version": "v3.28.2"
+      },
+      "calico/cni": {
+        "version": "v3.28.2"
+      },
+      "calico/apiserver": {
+        "version": "v3.28.2"
+      },
+      "calico/kube-controllers": {
+        "version": "v3.28.2"
+      },
+      "calico/flannel-migration-controller": {
+        "version": "v3.28.2"
+      },
+      "calico/windows": {
+        "version": "v3.28.2"
+      },
+      "networking-calico": {
+        "version": "v3.28.2"
+      },
+      "flannel": {
+        "version": "v0.16.3"
+      },
+      "calico/dikastes": {
+        "version": "v3.28.2"
+      },
+      "flexvol": {
+        "version": "v3.28.2"
+      },
+      "csi-driver": {
+        "version": "v3.28.2"
+      },
+      "csi-node-driver-registrar": {
+        "version": "v3.28.2"
+      }
+    }
+  },
+  {
     "title": "v3.28.1",
     "tigera-operator": {
       "image": "tigera/operator",

--- a/calico_versioned_docs/version-3.28/releases.json
+++ b/calico_versioned_docs/version-3.28/releases.json
@@ -4,7 +4,7 @@
     "tigera-operator": {
       "image": "tigera/operator",
       "registry": "quay.io",
-      "version": "v1.34.3"
+      "version": "v1.34.5"
     },
     "components": {
       "typha": {

--- a/calico_versioned_docs/version-3.28/variables.js
+++ b/calico_versioned_docs/version-3.28/variables.js
@@ -1,7 +1,7 @@
 const releases = require('./releases.json');
 
 const variables = {
-  releaseTitle: 'v3.28.1',
+  releaseTitle: 'v3.28.2',
   prodname: 'Calico',
   prodnamedash: 'calico',
   version: 'v3.28',
@@ -17,7 +17,7 @@ const variables = {
   noderunning: 'calico-node',
   rootDirWindows: 'C:\\CalicoWindows',
   ppa_repo_name: 'calico-3.28',
-  manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.28.1',
+  manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.28.2',
   releases,
   registry: '',
   vppbranch: 'v3.28.0',


### PR DESCRIPTION
@coutinhop @danudey 
Still needs:
* operator version
* flannel version, if applicable
* autogenerated RN items