### PR TITLE
DOCS-2339: Fixes broken anchors for operator reference links

### DIFF
--- a/calico-cloud/networking/configuring/dual-tor.mdx
+++ b/calico-cloud/networking/configuring/dual-tor.mdx
@@ -640,7 +640,7 @@ The only connections using interface-specific addresses should be BGP.
 If you plan to use [Egress Gateways](../egress/egress-gateway-on-prem.mdx) in your cluster, you must also adjust the {variables.nodecontainer} IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-{variables.prodname} [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+{variables.prodname} [Installation resource](../../reference/installation/api.mdx#NodeAddressAutodetection.
 
 :::
 

--- a/calico-cloud/networking/configuring/multiple-networks.mdx
+++ b/calico-cloud/networking/configuring/multiple-networks.mdx
@@ -79,7 +79,7 @@ Although the following {variables.prodname} features are supported for your defa
 
 ### Configure cluster for multiple networks
 
-In the [Installation custom resource](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoNetworkSpec), set the `MultiInterfaceMode` to **Multus**.
+In the [Installation custom resource](../../reference/installation/api.mdx#CalicoNetworkSpec, set the `MultiInterfaceMode` to **Multus**.
 
 ### Create a new network
 

--- a/calico-cloud/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-cloud/networking/egress/egress-gateway-on-prem.mdx
@@ -350,7 +350,7 @@ To modify the iptables backend for egress gateways, you must change the `iptable
 If you plan to use Egress Gateways in a [dual-ToR cluster](../configuring/dual-tor.mdx), you must also adjust the {variables.nodecontainer} IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-{variables.prodname} [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+{variables.prodname} [Installation resource](../../reference/installation/api.mdx#NodeAddressAutodetection.
 
 ### Configure namespaces and pods to use egress gateways
 

--- a/calico-cloud/networking/ipam/initial-ippool.mdx
+++ b/calico-cloud/networking/ipam/initial-ippool.mdx
@@ -24,7 +24,7 @@ The **Kubernetes pod CIDR** is the expected IP address range for pod IPs. It is 
 
 [Calico IP pools](../../reference/resources/ippool.mdx) are ranges of IP addresses that Calico uses to assign to pods; the ranges must within the Kubernetes pod CIDR.
 
-The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#Installation
 resource and configures the default Calico IP pool. Note the following:
 
 - Default fields for any that are omitted:
@@ -44,7 +44,7 @@ resource and configures the default Calico IP pool. Note the following:
 ## How to
 
 1. Download the custom-resource.yaml file.
-1. Edit the [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation).  
+1. Edit the [Installation resource](../../reference/installation/api.mdx#Installation.  
    **Required values**: `cidr:`  
    **Empty values**: Defaulted
 

--- a/calico-cloud/networking/ipam/ip-autodetection.mdx
+++ b/calico-cloud/networking/ipam/ip-autodetection.mdx
@@ -51,7 +51,7 @@ By default, {variables.prodname} uses the **firstFound** method; the first valid
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#NodeAddressAutodetection in the operator Installation reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-cloud/operations/comms/certificate-management.mdx
+++ b/calico-cloud/operations/comms/certificate-management.mdx
@@ -21,7 +21,7 @@ certificate issuance, {variables.prodname} provides a simple configuration optio
 **Limitations**
 
 If your cluster is already running {variables.prodname} and you would like to enable certificate management, you need to
-temporarily remove [the logstorage resource](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+temporarily remove [the logstorage resource](../../reference/installation/api.mdx#LogStorage
 before following the steps to enable certificate management and then re-apply afterwards.
 
 {/*TODO-XREFS-CC
@@ -40,7 +40,7 @@ Currently, this feature is not supported in combination with [Multi-cluster mana
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../../reference/installation/api.mdx#Installation
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
 ```yaml

--- a/calico-cloud/reference/component-resources/configuration.mdx
+++ b/calico-cloud/reference/component-resources/configuration.mdx
@@ -241,7 +241,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#Installation API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico-cloud/reference/component-resources/configure-resources.mdx
+++ b/calico-cloud/reference/component-resources/configure-resources.mdx
@@ -16,11 +16,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../../reference/installation/api.mdx#APIServer CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the installation CR using the below command:
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#APIServerDeployment, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch apiserver tigera-secure  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -68,11 +68,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## ApplicationLayer custom resource
 
-The [ApplicationLayer](../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
+The [ApplicationLayer](../../reference/installation/api.mdx#ApplicationLayer CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
 
 ### L7LogCollectorDaemonSet
 
-To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.L7LogCollectorDaemonSet), patch the ApplicationLayer CR using the below command:
+To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#L7LogCollectorDaemonSet, patch the ApplicationLayer CR using the below command:
 
 ```bash
 $ kubectl patch applicationlayer tigera-secure  --type=merge --patch='{"spec": {"l7LogCollectorDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"l7-collector","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"envoy-proxy","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -121,11 +121,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Compliance custom resource
 
-The [Compliance](../../reference/installation/api.mdx#operator.tigera.io/v1.Compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
+The [Compliance](../../reference/installation/api.mdx#Compliance CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
 
 ### ComplianceControllerDeployment
 
-To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceControllerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#ComplianceControllerDeployment, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -161,7 +161,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceSnapshotterDeployment
 
-To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceSnapshotterDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#ComplianceSnapshotterDeployment, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceSnapshotterDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-snapshotter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -197,7 +197,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceBenchmarkerDaemonSet
 
-To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#ComplianceBenchmarkerDaemonSet, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceBenchmarkerDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-benchmarker","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -232,7 +232,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceServerDeployment
 
-To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceServerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#ComplianceServerDeployment, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -268,7 +268,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceReporterPodTemplate.
 
-To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceReporterPodTemplate), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#ComplianceReporterPodTemplate, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceReporterPodTemplate": {"template": {"spec": {"containers":[{"name":"reporter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}'
@@ -310,7 +310,7 @@ Example Configurations:
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#TyphaDeployment, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -346,7 +346,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#calicoNodeDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -381,7 +381,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#calicoNodeWindowsDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -416,7 +416,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#CalicoKubeControllersDeployment component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -452,7 +452,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#CSINodeDriverDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -500,11 +500,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## IntrusionDetection custom resource
 
-The [IntrusionDetection](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
+The [IntrusionDetection](../../reference/installation/api.mdx#IntrusionDetection CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
 
 ### IntrusionDetectionControllerDeployment.
 
-To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionControllerDeployment), patch the IntrusionDetection CR using the below command:
+To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#IntrusionDetectionControllerDeployment, patch the IntrusionDetection CR using the below command:
 
 ```bash
 $ kubectl patch intrusiondetection tigera-secure  --type=merge --patch='{"spec": {"intrusionDetectionControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"webhooks-processor","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}},{"name":"controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -552,11 +552,11 @@ This command will output the configured resource requests and limits for the Int
 
 ## LogCollector custom resource
 
-The [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
+The [LogCollector](../../reference/installation/api.mdx#LogCollector CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
 
 ### FluentdDaemonSet.
 
-To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.FluentdDaemonSet), patch the LogCollector CR using the below command:
+To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#FluentdDaemonSet, patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"fluentdDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"fluentd","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -592,7 +592,7 @@ This command will output the configured resource requests and limits for the Flu
 
 ### EKSLogForwarderDeployment.
 
-To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.EKSLogForwarderDeployment), patch the LogCollector CR using the below command:
+To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#EKSLogForwarderDeployment, patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"eksLogForwarderDeployment": {"spec": {"template": {"spec": {"containers":[{"name":"eks-log-forwarder","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -627,11 +627,11 @@ This command will output the configured resource requests and limits for the EKS
 
 ## ManagementClusterConnection custom resource
 
-The [ManagementClusterConnection](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
+The [ManagementClusterConnection](../../reference/installation/api.mdx#ManagementClusterConnection CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
 
 ### GuardianDeployment.
 
-To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.GuardianDeployment), patch the ManagementClusterConnection CR using the below command:
+To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#GuardianDeployment, patch the ManagementClusterConnection CR using the below command:
 
 ```bash
 kubectl patch managementclusterconnection tigera-secure  --type=merge --patch='{"spec": {"guardianDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-guardian","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -663,11 +663,11 @@ This command will output the configured resource requests and limits for the Gua
 
 ## PacketCaptureAPI custom resource
 
-The [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
+The [PacketCaptureAPI](../../reference/installation/api.mdx#PacketCaptureAPI CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
 
 ### PacketCaptureAPIDeployment
 
-To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI), patch the PacketCapture CR using the below command:
+To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#PacketCaptureAPI, patch the PacketCapture CR using the below command:
 
 ```bash
 kubectl patch packetcaptureapis tigera-secure  --type=merge --patch='{"spec": {"packetCaptureAPIDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-packetcapture-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'

--- a/calico-cloud/reference/installation/_api.mdx
+++ b/calico-cloud/reference/installation/_api.mdx
@@ -15,43 +15,43 @@ API Schema definitions for configuring the installation of Calico and Calico Ent
 </p>
 Resource Types:
 <ul><li>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>
+<a href="#APIServer">APIServer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.AmazonCloudIntegration">AmazonCloudIntegration</a>
+<a href="#AmazonCloudIntegration">AmazonCloudIntegration</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>
+<a href="#ApplicationLayer">ApplicationLayer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>
+<a href="#Authentication">Authentication</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>
+<a href="#Compliance">Compliance</a>
 </li><li>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>
+<a href="#EgressGateway">EgressGateway</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>
+<a href="#ImageSet">ImageSet</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>
+<a href="#Installation">Installation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>
+<a href="#IntrusionDetection">IntrusionDetection</a>
 </li><li>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>
+<a href="#LogCollector">LogCollector</a>
 </li><li>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>
+<a href="#LogStorage">LogStorage</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ManagementCluster">ManagementCluster</a>
+<a href="#ManagementCluster">ManagementCluster</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>
+<a href="#Manager">Manager</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>
+<a href="#Monitor">Monitor</a>
 </li><li>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>
+<a href="#PolicyRecommendation">PolicyRecommendation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>
+<a href="#Tenant">Tenant</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>
+<a href="#TigeraStatus">TigeraStatus</a>
 </li></ul>
-<h3 id="operator.tigera.io/v1.APIServer">APIServer</h3>
+<h3 id="APIServer">APIServer</h3>
 <p>
 APIServer installs the Tigera API server and related resources. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo; or &ldquo;tigera-secure&rdquo;.
@@ -112,7 +112,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerSpec">
+<a href="#APIServerSpec">
 APIServerSpec
 </a>
 </em>
@@ -130,7 +130,7 @@ Specification of the desired state for the Tigera API server.
 <td>
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -154,7 +154,7 @@ take precedence.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerStatus">
+<a href="#APIServerStatus">
 APIServerStatus
 </a>
 </em>
@@ -170,7 +170,7 @@ Most recently observed status for the Tigera API server.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AmazonCloudIntegration">AmazonCloudIntegration</h3>
+<h3 id="AmazonCloudIntegration">AmazonCloudIntegration</h3>
 <p>
 AmazonCloudIntegration is the Schema for the amazoncloudintegrations API
 </p>
@@ -230,7 +230,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AmazonCloudIntegrationSpec">
+<a href="#AmazonCloudIntegrationSpec">
 AmazonCloudIntegrationSpec
 </a>
 </em>
@@ -245,7 +245,7 @@ AmazonCloudIntegrationSpec
 <td>
 <code>defaultPodMetadataAccess</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MetadataAccessAllowedType">
+<a href="#MetadataAccessAllowedType">
 MetadataAccessAllowedType
 </a>
 </em>
@@ -393,7 +393,7 @@ to all ENIs in the VPC.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AmazonCloudIntegrationStatus">
+<a href="#AmazonCloudIntegrationStatus">
 AmazonCloudIntegrationStatus
 </a>
 </em>
@@ -406,7 +406,7 @@ AmazonCloudIntegrationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</h3>
+<h3 id="ApplicationLayer">ApplicationLayer</h3>
 <p>
 ApplicationLayer is the Schema for the applicationlayers API
 </p>
@@ -466,7 +466,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">
+<a href="#ApplicationLayerSpec">
 ApplicationLayerSpec
 </a>
 </em>
@@ -481,7 +481,7 @@ ApplicationLayerSpec
 <td>
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -501,7 +501,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -520,7 +520,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -540,7 +540,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -562,7 +562,7 @@ User-configurable settings for the Envoy proxy.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerStatus">
+<a href="#ApplicationLayerStatus">
 ApplicationLayerStatus
 </a>
 </em>
@@ -575,7 +575,7 @@ ApplicationLayerStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Authentication">Authentication</h3>
+<h3 id="Authentication">Authentication</h3>
 <p>
 Authentication is the Schema for the authentications API
 </p>
@@ -635,7 +635,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">
+<a href="#AuthenticationSpec">
 AuthenticationSpec
 </a>
 </em>
@@ -707,7 +707,7 @@ ClusterRoleBindings into Elastic.
 
 <code>oidc</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">
+<a href="#AuthenticationOIDC">
 AuthenticationOIDC
 </a>
 </em>
@@ -727,7 +727,7 @@ OIDC contains the configuration needed to setup OIDC authentication.
 
 <code>openshift</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOpenshift">
+<a href="#AuthenticationOpenshift">
 AuthenticationOpenshift
 </a>
 </em>
@@ -747,7 +747,7 @@ Openshift contains the configuration needed to setup Openshift OAuth authenticat
 
 <code>ldap</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">
+<a href="#AuthenticationLDAP">
 AuthenticationLDAP
 </a>
 </em>
@@ -770,7 +770,7 @@ LDAP contains the configuration needed to setup LDAP authentication.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationStatus">
+<a href="#AuthenticationStatus">
 AuthenticationStatus
 </a>
 </em>
@@ -783,7 +783,7 @@ AuthenticationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Compliance">Compliance</h3>
+<h3 id="Compliance">Compliance</h3>
 <p>
 Compliance installs the components required for Tigera compliance reporting. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -844,7 +844,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">
+<a href="#ComplianceSpec">
 ComplianceSpec
 </a>
 </em>
@@ -867,7 +867,7 @@ Specification of the desired state for Tigera compliance reporting.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceStatus">
+<a href="#ComplianceStatus">
 ComplianceStatus
 </a>
 </em>
@@ -883,7 +883,7 @@ Most recently observed state for Tigera compliance reporting.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGateway">EgressGateway</h3>
+<h3 id="EgressGateway">EgressGateway</h3>
 <p>
 EgressGateway is the Schema for the egressgateways API
 </p>
@@ -943,7 +943,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">
+<a href="#EgressGatewaySpec">
 EgressGatewaySpec
 </a>
 </em>
@@ -976,7 +976,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -1017,7 +1017,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -1038,7 +1038,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -1058,7 +1058,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -1082,7 +1082,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -1105,7 +1105,7 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayStatus">
+<a href="#EgressGatewayStatus">
 EgressGatewayStatus
 </a>
 </em>
@@ -1118,7 +1118,7 @@ EgressGatewayStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSet">ImageSet</h3>
+<h3 id="ImageSet">ImageSet</h3>
 <p>
 ImageSet is used to specify image digests for the images that the operator deploys.
 The name of the ImageSet is expected to be in the format <code>&lt;variant&gt;-&lt;release&gt;</code>.
@@ -1183,7 +1183,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">
+<a href="#ImageSetSpec">
 ImageSetSpec
 </a>
 </em>
@@ -1198,7 +1198,7 @@ ImageSetSpec
 <td>
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -1218,7 +1218,7 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Installation">Installation</h3>
+<h3 id="Installation">Installation</h3>
 <p>
 Installation configures an installation of Calico or Calico Enterprise. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo;. The Installation API installs core networking
@@ -1280,7 +1280,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -1298,7 +1298,7 @@ Specification of the desired state for the Calico or Calico Enterprise installat
 <td>
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -1426,7 +1426,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -1449,7 +1449,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -1469,7 +1469,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -1489,7 +1489,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -1668,7 +1668,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -1690,7 +1690,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -1712,7 +1712,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -1732,7 +1732,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -1752,7 +1752,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -1771,7 +1771,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -1791,7 +1791,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -1811,7 +1811,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -1831,7 +1831,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -1850,7 +1850,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -1871,7 +1871,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -1891,7 +1891,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -1932,7 +1932,7 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationStatus">
+<a href="#InstallationStatus">
 InstallationStatus
 </a>
 </em>
@@ -1948,7 +1948,7 @@ Most recently observed state for the Calico or Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</h3>
+<h3 id="IntrusionDetection">IntrusionDetection</h3>
 <p>
 IntrusionDetection installs the components required for Tigera intrusion detection. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2009,7 +2009,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">
+<a href="#IntrusionDetectionSpec">
 IntrusionDetectionSpec
 </a>
 </em>
@@ -2027,7 +2027,7 @@ Specification of the desired state for Tigera intrusion detection.
 <td>
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">
+<a href="#IntrusionDetectionComponentResource">
 []IntrusionDetectionComponentResource
 </a>
 </em>
@@ -2048,7 +2048,7 @@ Only DeepPacketInspection is supported for this spec.
 
 <code>anomalyDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+<a href="#AnomalyDetectionSpec">
 AnomalyDetectionSpec
 </a>
 </em>
@@ -2071,7 +2071,7 @@ AnomalyDetection is now deprecated, and configuring it has no effect.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionStatus">
+<a href="#IntrusionDetectionStatus">
 IntrusionDetectionStatus
 </a>
 </em>
@@ -2087,7 +2087,7 @@ Most recently observed state for Tigera intrusion detection.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollector">LogCollector</h3>
+<h3 id="LogCollector">LogCollector</h3>
 <p>
 LogCollector installs the components required for Tigera flow and DNS log collection. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;. When created, this installs fluentd on all nodes
@@ -2149,7 +2149,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">
+<a href="#LogCollectorSpec">
 LogCollectorSpec
 </a>
 </em>
@@ -2167,7 +2167,7 @@ Specification of the desired state for Tigera log collection.
 <td>
 <code>additionalStores</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">
+<a href="#AdditionalLogStoreSpec">
 AdditionalLogStoreSpec
 </a>
 </em>
@@ -2187,7 +2187,7 @@ Configuration for exporting flow, audit, and DNS logs to external storage.
 
 <code>additionalSources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">
+<a href="#AdditionalLogSourceSpec">
 AdditionalLogSourceSpec
 </a>
 </em>
@@ -2207,7 +2207,7 @@ Configuration for importing audit logs from managed kubernetes cluster log sourc
 
 <code>collectProcessPath</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CollectProcessPathOption">
+<a href="#CollectProcessPathOption">
 CollectProcessPathOption
 </a>
 </em>
@@ -2251,7 +2251,7 @@ the management cluster&rsquo;s tenant services are running.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectorStatus">
+<a href="#LogCollectorStatus">
 LogCollectorStatus
 </a>
 </em>
@@ -2267,7 +2267,7 @@ Most recently observed state for Tigera log collection.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorage">LogStorage</h3>
+<h3 id="LogStorage">LogStorage</h3>
 <p>
 LogStorage installs the components required for Tigera flow and DNS log storage. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;. When created, this installs an Elasticsearch cluster for use by
@@ -2329,7 +2329,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">
+<a href="#LogStorageSpec">
 LogStorageSpec
 </a>
 </em>
@@ -2347,7 +2347,7 @@ Specification of the desired state for Tigera log storage.
 <td>
 <code>nodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Nodes">
+<a href="#Nodes">
 Nodes
 </a>
 </em>
@@ -2366,7 +2366,7 @@ Nodes defines the configuration for a set of identical Elasticsearch cluster nod
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Indices">
+<a href="#Indices">
 Indices
 </a>
 </em>
@@ -2386,7 +2386,7 @@ Index defines the configuration for the indices in the Elasticsearch cluster.
 
 <code>retention</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Retention">
+<a href="#Retention">
 Retention
 </a>
 </em>
@@ -2448,7 +2448,7 @@ each of the indicated key-value pairs as labels as well as access to the specifi
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">
+<a href="#LogStorageComponentResource">
 []LogStorageComponentResource
 </a>
 </em>
@@ -2472,7 +2472,7 @@ Only ECKOperator is supported for this spec.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageStatus">
+<a href="#LogStorageStatus">
 LogStorageStatus
 </a>
 </em>
@@ -2488,7 +2488,7 @@ Most recently observed state for Tigera log storage.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementCluster">ManagementCluster</h3>
+<h3 id="ManagementCluster">ManagementCluster</h3>
 <p>
 The presence of ManagementCluster in your cluster, will configure it to be the management plane to which managed
 clusters can connect. At most one instance of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2549,7 +2549,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterSpec">
+<a href="#ManagementClusterSpec">
 ManagementClusterSpec
 </a>
 </em>
@@ -2584,7 +2584,7 @@ Valid examples are: &ldquo;0.0.0.0:31000&rdquo;, &ldquo;example.com:32000&rdquo;
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLS">
+<a href="#TLS">
 TLS
 </a>
 </em>
@@ -2604,7 +2604,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</h3>
+<h3 id="ManagementClusterConnection">ManagementClusterConnection</h3>
 <p>
 ManagementClusterConnection represents a link between a managed cluster and a management cluster. At most one
 instance of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2665,7 +2665,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">
+<a href="#ManagementClusterConnectionSpec">
 ManagementClusterConnectionSpec
 </a>
 </em>
@@ -2699,7 +2699,7 @@ should be able to access this address. This field is used by managed clusters on
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">
+<a href="#ManagementClusterTLS">
 ManagementClusterTLS
 </a>
 </em>
@@ -2722,7 +2722,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionStatus">
+<a href="#ManagementClusterConnectionStatus">
 ManagementClusterConnectionStatus
 </a>
 </em>
@@ -2735,7 +2735,7 @@ ManagementClusterConnectionStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Manager">Manager</h3>
+<h3 id="Manager">Manager</h3>
 <p>
 Manager installs the Calico Enterprise manager graphical user interface. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2796,7 +2796,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerSpec">
+<a href="#ManagerSpec">
 ManagerSpec
 </a>
 </em>
@@ -2814,7 +2814,7 @@ Specification of the desired state for the Calico Enterprise manager.
 <td>
 <code>auth</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Auth">
+<a href="#Auth">
 Auth
 </a>
 </em>
@@ -2837,7 +2837,7 @@ Deprecated. Please use the Authentication CR for configuring authentication.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerStatus">
+<a href="#ManagerStatus">
 ManagerStatus
 </a>
 </em>
@@ -2853,7 +2853,7 @@ Most recently observed state for the Calico Enterprise manager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Monitor">Monitor</h3>
+<h3 id="Monitor">Monitor</h3>
 <p>
 Monitor is the Schema for the monitor API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2914,7 +2914,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorSpec">
+<a href="#MonitorSpec">
 MonitorSpec
 </a>
 </em>
@@ -2929,7 +2929,7 @@ MonitorSpec
 <td>
 <code>externalPrometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">
+<a href="#ExternalPrometheus">
 ExternalPrometheus
 </a>
 </em>
@@ -2953,7 +2953,7 @@ scraping from git-ops tools without the need of post-installation steps.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorStatus">
+<a href="#MonitorStatus">
 MonitorStatus
 </a>
 </em>
@@ -2966,7 +2966,7 @@ MonitorStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</h3>
+<h3 id="PolicyRecommendation">PolicyRecommendation</h3>
 <p>
 PolicyRecommendation is the Schema for the policy recommendation API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -3027,7 +3027,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationSpec">
+<a href="#PolicyRecommendationSpec">
 PolicyRecommendationSpec
 </a>
 </em>
@@ -3047,7 +3047,7 @@ PolicyRecommendationSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationStatus">
+<a href="#PolicyRecommendationStatus">
 PolicyRecommendationStatus
 </a>
 </em>
@@ -3060,7 +3060,7 @@ PolicyRecommendationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Tenant">Tenant</h3>
+<h3 id="Tenant">Tenant</h3>
 <p>
 Tenant is the Schema for the tenants API
 </p>
@@ -3120,7 +3120,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantSpec">
+<a href="#TenantSpec">
 TenantSpec
 </a>
 </em>
@@ -3169,7 +3169,7 @@ Name is a human readable name for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -3188,7 +3188,7 @@ Indices defines the how to store a tenant&rsquo;s data
 
 <code>elastic</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantElasticSpec">
+<a href="#TenantElasticSpec">
 TenantElasticSpec
 </a>
 </em>
@@ -3230,7 +3230,7 @@ in the Tenant&rsquo;s namespace. Defaults to the controlPlaneReplicas in Install
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantStatus">
+<a href="#TenantStatus">
 TenantStatus
 </a>
 </em>
@@ -3243,7 +3243,7 @@ TenantStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatus">TigeraStatus</h3>
+<h3 id="TigeraStatus">TigeraStatus</h3>
 <p>
 TigeraStatus represents the most recently observed status for Calico or a Calico Enterprise functional area.
 </p>
@@ -3303,7 +3303,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusSpec">
+<a href="#TigeraStatusSpec">
 TigeraStatusSpec
 </a>
 </em>
@@ -3323,7 +3323,7 @@ TigeraStatusSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">
+<a href="#TigeraStatusStatus">
 TigeraStatusStatus
 </a>
 </em>
@@ -3336,11 +3336,11 @@ TigeraStatusStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</h3>
+<h3 id="APIServerDeployment">APIServerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerSpec">APIServerSpec</a>)
+<a href="#APIServerSpec">APIServerSpec</a>)
 
 </p>
 <p>
@@ -3359,7 +3359,7 @@ APIServerDeployment is the configuration for the API server Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3379,7 +3379,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">
+<a href="#APIServerDeploymentSpec">
 APIServerDeploymentSpec
 </a>
 </em>
@@ -3400,11 +3400,11 @@ Spec is the specification of the API server Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
+<h3 id="APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -3460,11 +3460,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
+<h3 id="APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -3519,11 +3519,11 @@ If omitted, the API server Deployment will use its default value for this init c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
+<h3 id="APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -3542,7 +3542,7 @@ APIServerDeploymentDeploymentPodSpec is the API server Deployment&rsquo;s PodSpe
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentInitContainer">
+<a href="#APIServerDeploymentInitContainer">
 []APIServerDeploymentInitContainer
 </a>
 </em>
@@ -3564,7 +3564,7 @@ If omitted, the API server Deployment will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentContainer">
+<a href="#APIServerDeploymentContainer">
 []APIServerDeploymentContainer
 </a>
 </em>
@@ -3675,11 +3675,11 @@ WARNING: Please note that this field will override the default API server Deploy
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
+<h3 id="APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
+<a href="#APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -3698,7 +3698,7 @@ APIServerDeploymentPodTemplateSpec is the API server Deployment&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3719,7 +3719,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">
+<a href="#APIServerDeploymentPodSpec">
 APIServerDeploymentPodSpec
 </a>
 </em>
@@ -3740,11 +3740,11 @@ Spec is the API server Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
+<h3 id="APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>)
 
 </p>
 <p>
@@ -3784,7 +3784,7 @@ If omitted, the API server Deployment will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">
+<a href="#APIServerDeploymentPodTemplateSpec">
 APIServerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -3801,11 +3801,11 @@ Template describes the API server Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerSpec">APIServerSpec</h3>
+<h3 id="APIServerSpec">APIServerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -3824,7 +3824,7 @@ APIServerSpec defines the desired state of Tigera API server.
 
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -3842,11 +3842,11 @@ take precedence.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerStatus">APIServerStatus</h3>
+<h3 id="APIServerStatus">APIServerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -3900,11 +3900,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</h3>
+<h3 id="AWSEgressGateway">AWSEgressGateway</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -3923,7 +3923,7 @@ AWSEgressGateway defines the configurations for deploying EgressGateway in AWS
 
 <code>nativeIP</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NativeIP">
+<a href="#NativeIP">
 NativeIP
 </a>
 </em>
@@ -3960,11 +3960,11 @@ NativeIP must be Enabled if elastic IPs are set.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AdditionalLogSourceSpec">AdditionalLogSourceSpec</h3>
+<h3 id="AdditionalLogSourceSpec">AdditionalLogSourceSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <table>
@@ -3980,7 +3980,7 @@ NativeIP must be Enabled if elastic IPs are set.
 
 <code>eksCloudwatchLog</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EksCloudwatchLogsSpec">
+<a href="#EksCloudwatchLogsSpec">
 EksCloudwatchLogsSpec
 </a>
 </em>
@@ -3998,11 +3998,11 @@ audit logs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</h3>
+<h3 id="AdditionalLogStoreSpec">AdditionalLogStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <table>
@@ -4018,7 +4018,7 @@ audit logs.
 
 <code>s3</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.S3StoreSpec">
+<a href="#S3StoreSpec">
 S3StoreSpec
 </a>
 </em>
@@ -4038,7 +4038,7 @@ If specified, enables exporting of flow, audit, and DNS logs to Amazon S3 storag
 
 <code>syslog</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">
+<a href="#SyslogStoreSpec">
 SyslogStoreSpec
 </a>
 </em>
@@ -4058,7 +4058,7 @@ If specified, enables exporting of flow, audit, and DNS logs to syslog.
 
 <code>splunk</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SplunkStoreSpec">
+<a href="#SplunkStoreSpec">
 SplunkStoreSpec
 </a>
 </em>
@@ -4075,11 +4075,11 @@ If specified, enables exporting of flow, audit, and DNS logs to splunk.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AmazonCloudIntegrationSpec">AmazonCloudIntegrationSpec</h3>
+<h3 id="AmazonCloudIntegrationSpec">AmazonCloudIntegrationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AmazonCloudIntegration">AmazonCloudIntegration</a>)
+<a href="#AmazonCloudIntegration">AmazonCloudIntegration</a>)
 
 </p>
 <p>
@@ -4098,7 +4098,7 @@ AmazonCloudIntegrationSpec defines the desired state of AmazonCloudIntegration
 
 <code>defaultPodMetadataAccess</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MetadataAccessAllowedType">
+<a href="#MetadataAccessAllowedType">
 MetadataAccessAllowedType
 </a>
 </em>
@@ -4240,11 +4240,11 @@ to all ENIs in the VPC.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AmazonCloudIntegrationStatus">AmazonCloudIntegrationStatus</h3>
+<h3 id="AmazonCloudIntegrationStatus">AmazonCloudIntegrationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AmazonCloudIntegration">AmazonCloudIntegration</a>)
+<a href="#AmazonCloudIntegration">AmazonCloudIntegration</a>)
 
 </p>
 <p>
@@ -4298,11 +4298,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
+<h3 id="AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <table>
@@ -4333,19 +4333,19 @@ StorageClassName is now deprecated, and configuring it has no effect.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
+<h3 id="ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</h3>
+<h3 id="ApplicationLayerSpec">ApplicationLayerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -4364,7 +4364,7 @@ ApplicationLayerSpec defines the desired state of ApplicationLayer
 
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -4384,7 +4384,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -4403,7 +4403,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -4423,7 +4423,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -4439,11 +4439,11 @@ User-configurable settings for the Envoy proxy.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerStatus">ApplicationLayerStatus</h3>
+<h3 id="ApplicationLayerStatus">ApplicationLayerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -4497,12 +4497,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Auth">Auth</h3>
+<h3 id="Auth">Auth</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerSpec">ManagerSpec</a>, 
-<a href="#operator.tigera.io/v1.ManagerStatus">ManagerStatus</a>)
+<a href="#ManagerSpec">ManagerSpec</a>, 
+<a href="#ManagerStatus">ManagerStatus</a>)
 
 </p>
 <p>
@@ -4521,7 +4521,7 @@ Auth defines authentication configuration.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthType">
+<a href="#AuthType">
 AuthType
 </a>
 </em>
@@ -4574,25 +4574,25 @@ ClientId configures the OAuth2/OIDC client ID to use for OAuth2 or OIDC login.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthMethod">AuthMethod
+<h3 id="AuthMethod">AuthMethod
 (<code>string</code> alias)</h3>
-<h3 id="operator.tigera.io/v1.AuthType">AuthType
+<h3 id="AuthType">AuthType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Auth">Auth</a>)
+<a href="#Auth">Auth</a>)
 
 </p>
 <p>
 AuthType represents the type of authentication to use. Valid
 options are: Token, Basic, OIDC, OAuth
 </p>
-<h3 id="operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</h3>
+<h3 id="AuthenticationLDAP">AuthenticationLDAP</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -4648,7 +4648,7 @@ the ldaps:// protocol.
 
 <code>userSearch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.UserSearch">
+<a href="#UserSearch">
 UserSearch
 </a>
 </em>
@@ -4667,7 +4667,7 @@ User entry search configuration to match the credentials with a user.
 
 <code>groupSearch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GroupSearch">
+<a href="#GroupSearch">
 GroupSearch
 </a>
 </em>
@@ -4684,11 +4684,11 @@ Group search configuration to find the groups that a user is in.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</h3>
+<h3 id="AuthenticationOIDC">AuthenticationOIDC</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -4814,7 +4814,7 @@ Deprecated. Please use Authentication.Spec.GroupsPrefix instead.
 
 <code>emailVerification</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EmailVerificationType">
+<a href="#EmailVerificationType">
 EmailVerificationType
 </a>
 </em>
@@ -4837,7 +4837,7 @@ Default: Verify
 
 <code>promptTypes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PromptType">
+<a href="#PromptType">
 []PromptType
 </a>
 </em>
@@ -4860,7 +4860,7 @@ Default: &ldquo;Consent&rdquo;
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.OIDCType">
+<a href="#OIDCType">
 OIDCType
 </a>
 </em>
@@ -4877,11 +4877,11 @@ Default: &ldquo;Dex&rdquo;
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationOpenshift">AuthenticationOpenshift</h3>
+<h3 id="AuthenticationOpenshift">AuthenticationOpenshift</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -4914,11 +4914,11 @@ IssuerURL is the URL to the Openshift OAuth provider. Ex.: <a href="https://api.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</h3>
+<h3 id="AuthenticationSpec">AuthenticationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>)
+<a href="#Authentication">Authentication</a>)
 
 </p>
 <p>
@@ -4994,7 +4994,7 @@ ClusterRoleBindings into Elastic.
 
 <code>oidc</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">
+<a href="#AuthenticationOIDC">
 AuthenticationOIDC
 </a>
 </em>
@@ -5014,7 +5014,7 @@ OIDC contains the configuration needed to setup OIDC authentication.
 
 <code>openshift</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOpenshift">
+<a href="#AuthenticationOpenshift">
 AuthenticationOpenshift
 </a>
 </em>
@@ -5034,7 +5034,7 @@ Openshift contains the configuration needed to setup Openshift OAuth authenticat
 
 <code>ldap</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">
+<a href="#AuthenticationLDAP">
 AuthenticationLDAP
 </a>
 </em>
@@ -5051,11 +5051,11 @@ LDAP contains the configuration needed to setup LDAP authentication.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationStatus">AuthenticationStatus</h3>
+<h3 id="AuthenticationStatus">AuthenticationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>)
+<a href="#Authentication">Authentication</a>)
 
 </p>
 <p>
@@ -5109,12 +5109,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.BGPOption">BGPOption
+<h3 id="BGPOption">BGPOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -5123,12 +5123,12 @@ BGPOption describes the mode of BGP to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.CAType">CAType
+<h3 id="CAType">CAType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">ManagementClusterTLS</a>)
+<a href="#ManagementClusterTLS">ManagementClusterTLS</a>)
 
 </p>
 <p>
@@ -5137,11 +5137,11 @@ CAType specifies which verification method the tunnel client should use to verif
 <p>
 One of: Tigera, Public
 </p>
-<h3 id="operator.tigera.io/v1.CNILogging">CNILogging</h3>
+<h3 id="CNILogging">CNILogging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Logging">Logging</a>)
+<a href="#Logging">Logging</a>)
 
 </p>
 <table>
@@ -5157,7 +5157,7 @@ One of: Tigera, Public
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -5228,12 +5228,12 @@ Default: 10
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CNIPluginType">CNIPluginType
+<h3 id="CNIPluginType">CNIPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -5242,11 +5242,11 @@ CNIPluginType describes the type of CNI plugin used.
 <p>
 One of: Calico, GKE, AmazonVPC, AzureVNET
 </p>
-<h3 id="operator.tigera.io/v1.CNISpec">CNISpec</h3>
+<h3 id="CNISpec">CNISpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5265,7 +5265,7 @@ CNISpec contains configuration for the CNI plugin.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNIPluginType">
+<a href="#CNIPluginType">
 CNIPluginType
 </a>
 </em>
@@ -5297,7 +5297,7 @@ Default: Calico
 
 <code>ipam</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMSpec">
+<a href="#IPAMSpec">
 IPAMSpec
 </a>
 </em>
@@ -5315,11 +5315,11 @@ Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
+<h3 id="CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5338,7 +5338,7 @@ CSINodeDriverDaemonSet is the configuration for the csi-node-driver DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5358,7 +5358,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">
+<a href="#CSINodeDriverDaemonSetSpec">
 CSINodeDriverDaemonSetSpec
 </a>
 </em>
@@ -5379,11 +5379,11 @@ Spec is the specification of the csi-node-driver DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
+<h3 id="CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -5438,11 +5438,11 @@ If omitted, the csi-node-driver DaemonSet will use its default value for this co
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -5461,7 +5461,7 @@ CSINodeDriverDaemonSetPodSpec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">
+<a href="#CSINodeDriverDaemonSetContainer">
 []CSINodeDriverDaemonSetContainer
 </a>
 </em>
@@ -5548,11 +5548,11 @@ WARNING: Please note that this field will override the default csi-node-driver D
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
+<a href="#CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -5571,7 +5571,7 @@ CSINodeDriverDaemonSetPodTemplateSpec is the csi-node-driver DaemonSet&rsquo;s P
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5592,7 +5592,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">
+<a href="#CSINodeDriverDaemonSetPodSpec">
 CSINodeDriverDaemonSetPodSpec
 </a>
 </em>
@@ -5613,11 +5613,11 @@ Spec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
+<h3 id="CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
 
 </p>
 <p>
@@ -5657,7 +5657,7 @@ If omitted, the csi-node-driver DaemonSet will use its default value for minRead
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">
 CSINodeDriverDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -5674,11 +5674,11 @@ Template describes the csi-node-driver DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
+<h3 id="CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5697,7 +5697,7 @@ CalicoKubeControllersDeployment is the configuration for the calico-kube-control
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5717,7 +5717,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">
+<a href="#CalicoKubeControllersDeploymentSpec">
 CalicoKubeControllersDeploymentSpec
 </a>
 </em>
@@ -5738,11 +5738,11 @@ Spec is the specification of the calico-kube-controllers Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
+<h3 id="CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -5798,11 +5798,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -5821,7 +5821,7 @@ CalicoKubeControllersDeploymentPodSpec is the calico-kube-controller Deployment&
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">
+<a href="#CalicoKubeControllersDeploymentContainer">
 []CalicoKubeControllersDeploymentContainer
 </a>
 </em>
@@ -5910,11 +5910,11 @@ WARNING: Please note that this field will override the default calico-kube-contr
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
+<a href="#CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
 
 </p>
 <p>
@@ -5933,7 +5933,7 @@ CalicoKubeControllersDeploymentPodTemplateSpec is the calico-kube-controllers De
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5954,7 +5954,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">
+<a href="#CalicoKubeControllersDeploymentPodSpec">
 CalicoKubeControllersDeploymentPodSpec
 </a>
 </em>
@@ -5975,11 +5975,11 @@ Spec is the calico-kube-controllers Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
 
 </p>
 <p>
@@ -6019,7 +6019,7 @@ If omitted, the calico-kube-controllers Deployment will use its default value fo
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">
 CalicoKubeControllersDeploymentPodTemplateSpec
 </a>
 </em>
@@ -6036,11 +6036,11 @@ Template describes the calico-kube-controllers Deployment pod that will be creat
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</h3>
+<h3 id="CalicoNetworkSpec">CalicoNetworkSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -6059,7 +6059,7 @@ CalicoNetworkSpec specifies configuration options for Calico provided pod networ
 
 <code>linuxDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinuxDataplaneOption">
+<a href="#LinuxDataplaneOption">
 LinuxDataplaneOption
 </a>
 </em>
@@ -6082,7 +6082,7 @@ Default: Iptables
 
 <code>windowsDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsDataplaneOption">
+<a href="#WindowsDataplaneOption">
 WindowsDataplaneOption
 </a>
 </em>
@@ -6105,7 +6105,7 @@ Default: Disabled
 
 <code>bgp</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.BGPOption">
+<a href="#BGPOption">
 BGPOption
 </a>
 </em>
@@ -6125,7 +6125,7 @@ BGP configures whether or not to enable Calico&rsquo;s BGP capabilities.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPPool">
+<a href="#IPPool">
 []IPPool
 </a>
 </em>
@@ -6165,7 +6165,7 @@ If not specified, Calico will perform MTU auto-detection based on the cluster ne
 
 <code>nodeAddressAutodetectionV4</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -6186,7 +6186,7 @@ will use default auto-detection settings to acquire an IPv4 address for each nod
 
 <code>nodeAddressAutodetectionV6</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -6207,7 +6207,7 @@ IPv6 addresses will not be auto-detected.
 
 <code>hostPorts</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HostPortsType">
+<a href="#HostPortsType">
 HostPortsType
 </a>
 </em>
@@ -6228,7 +6228,7 @@ Default: Enabled
 
 <code>multiInterfaceMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MultiInterfaceMode">
+<a href="#MultiInterfaceMode">
 MultiInterfaceMode
 </a>
 </em>
@@ -6250,7 +6250,7 @@ Default: None
 
 <code>containerIPForwarding</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ContainerIPForwardingType">
+<a href="#ContainerIPForwardingType">
 ContainerIPForwardingType
 </a>
 </em>
@@ -6271,7 +6271,7 @@ Default: Disabled
 
 <code>sysctl</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Sysctl">
+<a href="#Sysctl">
 []Sysctl
 </a>
 </em>
@@ -6288,11 +6288,11 @@ Sysctl configures sysctl parameters for tuning plugin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
+<h3 id="CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -6311,7 +6311,7 @@ CalicoNodeDaemonSet is the configuration for the calico-node DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6331,7 +6331,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">
+<a href="#CalicoNodeDaemonSetSpec">
 CalicoNodeDaemonSetSpec
 </a>
 </em>
@@ -6352,11 +6352,11 @@ Spec is the specification of the calico-node DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
+<h3 id="CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6412,11 +6412,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6472,11 +6472,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6495,7 +6495,7 @@ CalicoNodeDaemonSetPodSpec is the calico-node DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">
+<a href="#CalicoNodeDaemonSetInitContainer">
 []CalicoNodeDaemonSetInitContainer
 </a>
 </em>
@@ -6517,7 +6517,7 @@ If omitted, the calico-node DaemonSet will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetContainer">
+<a href="#CalicoNodeDaemonSetContainer">
 []CalicoNodeDaemonSetContainer
 </a>
 </em>
@@ -6604,11 +6604,11 @@ WARNING: Please note that this field will override the default calico-node Daemo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
+<a href="#CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -6627,7 +6627,7 @@ CalicoNodeDaemonSetPodTemplateSpec is the calico-node DaemonSet&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6648,7 +6648,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">
+<a href="#CalicoNodeDaemonSetPodSpec">
 CalicoNodeDaemonSetPodSpec
 </a>
 </em>
@@ -6669,11 +6669,11 @@ Spec is the calico-node DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
+<h3 id="CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
 
 </p>
 <p>
@@ -6713,7 +6713,7 @@ If omitted, the calico-node DaemonSet will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">
 CalicoNodeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -6730,11 +6730,11 @@ Template describes the calico-node DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
+<h3 id="CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -6753,7 +6753,7 @@ CalicoNodeWindowsDaemonSet is the configuration for the calico-node-windows Daem
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6773,7 +6773,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">
+<a href="#CalicoNodeWindowsDaemonSetSpec">
 CalicoNodeWindowsDaemonSetSpec
 </a>
 </em>
@@ -6794,11 +6794,11 @@ Spec is the specification of the calico-node-windows DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6854,11 +6854,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6914,11 +6914,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6937,7 +6937,7 @@ CalicoNodeWindowsDaemonSetPodSpec is the calico-node-windows DaemonSet&rsquo;s P
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">
+<a href="#CalicoNodeWindowsDaemonSetInitContainer">
 []CalicoNodeWindowsDaemonSetInitContainer
 </a>
 </em>
@@ -6959,7 +6959,7 @@ If omitted, the calico-node-windows DaemonSet will use its default values for it
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">
+<a href="#CalicoNodeWindowsDaemonSetContainer">
 []CalicoNodeWindowsDaemonSetContainer
 </a>
 </em>
@@ -7046,11 +7046,11 @@ WARNING: Please note that this field will override the default calico-node-windo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7069,7 +7069,7 @@ CalicoNodeWindowsDaemonSetPodTemplateSpec is the calico-node-windows DaemonSet&r
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7090,7 +7090,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">
 CalicoNodeWindowsDaemonSetPodSpec
 </a>
 </em>
@@ -7111,11 +7111,11 @@ Spec is the calico-node-windows DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
 
 </p>
 <p>
@@ -7155,7 +7155,7 @@ If omitted, the calico-node-windows DaemonSet will use its default value for min
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">
 CalicoNodeWindowsDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -7172,11 +7172,11 @@ Template describes the calico-node-windows DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7196,7 +7196,7 @@ CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrad
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7216,7 +7216,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">
 CalicoWindowsUpgradeDaemonSetSpec
 </a>
 </em>
@@ -7237,11 +7237,11 @@ Spec is the specification of the calico-windows-upgrade DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -7296,11 +7296,11 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7319,7 +7319,7 @@ CalicoWindowsUpgradeDaemonSetPodSpec is the calico-windows-upgrade DaemonSet&rsq
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">
+<a href="#CalicoWindowsUpgradeDaemonSetContainer">
 []CalicoWindowsUpgradeDaemonSetContainer
 </a>
 </em>
@@ -7406,11 +7406,11 @@ WARNING: Please note that this field will override the default calico-windows-up
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7429,7 +7429,7 @@ CalicoWindowsUpgradeDaemonSetPodTemplateSpec is the calico-windows-upgrade Daemo
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7450,7 +7450,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">
 CalicoWindowsUpgradeDaemonSetPodSpec
 </a>
 </em>
@@ -7471,11 +7471,11 @@ Spec is the calico-windows-upgrade DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
 
 </p>
 <p>
@@ -7515,7 +7515,7 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
 CalicoWindowsUpgradeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -7532,11 +7532,11 @@ Template describes the calico-windows-upgrade DaemonSet pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CertificateManagement">CertificateManagement</h3>
+<h3 id="CertificateManagement">CertificateManagement</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7628,29 +7628,29 @@ Default: SHA256WithRSA
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CollectProcessPathOption">CollectProcessPathOption
+<h3 id="CollectProcessPathOption">CollectProcessPathOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</h3>
+<h3 id="ComplianceSpec">ComplianceSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>)
+<a href="#Compliance">Compliance</a>)
 
 </p>
 <p>
 ComplianceSpec defines the desired state of Tigera compliance reporting capabilities.
 </p>
-<h3 id="operator.tigera.io/v1.ComplianceStatus">ComplianceStatus</h3>
+<h3 id="ComplianceStatus">ComplianceStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>)
+<a href="#Compliance">Compliance</a>)
 
 </p>
 <p>
@@ -7704,12 +7704,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComponentName">ComponentName
+<h3 id="ComponentName">ComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComponentResource">ComponentResource</a>)
+<a href="#ComponentResource">ComponentResource</a>)
 
 </p>
 <p>
@@ -7718,11 +7718,11 @@ ComponentName represents a single component.
 <p>
 One of: Node, Typha, KubeControllers
 </p>
-<h3 id="operator.tigera.io/v1.ComponentResource">ComponentResource</h3>
+<h3 id="ComponentResource">ComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7742,7 +7742,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentName">
+<a href="#ComponentName">
 ComponentName
 </a>
 </em>
@@ -7777,44 +7777,44 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ConditionStatus">ConditionStatus
+<h3 id="ConditionStatus">ConditionStatus
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 ConditionStatus represents the status of a particular condition. A condition may be one of: True, False, Unknown.
 </p>
-<h3 id="operator.tigera.io/v1.ContainerIPForwardingType">ContainerIPForwardingType
+<h3 id="ContainerIPForwardingType">ContainerIPForwardingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
 ContainerIPForwardingType specifies whether the CNI config for container ip forwarding is enabled.
 </p>
-<h3 id="operator.tigera.io/v1.DataType">DataType
+<h3 id="DataType">DataType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Index">Index</a>)
+<a href="#Index">Index</a>)
 
 </p>
 <p>
 DataType represent the type of data stored
 </p>
-<h3 id="operator.tigera.io/v1.EGWDeploymentContainer">EGWDeploymentContainer</h3>
+<h3 id="EGWDeploymentContainer">EGWDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -7870,11 +7870,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
+<h3 id="EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -7930,11 +7930,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
+<h3 id="EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7953,7 +7953,7 @@ EgressGatewayDeploymentPodSpec is the Egress Gateway Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentInitContainer">
+<a href="#EGWDeploymentInitContainer">
 []EGWDeploymentInitContainer
 </a>
 </em>
@@ -7975,7 +7975,7 @@ If omitted, the EGW Deployment will use its default values for its init containe
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentContainer">
+<a href="#EGWDeploymentContainer">
 []EGWDeploymentContainer
 </a>
 </em>
@@ -8092,11 +8092,11 @@ If omitted, the EGW Deployment will use its default value for tolerations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
+<h3 id="EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -8115,7 +8115,7 @@ EgressGatewayDeploymentPodTemplateSpec is the EGW Deployment&rsquo;s PodTemplate
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayMetadata">
+<a href="#EgressGatewayMetadata">
 EgressGatewayMetadata
 </a>
 </em>
@@ -8136,7 +8136,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">
+<a href="#EgressGatewayDeploymentPodSpec">
 EgressGatewayDeploymentPodSpec
 </a>
 </em>
@@ -8157,11 +8157,11 @@ Spec is the EGW Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
+<h3 id="EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -8202,7 +8202,7 @@ Default: 90
 
 <code>icmpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ICMPProbe">
+<a href="#ICMPProbe">
 ICMPProbe
 </a>
 </em>
@@ -8224,7 +8224,7 @@ fail. Timeout must be greater than interval.
 
 <code>httpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HTTPProbe">
+<a href="#HTTPProbe">
 HTTPProbe
 </a>
 </em>
@@ -8243,11 +8243,11 @@ fail. Timeout must be greater than interval.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayIPPool">EgressGatewayIPPool</h3>
+<h3 id="EgressGatewayIPPool">EgressGatewayIPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <table>
@@ -8296,11 +8296,11 @@ CIDR is the IPPool CIDR that the Egress Gateways can use.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayMetadata">EgressGatewayMetadata</h3>
+<h3 id="EgressGatewayMetadata">EgressGatewayMetadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8358,11 +8358,11 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</h3>
+<h3 id="EgressGatewaySpec">EgressGatewaySpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -8399,7 +8399,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -8440,7 +8440,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -8461,7 +8461,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -8481,7 +8481,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -8505,7 +8505,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -8522,11 +8522,11 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayStatus">EgressGatewayStatus</h3>
+<h3 id="EgressGatewayStatus">EgressGatewayStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -8580,11 +8580,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EksCloudwatchLogsSpec">EksCloudwatchLogsSpec</h3>
+<h3 id="EksCloudwatchLogsSpec">EksCloudwatchLogsSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">AdditionalLogSourceSpec</a>)
+<a href="#AdditionalLogSourceSpec">AdditionalLogSourceSpec</a>)
 
 </p>
 <p>
@@ -8672,20 +8672,20 @@ Default: 60
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EmailVerificationType">EmailVerificationType
+<h3 id="EmailVerificationType">EmailVerificationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.EncapsulationType">EncapsulationType
+<h3 id="EncapsulationType">EncapsulationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -8694,12 +8694,12 @@ EncapsulationType is the type of encapsulation to use on an IP pool.
 <p>
 One of: IPIP, VXLAN, IPIPCrossSubnet, VXLANCrossSubnet, None
 </p>
-<h3 id="operator.tigera.io/v1.EncryptionOption">EncryptionOption
+<h3 id="EncryptionOption">EncryptionOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</a>)
+<a href="#SyslogStoreSpec">SyslogStoreSpec</a>)
 
 </p>
 <p>
@@ -8708,11 +8708,11 @@ EncryptionOption specifies the traffic encryption mode when connecting to a Sysl
 <p>
 One of: None, TLS
 </p>
-<h3 id="operator.tigera.io/v1.Endpoint">Endpoint</h3>
+<h3 id="Endpoint">Endpoint</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ServiceMonitor">ServiceMonitor</a>)
+<a href="#ServiceMonitor">ServiceMonitor</a>)
 
 </p>
 <p>
@@ -8873,11 +8873,11 @@ More info: <a href="https://prometheus.io/docs/prometheus/latest/configuration/c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EnvoySettings">EnvoySettings</h3>
+<h3 id="EnvoySettings">EnvoySettings</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -8930,11 +8930,11 @@ manipulating various headers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ExternalPrometheus">ExternalPrometheus</h3>
+<h3 id="ExternalPrometheus">ExternalPrometheus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.MonitorSpec">MonitorSpec</a>)
+<a href="#MonitorSpec">MonitorSpec</a>)
 
 </p>
 <table>
@@ -8950,7 +8950,7 @@ manipulating various headers.
 
 <code>serviceMonitor</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ServiceMonitor">
+<a href="#ServiceMonitor">
 ServiceMonitor
 </a>
 </em>
@@ -8990,19 +8990,19 @@ must be created before the operator will create Prometheus resources.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FIPSMode">FIPSMode
+<h3 id="FIPSMode">FIPSMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.GroupSearch">GroupSearch</h3>
+<h3 id="GroupSearch">GroupSearch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</a>)
+<a href="#AuthenticationLDAP">AuthenticationLDAP</a>)
 
 </p>
 <p>
@@ -9074,7 +9074,7 @@ The attribute of the group that represents its name. This attribute can be used 
 
 <code>userMatchers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.UserMatch">
+<a href="#UserMatch">
 []UserMatch
 </a>
 </em>
@@ -9092,11 +9092,11 @@ attribute value.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HTTPProbe">HTTPProbe</h3>
+<h3 id="HTTPProbe">HTTPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -9168,12 +9168,12 @@ Default: 30
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HostPortsType">HostPortsType
+<h3 id="HostPortsType">HostPortsType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -9182,11 +9182,11 @@ HostPortsType specifies host port support.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.ICMPProbe">ICMPProbe</h3>
+<h3 id="ICMPProbe">ICMPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -9258,19 +9258,19 @@ Default: 15
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPAMPluginType">IPAMPluginType
+<h3 id="IPAMPluginType">IPAMPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPAMSpec">IPAMSpec</a>)
+<a href="#IPAMSpec">IPAMSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IPAMSpec">IPAMSpec</h3>
+<h3 id="IPAMSpec">IPAMSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -9289,7 +9289,7 @@ IPAMSpec contains configuration for pod IP address management.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMPluginType">
+<a href="#IPAMPluginType">
 IPAMPluginType
 </a>
 </em>
@@ -9317,11 +9317,11 @@ Default: Calico
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPPool">IPPool</h3>
+<h3 id="IPPool">IPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -9354,7 +9354,7 @@ CIDR contains the address range for the IP Pool in classless inter-domain routin
 
 <code>encapsulation</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncapsulationType">
+<a href="#EncapsulationType">
 EncapsulationType
 </a>
 </em>
@@ -9376,7 +9376,7 @@ Default: IPIP
 
 <code>natOutgoing</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NATOutgoingType">
+<a href="#NATOutgoingType">
 NATOutgoingType
 </a>
 </em>
@@ -9452,11 +9452,11 @@ Default: false
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Image">Image</h3>
+<h3 id="Image">Image</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</a>)
+<a href="#ImageSetSpec">ImageSetSpec</a>)
 
 </p>
 <table>
@@ -9507,11 +9507,11 @@ The field should not include a leading <code>@</code> and must be prefixed with 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</h3>
+<h3 id="ImageSetSpec">ImageSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>)
+<a href="#ImageSet">ImageSet</a>)
 
 </p>
 <p>
@@ -9530,7 +9530,7 @@ ImageSetSpec defines the desired state of ImageSet.
 
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -9547,11 +9547,11 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Index">Index</h3>
+<h3 id="Index">Index</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -9589,7 +9589,7 @@ excludes the numerical identifier suffix)
 
 <code>dataType</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DataType">
+<a href="#DataType">
 DataType
 </a>
 </em>
@@ -9605,11 +9605,11 @@ DataType represents the type of data stored in the defined index
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Indices">Indices</h3>
+<h3 id="Indices">Indices</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -9643,12 +9643,12 @@ Replicas defines how many replicas each index will have. See <a href="https://ww
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationSpec">InstallationSpec</h3>
+<h3 id="InstallationSpec">InstallationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#Installation">Installation</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -9667,7 +9667,7 @@ InstallationSpec defines configuration for a Calico or Calico Enterprise install
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -9795,7 +9795,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -9818,7 +9818,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -9838,7 +9838,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -9858,7 +9858,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -10037,7 +10037,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -10059,7 +10059,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -10081,7 +10081,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -10101,7 +10101,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -10121,7 +10121,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -10140,7 +10140,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -10160,7 +10160,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -10180,7 +10180,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -10200,7 +10200,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -10219,7 +10219,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -10240,7 +10240,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -10260,7 +10260,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -10295,11 +10295,11 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationStatus">InstallationStatus</h3>
+<h3 id="InstallationStatus">InstallationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>)
+<a href="#Installation">Installation</a>)
 
 </p>
 <p>
@@ -10318,7 +10318,7 @@ InstallationStatus defines the observed state of the Calico or Calico Enterprise
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -10374,7 +10374,7 @@ that is being used. If an ImageSet is not being used then this will not be set.
 
 <code>computed</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -10431,19 +10431,19 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionComponentName">IntrusionDetectionComponentName
+<h3 id="IntrusionDetectionComponentName">IntrusionDetectionComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</a>)
+<a href="#IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</h3>
+<h3 id="IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <p>
@@ -10462,7 +10462,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentName">
+<a href="#IntrusionDetectionComponentName">
 IntrusionDetectionComponentName
 </a>
 </em>
@@ -10497,11 +10497,11 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</h3>
+<h3 id="IntrusionDetectionSpec">IntrusionDetectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>)
+<a href="#IntrusionDetection">IntrusionDetection</a>)
 
 </p>
 <p>
@@ -10520,7 +10520,7 @@ IntrusionDetectionSpec defines the desired state of Tigera intrusion detection c
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">
+<a href="#IntrusionDetectionComponentResource">
 []IntrusionDetectionComponentResource
 </a>
 </em>
@@ -10541,7 +10541,7 @@ Only DeepPacketInspection is supported for this spec.
 
 <code>anomalyDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+<a href="#AnomalyDetectionSpec">
 AnomalyDetectionSpec
 </a>
 </em>
@@ -10558,11 +10558,11 @@ AnomalyDetection is now deprecated, and configuring it has no effect.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionStatus">IntrusionDetectionStatus</h3>
+<h3 id="IntrusionDetectionStatus">IntrusionDetectionStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>)
+<a href="#IntrusionDetection">IntrusionDetection</a>)
 
 </p>
 <p>
@@ -10616,12 +10616,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
+<h3 id="KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</a>)
+<a href="#NodeAddressAutodetection">NodeAddressAutodetection</a>)
 
 </p>
 <p>
@@ -10630,12 +10630,12 @@ KubernetesAutodetectionMethod is a method of detecting an IP address based on th
 <p>
 One of: NodeInternalIP
 </p>
-<h3 id="operator.tigera.io/v1.LinuxDataplaneOption">LinuxDataplaneOption
+<h3 id="LinuxDataplaneOption">LinuxDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -10644,11 +10644,11 @@ LinuxDataplaneOption controls which dataplane is to be used on Linux nodes.
 <p>
 One of: Iptables, BPF
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</h3>
+<h3 id="LogCollectionSpec">LogCollectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -10664,7 +10664,7 @@ One of: Iptables, BPF
 
 <code>collectLogs</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionStatusType">
+<a href="#LogCollectionStatusType">
 LogCollectionStatusType
 </a>
 </em>
@@ -10722,19 +10722,19 @@ Default: -1
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectionStatusType">LogCollectionStatusType
+<h3 id="LogCollectionStatusType">LogCollectionStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</a>)
+<a href="#LogCollectionSpec">LogCollectionSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</h3>
+<h3 id="LogCollectorSpec">LogCollectorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>)
+<a href="#LogCollector">LogCollector</a>)
 
 </p>
 <p>
@@ -10753,7 +10753,7 @@ LogCollectorSpec defines the desired state of Tigera flow, audit, and DNS log co
 
 <code>additionalStores</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">
+<a href="#AdditionalLogStoreSpec">
 AdditionalLogStoreSpec
 </a>
 </em>
@@ -10773,7 +10773,7 @@ Configuration for exporting flow, audit, and DNS logs to external storage.
 
 <code>additionalSources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">
+<a href="#AdditionalLogSourceSpec">
 AdditionalLogSourceSpec
 </a>
 </em>
@@ -10793,7 +10793,7 @@ Configuration for importing audit logs from managed kubernetes cluster log sourc
 
 <code>collectProcessPath</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CollectProcessPathOption">
+<a href="#CollectProcessPathOption">
 CollectProcessPathOption
 </a>
 </em>
@@ -10831,11 +10831,11 @@ the management cluster&rsquo;s tenant services are running.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectorStatus">LogCollectorStatus</h3>
+<h3 id="LogCollectorStatus">LogCollectorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>)
+<a href="#LogCollector">LogCollector</a>)
 
 </p>
 <p>
@@ -10889,31 +10889,31 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogLevel">LogLevel
+<h3 id="LogLevel">LogLevel
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNILogging">CNILogging</a>, 
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#CNILogging">CNILogging</a>, 
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogStorageComponentName">LogStorageComponentName
+<h3 id="LogStorageComponentName">LogStorageComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">LogStorageComponentResource</a>)
+<a href="#LogStorageComponentResource">LogStorageComponentResource</a>)
 
 </p>
 <p>
 LogStorageComponentName CRD enum
 </p>
-<h3 id="operator.tigera.io/v1.LogStorageComponentResource">LogStorageComponentResource</h3>
+<h3 id="LogStorageComponentResource">LogStorageComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -10932,7 +10932,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentName">
+<a href="#LogStorageComponentName">
 LogStorageComponentName
 </a>
 </em>
@@ -10967,11 +10967,11 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</h3>
+<h3 id="LogStorageSpec">LogStorageSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>)
+<a href="#LogStorage">LogStorage</a>)
 
 </p>
 <p>
@@ -10990,7 +10990,7 @@ LogStorageSpec defines the desired state of Tigera flow and DNS log storage.
 
 <code>nodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Nodes">
+<a href="#Nodes">
 Nodes
 </a>
 </em>
@@ -11009,7 +11009,7 @@ Nodes defines the configuration for a set of identical Elasticsearch cluster nod
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Indices">
+<a href="#Indices">
 Indices
 </a>
 </em>
@@ -11029,7 +11029,7 @@ Index defines the configuration for the indices in the Elasticsearch cluster.
 
 <code>retention</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Retention">
+<a href="#Retention">
 Retention
 </a>
 </em>
@@ -11091,7 +11091,7 @@ each of the indicated key-value pairs as labels as well as access to the specifi
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">
+<a href="#LogStorageComponentResource">
 []LogStorageComponentResource
 </a>
 </em>
@@ -11109,11 +11109,11 @@ Only ECKOperator is supported for this spec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorageStatus">LogStorageStatus</h3>
+<h3 id="LogStorageStatus">LogStorageStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>)
+<a href="#LogStorage">LogStorage</a>)
 
 </p>
 <p>
@@ -11203,11 +11203,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Logging">Logging</h3>
+<h3 id="Logging">Logging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>
@@ -11223,7 +11223,7 @@ Ready, Progressing, Degraded or other customer types.
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNILogging">
+<a href="#CNILogging">
 CNILogging
 </a>
 </em>
@@ -11240,11 +11240,11 @@ Customized logging specification for calico-cni plugin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</h3>
+<h3 id="ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>)
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>)
 
 </p>
 <p>
@@ -11282,7 +11282,7 @@ should be able to access this address. This field is used by managed clusters on
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">
+<a href="#ManagementClusterTLS">
 ManagementClusterTLS
 </a>
 </em>
@@ -11299,11 +11299,11 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnectionStatus">ManagementClusterConnectionStatus</h3>
+<h3 id="ManagementClusterConnectionStatus">ManagementClusterConnectionStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>)
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>)
 
 </p>
 <p>
@@ -11340,11 +11340,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterSpec">ManagementClusterSpec</h3>
+<h3 id="ManagementClusterSpec">ManagementClusterSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementCluster">ManagementCluster</a>)
+<a href="#ManagementCluster">ManagementCluster</a>)
 
 </p>
 <p>
@@ -11383,7 +11383,7 @@ Valid examples are: &ldquo;0.0.0.0:31000&rdquo;, &ldquo;example.com:32000&rdquo;
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLS">
+<a href="#TLS">
 TLS
 </a>
 </em>
@@ -11400,11 +11400,11 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterTLS">ManagementClusterTLS</h3>
+<h3 id="ManagementClusterTLS">ManagementClusterTLS</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
+<a href="#ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
 
 </p>
 <table>
@@ -11420,7 +11420,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>ca</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CAType">
+<a href="#CAType">
 CAType
 </a>
 </em>
@@ -11446,11 +11446,11 @@ Default: Tigera
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerSpec">ManagerSpec</h3>
+<h3 id="ManagerSpec">ManagerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>)
+<a href="#Manager">Manager</a>)
 
 </p>
 <p>
@@ -11469,7 +11469,7 @@ ManagerSpec defines configuration for the Calico Enterprise manager GUI.
 
 <code>auth</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Auth">
+<a href="#Auth">
 Auth
 </a>
 </em>
@@ -11486,11 +11486,11 @@ Deprecated. Please use the Authentication CR for configuring authentication.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerStatus">ManagerStatus</h3>
+<h3 id="ManagerStatus">ManagerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>)
+<a href="#Manager">Manager</a>)
 
 </p>
 <p>
@@ -11509,7 +11509,7 @@ ManagerStatus defines the observed state of the Calico Enterprise manager GUI.
 
 <code>auth</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Auth">
+<a href="#Auth">
 Auth
 </a>
 </em>
@@ -11564,24 +11564,24 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Metadata">Metadata</h3>
+<h3 id="Metadata">Metadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>, 
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>, 
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
+<a href="#TyphaDeployment">TyphaDeployment</a>, 
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11637,22 +11637,22 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MetadataAccessAllowedType">MetadataAccessAllowedType
+<h3 id="MetadataAccessAllowedType">MetadataAccessAllowedType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AmazonCloudIntegrationSpec">AmazonCloudIntegrationSpec</a>)
+<a href="#AmazonCloudIntegrationSpec">AmazonCloudIntegrationSpec</a>)
 
 </p>
 <p>
 MetadataAccessAllowedType
 </p>
-<h3 id="operator.tigera.io/v1.MonitorSpec">MonitorSpec</h3>
+<h3 id="MonitorSpec">MonitorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -11671,7 +11671,7 @@ MonitorSpec defines the desired state of Tigera monitor.
 
 <code>externalPrometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">
+<a href="#ExternalPrometheus">
 ExternalPrometheus
 </a>
 </em>
@@ -11689,11 +11689,11 @@ scraping from git-ops tools without the need of post-installation steps.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MonitorStatus">MonitorStatus</h3>
+<h3 id="MonitorStatus">MonitorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -11747,12 +11747,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MultiInterfaceMode">MultiInterfaceMode
+<h3 id="MultiInterfaceMode">MultiInterfaceMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -11761,12 +11761,12 @@ MultiInterfaceMode describes the method of providing multiple pod interfaces.
 <p>
 One of: None, Multus
 </p>
-<h3 id="operator.tigera.io/v1.NATOutgoingType">NATOutgoingType
+<h3 id="NATOutgoingType">NATOutgoingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -11775,23 +11775,23 @@ NATOutgoingType describe the type of outgoing NAT to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.NativeIP">NativeIP
+<h3 id="NativeIP">NativeIP
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</a>)
+<a href="#AWSEgressGateway">AWSEgressGateway</a>)
 
 </p>
 <p>
 NativeIP defines if Egress Gateway pods should have AWS IPs.
 When NativeIP is enabled, the IPPools should be backed by AWS subnet.
 </p>
-<h3 id="operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</h3>
+<h3 id="NodeAddressAutodetection">NodeAddressAutodetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -11831,7 +11831,7 @@ filtering based on well-known interface names.
 
 <code>kubernetes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KubernetesAutodetectionMethod">
+<a href="#KubernetesAutodetectionMethod">
 KubernetesAutodetectionMethod
 </a>
 </em>
@@ -11922,11 +11922,11 @@ one of the provided CIDRs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeAffinity">NodeAffinity</h3>
+<h3 id="NodeAffinity">NodeAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</a>)
+<a href="#TyphaAffinity">TyphaAffinity</a>)
 
 </p>
 <p>
@@ -11995,11 +11995,11 @@ may or may not try to eventually evict the pod from its node.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeSet">NodeSet</h3>
+<h3 id="NodeSet">NodeSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Nodes">Nodes</a>)
+<a href="#Nodes">Nodes</a>)
 
 </p>
 <p>
@@ -12018,7 +12018,7 @@ NodeSets defines configuration specific to each Elasticsearch Node Set
 
 <code>selectionAttributes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeSetSelectionAttribute">
+<a href="#NodeSetSelectionAttribute">
 []NodeSetSelectionAttribute
 </a>
 </em>
@@ -12036,11 +12036,11 @@ to define Node Affinities and set the node awareness configuration in the runnin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeSetSelectionAttribute">NodeSetSelectionAttribute</h3>
+<h3 id="NodeSetSelectionAttribute">NodeSetSelectionAttribute</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeSet">NodeSet</a>)
+<a href="#NodeSet">NodeSet</a>)
 
 </p>
 <p>
@@ -12100,11 +12100,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Nodes">Nodes</h3>
+<h3 id="Nodes">Nodes</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -12140,7 +12140,7 @@ Count defines the number of nodes in the Elasticsearch cluster.
 
 <code>nodeSets</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeSet">
+<a href="#NodeSet">
 []NodeSet
 </a>
 </em>
@@ -12177,12 +12177,12 @@ ResourceRequirements defines the resource limits and requirements for the Elasti
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NonPrivilegedType">NonPrivilegedType
+<h3 id="NonPrivilegedType">NonPrivilegedType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -12191,12 +12191,12 @@ NonPrivilegedType specifies whether Calico runs as permissioned or not
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.OIDCType">OIDCType
+<h3 id="OIDCType">OIDCType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
 <p>
@@ -12204,22 +12204,22 @@ OIDCType defines how OIDC is configured for Tigera Enterprise. Dex should be the
 The Tigera option can help in specific use-cases, for instance, when you are unable to configure a client secret.
 One of: Dex, Tigera
 </p>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
+<h3 id="PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
 PolicyRecommendationSpec defines configuration for the Calico Enterprise Policy Recommendation
 service.
 </p>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
+<h3 id="PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
@@ -12252,13 +12252,13 @@ State provides user-readable status.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ProductVariant">ProductVariant
+<h3 id="ProductVariant">ProductVariant
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#InstallationSpec">InstallationSpec</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -12267,12 +12267,12 @@ ProductVariant represents the variant of the product.
 <p>
 One of: Calico, TigeraSecureEnterprise
 </p>
-<h3 id="operator.tigera.io/v1.PromptType">PromptType
+<h3 id="PromptType">PromptType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
 <p>
@@ -12280,23 +12280,23 @@ PromptType is a value that specifies whether the identity provider prompts the e
 consent.
 One of: None, Login, Consent, SelectAccount.
 </p>
-<h3 id="operator.tigera.io/v1.Provider">Provider
+<h3 id="Provider">Provider
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
 Provider represents a particular provider or flavor of Kubernetes. Valid options
 are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise.
 </p>
-<h3 id="operator.tigera.io/v1.Retention">Retention</h3>
+<h3 id="Retention">Retention</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -12438,11 +12438,11 @@ Default: 8
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.S3StoreSpec">S3StoreSpec</h3>
+<h3 id="S3StoreSpec">S3StoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -12509,11 +12509,11 @@ Path in the S3 bucket where to send logs
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ServiceMonitor">ServiceMonitor</h3>
+<h3 id="ServiceMonitor">ServiceMonitor</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">ExternalPrometheus</a>)
+<a href="#ExternalPrometheus">ExternalPrometheus</a>)
 
 </p>
 <table>
@@ -12548,7 +12548,7 @@ Default: k8s-app=tigera-prometheus
 
 <code>endpoints</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Endpoint">
+<a href="#Endpoint">
 []Endpoint
 </a>
 </em>
@@ -12565,11 +12565,11 @@ related to connecting to our Prometheus server are automatically set by the oper
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SplunkStoreSpec">SplunkStoreSpec</h3>
+<h3 id="SplunkStoreSpec">SplunkStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -12602,22 +12602,22 @@ Location for splunk&rsquo;s http event collector end point. example <code>https:
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.StatusConditionType">StatusConditionType
+<h3 id="StatusConditionType">StatusConditionType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 StatusConditionType is a type of condition that may apply to a particular component.
 </p>
-<h3 id="operator.tigera.io/v1.Sysctl">Sysctl</h3>
+<h3 id="Sysctl">Sysctl</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -12658,12 +12658,12 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SyslogLogType">SyslogLogType
+<h3 id="SyslogLogType">SyslogLogType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</a>)
+<a href="#SyslogStoreSpec">SyslogStoreSpec</a>)
 
 </p>
 <p>
@@ -12674,11 +12674,11 @@ Allowable values are Audit, DNS, Flows and IDSEvents.
 * Flows corresponds to flow logs generated by Calico node.
 * IDSEvents corresponds to event logs for the intrusion detection system (anomaly detection, suspicious IPs, suspicious domains and global alerts).
 </p>
-<h3 id="operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</h3>
+<h3 id="SyslogStoreSpec">SyslogStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -12734,7 +12734,7 @@ Default: 1024
 
 <code>logTypes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SyslogLogType">
+<a href="#SyslogLogType">
 []SyslogLogType
 </a>
 </em>
@@ -12754,7 +12754,7 @@ Default: Audit, DNS, Flows
 
 <code>encryption</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncryptionOption">
+<a href="#EncryptionOption">
 EncryptionOption
 </a>
 </em>
@@ -12772,11 +12772,11 @@ Default: None
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLS">TLS</h3>
+<h3 id="TLS">TLS</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterSpec">ManagementClusterSpec</a>)
+<a href="#ManagementClusterSpec">ManagementClusterSpec</a>)
 
 </p>
 <table>
@@ -12826,11 +12826,11 @@ Default: tigera-management-cluster-connection
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantElasticSpec">TenantElasticSpec</h3>
+<h3 id="TenantElasticSpec">TenantElasticSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <table>
@@ -12885,11 +12885,11 @@ bool
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantSpec">TenantSpec</h3>
+<h3 id="TenantSpec">TenantSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
 <table>
@@ -12939,7 +12939,7 @@ Name is a human readable name for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -12958,7 +12958,7 @@ Indices defines the how to store a tenant&rsquo;s data
 
 <code>elastic</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantElasticSpec">
+<a href="#TenantElasticSpec">
 TenantElasticSpec
 </a>
 </em>
@@ -12994,18 +12994,18 @@ in the Tenant&rsquo;s namespace. Defaults to the controlPlaneReplicas in Install
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantStatus">TenantStatus</h3>
+<h3 id="TenantStatus">TenantStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</h3>
+<h3 id="TigeraStatusCondition">TigeraStatusCondition</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</a>)
+<a href="#TigeraStatusStatus">TigeraStatusStatus</a>)
 
 </p>
 <p>
@@ -13024,7 +13024,7 @@ TigeraStatusCondition represents a condition attached to a particular component.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.StatusConditionType">
+<a href="#StatusConditionType">
 StatusConditionType
 </a>
 </em>
@@ -13043,7 +13043,7 @@ The type of condition. May be Available, Progressing, or Degraded.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ConditionStatus">
+<a href="#ConditionStatus">
 ConditionStatus
 </a>
 </em>
@@ -13132,26 +13132,26 @@ with respect to the current state of the instance.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatusReason">TigeraStatusReason
+<h3 id="TigeraStatusReason">TigeraStatusReason
 (<code>string</code> alias)</h3>
 <p>
 TigeraStatusReason represents the reason for a particular condition.
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusSpec">TigeraStatusSpec</h3>
+<h3 id="TigeraStatusSpec">TigeraStatusSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
 TigeraStatusSpec defines the desired state of TigeraStatus
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</h3>
+<h3 id="TigeraStatusStatus">TigeraStatusStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
@@ -13170,7 +13170,7 @@ TigeraStatusStatus defines the observed state of TigeraStatus
 
 <code>conditions</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">
+<a href="#TigeraStatusCondition">
 []TigeraStatusCondition
 </a>
 </em>
@@ -13187,11 +13187,11 @@ Available, Progressing, or Degraded.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</h3>
+<h3 id="TyphaAffinity">TyphaAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -13211,7 +13211,7 @@ TyphaAffinity allows configuration of node affinity characteristics for Typha po
 
 <code>nodeAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAffinity">
+<a href="#NodeAffinity">
 NodeAffinity
 </a>
 </em>
@@ -13228,11 +13228,11 @@ NodeAffinity describes node affinity scheduling rules for typha.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</h3>
+<h3 id="TyphaDeployment">TyphaDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -13251,7 +13251,7 @@ TyphaDeployment is the configuration for the typha Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -13271,7 +13271,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">
+<a href="#TyphaDeploymentSpec">
 TyphaDeploymentSpec
 </a>
 </em>
@@ -13292,11 +13292,11 @@ Spec is the specification of the typha Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
+<h3 id="TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -13352,11 +13352,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
+<h3 id="TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -13412,11 +13412,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
+<h3 id="TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -13435,7 +13435,7 @@ TyphaDeploymentPodSpec is the typha Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentInitContainer">
+<a href="#TyphaDeploymentInitContainer">
 []TyphaDeploymentInitContainer
 </a>
 </em>
@@ -13457,7 +13457,7 @@ If omitted, the typha Deployment will use its default values for its init contai
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentContainer">
+<a href="#TyphaDeploymentContainer">
 []TyphaDeploymentContainer
 </a>
 </em>
@@ -13591,11 +13591,11 @@ WARNING: Please note that this field will override the default calico-typha Depl
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
+<h3 id="TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -13614,7 +13614,7 @@ TyphaDeploymentPodTemplateSpec is the typha Deployment&rsquo;s PodTemplateSpec
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -13635,7 +13635,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">
+<a href="#TyphaDeploymentPodSpec">
 TyphaDeploymentPodSpec
 </a>
 </em>
@@ -13656,11 +13656,11 @@ Spec is the typha Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
+<h3 id="TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>)
+<a href="#TyphaDeployment">TyphaDeployment</a>)
 
 </p>
 <p>
@@ -13700,7 +13700,7 @@ If omitted, the typha Deployment will use its default value for minReadySeconds.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">
+<a href="#TyphaDeploymentPodTemplateSpec">
 TyphaDeploymentPodTemplateSpec
 </a>
 </em>
@@ -13720,7 +13720,7 @@ Template describes the typha Deployment pod that will be created.
 
 <code>strategy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentStrategy">
+<a href="#TyphaDeploymentStrategy">
 TyphaDeploymentStrategy
 </a>
 </em>
@@ -13737,11 +13737,11 @@ The deployment strategy to use to replace existing pods with new ones.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
+<h3 id="TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -13780,11 +13780,11 @@ to be.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.UserMatch">UserMatch</h3>
+<h3 id="UserMatch">UserMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GroupSearch">GroupSearch</a>)
+<a href="#GroupSearch">GroupSearch</a>)
 
 </p>
 <p>
@@ -13834,11 +13834,11 @@ The attribute of a group that links it to a user.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.UserSearch">UserSearch</h3>
+<h3 id="UserSearch">UserSearch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</a>)
+<a href="#AuthenticationLDAP">AuthenticationLDAP</a>)
 
 </p>
 <p>
@@ -13908,27 +13908,27 @@ Default: uid
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.WAFStatusType">WAFStatusType
+<h3 id="WAFStatusType">WAFStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsDataplaneOption">WindowsDataplaneOption
+<h3 id="WindowsDataplaneOption">WindowsDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsNodeSpec">WindowsNodeSpec</h3>
+<h3 id="WindowsNodeSpec">WindowsNodeSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>

--- a/calico-cloud/threat/deeppacketinspection.mdx
+++ b/calico-cloud/threat/deeppacketinspection.mdx
@@ -76,7 +76,7 @@ spec:
 
 ### Configure resource requirements
 
-Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionComponentResource).
+Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#IntrusionDetectionComponentResource.
 
 For a data transfer rate of 1GB/sec on workload endpoints being monitored, we recommend a minimum of 1 CPU and 1GB RAM.
 

--- a/calico-cloud/threat/web-application-firewall.mdx
+++ b/calico-cloud/threat/web-application-firewall.mdx
@@ -352,7 +352,7 @@ kubectl annotate svc <service-name> -n <service-namespace> projectcalico.org/l7-
 
 ### Disable WAF feature from your cluster
 
-To disable WAF, update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the `webApplicationFirewall` field, and ensure it is set to `Disabled`.
+To disable WAF, update the [ApplicationLayer](../reference/installation/api#ApplicationLayer resource to include the `webApplicationFirewall` field, and ensure it is set to `Disabled`.
 
 Example:
 

--- a/calico-cloud/visibility/elastic/archive-storage.mdx
+++ b/calico-cloud/visibility/elastic/archive-storage.mdx
@@ -48,8 +48,8 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
     -n tigera-operator
    ```
 
-3. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#operator.tigera.io/v1.S3StoreSpec)
+3. Update the [LogCollector](../../reference/installation/api.mdx#LogCollector
+   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#S3StoreSpec
    with your information noted from above.
    Example:
 
@@ -76,8 +76,8 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
 </TabItem>
 <TabItem label="Syslog" value="Syslog-1">
 
-1. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+1. Update the [LogCollector](../../reference/installation/api.mdx#LogCollector
+   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec
    with your syslog information.
    Example:
    ```yaml
@@ -104,7 +104,7 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    kubectl edit logcollector tigera-secure
    ```
 2. You can control which types of {variables.prodname} log data you would like to send to syslog.
-   The [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+   The [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec
    contains a field called `logTypes` which allows you to list which log types you would like to include.
    The allowable log types are:
 
@@ -113,11 +113,11 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    - Flows
    - IDSEvents
 
-   Refer to the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec) for more details on what data each log type represents.
+   Refer to the [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec for more details on what data each log type represents.
 
    :::note
 
-   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
+   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#LogStorage configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
 
    :::
 
@@ -125,7 +125,7 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
 
 **TLS configuration**
 
-3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec).
+3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec.
 
    ```yaml
    apiVersion: operator.tigera.io/v1
@@ -182,9 +182,9 @@ In this release, only [Splunk Enterprise](https://www.splunk.com/en_us/products/
    ```
 
 3. Update the
-   [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
+   [LogCollector](../../reference/installation/api.mdx#LogCollector
    resource named `tigera-secure` to include
-   a [Splunk section](../../reference/installation/api.mdx#operator.tigera.io/v1.SplunkStoreSpec)
+   a [Splunk section](../../reference/installation/api.mdx#SplunkStoreSpec
    with your Splunk information.
    Example:
 

--- a/calico-cloud/visibility/elastic/l7/configure.mdx
+++ b/calico-cloud/visibility/elastic/l7/configure.mdx
@@ -70,7 +70,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
 
 **Configure the ApplicationLayer resource for L7 logs**
 
-1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) resource named, `tigera-secure` to include a logCollection section of the file, `_api.html` [here](../../../reference/installation/api.mdx).
+1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#ApplicationLayer resource named, `tigera-secure` to include a logCollection section of the file, `_api.html` [here](../../../reference/installation/api.mdx).
 
 1. Ensure that the `collectLogs` field is set to `Enabled`.
 

--- a/calico-cloud/visibility/elastic/overview.mdx
+++ b/calico-cloud/visibility/elastic/overview.mdx
@@ -93,7 +93,7 @@ verbs: ['get']
 - Global network policies
 - Network sets
 
-{variables.prodname} also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec).
+{variables.prodname} also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#LogCollectorSpec.
 
 ## Additional resources
 
@@ -102,4 +102,4 @@ verbs: ['get']
 - [BGP logs](bgp.mdx)
 - [DNS logs](dns/dns-logs.mdx)
 - [Archive logs](archive-storage.mdx)
-- [Log collection options](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../reference/installation/api.mdx#LogCollectorSpec

--- a/calico-cloud_versioned_docs/version-19-2/networking/configuring/dual-tor.mdx
+++ b/calico-cloud_versioned_docs/version-19-2/networking/configuring/dual-tor.mdx
@@ -640,7 +640,7 @@ The only connections using interface-specific addresses should be BGP.
 If you plan to use [Egress Gateways](../egress/egress-gateway-on-prem.mdx) in your cluster, you must also adjust the {variables.nodecontainer} IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-{variables.prodname} [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+{variables.prodname} [Installation resource](../../reference/installation/api.mdx#NodeAddressAutodetection.
 
 :::
 

--- a/calico-cloud_versioned_docs/version-19-2/networking/configuring/multiple-networks.mdx
+++ b/calico-cloud_versioned_docs/version-19-2/networking/configuring/multiple-networks.mdx
@@ -79,7 +79,7 @@ Although the following {variables.prodname} features are supported for your defa
 
 ### Configure cluster for multiple networks
 
-In the [Installation custom resource](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoNetworkSpec), set the `MultiInterfaceMode` to **Multus**.
+In the [Installation custom resource](../../reference/installation/api.mdx#CalicoNetworkSpec, set the `MultiInterfaceMode` to **Multus**.
 
 ### Create a new network
 

--- a/calico-cloud_versioned_docs/version-19-2/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-cloud_versioned_docs/version-19-2/networking/egress/egress-gateway-on-prem.mdx
@@ -350,7 +350,7 @@ To modify the iptables backend for egress gateways, you must change the `iptable
 If you plan to use Egress Gateways in a [dual-ToR cluster](../configuring/dual-tor.mdx), you must also adjust the {variables.nodecontainer} IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-{variables.prodname} [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+{variables.prodname} [Installation resource](../../reference/installation/api.mdx#NodeAddressAutodetection.
 
 ### Configure namespaces and pods to use egress gateways
 

--- a/calico-cloud_versioned_docs/version-19-2/networking/ipam/initial-ippool.mdx
+++ b/calico-cloud_versioned_docs/version-19-2/networking/ipam/initial-ippool.mdx
@@ -24,7 +24,7 @@ The **Kubernetes pod CIDR** is the expected IP address range for pod IPs. It is 
 
 [Calico IP pools](../../reference/resources/ippool.mdx) are ranges of IP addresses that Calico uses to assign to pods; the ranges must within the Kubernetes pod CIDR.
 
-The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#Installation
 resource and configures the default Calico IP pool. Note the following:
 
 - Default fields for any that are omitted:
@@ -44,7 +44,7 @@ resource and configures the default Calico IP pool. Note the following:
 ## How to
 
 1. Download the custom-resource.yaml file.
-1. Edit the [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation).  
+1. Edit the [Installation resource](../../reference/installation/api.mdx#Installation.  
    **Required values**: `cidr:`  
    **Empty values**: Defaulted
 

--- a/calico-cloud_versioned_docs/version-19-2/networking/ipam/ip-autodetection.mdx
+++ b/calico-cloud_versioned_docs/version-19-2/networking/ipam/ip-autodetection.mdx
@@ -51,7 +51,7 @@ By default, {variables.prodname} uses the **firstFound** method; the first valid
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#NodeAddressAutodetection in the operator Installation reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-cloud_versioned_docs/version-19-2/operations/comms/certificate-management.mdx
+++ b/calico-cloud_versioned_docs/version-19-2/operations/comms/certificate-management.mdx
@@ -21,7 +21,7 @@ certificate issuance, {variables.prodname} provides a simple configuration optio
 **Limitations**
 
 If your cluster is already running {variables.prodname} and you would like to enable certificate management, you need to
-temporarily remove [the logstorage resource](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+temporarily remove [the logstorage resource](../../reference/installation/api.mdx#LogStorage
 before following the steps to enable certificate management and then re-apply afterwards.
 
 {/*TODO-XREFS-CC
@@ -40,7 +40,7 @@ Currently, this feature is not supported in combination with [Multi-cluster mana
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../../reference/installation/api.mdx#Installation
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
 ```yaml

--- a/calico-cloud_versioned_docs/version-19-2/reference/component-resources/configuration.mdx
+++ b/calico-cloud_versioned_docs/version-19-2/reference/component-resources/configuration.mdx
@@ -241,7 +241,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#Installation API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico-cloud_versioned_docs/version-19-2/reference/component-resources/configure-resources.mdx
+++ b/calico-cloud_versioned_docs/version-19-2/reference/component-resources/configure-resources.mdx
@@ -16,11 +16,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../../reference/installation/api.mdx#APIServer CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the installation CR using the below command:
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#APIServerDeployment, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch apiserver tigera-secure  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -68,11 +68,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## ApplicationLayer custom resource
 
-The [ApplicationLayer](../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
+The [ApplicationLayer](../../reference/installation/api.mdx#ApplicationLayer CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
 
 ### L7LogCollectorDaemonSet
 
-To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.L7LogCollectorDaemonSet), patch the ApplicationLayer CR using the below command:
+To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#L7LogCollectorDaemonSet, patch the ApplicationLayer CR using the below command:
 
 ```bash
 $ kubectl patch applicationlayer tigera-secure  --type=merge --patch='{"spec": {"l7LogCollectorDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"l7-collector","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"envoy-proxy","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -121,11 +121,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Compliance custom resource
 
-The [Compliance](../../reference/installation/api.mdx#operator.tigera.io/v1.Compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
+The [Compliance](../../reference/installation/api.mdx#Compliance CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
 
 ### ComplianceControllerDeployment
 
-To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceControllerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#ComplianceControllerDeployment, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -161,7 +161,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceSnapshotterDeployment
 
-To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceSnapshotterDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#ComplianceSnapshotterDeployment, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceSnapshotterDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-snapshotter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -197,7 +197,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceBenchmarkerDaemonSet
 
-To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#ComplianceBenchmarkerDaemonSet, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceBenchmarkerDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-benchmarker","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -232,7 +232,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceServerDeployment
 
-To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceServerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#ComplianceServerDeployment, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -268,7 +268,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceReporterPodTemplate.
 
-To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceReporterPodTemplate), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#ComplianceReporterPodTemplate, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceReporterPodTemplate": {"template": {"spec": {"containers":[{"name":"reporter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}'
@@ -310,7 +310,7 @@ Example Configurations:
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#TyphaDeployment, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -346,7 +346,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#calicoNodeDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -381,7 +381,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#calicoNodeWindowsDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -416,7 +416,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#CalicoKubeControllersDeployment component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -452,7 +452,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#CSINodeDriverDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -500,11 +500,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## IntrusionDetection custom resource
 
-The [IntrusionDetection](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
+The [IntrusionDetection](../../reference/installation/api.mdx#IntrusionDetection CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
 
 ### IntrusionDetectionControllerDeployment.
 
-To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionControllerDeployment), patch the IntrusionDetection CR using the below command:
+To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#IntrusionDetectionControllerDeployment, patch the IntrusionDetection CR using the below command:
 
 ```bash
 $ kubectl patch intrusiondetection tigera-secure  --type=merge --patch='{"spec": {"intrusionDetectionControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"webhooks-processor","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}},{"name":"controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -552,11 +552,11 @@ This command will output the configured resource requests and limits for the Int
 
 ## LogCollector custom resource
 
-The [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
+The [LogCollector](../../reference/installation/api.mdx#LogCollector CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
 
 ### FluentdDaemonSet.
 
-To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.FluentdDaemonSet), patch the LogCollector CR using the below command:
+To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#FluentdDaemonSet, patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"fluentdDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"fluentd","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -592,7 +592,7 @@ This command will output the configured resource requests and limits for the Flu
 
 ### EKSLogForwarderDeployment.
 
-To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.EKSLogForwarderDeployment), patch the LogCollector CR using the below command:
+To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#EKSLogForwarderDeployment, patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"eksLogForwarderDeployment": {"spec": {"template": {"spec": {"containers":[{"name":"eks-log-forwarder","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -627,11 +627,11 @@ This command will output the configured resource requests and limits for the EKS
 
 ## ManagementClusterConnection custom resource
 
-The [ManagementClusterConnection](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
+The [ManagementClusterConnection](../../reference/installation/api.mdx#ManagementClusterConnection CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
 
 ### GuardianDeployment.
 
-To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.GuardianDeployment), patch the ManagementClusterConnection CR using the below command:
+To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#GuardianDeployment, patch the ManagementClusterConnection CR using the below command:
 
 ```bash
 kubectl patch managementclusterconnection tigera-secure  --type=merge --patch='{"spec": {"guardianDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-guardian","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -663,11 +663,11 @@ This command will output the configured resource requests and limits for the Gua
 
 ## PacketCaptureAPI custom resource
 
-The [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
+The [PacketCaptureAPI](../../reference/installation/api.mdx#PacketCaptureAPI CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
 
 ### PacketCaptureAPIDeployment
 
-To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI), patch the PacketCapture CR using the below command:
+To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#PacketCaptureAPI, patch the PacketCapture CR using the below command:
 
 ```bash
 kubectl patch packetcaptureapis tigera-secure  --type=merge --patch='{"spec": {"packetCaptureAPIDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-packetcapture-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'

--- a/calico-cloud_versioned_docs/version-19-2/reference/installation/_api.mdx
+++ b/calico-cloud_versioned_docs/version-19-2/reference/installation/_api.mdx
@@ -15,47 +15,47 @@ API Schema definitions for configuring the installation of Calico and Calico Ent
 </p>
 Resource Types:
 <ul><li>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>
+<a href="#APIServer">APIServer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>
+<a href="#ApplicationLayer">ApplicationLayer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>
+<a href="#Authentication">Authentication</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>
+<a href="#Compliance">Compliance</a>
 </li><li>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>
+<a href="#EgressGateway">EgressGateway</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>
+<a href="#ImageSet">ImageSet</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>
+<a href="#Installation">Installation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>
+<a href="#IntrusionDetection">IntrusionDetection</a>
 </li><li>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>
+<a href="#LogCollector">LogCollector</a>
 </li><li>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>
+<a href="#LogStorage">LogStorage</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ManagementCluster">ManagementCluster</a>
+<a href="#ManagementCluster">ManagementCluster</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>
+<a href="#Manager">Manager</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>
+<a href="#Monitor">Monitor</a>
 </li><li>
-<a href="#operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</a>
+<a href="#PacketCaptureAPI">PacketCaptureAPI</a>
 </li><li>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>
+<a href="#PolicyRecommendation">PolicyRecommendation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TLSPassThroughRoute">TLSPassThroughRoute</a>
+<a href="#TLSPassThroughRoute">TLSPassThroughRoute</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TLSTerminatedRoute">TLSTerminatedRoute</a>
+<a href="#TLSTerminatedRoute">TLSTerminatedRoute</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>
+<a href="#Tenant">Tenant</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>
+<a href="#TigeraStatus">TigeraStatus</a>
 </li></ul>
-<h3 id="operator.tigera.io/v1.APIServer">APIServer</h3>
+<h3 id="APIServer">APIServer</h3>
 <p>
 APIServer installs the Tigera API server and related resources. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo; or &ldquo;tigera-secure&rdquo;.
@@ -116,7 +116,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerSpec">
+<a href="#APIServerSpec">
 APIServerSpec
 </a>
 </em>
@@ -134,7 +134,7 @@ Specification of the desired state for the Tigera API server.
 <td>
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -158,7 +158,7 @@ take precedence.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerStatus">
+<a href="#APIServerStatus">
 APIServerStatus
 </a>
 </em>
@@ -174,7 +174,7 @@ Most recently observed status for the Tigera API server.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</h3>
+<h3 id="ApplicationLayer">ApplicationLayer</h3>
 <p>
 ApplicationLayer is the Schema for the applicationlayers API
 </p>
@@ -234,7 +234,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">
+<a href="#ApplicationLayerSpec">
 ApplicationLayerSpec
 </a>
 </em>
@@ -249,7 +249,7 @@ ApplicationLayerSpec
 <td>
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -269,7 +269,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -288,7 +288,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -308,7 +308,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -327,7 +327,7 @@ User-configurable settings for the Envoy proxy.
 
 <code>l7LogCollectorDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSet">
+<a href="#L7LogCollectorDaemonSet">
 L7LogCollectorDaemonSet
 </a>
 </em>
@@ -350,7 +350,7 @@ L7LogCollectorDaemonSet configures the L7LogCollector DaemonSet.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerStatus">
+<a href="#ApplicationLayerStatus">
 ApplicationLayerStatus
 </a>
 </em>
@@ -363,7 +363,7 @@ ApplicationLayerStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Authentication">Authentication</h3>
+<h3 id="Authentication">Authentication</h3>
 <p>
 Authentication is the Schema for the authentications API
 </p>
@@ -423,7 +423,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">
+<a href="#AuthenticationSpec">
 AuthenticationSpec
 </a>
 </em>
@@ -495,7 +495,7 @@ ClusterRoleBindings into Elastic.
 
 <code>oidc</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">
+<a href="#AuthenticationOIDC">
 AuthenticationOIDC
 </a>
 </em>
@@ -515,7 +515,7 @@ OIDC contains the configuration needed to setup OIDC authentication.
 
 <code>openshift</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOpenshift">
+<a href="#AuthenticationOpenshift">
 AuthenticationOpenshift
 </a>
 </em>
@@ -535,7 +535,7 @@ Openshift contains the configuration needed to setup Openshift OAuth authenticat
 
 <code>ldap</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">
+<a href="#AuthenticationLDAP">
 AuthenticationLDAP
 </a>
 </em>
@@ -555,7 +555,7 @@ LDAP contains the configuration needed to setup LDAP authentication.
 
 <code>dexDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeployment">
+<a href="#DexDeployment">
 DexDeployment
 </a>
 </em>
@@ -578,7 +578,7 @@ DexDeployment configures the Dex Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationStatus">
+<a href="#AuthenticationStatus">
 AuthenticationStatus
 </a>
 </em>
@@ -591,7 +591,7 @@ AuthenticationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Compliance">Compliance</h3>
+<h3 id="Compliance">Compliance</h3>
 <p>
 Compliance installs the components required for Tigera compliance reporting. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -652,7 +652,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">
+<a href="#ComplianceSpec">
 ComplianceSpec
 </a>
 </em>
@@ -670,7 +670,7 @@ Specification of the desired state for Tigera compliance reporting.
 <td>
 <code>complianceControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeployment">
+<a href="#ComplianceControllerDeployment">
 ComplianceControllerDeployment
 </a>
 </em>
@@ -690,7 +690,7 @@ ComplianceControllerDeployment configures the Compliance Controller Deployment.
 
 <code>complianceSnapshotterDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeployment">
+<a href="#ComplianceSnapshotterDeployment">
 ComplianceSnapshotterDeployment
 </a>
 </em>
@@ -710,7 +710,7 @@ ComplianceSnapshotterDeployment configures the Compliance Snapshotter Deployment
 
 <code>complianceBenchmarkerDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">
+<a href="#ComplianceBenchmarkerDaemonSet">
 ComplianceBenchmarkerDaemonSet
 </a>
 </em>
@@ -730,7 +730,7 @@ ComplianceBenchmarkerDaemonSet configures the Compliance Benchmarker DaemonSet.
 
 <code>complianceServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeployment">
+<a href="#ComplianceServerDeployment">
 ComplianceServerDeployment
 </a>
 </em>
@@ -750,7 +750,7 @@ ComplianceServerDeployment configures the Compliance Server Deployment.
 
 <code>complianceReporterPodTemplate</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplate">
+<a href="#ComplianceReporterPodTemplate">
 ComplianceReporterPodTemplate
 </a>
 </em>
@@ -773,7 +773,7 @@ ComplianceReporterPodTemplate configures the Compliance Reporter PodTemplate.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceStatus">
+<a href="#ComplianceStatus">
 ComplianceStatus
 </a>
 </em>
@@ -789,7 +789,7 @@ Most recently observed state for Tigera compliance reporting.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGateway">EgressGateway</h3>
+<h3 id="EgressGateway">EgressGateway</h3>
 <p>
 EgressGateway is the Schema for the egressgateways API
 </p>
@@ -849,7 +849,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">
+<a href="#EgressGatewaySpec">
 EgressGatewaySpec
 </a>
 </em>
@@ -882,7 +882,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -923,7 +923,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -944,7 +944,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -964,7 +964,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -988,7 +988,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -1011,7 +1011,7 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayStatus">
+<a href="#EgressGatewayStatus">
 EgressGatewayStatus
 </a>
 </em>
@@ -1024,7 +1024,7 @@ EgressGatewayStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSet">ImageSet</h3>
+<h3 id="ImageSet">ImageSet</h3>
 <p>
 ImageSet is used to specify image digests for the images that the operator deploys.
 The name of the ImageSet is expected to be in the format <code>&lt;variant&gt;-&lt;release&gt;</code>.
@@ -1089,7 +1089,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">
+<a href="#ImageSetSpec">
 ImageSetSpec
 </a>
 </em>
@@ -1104,7 +1104,7 @@ ImageSetSpec
 <td>
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -1124,7 +1124,7 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Installation">Installation</h3>
+<h3 id="Installation">Installation</h3>
 <p>
 Installation configures an installation of Calico or Calico Enterprise. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo;. The Installation API installs core networking
@@ -1186,7 +1186,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -1204,7 +1204,7 @@ Specification of the desired state for the Calico or Calico Enterprise installat
 <td>
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -1332,7 +1332,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -1355,7 +1355,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -1375,7 +1375,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -1395,7 +1395,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -1574,7 +1574,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -1596,7 +1596,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -1618,7 +1618,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -1638,7 +1638,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -1658,7 +1658,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -1677,7 +1677,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -1697,7 +1697,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -1717,7 +1717,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -1737,7 +1737,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -1756,7 +1756,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -1777,7 +1777,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -1797,7 +1797,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -1838,7 +1838,7 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationStatus">
+<a href="#InstallationStatus">
 InstallationStatus
 </a>
 </em>
@@ -1854,7 +1854,7 @@ Most recently observed state for the Calico or Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</h3>
+<h3 id="IntrusionDetection">IntrusionDetection</h3>
 <p>
 IntrusionDetection installs the components required for Tigera intrusion detection. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -1915,7 +1915,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">
+<a href="#IntrusionDetectionSpec">
 IntrusionDetectionSpec
 </a>
 </em>
@@ -1933,7 +1933,7 @@ Specification of the desired state for Tigera intrusion detection.
 <td>
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">
+<a href="#IntrusionDetectionComponentResource">
 []IntrusionDetectionComponentResource
 </a>
 </em>
@@ -1954,7 +1954,7 @@ Only DeepPacketInspection is supported for this spec.
 
 <code>anomalyDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+<a href="#AnomalyDetectionSpec">
 AnomalyDetectionSpec
 </a>
 </em>
@@ -1974,7 +1974,7 @@ AnomalyDetection is now deprecated, and configuring it has no effect.
 
 <code>intrusionDetectionControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeployment">
+<a href="#IntrusionDetectionControllerDeployment">
 IntrusionDetectionControllerDeployment
 </a>
 </em>
@@ -1997,7 +1997,7 @@ IntrusionDetectionControllerDeployment configures the IntrusionDetection Control
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionStatus">
+<a href="#IntrusionDetectionStatus">
 IntrusionDetectionStatus
 </a>
 </em>
@@ -2013,7 +2013,7 @@ Most recently observed state for Tigera intrusion detection.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollector">LogCollector</h3>
+<h3 id="LogCollector">LogCollector</h3>
 <p>
 LogCollector installs the components required for Tigera flow and DNS log collection. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;. When created, this installs fluentd on all nodes
@@ -2075,7 +2075,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">
+<a href="#LogCollectorSpec">
 LogCollectorSpec
 </a>
 </em>
@@ -2093,7 +2093,7 @@ Specification of the desired state for Tigera log collection.
 <td>
 <code>additionalStores</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">
+<a href="#AdditionalLogStoreSpec">
 AdditionalLogStoreSpec
 </a>
 </em>
@@ -2113,7 +2113,7 @@ Configuration for exporting flow, audit, and DNS logs to external storage.
 
 <code>additionalSources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">
+<a href="#AdditionalLogSourceSpec">
 AdditionalLogSourceSpec
 </a>
 </em>
@@ -2133,7 +2133,7 @@ Configuration for importing audit logs from managed kubernetes cluster log sourc
 
 <code>collectProcessPath</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CollectProcessPathOption">
+<a href="#CollectProcessPathOption">
 CollectProcessPathOption
 </a>
 </em>
@@ -2174,7 +2174,7 @@ the management cluster&rsquo;s tenant services are running.
 
 <code>fluentdDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSet">
+<a href="#FluentdDaemonSet">
 FluentdDaemonSet
 </a>
 </em>
@@ -2193,7 +2193,7 @@ FluentdDaemonSet configures the Fluentd DaemonSet.
 
 <code>eksLogForwarderDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeployment">
+<a href="#EKSLogForwarderDeployment">
 EKSLogForwarderDeployment
 </a>
 </em>
@@ -2216,7 +2216,7 @@ EKSLogForwarderDeployment configures the EKSLogForwarderDeployment Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectorStatus">
+<a href="#LogCollectorStatus">
 LogCollectorStatus
 </a>
 </em>
@@ -2232,7 +2232,7 @@ Most recently observed state for Tigera log collection.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorage">LogStorage</h3>
+<h3 id="LogStorage">LogStorage</h3>
 <p>
 LogStorage installs the components required for Tigera flow and DNS log storage. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;. When created, this installs an Elasticsearch cluster for use by
@@ -2294,7 +2294,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">
+<a href="#LogStorageSpec">
 LogStorageSpec
 </a>
 </em>
@@ -2312,7 +2312,7 @@ Specification of the desired state for Tigera log storage.
 <td>
 <code>nodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Nodes">
+<a href="#Nodes">
 Nodes
 </a>
 </em>
@@ -2331,7 +2331,7 @@ Nodes defines the configuration for a set of identical Elasticsearch cluster nod
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Indices">
+<a href="#Indices">
 Indices
 </a>
 </em>
@@ -2351,7 +2351,7 @@ Index defines the configuration for the indices in the Elasticsearch cluster.
 
 <code>retention</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Retention">
+<a href="#Retention">
 Retention
 </a>
 </em>
@@ -2413,7 +2413,7 @@ each of the indicated key-value pairs as labels as well as access to the specifi
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">
+<a href="#LogStorageComponentResource">
 []LogStorageComponentResource
 </a>
 </em>
@@ -2434,7 +2434,7 @@ Only ECKOperator is supported for this spec.
 
 <code>eckOperatorStatefulSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSet">
+<a href="#ECKOperatorStatefulSet">
 ECKOperatorStatefulSet
 </a>
 </em>
@@ -2455,7 +2455,7 @@ ComponentResources, then these overrides take precedence.
 
 <code>kibana</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Kibana">
+<a href="#Kibana">
 Kibana
 </a>
 </em>
@@ -2475,7 +2475,7 @@ Kibana configures the Kibana Spec.
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -2494,7 +2494,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>elasticsearchMetricsDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeployment">
+<a href="#ElasticsearchMetricsDeployment">
 ElasticsearchMetricsDeployment
 </a>
 </em>
@@ -2516,7 +2516,7 @@ ElasticsearchMetricsDeployment configures the tigera-elasticsearch-metric Deploy
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageStatus">
+<a href="#LogStorageStatus">
 LogStorageStatus
 </a>
 </em>
@@ -2532,7 +2532,7 @@ Most recently observed state for Tigera log storage.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementCluster">ManagementCluster</h3>
+<h3 id="ManagementCluster">ManagementCluster</h3>
 <p>
 The presence of ManagementCluster in your cluster, will configure it to be the management plane to which managed
 clusters can connect. At most one instance of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2593,7 +2593,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterSpec">
+<a href="#ManagementClusterSpec">
 ManagementClusterSpec
 </a>
 </em>
@@ -2628,7 +2628,7 @@ Valid examples are: &ldquo;0.0.0.0:31000&rdquo;, &ldquo;example.com:32000&rdquo;
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLS">
+<a href="#TLS">
 TLS
 </a>
 </em>
@@ -2648,7 +2648,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</h3>
+<h3 id="ManagementClusterConnection">ManagementClusterConnection</h3>
 <p>
 ManagementClusterConnection represents a link between a managed cluster and a management cluster. At most one
 instance of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2709,7 +2709,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">
+<a href="#ManagementClusterConnectionSpec">
 ManagementClusterConnectionSpec
 </a>
 </em>
@@ -2743,7 +2743,7 @@ should be able to access this address. This field is used by managed clusters on
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">
+<a href="#ManagementClusterTLS">
 ManagementClusterTLS
 </a>
 </em>
@@ -2763,7 +2763,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>guardianDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeployment">
+<a href="#GuardianDeployment">
 GuardianDeployment
 </a>
 </em>
@@ -2785,7 +2785,7 @@ GuardianDeployment configures the guardian Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionStatus">
+<a href="#ManagementClusterConnectionStatus">
 ManagementClusterConnectionStatus
 </a>
 </em>
@@ -2798,7 +2798,7 @@ ManagementClusterConnectionStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Manager">Manager</h3>
+<h3 id="Manager">Manager</h3>
 <p>
 Manager installs the Calico Enterprise manager graphical user interface. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2859,7 +2859,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerSpec">
+<a href="#ManagerSpec">
 ManagerSpec
 </a>
 </em>
@@ -2877,7 +2877,7 @@ Specification of the desired state for the Calico Enterprise manager.
 <td>
 <code>managerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeployment">
+<a href="#ManagerDeployment">
 ManagerDeployment
 </a>
 </em>
@@ -2900,7 +2900,7 @@ ManagerDeployment configures the Manager Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerStatus">
+<a href="#ManagerStatus">
 ManagerStatus
 </a>
 </em>
@@ -2916,7 +2916,7 @@ Most recently observed state for the Calico Enterprise manager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Monitor">Monitor</h3>
+<h3 id="Monitor">Monitor</h3>
 <p>
 Monitor is the Schema for the monitor API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2977,7 +2977,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorSpec">
+<a href="#MonitorSpec">
 MonitorSpec
 </a>
 </em>
@@ -2992,7 +2992,7 @@ MonitorSpec
 <td>
 <code>externalPrometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">
+<a href="#ExternalPrometheus">
 ExternalPrometheus
 </a>
 </em>
@@ -3013,7 +3013,7 @@ scraping from git-ops tools without the need of post-installation steps.
 
 <code>prometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Prometheus">
+<a href="#Prometheus">
 Prometheus
 </a>
 </em>
@@ -3033,7 +3033,7 @@ Prometheus is the configuration for the Prometheus.
 
 <code>alertManager</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AlertManager">
+<a href="#AlertManager">
 AlertManager
 </a>
 </em>
@@ -3056,7 +3056,7 @@ AlertManager is the configuration for the AlertManager.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorStatus">
+<a href="#MonitorStatus">
 MonitorStatus
 </a>
 </em>
@@ -3069,7 +3069,7 @@ MonitorStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</h3>
+<h3 id="PacketCaptureAPI">PacketCaptureAPI</h3>
 <p>
 PacketCaptureAPI is used to configure the resource requirement for PacketCaptureAPI deployment. It must be named &ldquo;tigera-secure&rdquo;.
 </p>
@@ -3129,7 +3129,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPISpec">
+<a href="#PacketCaptureAPISpec">
 PacketCaptureAPISpec
 </a>
 </em>
@@ -3147,7 +3147,7 @@ Specification of the desired state for the PacketCaptureAPI.
 <td>
 <code>packetCaptureAPIDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeployment">
+<a href="#PacketCaptureAPIDeployment">
 PacketCaptureAPIDeployment
 </a>
 </em>
@@ -3170,7 +3170,7 @@ PacketCaptureAPIDeployment configures the PacketCaptureAPI Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIStatus">
+<a href="#PacketCaptureAPIStatus">
 PacketCaptureAPIStatus
 </a>
 </em>
@@ -3186,7 +3186,7 @@ Most recently observed state for the PacketCaptureAPI.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</h3>
+<h3 id="PolicyRecommendation">PolicyRecommendation</h3>
 <p>
 PolicyRecommendation is the Schema for the policy recommendation API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -3247,7 +3247,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationSpec">
+<a href="#PolicyRecommendationSpec">
 PolicyRecommendationSpec
 </a>
 </em>
@@ -3262,7 +3262,7 @@ PolicyRecommendationSpec
 <td>
 <code>policyRecommendationDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeployment">
+<a href="#PolicyRecommendationDeployment">
 PolicyRecommendationDeployment
 </a>
 </em>
@@ -3285,7 +3285,7 @@ PolicyRecommendation configures the PolicyRecommendation Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationStatus">
+<a href="#PolicyRecommendationStatus">
 PolicyRecommendationStatus
 </a>
 </em>
@@ -3298,7 +3298,7 @@ PolicyRecommendationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSPassThroughRoute">TLSPassThroughRoute</h3>
+<h3 id="TLSPassThroughRoute">TLSPassThroughRoute</h3>
 <table>
 <thead>
 <tr>
@@ -3355,7 +3355,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRouteSpec">
+<a href="#TLSPassThroughRouteSpec">
 TLSPassThroughRouteSpec
 </a>
 </em>
@@ -3373,7 +3373,7 @@ Dest is the destination URL
 <td>
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -3389,7 +3389,7 @@ TargetType
 
 <code>sniMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SNIMatch">
+<a href="#SNIMatch">
 SNIMatch
 </a>
 </em>
@@ -3426,7 +3426,7 @@ Destination is the destination url to proxy the request to.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSTerminatedRoute">TLSTerminatedRoute</h3>
+<h3 id="TLSTerminatedRoute">TLSTerminatedRoute</h3>
 <table>
 <thead>
 <tr>
@@ -3483,7 +3483,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLSTerminatedRouteSpec">
+<a href="#TLSTerminatedRouteSpec">
 TLSTerminatedRouteSpec
 </a>
 </em>
@@ -3498,7 +3498,7 @@ TLSTerminatedRouteSpec
 <td>
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -3514,7 +3514,7 @@ TargetType
 
 <code>pathMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PathMatch">
+<a href="#PathMatch">
 PathMatch
 </a>
 </em>
@@ -3632,7 +3632,7 @@ is UI.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Tenant">Tenant</h3>
+<h3 id="Tenant">Tenant</h3>
 <p>
 Tenant is the Schema for the tenants API
 </p>
@@ -3692,7 +3692,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantSpec">
+<a href="#TenantSpec">
 TenantSpec
 </a>
 </em>
@@ -3741,7 +3741,7 @@ Name is a human readable name for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -3760,7 +3760,7 @@ Indices defines the how to store a tenant&rsquo;s data
 
 <code>elastic</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantElasticSpec">
+<a href="#TenantElasticSpec">
 TenantElasticSpec
 </a>
 </em>
@@ -3799,7 +3799,7 @@ in the Tenant&rsquo;s namespace. Defaults to the controlPlaneReplicas in Install
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -3818,7 +3818,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>dashboardsJob</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJob">
+<a href="#DashboardsJob">
 DashboardsJob
 </a>
 </em>
@@ -3840,7 +3840,7 @@ DashboardsJob configures the Dashboards job
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantStatus">
+<a href="#TenantStatus">
 TenantStatus
 </a>
 </em>
@@ -3853,7 +3853,7 @@ TenantStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatus">TigeraStatus</h3>
+<h3 id="TigeraStatus">TigeraStatus</h3>
 <p>
 TigeraStatus represents the most recently observed status for Calico or a Calico Enterprise functional area.
 </p>
@@ -3913,7 +3913,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusSpec">
+<a href="#TigeraStatusSpec">
 TigeraStatusSpec
 </a>
 </em>
@@ -3933,7 +3933,7 @@ TigeraStatusSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">
+<a href="#TigeraStatusStatus">
 TigeraStatusStatus
 </a>
 </em>
@@ -3946,11 +3946,11 @@ TigeraStatusStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</h3>
+<h3 id="APIServerDeployment">APIServerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerSpec">APIServerSpec</a>)
+<a href="#APIServerSpec">APIServerSpec</a>)
 
 </p>
 <p>
@@ -3969,7 +3969,7 @@ APIServerDeployment is the configuration for the API server Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3989,7 +3989,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">
+<a href="#APIServerDeploymentSpec">
 APIServerDeploymentSpec
 </a>
 </em>
@@ -4010,11 +4010,11 @@ Spec is the specification of the API server Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
+<h3 id="APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -4071,11 +4071,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
+<h3 id="APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -4131,11 +4131,11 @@ If omitted, the API server Deployment will use its default value for this init c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
+<h3 id="APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -4154,7 +4154,7 @@ APIServerDeploymentDeploymentPodSpec is the API server Deployment&rsquo;s PodSpe
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentInitContainer">
+<a href="#APIServerDeploymentInitContainer">
 []APIServerDeploymentInitContainer
 </a>
 </em>
@@ -4176,7 +4176,7 @@ If omitted, the API server Deployment will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentContainer">
+<a href="#APIServerDeploymentContainer">
 []APIServerDeploymentContainer
 </a>
 </em>
@@ -4287,11 +4287,11 @@ WARNING: Please note that this field will override the default API server Deploy
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
+<h3 id="APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
+<a href="#APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -4310,7 +4310,7 @@ APIServerDeploymentPodTemplateSpec is the API server Deployment&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4331,7 +4331,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">
+<a href="#APIServerDeploymentPodSpec">
 APIServerDeploymentPodSpec
 </a>
 </em>
@@ -4352,11 +4352,11 @@ Spec is the API server Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
+<h3 id="APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>)
 
 </p>
 <p>
@@ -4396,7 +4396,7 @@ If omitted, the API server Deployment will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">
+<a href="#APIServerDeploymentPodTemplateSpec">
 APIServerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -4413,11 +4413,11 @@ Template describes the API server Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerSpec">APIServerSpec</h3>
+<h3 id="APIServerSpec">APIServerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -4436,7 +4436,7 @@ APIServerSpec defines the desired state of Tigera API server.
 
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -4454,11 +4454,11 @@ take precedence.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerStatus">APIServerStatus</h3>
+<h3 id="APIServerStatus">APIServerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -4512,11 +4512,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</h3>
+<h3 id="AWSEgressGateway">AWSEgressGateway</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -4535,7 +4535,7 @@ AWSEgressGateway defines the configurations for deploying EgressGateway in AWS
 
 <code>nativeIP</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NativeIP">
+<a href="#NativeIP">
 NativeIP
 </a>
 </em>
@@ -4572,11 +4572,11 @@ NativeIP must be Enabled if elastic IPs are set.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AdditionalLogSourceSpec">AdditionalLogSourceSpec</h3>
+<h3 id="AdditionalLogSourceSpec">AdditionalLogSourceSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <table>
@@ -4592,7 +4592,7 @@ NativeIP must be Enabled if elastic IPs are set.
 
 <code>eksCloudwatchLog</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EksCloudwatchLogsSpec">
+<a href="#EksCloudwatchLogsSpec">
 EksCloudwatchLogsSpec
 </a>
 </em>
@@ -4610,11 +4610,11 @@ audit logs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</h3>
+<h3 id="AdditionalLogStoreSpec">AdditionalLogStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <table>
@@ -4630,7 +4630,7 @@ audit logs.
 
 <code>s3</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.S3StoreSpec">
+<a href="#S3StoreSpec">
 S3StoreSpec
 </a>
 </em>
@@ -4650,7 +4650,7 @@ If specified, enables exporting of flow, audit, and DNS logs to Amazon S3 storag
 
 <code>syslog</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">
+<a href="#SyslogStoreSpec">
 SyslogStoreSpec
 </a>
 </em>
@@ -4670,7 +4670,7 @@ If specified, enables exporting of flow, audit, and DNS logs to syslog.
 
 <code>splunk</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SplunkStoreSpec">
+<a href="#SplunkStoreSpec">
 SplunkStoreSpec
 </a>
 </em>
@@ -4687,11 +4687,11 @@ If specified, enables exporting of flow, audit, and DNS logs to splunk.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AlertManager">AlertManager</h3>
+<h3 id="AlertManager">AlertManager</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.MonitorSpec">MonitorSpec</a>)
+<a href="#MonitorSpec">MonitorSpec</a>)
 
 </p>
 <table>
@@ -4707,7 +4707,7 @@ If specified, enables exporting of flow, audit, and DNS logs to splunk.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AlertManagerSpec">
+<a href="#AlertManagerSpec">
 AlertManagerSpec
 </a>
 </em>
@@ -4728,11 +4728,11 @@ Spec is the specification of the Alertmanager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AlertManagerSpec">AlertManagerSpec</h3>
+<h3 id="AlertManagerSpec">AlertManagerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AlertManager">AlertManager</a>)
+<a href="#AlertManager">AlertManager</a>)
 
 </p>
 <table>
@@ -4764,11 +4764,11 @@ Define resources requests and limits for single Pods.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
+<h3 id="AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <table>
@@ -4799,19 +4799,19 @@ StorageClassName is now deprecated, and configuring it has no effect.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
+<h3 id="ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</h3>
+<h3 id="ApplicationLayerSpec">ApplicationLayerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -4830,7 +4830,7 @@ ApplicationLayerSpec defines the desired state of ApplicationLayer
 
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -4850,7 +4850,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -4869,7 +4869,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -4889,7 +4889,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -4908,7 +4908,7 @@ User-configurable settings for the Envoy proxy.
 
 <code>l7LogCollectorDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSet">
+<a href="#L7LogCollectorDaemonSet">
 L7LogCollectorDaemonSet
 </a>
 </em>
@@ -4925,11 +4925,11 @@ L7LogCollectorDaemonSet configures the L7LogCollector DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerStatus">ApplicationLayerStatus</h3>
+<h3 id="ApplicationLayerStatus">ApplicationLayerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -4983,13 +4983,13 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthMethod">AuthMethod
+<h3 id="AuthMethod">AuthMethod
 (<code>string</code> alias)</h3>
-<h3 id="operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</h3>
+<h3 id="AuthenticationLDAP">AuthenticationLDAP</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -5045,7 +5045,7 @@ the ldaps:// protocol.
 
 <code>userSearch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.UserSearch">
+<a href="#UserSearch">
 UserSearch
 </a>
 </em>
@@ -5064,7 +5064,7 @@ User entry search configuration to match the credentials with a user.
 
 <code>groupSearch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GroupSearch">
+<a href="#GroupSearch">
 GroupSearch
 </a>
 </em>
@@ -5081,11 +5081,11 @@ Group search configuration to find the groups that a user is in.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</h3>
+<h3 id="AuthenticationOIDC">AuthenticationOIDC</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -5211,7 +5211,7 @@ Deprecated. Please use Authentication.Spec.GroupsPrefix instead.
 
 <code>emailVerification</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EmailVerificationType">
+<a href="#EmailVerificationType">
 EmailVerificationType
 </a>
 </em>
@@ -5234,7 +5234,7 @@ Default: Verify
 
 <code>promptTypes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PromptType">
+<a href="#PromptType">
 []PromptType
 </a>
 </em>
@@ -5257,7 +5257,7 @@ Default: &ldquo;Consent&rdquo;
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.OIDCType">
+<a href="#OIDCType">
 OIDCType
 </a>
 </em>
@@ -5274,11 +5274,11 @@ Default: &ldquo;Dex&rdquo;
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationOpenshift">AuthenticationOpenshift</h3>
+<h3 id="AuthenticationOpenshift">AuthenticationOpenshift</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -5311,11 +5311,11 @@ IssuerURL is the URL to the Openshift OAuth provider. Ex.: <a href="https://api.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</h3>
+<h3 id="AuthenticationSpec">AuthenticationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>)
+<a href="#Authentication">Authentication</a>)
 
 </p>
 <p>
@@ -5391,7 +5391,7 @@ ClusterRoleBindings into Elastic.
 
 <code>oidc</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">
+<a href="#AuthenticationOIDC">
 AuthenticationOIDC
 </a>
 </em>
@@ -5411,7 +5411,7 @@ OIDC contains the configuration needed to setup OIDC authentication.
 
 <code>openshift</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOpenshift">
+<a href="#AuthenticationOpenshift">
 AuthenticationOpenshift
 </a>
 </em>
@@ -5431,7 +5431,7 @@ Openshift contains the configuration needed to setup Openshift OAuth authenticat
 
 <code>ldap</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">
+<a href="#AuthenticationLDAP">
 AuthenticationLDAP
 </a>
 </em>
@@ -5451,7 +5451,7 @@ LDAP contains the configuration needed to setup LDAP authentication.
 
 <code>dexDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeployment">
+<a href="#DexDeployment">
 DexDeployment
 </a>
 </em>
@@ -5468,11 +5468,11 @@ DexDeployment configures the Dex Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationStatus">AuthenticationStatus</h3>
+<h3 id="AuthenticationStatus">AuthenticationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>)
+<a href="#Authentication">Authentication</a>)
 
 </p>
 <p>
@@ -5526,12 +5526,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.BGPOption">BGPOption
+<h3 id="BGPOption">BGPOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -5540,12 +5540,12 @@ BGPOption describes the mode of BGP to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.CAType">CAType
+<h3 id="CAType">CAType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">ManagementClusterTLS</a>)
+<a href="#ManagementClusterTLS">ManagementClusterTLS</a>)
 
 </p>
 <p>
@@ -5554,11 +5554,11 @@ CAType specifies which verification method the tunnel client should use to verif
 <p>
 One of: Tigera, Public
 </p>
-<h3 id="operator.tigera.io/v1.CNILogging">CNILogging</h3>
+<h3 id="CNILogging">CNILogging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Logging">Logging</a>)
+<a href="#Logging">Logging</a>)
 
 </p>
 <table>
@@ -5574,7 +5574,7 @@ One of: Tigera, Public
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -5645,12 +5645,12 @@ Default: 10
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CNIPluginType">CNIPluginType
+<h3 id="CNIPluginType">CNIPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -5659,11 +5659,11 @@ CNIPluginType describes the type of CNI plugin used.
 <p>
 One of: Calico, GKE, AmazonVPC, AzureVNET
 </p>
-<h3 id="operator.tigera.io/v1.CNISpec">CNISpec</h3>
+<h3 id="CNISpec">CNISpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5682,7 +5682,7 @@ CNISpec contains configuration for the CNI plugin.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNIPluginType">
+<a href="#CNIPluginType">
 CNIPluginType
 </a>
 </em>
@@ -5714,7 +5714,7 @@ Default: Calico
 
 <code>ipam</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMSpec">
+<a href="#IPAMSpec">
 IPAMSpec
 </a>
 </em>
@@ -5732,11 +5732,11 @@ Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
+<h3 id="CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5755,7 +5755,7 @@ CSINodeDriverDaemonSet is the configuration for the csi-node-driver DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5775,7 +5775,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">
+<a href="#CSINodeDriverDaemonSetSpec">
 CSINodeDriverDaemonSetSpec
 </a>
 </em>
@@ -5796,11 +5796,11 @@ Spec is the specification of the csi-node-driver DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
+<h3 id="CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -5856,11 +5856,11 @@ If omitted, the csi-node-driver DaemonSet will use its default value for this co
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -5879,7 +5879,7 @@ CSINodeDriverDaemonSetPodSpec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">
+<a href="#CSINodeDriverDaemonSetContainer">
 []CSINodeDriverDaemonSetContainer
 </a>
 </em>
@@ -5966,11 +5966,11 @@ WARNING: Please note that this field will override the default csi-node-driver D
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
+<a href="#CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -5989,7 +5989,7 @@ CSINodeDriverDaemonSetPodTemplateSpec is the csi-node-driver DaemonSet&rsquo;s P
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6010,7 +6010,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">
+<a href="#CSINodeDriverDaemonSetPodSpec">
 CSINodeDriverDaemonSetPodSpec
 </a>
 </em>
@@ -6031,11 +6031,11 @@ Spec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
+<h3 id="CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
 
 </p>
 <p>
@@ -6075,7 +6075,7 @@ If omitted, the csi-node-driver DaemonSet will use its default value for minRead
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">
 CSINodeDriverDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -6092,11 +6092,11 @@ Template describes the csi-node-driver DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
+<h3 id="CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -6115,7 +6115,7 @@ CalicoKubeControllersDeployment is the configuration for the calico-kube-control
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6135,7 +6135,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">
+<a href="#CalicoKubeControllersDeploymentSpec">
 CalicoKubeControllersDeploymentSpec
 </a>
 </em>
@@ -6156,11 +6156,11 @@ Spec is the specification of the calico-kube-controllers Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
+<h3 id="CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -6217,11 +6217,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6240,7 +6240,7 @@ CalicoKubeControllersDeploymentPodSpec is the calico-kube-controller Deployment&
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">
+<a href="#CalicoKubeControllersDeploymentContainer">
 []CalicoKubeControllersDeploymentContainer
 </a>
 </em>
@@ -6329,11 +6329,11 @@ WARNING: Please note that this field will override the default calico-kube-contr
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
+<a href="#CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
 
 </p>
 <p>
@@ -6352,7 +6352,7 @@ CalicoKubeControllersDeploymentPodTemplateSpec is the calico-kube-controllers De
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6373,7 +6373,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">
+<a href="#CalicoKubeControllersDeploymentPodSpec">
 CalicoKubeControllersDeploymentPodSpec
 </a>
 </em>
@@ -6394,11 +6394,11 @@ Spec is the calico-kube-controllers Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
 
 </p>
 <p>
@@ -6438,7 +6438,7 @@ If omitted, the calico-kube-controllers Deployment will use its default value fo
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">
 CalicoKubeControllersDeploymentPodTemplateSpec
 </a>
 </em>
@@ -6455,11 +6455,11 @@ Template describes the calico-kube-controllers Deployment pod that will be creat
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</h3>
+<h3 id="CalicoNetworkSpec">CalicoNetworkSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -6478,7 +6478,7 @@ CalicoNetworkSpec specifies configuration options for Calico provided pod networ
 
 <code>linuxDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinuxDataplaneOption">
+<a href="#LinuxDataplaneOption">
 LinuxDataplaneOption
 </a>
 </em>
@@ -6501,7 +6501,7 @@ Default: Iptables
 
 <code>windowsDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsDataplaneOption">
+<a href="#WindowsDataplaneOption">
 WindowsDataplaneOption
 </a>
 </em>
@@ -6524,7 +6524,7 @@ Default: Disabled
 
 <code>bgp</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.BGPOption">
+<a href="#BGPOption">
 BGPOption
 </a>
 </em>
@@ -6544,7 +6544,7 @@ BGP configures whether or not to enable Calico&rsquo;s BGP capabilities.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPPool">
+<a href="#IPPool">
 []IPPool
 </a>
 </em>
@@ -6584,7 +6584,7 @@ If not specified, Calico will perform MTU auto-detection based on the cluster ne
 
 <code>nodeAddressAutodetectionV4</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -6605,7 +6605,7 @@ will use default auto-detection settings to acquire an IPv4 address for each nod
 
 <code>nodeAddressAutodetectionV6</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -6626,7 +6626,7 @@ IPv6 addresses will not be auto-detected.
 
 <code>hostPorts</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HostPortsType">
+<a href="#HostPortsType">
 HostPortsType
 </a>
 </em>
@@ -6647,7 +6647,7 @@ Default: Enabled
 
 <code>multiInterfaceMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MultiInterfaceMode">
+<a href="#MultiInterfaceMode">
 MultiInterfaceMode
 </a>
 </em>
@@ -6669,7 +6669,7 @@ Default: None
 
 <code>containerIPForwarding</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ContainerIPForwardingType">
+<a href="#ContainerIPForwardingType">
 ContainerIPForwardingType
 </a>
 </em>
@@ -6690,7 +6690,7 @@ Default: Disabled
 
 <code>sysctl</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Sysctl">
+<a href="#Sysctl">
 []Sysctl
 </a>
 </em>
@@ -6737,11 +6737,11 @@ Default: 0
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
+<h3 id="CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -6760,7 +6760,7 @@ CalicoNodeDaemonSet is the configuration for the calico-node DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6780,7 +6780,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">
+<a href="#CalicoNodeDaemonSetSpec">
 CalicoNodeDaemonSetSpec
 </a>
 </em>
@@ -6801,11 +6801,11 @@ Spec is the specification of the calico-node DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
+<h3 id="CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6862,11 +6862,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6923,11 +6923,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6946,7 +6946,7 @@ CalicoNodeDaemonSetPodSpec is the calico-node DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">
+<a href="#CalicoNodeDaemonSetInitContainer">
 []CalicoNodeDaemonSetInitContainer
 </a>
 </em>
@@ -6968,7 +6968,7 @@ If omitted, the calico-node DaemonSet will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetContainer">
+<a href="#CalicoNodeDaemonSetContainer">
 []CalicoNodeDaemonSetContainer
 </a>
 </em>
@@ -7055,11 +7055,11 @@ WARNING: Please note that this field will override the default calico-node Daemo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
+<a href="#CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7078,7 +7078,7 @@ CalicoNodeDaemonSetPodTemplateSpec is the calico-node DaemonSet&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7099,7 +7099,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">
+<a href="#CalicoNodeDaemonSetPodSpec">
 CalicoNodeDaemonSetPodSpec
 </a>
 </em>
@@ -7120,11 +7120,11 @@ Spec is the calico-node DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
+<h3 id="CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
 
 </p>
 <p>
@@ -7164,7 +7164,7 @@ If omitted, the calico-node DaemonSet will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">
 CalicoNodeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -7181,11 +7181,11 @@ Template describes the calico-node DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
+<h3 id="CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7204,7 +7204,7 @@ CalicoNodeWindowsDaemonSet is the configuration for the calico-node-windows Daem
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7224,7 +7224,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">
+<a href="#CalicoNodeWindowsDaemonSetSpec">
 CalicoNodeWindowsDaemonSetSpec
 </a>
 </em>
@@ -7245,11 +7245,11 @@ Spec is the specification of the calico-node-windows DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -7306,11 +7306,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -7367,11 +7367,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7390,7 +7390,7 @@ CalicoNodeWindowsDaemonSetPodSpec is the calico-node-windows DaemonSet&rsquo;s P
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">
+<a href="#CalicoNodeWindowsDaemonSetInitContainer">
 []CalicoNodeWindowsDaemonSetInitContainer
 </a>
 </em>
@@ -7412,7 +7412,7 @@ If omitted, the calico-node-windows DaemonSet will use its default values for it
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">
+<a href="#CalicoNodeWindowsDaemonSetContainer">
 []CalicoNodeWindowsDaemonSetContainer
 </a>
 </em>
@@ -7499,11 +7499,11 @@ WARNING: Please note that this field will override the default calico-node-windo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7522,7 +7522,7 @@ CalicoNodeWindowsDaemonSetPodTemplateSpec is the calico-node-windows DaemonSet&r
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7543,7 +7543,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">
 CalicoNodeWindowsDaemonSetPodSpec
 </a>
 </em>
@@ -7564,11 +7564,11 @@ Spec is the calico-node-windows DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
 
 </p>
 <p>
@@ -7608,7 +7608,7 @@ If omitted, the calico-node-windows DaemonSet will use its default value for min
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">
 CalicoNodeWindowsDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -7625,11 +7625,11 @@ Template describes the calico-node-windows DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7649,7 +7649,7 @@ CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrad
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7669,7 +7669,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">
 CalicoWindowsUpgradeDaemonSetSpec
 </a>
 </em>
@@ -7690,11 +7690,11 @@ Spec is the specification of the calico-windows-upgrade DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -7749,11 +7749,11 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7772,7 +7772,7 @@ CalicoWindowsUpgradeDaemonSetPodSpec is the calico-windows-upgrade DaemonSet&rsq
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">
+<a href="#CalicoWindowsUpgradeDaemonSetContainer">
 []CalicoWindowsUpgradeDaemonSetContainer
 </a>
 </em>
@@ -7859,11 +7859,11 @@ WARNING: Please note that this field will override the default calico-windows-up
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7882,7 +7882,7 @@ CalicoWindowsUpgradeDaemonSetPodTemplateSpec is the calico-windows-upgrade Daemo
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7903,7 +7903,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">
 CalicoWindowsUpgradeDaemonSetPodSpec
 </a>
 </em>
@@ -7924,11 +7924,11 @@ Spec is the calico-windows-upgrade DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
 
 </p>
 <p>
@@ -7968,7 +7968,7 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
 CalicoWindowsUpgradeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -7985,11 +7985,11 @@ Template describes the calico-windows-upgrade DaemonSet pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CertificateManagement">CertificateManagement</h3>
+<h3 id="CertificateManagement">CertificateManagement</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -8081,19 +8081,19 @@ Default: SHA256WithRSA
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CollectProcessPathOption">CollectProcessPathOption
+<h3 id="CollectProcessPathOption">CollectProcessPathOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.CommonPrometheusFields">CommonPrometheusFields</h3>
+<h3 id="CommonPrometheusFields">CommonPrometheusFields</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PrometheusSpec">PrometheusSpec</a>)
+<a href="#PrometheusSpec">PrometheusSpec</a>)
 
 </p>
 <table>
@@ -8109,7 +8109,7 @@ Default: SHA256WithRSA
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PrometheusContainer">
+<a href="#PrometheusContainer">
 []PrometheusContainer
 </a>
 </em>
@@ -8147,11 +8147,11 @@ Define resources requests and limits for single Pods.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</h3>
+<h3 id="ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -8170,7 +8170,7 @@ ComplianceBenchmarkerDaemonSet is the configuration for the Compliance Benchmark
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetSpec">
+<a href="#ComplianceBenchmarkerDaemonSetSpec">
 ComplianceBenchmarkerDaemonSetSpec
 </a>
 </em>
@@ -8191,11 +8191,11 @@ Spec is the specification of the Compliance Benchmarker DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetContainer">ComplianceBenchmarkerDaemonSetContainer</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetContainer">ComplianceBenchmarkerDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -8251,11 +8251,11 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetInitContainer">ComplianceBenchmarkerDaemonSetInitContainer</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetInitContainer">ComplianceBenchmarkerDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -8311,11 +8311,11 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8334,7 +8334,7 @@ ComplianceBenchmarkerDaemonSetPodSpec is the Compliance Benchmarker DaemonSet&rs
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetInitContainer">
+<a href="#ComplianceBenchmarkerDaemonSetInitContainer">
 []ComplianceBenchmarkerDaemonSetInitContainer
 </a>
 </em>
@@ -8356,7 +8356,7 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default values for
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetContainer">
+<a href="#ComplianceBenchmarkerDaemonSetContainer">
 []ComplianceBenchmarkerDaemonSetContainer
 </a>
 </em>
@@ -8375,11 +8375,11 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default values for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -8398,7 +8398,7 @@ ComplianceBenchmarkerDaemonSetPodTemplateSpec is the Compliance Benchmarker Daem
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">
+<a href="#ComplianceBenchmarkerDaemonSetPodSpec">
 ComplianceBenchmarkerDaemonSetPodSpec
 </a>
 </em>
@@ -8419,11 +8419,11 @@ Spec is the Compliance Benchmarker DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</a>)
+<a href="#ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</a>)
 
 </p>
 <p>
@@ -8442,7 +8442,7 @@ ComplianceBenchmarkerDaemonSetSpec defines configuration for the Compliance Benc
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodTemplateSpec">
+<a href="#ComplianceBenchmarkerDaemonSetPodTemplateSpec">
 ComplianceBenchmarkerDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -8459,11 +8459,11 @@ Template describes the Compliance Benchmarker DaemonSet pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeployment">ComplianceControllerDeployment</h3>
+<h3 id="ComplianceControllerDeployment">ComplianceControllerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -8482,7 +8482,7 @@ ComplianceControllerDeployment is the configuration for the compliance controlle
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentSpec">
+<a href="#ComplianceControllerDeploymentSpec">
 ComplianceControllerDeploymentSpec
 </a>
 </em>
@@ -8503,11 +8503,11 @@ Spec is the specification of the compliance controller Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentContainer">ComplianceControllerDeploymentContainer</h3>
+<h3 id="ComplianceControllerDeploymentContainer">ComplianceControllerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
+<a href="#ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -8563,11 +8563,11 @@ If omitted, the compliance controller Deployment will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentInitContainer">ComplianceControllerDeploymentInitContainer</h3>
+<h3 id="ComplianceControllerDeploymentInitContainer">ComplianceControllerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
+<a href="#ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -8623,11 +8623,11 @@ If omitted, the compliance controller Deployment will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</h3>
+<h3 id="ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</a>)
+<a href="#ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8646,7 +8646,7 @@ ComplianceControllerDeploymentPodSpec is the compliance controller Deployment&rs
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentInitContainer">
+<a href="#ComplianceControllerDeploymentInitContainer">
 []ComplianceControllerDeploymentInitContainer
 </a>
 </em>
@@ -8668,7 +8668,7 @@ If omitted, the compliance controller Deployment will use its default values for
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentContainer">
+<a href="#ComplianceControllerDeploymentContainer">
 []ComplianceControllerDeploymentContainer
 </a>
 </em>
@@ -8687,11 +8687,11 @@ If omitted, the compliance controller Deployment will use its default values for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</h3>
+<h3 id="ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</a>)
+<a href="#ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -8710,7 +8710,7 @@ ComplianceControllerDeploymentPodTemplateSpec is the compliance controller Deplo
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">
+<a href="#ComplianceControllerDeploymentPodSpec">
 ComplianceControllerDeploymentPodSpec
 </a>
 </em>
@@ -8731,11 +8731,11 @@ Spec is the compliance controller Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</h3>
+<h3 id="ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeployment">ComplianceControllerDeployment</a>)
+<a href="#ComplianceControllerDeployment">ComplianceControllerDeployment</a>)
 
 </p>
 <p>
@@ -8754,7 +8754,7 @@ ComplianceControllerDeploymentSpec defines configuration for the compliance cont
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodTemplateSpec">
+<a href="#ComplianceControllerDeploymentPodTemplateSpec">
 ComplianceControllerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -8771,11 +8771,11 @@ Template describes the compliance controller Deployment pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodSpec">ComplianceReporterPodSpec</h3>
+<h3 id="ComplianceReporterPodSpec">ComplianceReporterPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</a>)
+<a href="#ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8794,7 +8794,7 @@ ComplianceReporterPodSpec is the ComplianceReporter PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateInitContainer">
+<a href="#ComplianceReporterPodTemplateInitContainer">
 []ComplianceReporterPodTemplateInitContainer
 </a>
 </em>
@@ -8816,7 +8816,7 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateContainer">
+<a href="#ComplianceReporterPodTemplateContainer">
 []ComplianceReporterPodTemplateContainer
 </a>
 </em>
@@ -8835,11 +8835,11 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</h3>
+<h3 id="ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -8858,7 +8858,7 @@ ComplianceReporterPodTemplate is the configuration for the ComplianceReporter Po
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateSpec">
+<a href="#ComplianceReporterPodTemplateSpec">
 ComplianceReporterPodTemplateSpec
 </a>
 </em>
@@ -8875,11 +8875,11 @@ Spec is the specification of the ComplianceReporter PodTemplateSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplateContainer">ComplianceReporterPodTemplateContainer</h3>
+<h3 id="ComplianceReporterPodTemplateContainer">ComplianceReporterPodTemplateContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
+<a href="#ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
 
 </p>
 <p>
@@ -8935,11 +8935,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplateInitContainer">ComplianceReporterPodTemplateInitContainer</h3>
+<h3 id="ComplianceReporterPodTemplateInitContainer">ComplianceReporterPodTemplateInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
+<a href="#ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
 
 </p>
 <p>
@@ -8995,11 +8995,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</h3>
+<h3 id="ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</a>)
+<a href="#ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</a>)
 
 </p>
 <p>
@@ -9018,7 +9018,7 @@ ComplianceReporterPodTemplateSpec is the ComplianceReporter PodTemplateSpec.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodSpec">
+<a href="#ComplianceReporterPodSpec">
 ComplianceReporterPodSpec
 </a>
 </em>
@@ -9039,11 +9039,11 @@ Spec is the ComplianceReporter PodTemplate&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeployment">ComplianceServerDeployment</h3>
+<h3 id="ComplianceServerDeployment">ComplianceServerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -9062,7 +9062,7 @@ ComplianceServerDeployment is the configuration for the ComplianceServer Deploym
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentSpec">
+<a href="#ComplianceServerDeploymentSpec">
 ComplianceServerDeploymentSpec
 </a>
 </em>
@@ -9083,11 +9083,11 @@ Spec is the specification of the ComplianceServer Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentContainer">ComplianceServerDeploymentContainer</h3>
+<h3 id="ComplianceServerDeploymentContainer">ComplianceServerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
+<a href="#ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9143,11 +9143,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentInitContainer">ComplianceServerDeploymentInitContainer</h3>
+<h3 id="ComplianceServerDeploymentInitContainer">ComplianceServerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
+<a href="#ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9203,11 +9203,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</h3>
+<h3 id="ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</a>)
+<a href="#ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -9226,7 +9226,7 @@ ComplianceServerDeploymentPodSpec is the ComplianceServer Deployment&rsquo;s Pod
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentInitContainer">
+<a href="#ComplianceServerDeploymentInitContainer">
 []ComplianceServerDeploymentInitContainer
 </a>
 </em>
@@ -9248,7 +9248,7 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentContainer">
+<a href="#ComplianceServerDeploymentContainer">
 []ComplianceServerDeploymentContainer
 </a>
 </em>
@@ -9267,11 +9267,11 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</h3>
+<h3 id="ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</a>)
+<a href="#ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -9290,7 +9290,7 @@ ComplianceServerDeploymentPodTemplateSpec is the ComplianceServer Deployment&rsq
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">
+<a href="#ComplianceServerDeploymentPodSpec">
 ComplianceServerDeploymentPodSpec
 </a>
 </em>
@@ -9311,11 +9311,11 @@ Spec is the ComplianceServer Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</h3>
+<h3 id="ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeployment">ComplianceServerDeployment</a>)
+<a href="#ComplianceServerDeployment">ComplianceServerDeployment</a>)
 
 </p>
 <p>
@@ -9334,7 +9334,7 @@ ComplianceServerDeploymentSpec defines configuration for the ComplianceServer De
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodTemplateSpec">
+<a href="#ComplianceServerDeploymentPodTemplateSpec">
 ComplianceServerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -9351,11 +9351,11 @@ Template describes the ComplianceServer Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</h3>
+<h3 id="ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -9374,7 +9374,7 @@ ComplianceSnapshotterDeployment is the configuration for the compliance snapshot
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentSpec">
+<a href="#ComplianceSnapshotterDeploymentSpec">
 ComplianceSnapshotterDeploymentSpec
 </a>
 </em>
@@ -9395,11 +9395,11 @@ Spec is the specification of the compliance snapshotter Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentContainer">ComplianceSnapshotterDeploymentContainer</h3>
+<h3 id="ComplianceSnapshotterDeploymentContainer">ComplianceSnapshotterDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9455,11 +9455,11 @@ If omitted, the compliance snapshotter Deployment will use its default value for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentInitContainer">ComplianceSnapshotterDeploymentInitContainer</h3>
+<h3 id="ComplianceSnapshotterDeploymentInitContainer">ComplianceSnapshotterDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9515,11 +9515,11 @@ If omitted, the compliance snapshotter Deployment will use its default value for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</h3>
+<h3 id="ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -9538,7 +9538,7 @@ ComplianceSnapshotterDeploymentPodSpec is the compliance snapshotter Deployment&
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentInitContainer">
+<a href="#ComplianceSnapshotterDeploymentInitContainer">
 []ComplianceSnapshotterDeploymentInitContainer
 </a>
 </em>
@@ -9560,7 +9560,7 @@ If omitted, the compliance snapshotter Deployment will use its default values fo
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentContainer">
+<a href="#ComplianceSnapshotterDeploymentContainer">
 []ComplianceSnapshotterDeploymentContainer
 </a>
 </em>
@@ -9579,11 +9579,11 @@ If omitted, the compliance snapshotter Deployment will use its default values fo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</h3>
+<h3 id="ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</a>)
 
 </p>
 <p>
@@ -9602,7 +9602,7 @@ ComplianceSnapshotterDeploymentPodTemplateSpec is the compliance snapshotter Dep
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">
+<a href="#ComplianceSnapshotterDeploymentPodSpec">
 ComplianceSnapshotterDeploymentPodSpec
 </a>
 </em>
@@ -9623,11 +9623,11 @@ Spec is the compliance snapshotter Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</h3>
+<h3 id="ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</a>)
+<a href="#ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</a>)
 
 </p>
 <p>
@@ -9646,7 +9646,7 @@ ComplianceSnapshotterDeploymentSpec defines configuration for the compliance sna
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodTemplateSpec">
+<a href="#ComplianceSnapshotterDeploymentPodTemplateSpec">
 ComplianceSnapshotterDeploymentPodTemplateSpec
 </a>
 </em>
@@ -9663,11 +9663,11 @@ Template describes the compliance snapshotter Deployment pod that will be create
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</h3>
+<h3 id="ComplianceSpec">ComplianceSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>)
+<a href="#Compliance">Compliance</a>)
 
 </p>
 <p>
@@ -9686,7 +9686,7 @@ ComplianceSpec defines the desired state of Tigera compliance reporting capabili
 
 <code>complianceControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeployment">
+<a href="#ComplianceControllerDeployment">
 ComplianceControllerDeployment
 </a>
 </em>
@@ -9706,7 +9706,7 @@ ComplianceControllerDeployment configures the Compliance Controller Deployment.
 
 <code>complianceSnapshotterDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeployment">
+<a href="#ComplianceSnapshotterDeployment">
 ComplianceSnapshotterDeployment
 </a>
 </em>
@@ -9726,7 +9726,7 @@ ComplianceSnapshotterDeployment configures the Compliance Snapshotter Deployment
 
 <code>complianceBenchmarkerDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">
+<a href="#ComplianceBenchmarkerDaemonSet">
 ComplianceBenchmarkerDaemonSet
 </a>
 </em>
@@ -9746,7 +9746,7 @@ ComplianceBenchmarkerDaemonSet configures the Compliance Benchmarker DaemonSet.
 
 <code>complianceServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeployment">
+<a href="#ComplianceServerDeployment">
 ComplianceServerDeployment
 </a>
 </em>
@@ -9766,7 +9766,7 @@ ComplianceServerDeployment configures the Compliance Server Deployment.
 
 <code>complianceReporterPodTemplate</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplate">
+<a href="#ComplianceReporterPodTemplate">
 ComplianceReporterPodTemplate
 </a>
 </em>
@@ -9783,11 +9783,11 @@ ComplianceReporterPodTemplate configures the Compliance Reporter PodTemplate.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceStatus">ComplianceStatus</h3>
+<h3 id="ComplianceStatus">ComplianceStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>)
+<a href="#Compliance">Compliance</a>)
 
 </p>
 <p>
@@ -9841,12 +9841,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComponentName">ComponentName
+<h3 id="ComponentName">ComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComponentResource">ComponentResource</a>)
+<a href="#ComponentResource">ComponentResource</a>)
 
 </p>
 <p>
@@ -9855,11 +9855,11 @@ ComponentName represents a single component.
 <p>
 One of: Node, Typha, KubeControllers
 </p>
-<h3 id="operator.tigera.io/v1.ComponentResource">ComponentResource</h3>
+<h3 id="ComponentResource">ComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -9879,7 +9879,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentName">
+<a href="#ComponentName">
 ComponentName
 </a>
 </em>
@@ -9914,33 +9914,33 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ConditionStatus">ConditionStatus
+<h3 id="ConditionStatus">ConditionStatus
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 ConditionStatus represents the status of a particular condition. A condition may be one of: True, False, Unknown.
 </p>
-<h3 id="operator.tigera.io/v1.ContainerIPForwardingType">ContainerIPForwardingType
+<h3 id="ContainerIPForwardingType">ContainerIPForwardingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
 ContainerIPForwardingType specifies whether the CNI config for container ip forwarding is enabled.
 </p>
-<h3 id="operator.tigera.io/v1.DashboardsJob">DashboardsJob</h3>
+<h3 id="DashboardsJob">DashboardsJob</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -9959,7 +9959,7 @@ DashboardsJob is the configuration for the Dashboards job.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobSpec">
+<a href="#DashboardsJobSpec">
 DashboardsJobSpec
 </a>
 </em>
@@ -9980,11 +9980,11 @@ Spec is the specification of the dashboards job.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobContainer">DashboardsJobContainer</h3>
+<h3 id="DashboardsJobContainer">DashboardsJobContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodSpec">DashboardsJobPodSpec</a>)
+<a href="#DashboardsJobPodSpec">DashboardsJobPodSpec</a>)
 
 </p>
 <p>
@@ -10040,11 +10040,11 @@ If omitted, the Dashboard Job will use its default value for this container&rsqu
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobPodSpec">DashboardsJobPodSpec</h3>
+<h3 id="DashboardsJobPodSpec">DashboardsJobPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</a>)
+<a href="#DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -10063,7 +10063,7 @@ DashboardsJobPodSpec is the Dashboards job&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobContainer">
+<a href="#DashboardsJobContainer">
 []DashboardsJobContainer
 </a>
 </em>
@@ -10082,11 +10082,11 @@ If omitted, the Dashboard job will use its default values for its containers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</h3>
+<h3 id="DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobSpec">DashboardsJobSpec</a>)
+<a href="#DashboardsJobSpec">DashboardsJobSpec</a>)
 
 </p>
 <p>
@@ -10105,7 +10105,7 @@ DashboardsJobPodTemplateSpec is the Dashboards job&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodSpec">
+<a href="#DashboardsJobPodSpec">
 DashboardsJobPodSpec
 </a>
 </em>
@@ -10126,11 +10126,11 @@ Spec is the Dashboard job&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobSpec">DashboardsJobSpec</h3>
+<h3 id="DashboardsJobSpec">DashboardsJobSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJob">DashboardsJob</a>)
+<a href="#DashboardsJob">DashboardsJob</a>)
 
 </p>
 <p>
@@ -10149,7 +10149,7 @@ DashboardsJobSpec defines configuration for the Dashboards job.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodTemplateSpec">
+<a href="#DashboardsJobPodTemplateSpec">
 DashboardsJobPodTemplateSpec
 </a>
 </em>
@@ -10166,22 +10166,22 @@ Template describes the Dashboards job pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DataType">DataType
+<h3 id="DataType">DataType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Index">Index</a>)
+<a href="#Index">Index</a>)
 
 </p>
 <p>
 DataType represent the type of data stored
 </p>
-<h3 id="operator.tigera.io/v1.DexDeployment">DexDeployment</h3>
+<h3 id="DexDeployment">DexDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -10200,7 +10200,7 @@ DexDeployment is the configuration for the Dex Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentSpec">
+<a href="#DexDeploymentSpec">
 DexDeploymentSpec
 </a>
 </em>
@@ -10221,11 +10221,11 @@ Spec is the specification of the Dex Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentContainer">DexDeploymentContainer</h3>
+<h3 id="DexDeploymentContainer">DexDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
+<a href="#DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10281,11 +10281,11 @@ If omitted, the Dex Deployment will use its default value for this container&rsq
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentInitContainer">DexDeploymentInitContainer</h3>
+<h3 id="DexDeploymentInitContainer">DexDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
+<a href="#DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10341,11 +10341,11 @@ If omitted, the Dex Deployment will use its default value for this init containe
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentPodSpec">DexDeploymentPodSpec</h3>
+<h3 id="DexDeploymentPodSpec">DexDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</a>)
+<a href="#DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -10364,7 +10364,7 @@ DexDeploymentPodSpec is the Dex Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentInitContainer">
+<a href="#DexDeploymentInitContainer">
 []DexDeploymentInitContainer
 </a>
 </em>
@@ -10386,7 +10386,7 @@ If omitted, the Dex Deployment will use its default values for its init containe
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentContainer">
+<a href="#DexDeploymentContainer">
 []DexDeploymentContainer
 </a>
 </em>
@@ -10405,11 +10405,11 @@ If omitted, the Dex Deployment will use its default values for its containers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</h3>
+<h3 id="DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentSpec">DexDeploymentSpec</a>)
+<a href="#DexDeploymentSpec">DexDeploymentSpec</a>)
 
 </p>
 <p>
@@ -10428,7 +10428,7 @@ DexDeploymentPodTemplateSpec is the Dex Deployment&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodSpec">
+<a href="#DexDeploymentPodSpec">
 DexDeploymentPodSpec
 </a>
 </em>
@@ -10449,11 +10449,11 @@ Spec is the Dex Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentSpec">DexDeploymentSpec</h3>
+<h3 id="DexDeploymentSpec">DexDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeployment">DexDeployment</a>)
+<a href="#DexDeployment">DexDeployment</a>)
 
 </p>
 <p>
@@ -10472,7 +10472,7 @@ DexDeploymentSpec defines configuration for the Dex Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodTemplateSpec">
+<a href="#DexDeploymentPodTemplateSpec">
 DexDeploymentPodTemplateSpec
 </a>
 </em>
@@ -10489,11 +10489,11 @@ Template describes the Dex Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSet">ECKOperatorStatefulSet</h3>
+<h3 id="ECKOperatorStatefulSet">ECKOperatorStatefulSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -10512,7 +10512,7 @@ ECKOperatorStatefulSet is the configuration for the ECKOperator StatefulSet.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetSpec">
+<a href="#ECKOperatorStatefulSetSpec">
 ECKOperatorStatefulSetSpec
 </a>
 </em>
@@ -10533,11 +10533,11 @@ Spec is the specification of the ECKOperator StatefulSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetContainer">ECKOperatorStatefulSetContainer</h3>
+<h3 id="ECKOperatorStatefulSetContainer">ECKOperatorStatefulSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
+<a href="#ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
 
 </p>
 <p>
@@ -10593,11 +10593,11 @@ If omitted, the ECKOperator StatefulSet will use its default value for this cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetInitContainer">ECKOperatorStatefulSetInitContainer</h3>
+<h3 id="ECKOperatorStatefulSetInitContainer">ECKOperatorStatefulSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
+<a href="#ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
 
 </p>
 <p>
@@ -10652,11 +10652,11 @@ If omitted, the ECKOperator StatefulSet will use its default value for this init
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</h3>
+<h3 id="ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</a>)
+<a href="#ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -10675,7 +10675,7 @@ ECKOperatorStatefulSetPodSpec is the ECKOperator StatefulSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetInitContainer">
+<a href="#ECKOperatorStatefulSetInitContainer">
 []ECKOperatorStatefulSetInitContainer
 </a>
 </em>
@@ -10697,7 +10697,7 @@ If omitted, the ECKOperator StatefulSet will use its default values for its init
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetContainer">
+<a href="#ECKOperatorStatefulSetContainer">
 []ECKOperatorStatefulSetContainer
 </a>
 </em>
@@ -10716,11 +10716,11 @@ If omitted, the ECKOperator StatefulSet will use its default values for its cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</h3>
+<h3 id="ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</a>)
+<a href="#ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</a>)
 
 </p>
 <p>
@@ -10739,7 +10739,7 @@ ECKOperatorStatefulSetPodTemplateSpec is the ECKOperator StatefulSet&rsquo;s Pod
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">
+<a href="#ECKOperatorStatefulSetPodSpec">
 ECKOperatorStatefulSetPodSpec
 </a>
 </em>
@@ -10760,11 +10760,11 @@ Spec is the ECKOperator StatefulSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</h3>
+<h3 id="ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSet">ECKOperatorStatefulSet</a>)
+<a href="#ECKOperatorStatefulSet">ECKOperatorStatefulSet</a>)
 
 </p>
 <p>
@@ -10783,7 +10783,7 @@ ECKOperatorStatefulSetSpec defines configuration for the ECKOperator StatefulSet
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodTemplateSpec">
+<a href="#ECKOperatorStatefulSetPodTemplateSpec">
 ECKOperatorStatefulSetPodTemplateSpec
 </a>
 </em>
@@ -10800,11 +10800,11 @@ Template describes the ECKOperator StatefulSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentContainer">EGWDeploymentContainer</h3>
+<h3 id="EGWDeploymentContainer">EGWDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10861,11 +10861,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
+<h3 id="EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10922,11 +10922,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeployment">EKSLogForwarderDeployment</h3>
+<h3 id="EKSLogForwarderDeployment">EKSLogForwarderDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <p>
@@ -10945,7 +10945,7 @@ EKSLogForwarderDeployment is the configuration for the EKSLogForwarder Deploymen
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentSpec">
+<a href="#EKSLogForwarderDeploymentSpec">
 EKSLogForwarderDeploymentSpec
 </a>
 </em>
@@ -10966,11 +10966,11 @@ Spec is the specification of the EKSLogForwarder Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentContainer">EKSLogForwarderDeploymentContainer</h3>
+<h3 id="EKSLogForwarderDeploymentContainer">EKSLogForwarderDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
+<a href="#EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -11026,11 +11026,11 @@ If omitted, the EKSLogForwarder Deployment will use its default value for this c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentInitContainer">EKSLogForwarderDeploymentInitContainer</h3>
+<h3 id="EKSLogForwarderDeploymentInitContainer">EKSLogForwarderDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
+<a href="#EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -11086,11 +11086,11 @@ If omitted, the EKSLogForwarder Deployment will use its default value for this i
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</h3>
+<h3 id="EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</a>)
+<a href="#EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11109,7 +11109,7 @@ EKSLogForwarderDeploymentPodSpec is the EKSLogForwarder Deployment&rsquo;s PodSp
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentInitContainer">
+<a href="#EKSLogForwarderDeploymentInitContainer">
 []EKSLogForwarderDeploymentInitContainer
 </a>
 </em>
@@ -11131,7 +11131,7 @@ If omitted, the EKSLogForwarder Deployment will use its default values for its i
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentContainer">
+<a href="#EKSLogForwarderDeploymentContainer">
 []EKSLogForwarderDeploymentContainer
 </a>
 </em>
@@ -11150,11 +11150,11 @@ If omitted, the EKSLogForwarder Deployment will use its default values for its c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</h3>
+<h3 id="EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</a>)
+<a href="#EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</a>)
 
 </p>
 <p>
@@ -11173,7 +11173,7 @@ EKSLogForwarderDeploymentPodTemplateSpec is the EKSLogForwarder Deployment&rsquo
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">
+<a href="#EKSLogForwarderDeploymentPodSpec">
 EKSLogForwarderDeploymentPodSpec
 </a>
 </em>
@@ -11194,11 +11194,11 @@ Spec is the EKSLogForwarder Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</h3>
+<h3 id="EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeployment">EKSLogForwarderDeployment</a>)
+<a href="#EKSLogForwarderDeployment">EKSLogForwarderDeployment</a>)
 
 </p>
 <p>
@@ -11217,7 +11217,7 @@ EKSLogForwarderDeploymentSpec defines configuration for the EKSLogForwarder Depl
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodTemplateSpec">
+<a href="#EKSLogForwarderDeploymentPodTemplateSpec">
 EKSLogForwarderDeploymentPodTemplateSpec
 </a>
 </em>
@@ -11234,11 +11234,11 @@ Template describes the EKSLogForwarder Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
+<h3 id="EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11257,7 +11257,7 @@ EgressGatewayDeploymentPodSpec is the Egress Gateway Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentInitContainer">
+<a href="#EGWDeploymentInitContainer">
 []EGWDeploymentInitContainer
 </a>
 </em>
@@ -11279,7 +11279,7 @@ If omitted, the EGW Deployment will use its default values for its init containe
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentContainer">
+<a href="#EGWDeploymentContainer">
 []EGWDeploymentContainer
 </a>
 </em>
@@ -11414,11 +11414,11 @@ PriorityClassName allows to specify a PriorityClass resource to be used.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
+<h3 id="EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -11437,7 +11437,7 @@ EgressGatewayDeploymentPodTemplateSpec is the EGW Deployment&rsquo;s PodTemplate
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayMetadata">
+<a href="#EgressGatewayMetadata">
 EgressGatewayMetadata
 </a>
 </em>
@@ -11458,7 +11458,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">
+<a href="#EgressGatewayDeploymentPodSpec">
 EgressGatewayDeploymentPodSpec
 </a>
 </em>
@@ -11479,11 +11479,11 @@ Spec is the EGW Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
+<h3 id="EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -11524,7 +11524,7 @@ Default: 90
 
 <code>icmpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ICMPProbe">
+<a href="#ICMPProbe">
 ICMPProbe
 </a>
 </em>
@@ -11546,7 +11546,7 @@ fail. Timeout must be greater than interval.
 
 <code>httpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HTTPProbe">
+<a href="#HTTPProbe">
 HTTPProbe
 </a>
 </em>
@@ -11565,11 +11565,11 @@ fail. Timeout must be greater than interval.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayIPPool">EgressGatewayIPPool</h3>
+<h3 id="EgressGatewayIPPool">EgressGatewayIPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <table>
@@ -11618,11 +11618,11 @@ CIDR is the IPPool CIDR that the Egress Gateways can use.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayMetadata">EgressGatewayMetadata</h3>
+<h3 id="EgressGatewayMetadata">EgressGatewayMetadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11680,11 +11680,11 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</h3>
+<h3 id="EgressGatewaySpec">EgressGatewaySpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -11721,7 +11721,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -11762,7 +11762,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -11783,7 +11783,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -11803,7 +11803,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -11827,7 +11827,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -11844,11 +11844,11 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayStatus">EgressGatewayStatus</h3>
+<h3 id="EgressGatewayStatus">EgressGatewayStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -11902,11 +11902,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EksCloudwatchLogsSpec">EksCloudwatchLogsSpec</h3>
+<h3 id="EksCloudwatchLogsSpec">EksCloudwatchLogsSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">AdditionalLogSourceSpec</a>)
+<a href="#AdditionalLogSourceSpec">AdditionalLogSourceSpec</a>)
 
 </p>
 <p>
@@ -11994,11 +11994,11 @@ Default: 60
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</h3>
+<h3 id="ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -12017,7 +12017,7 @@ ElasticsearchMetricsDeployment is the configuration for the tigera-elasticsearch
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentSpec">
+<a href="#ElasticsearchMetricsDeploymentSpec">
 ElasticsearchMetricsDeploymentSpec
 </a>
 </em>
@@ -12038,11 +12038,11 @@ Spec is the specification of the ElasticsearchMetrics Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentContainer">ElasticsearchMetricsDeploymentContainer</h3>
+<h3 id="ElasticsearchMetricsDeploymentContainer">ElasticsearchMetricsDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -12098,11 +12098,11 @@ If omitted, the ElasticsearchMetrics Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentInitContainer">ElasticsearchMetricsDeploymentInitContainer</h3>
+<h3 id="ElasticsearchMetricsDeploymentInitContainer">ElasticsearchMetricsDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -12158,11 +12158,11 @@ If omitted, the ElasticsearchMetrics Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</h3>
+<h3 id="ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -12181,7 +12181,7 @@ ElasticsearchMetricsDeploymentPodSpec is the tElasticsearchMetricsDeployment&rsq
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentInitContainer">
+<a href="#ElasticsearchMetricsDeploymentInitContainer">
 []ElasticsearchMetricsDeploymentInitContainer
 </a>
 </em>
@@ -12203,7 +12203,7 @@ If omitted, the ElasticsearchMetrics Deployment will use its default values for 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentContainer">
+<a href="#ElasticsearchMetricsDeploymentContainer">
 []ElasticsearchMetricsDeploymentContainer
 </a>
 </em>
@@ -12222,11 +12222,11 @@ If omitted, the ElasticsearchMetrics Deployment will use its default values for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</h3>
+<h3 id="ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</a>)
 
 </p>
 <p>
@@ -12245,7 +12245,7 @@ ElasticsearchMetricsDeploymentPodTemplateSpec is the ElasticsearchMetricsDeploym
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">
+<a href="#ElasticsearchMetricsDeploymentPodSpec">
 ElasticsearchMetricsDeploymentPodSpec
 </a>
 </em>
@@ -12266,11 +12266,11 @@ Spec is the ElasticsearchMetrics Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</h3>
+<h3 id="ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</a>)
+<a href="#ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</a>)
 
 </p>
 <p>
@@ -12289,7 +12289,7 @@ ElasticsearchMetricsDeploymentSpec defines configuration for the ElasticsearchMe
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodTemplateSpec">
+<a href="#ElasticsearchMetricsDeploymentPodTemplateSpec">
 ElasticsearchMetricsDeploymentPodTemplateSpec
 </a>
 </em>
@@ -12306,20 +12306,20 @@ Template describes the ElasticsearchMetrics Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EmailVerificationType">EmailVerificationType
+<h3 id="EmailVerificationType">EmailVerificationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.EncapsulationType">EncapsulationType
+<h3 id="EncapsulationType">EncapsulationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -12328,12 +12328,12 @@ EncapsulationType is the type of encapsulation to use on an IP pool.
 <p>
 One of: IPIP, VXLAN, IPIPCrossSubnet, VXLANCrossSubnet, None
 </p>
-<h3 id="operator.tigera.io/v1.EncryptionOption">EncryptionOption
+<h3 id="EncryptionOption">EncryptionOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</a>)
+<a href="#SyslogStoreSpec">SyslogStoreSpec</a>)
 
 </p>
 <p>
@@ -12342,11 +12342,11 @@ EncryptionOption specifies the traffic encryption mode when connecting to a Sysl
 <p>
 One of: None, TLS
 </p>
-<h3 id="operator.tigera.io/v1.Endpoint">Endpoint</h3>
+<h3 id="Endpoint">Endpoint</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ServiceMonitor">ServiceMonitor</a>)
+<a href="#ServiceMonitor">ServiceMonitor</a>)
 
 </p>
 <p>
@@ -12507,11 +12507,11 @@ More info: <a href="https://prometheus.io/docs/prometheus/latest/configuration/c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EnvoySettings">EnvoySettings</h3>
+<h3 id="EnvoySettings">EnvoySettings</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -12564,11 +12564,11 @@ manipulating various headers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ExternalPrometheus">ExternalPrometheus</h3>
+<h3 id="ExternalPrometheus">ExternalPrometheus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.MonitorSpec">MonitorSpec</a>)
+<a href="#MonitorSpec">MonitorSpec</a>)
 
 </p>
 <table>
@@ -12584,7 +12584,7 @@ manipulating various headers.
 
 <code>serviceMonitor</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ServiceMonitor">
+<a href="#ServiceMonitor">
 ServiceMonitor
 </a>
 </em>
@@ -12624,19 +12624,19 @@ must be created before the operator will create Prometheus resources.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FIPSMode">FIPSMode
+<h3 id="FIPSMode">FIPSMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSet">FluentdDaemonSet</h3>
+<h3 id="FluentdDaemonSet">FluentdDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <p>
@@ -12655,7 +12655,7 @@ FluentdDaemonSet is the configuration for the Fluentd DaemonSet.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetSpec">
+<a href="#FluentdDaemonSetSpec">
 FluentdDaemonSetSpec
 </a>
 </em>
@@ -12676,11 +12676,11 @@ Spec is the specification of the Fluentd DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetContainer">FluentdDaemonSetContainer</h3>
+<h3 id="FluentdDaemonSetContainer">FluentdDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
+<a href="#FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -12736,11 +12736,11 @@ If omitted, the Fluentd DaemonSet will use its default value for this container&
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetInitContainer">FluentdDaemonSetInitContainer</h3>
+<h3 id="FluentdDaemonSetInitContainer">FluentdDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
+<a href="#FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -12796,11 +12796,11 @@ If omitted, the Fluentd DaemonSet will use its default value for this init conta
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</h3>
+<h3 id="FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</a>)
+<a href="#FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -12819,7 +12819,7 @@ FluentdDaemonSetPodSpec is the Fluentd DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetInitContainer">
+<a href="#FluentdDaemonSetInitContainer">
 []FluentdDaemonSetInitContainer
 </a>
 </em>
@@ -12841,7 +12841,7 @@ If omitted, the Fluentd DaemonSet will use its default values for its init conta
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetContainer">
+<a href="#FluentdDaemonSetContainer">
 []FluentdDaemonSetContainer
 </a>
 </em>
@@ -12860,11 +12860,11 @@ If omitted, the Fluentd DaemonSet will use its default values for its containers
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</h3>
+<h3 id="FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetSpec">FluentdDaemonSetSpec</a>)
+<a href="#FluentdDaemonSetSpec">FluentdDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -12883,7 +12883,7 @@ FluentdDaemonSetPodTemplateSpec is the Fluentd DaemonSet&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodSpec">
+<a href="#FluentdDaemonSetPodSpec">
 FluentdDaemonSetPodSpec
 </a>
 </em>
@@ -12904,11 +12904,11 @@ Spec is the Fluentd DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetSpec">FluentdDaemonSetSpec</h3>
+<h3 id="FluentdDaemonSetSpec">FluentdDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSet">FluentdDaemonSet</a>)
+<a href="#FluentdDaemonSet">FluentdDaemonSet</a>)
 
 </p>
 <p>
@@ -12927,7 +12927,7 @@ FluentdDaemonSetSpec defines configuration for the Fluentd DaemonSet.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodTemplateSpec">
+<a href="#FluentdDaemonSetPodTemplateSpec">
 FluentdDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -12944,11 +12944,11 @@ Template describes the Fluentd DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GroupSearch">GroupSearch</h3>
+<h3 id="GroupSearch">GroupSearch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</a>)
+<a href="#AuthenticationLDAP">AuthenticationLDAP</a>)
 
 </p>
 <p>
@@ -13020,7 +13020,7 @@ The attribute of the group that represents its name. This attribute can be used 
 
 <code>userMatchers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.UserMatch">
+<a href="#UserMatch">
 []UserMatch
 </a>
 </em>
@@ -13038,11 +13038,11 @@ attribute value.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeployment">GuardianDeployment</h3>
+<h3 id="GuardianDeployment">GuardianDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
+<a href="#ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
 
 </p>
 <p>
@@ -13061,7 +13061,7 @@ GuardianDeployment is the configuration for the guardian Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentSpec">
+<a href="#GuardianDeploymentSpec">
 GuardianDeploymentSpec
 </a>
 </em>
@@ -13082,11 +13082,11 @@ Spec is the specification of the guardian Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentContainer">GuardianDeploymentContainer</h3>
+<h3 id="GuardianDeploymentContainer">GuardianDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
+<a href="#GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -13142,11 +13142,11 @@ If omitted, the guardian Deployment will use its default value for this containe
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentInitContainer">GuardianDeploymentInitContainer</h3>
+<h3 id="GuardianDeploymentInitContainer">GuardianDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
+<a href="#GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -13201,11 +13201,11 @@ If omitted, the guardian Deployment will use its default value for this init con
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</h3>
+<h3 id="GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</a>)
+<a href="#GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -13224,7 +13224,7 @@ GuardianDeploymentPodSpec is the guardian Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentInitContainer">
+<a href="#GuardianDeploymentInitContainer">
 []GuardianDeploymentInitContainer
 </a>
 </em>
@@ -13246,7 +13246,7 @@ If omitted, the guardian Deployment will use its default values for its init con
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentContainer">
+<a href="#GuardianDeploymentContainer">
 []GuardianDeploymentContainer
 </a>
 </em>
@@ -13265,11 +13265,11 @@ If omitted, the guardian Deployment will use its default values for its containe
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</h3>
+<h3 id="GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentSpec">GuardianDeploymentSpec</a>)
+<a href="#GuardianDeploymentSpec">GuardianDeploymentSpec</a>)
 
 </p>
 <p>
@@ -13288,7 +13288,7 @@ GuardianDeploymentPodTemplateSpec is the guardian Deployment&rsquo;s PodTemplate
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodSpec">
+<a href="#GuardianDeploymentPodSpec">
 GuardianDeploymentPodSpec
 </a>
 </em>
@@ -13309,11 +13309,11 @@ Spec is the guardian Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentSpec">GuardianDeploymentSpec</h3>
+<h3 id="GuardianDeploymentSpec">GuardianDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeployment">GuardianDeployment</a>)
+<a href="#GuardianDeployment">GuardianDeployment</a>)
 
 </p>
 <p>
@@ -13332,7 +13332,7 @@ GuardianDeploymentSpec defines configuration for the guardian Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodTemplateSpec">
+<a href="#GuardianDeploymentPodTemplateSpec">
 GuardianDeploymentPodTemplateSpec
 </a>
 </em>
@@ -13349,11 +13349,11 @@ Template describes the guardian Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HTTPProbe">HTTPProbe</h3>
+<h3 id="HTTPProbe">HTTPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -13425,12 +13425,12 @@ Default: 30
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HostPortsType">HostPortsType
+<h3 id="HostPortsType">HostPortsType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -13439,11 +13439,11 @@ HostPortsType specifies host port support.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.ICMPProbe">ICMPProbe</h3>
+<h3 id="ICMPProbe">ICMPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -13515,19 +13515,19 @@ Default: 15
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPAMPluginType">IPAMPluginType
+<h3 id="IPAMPluginType">IPAMPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPAMSpec">IPAMSpec</a>)
+<a href="#IPAMSpec">IPAMSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IPAMSpec">IPAMSpec</h3>
+<h3 id="IPAMSpec">IPAMSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -13546,7 +13546,7 @@ IPAMSpec contains configuration for pod IP address management.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMPluginType">
+<a href="#IPAMPluginType">
 IPAMPluginType
 </a>
 </em>
@@ -13574,11 +13574,11 @@ Default: Calico
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPPool">IPPool</h3>
+<h3 id="IPPool">IPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -13628,7 +13628,7 @@ CIDR contains the address range for the IP Pool in classless inter-domain routin
 
 <code>encapsulation</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncapsulationType">
+<a href="#EncapsulationType">
 EncapsulationType
 </a>
 </em>
@@ -13650,7 +13650,7 @@ Default: IPIP
 
 <code>natOutgoing</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NATOutgoingType">
+<a href="#NATOutgoingType">
 NATOutgoingType
 </a>
 </em>
@@ -13729,7 +13729,7 @@ Default: false
 
 <code>allowedUses</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPPoolAllowedUse">
+<a href="#IPPoolAllowedUse">
 []IPPoolAllowedUse
 </a>
 </em>
@@ -13746,19 +13746,19 @@ AllowedUse controls what the IP pool will be used for.  If not specified or empt
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPPoolAllowedUse">IPPoolAllowedUse
+<h3 id="IPPoolAllowedUse">IPPoolAllowedUse
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.Image">Image</h3>
+<h3 id="Image">Image</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</a>)
+<a href="#ImageSetSpec">ImageSetSpec</a>)
 
 </p>
 <table>
@@ -13809,11 +13809,11 @@ The field should not include a leading <code>@</code> and must be prefixed with 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</h3>
+<h3 id="ImageSetSpec">ImageSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>)
+<a href="#ImageSet">ImageSet</a>)
 
 </p>
 <p>
@@ -13832,7 +13832,7 @@ ImageSetSpec defines the desired state of ImageSet.
 
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -13849,11 +13849,11 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Index">Index</h3>
+<h3 id="Index">Index</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -13891,7 +13891,7 @@ excludes the numerical identifier suffix)
 
 <code>dataType</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DataType">
+<a href="#DataType">
 DataType
 </a>
 </em>
@@ -13907,11 +13907,11 @@ DataType represents the type of data stored in the defined index
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Indices">Indices</h3>
+<h3 id="Indices">Indices</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -13945,12 +13945,12 @@ Replicas defines how many replicas each index will have. See <a href="https://ww
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationSpec">InstallationSpec</h3>
+<h3 id="InstallationSpec">InstallationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#Installation">Installation</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -13969,7 +13969,7 @@ InstallationSpec defines configuration for a Calico or Calico Enterprise install
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -14097,7 +14097,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -14120,7 +14120,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -14140,7 +14140,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -14160,7 +14160,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -14339,7 +14339,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -14361,7 +14361,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -14383,7 +14383,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -14403,7 +14403,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -14423,7 +14423,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -14442,7 +14442,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -14462,7 +14462,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -14482,7 +14482,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -14502,7 +14502,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -14521,7 +14521,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -14542,7 +14542,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -14562,7 +14562,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -14597,11 +14597,11 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationStatus">InstallationStatus</h3>
+<h3 id="InstallationStatus">InstallationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>)
+<a href="#Installation">Installation</a>)
 
 </p>
 <p>
@@ -14620,7 +14620,7 @@ InstallationStatus defines the observed state of the Calico or Calico Enterprise
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -14676,7 +14676,7 @@ that is being used. If an ImageSet is not being used then this will not be set.
 
 <code>computed</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -14733,19 +14733,19 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionComponentName">IntrusionDetectionComponentName
+<h3 id="IntrusionDetectionComponentName">IntrusionDetectionComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</a>)
+<a href="#IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</h3>
+<h3 id="IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <p>
@@ -14764,7 +14764,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentName">
+<a href="#IntrusionDetectionComponentName">
 IntrusionDetectionComponentName
 </a>
 </em>
@@ -14799,11 +14799,11 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</h3>
+<h3 id="IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <p>
@@ -14822,7 +14822,7 @@ IntrusionDetectionControllerDeployment is the configuration for the IntrusionDet
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentSpec">
+<a href="#IntrusionDetectionControllerDeploymentSpec">
 IntrusionDetectionControllerDeploymentSpec
 </a>
 </em>
@@ -14843,11 +14843,11 @@ Spec is the specification of the IntrusionDetectionController Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentContainer">IntrusionDetectionControllerDeploymentContainer</h3>
+<h3 id="IntrusionDetectionControllerDeploymentContainer">IntrusionDetectionControllerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -14903,11 +14903,11 @@ If omitted, the IntrusionDetection Deployment will use its default value for thi
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentInitContainer">IntrusionDetectionControllerDeploymentInitContainer</h3>
+<h3 id="IntrusionDetectionControllerDeploymentInitContainer">IntrusionDetectionControllerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -14963,11 +14963,11 @@ If omitted, the IntrusionDetectionController Deployment will use its default val
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</h3>
+<h3 id="IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -14986,7 +14986,7 @@ IntrusionDetectionControllerDeploymentPodSpec is the IntrusionDetectionControlle
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentInitContainer">
+<a href="#IntrusionDetectionControllerDeploymentInitContainer">
 []IntrusionDetectionControllerDeploymentInitContainer
 </a>
 </em>
@@ -15008,7 +15008,7 @@ If omitted, the IntrusionDetectionController Deployment will use its default val
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentContainer">
+<a href="#IntrusionDetectionControllerDeploymentContainer">
 []IntrusionDetectionControllerDeploymentContainer
 </a>
 </em>
@@ -15027,11 +15027,11 @@ If omitted, the IntrusionDetectionController Deployment will use its default val
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</h3>
+<h3 id="IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -15050,7 +15050,7 @@ IntrusionDetectionControllerDeploymentPodTemplateSpec is the IntrusionDetectionC
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">
+<a href="#IntrusionDetectionControllerDeploymentPodSpec">
 IntrusionDetectionControllerDeploymentPodSpec
 </a>
 </em>
@@ -15071,11 +15071,11 @@ Spec is the IntrusionDetectionController Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</h3>
+<h3 id="IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</a>)
+<a href="#IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</a>)
 
 </p>
 <p>
@@ -15094,7 +15094,7 @@ IntrusionDetectionControllerDeploymentSpec defines configuration for the Intrusi
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodTemplateSpec">
+<a href="#IntrusionDetectionControllerDeploymentPodTemplateSpec">
 IntrusionDetectionControllerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -15111,11 +15111,11 @@ Template describes the IntrusionDetectionController Deployment pod that will be 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</h3>
+<h3 id="IntrusionDetectionSpec">IntrusionDetectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>)
+<a href="#IntrusionDetection">IntrusionDetection</a>)
 
 </p>
 <p>
@@ -15134,7 +15134,7 @@ IntrusionDetectionSpec defines the desired state of Tigera intrusion detection c
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">
+<a href="#IntrusionDetectionComponentResource">
 []IntrusionDetectionComponentResource
 </a>
 </em>
@@ -15155,7 +15155,7 @@ Only DeepPacketInspection is supported for this spec.
 
 <code>anomalyDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+<a href="#AnomalyDetectionSpec">
 AnomalyDetectionSpec
 </a>
 </em>
@@ -15175,7 +15175,7 @@ AnomalyDetection is now deprecated, and configuring it has no effect.
 
 <code>intrusionDetectionControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeployment">
+<a href="#IntrusionDetectionControllerDeployment">
 IntrusionDetectionControllerDeployment
 </a>
 </em>
@@ -15192,11 +15192,11 @@ IntrusionDetectionControllerDeployment configures the IntrusionDetection Control
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionStatus">IntrusionDetectionStatus</h3>
+<h3 id="IntrusionDetectionStatus">IntrusionDetectionStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>)
+<a href="#IntrusionDetection">IntrusionDetection</a>)
 
 </p>
 <p>
@@ -15250,11 +15250,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Kibana">Kibana</h3>
+<h3 id="Kibana">Kibana</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -15273,7 +15273,7 @@ Kibana is the configuration for the Kibana.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaSpec">
+<a href="#KibanaSpec">
 KibanaSpec
 </a>
 </em>
@@ -15294,11 +15294,11 @@ Spec is the specification of the Kibana.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaContainer">KibanaContainer</h3>
+<h3 id="KibanaContainer">KibanaContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaPodSpec">KibanaPodSpec</a>)
+<a href="#KibanaPodSpec">KibanaPodSpec</a>)
 
 </p>
 <p>
@@ -15354,11 +15354,11 @@ If omitted, the Kibana will use its default value for this container&rsquo;s res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaInitContainer">KibanaInitContainer</h3>
+<h3 id="KibanaInitContainer">KibanaInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaPodSpec">KibanaPodSpec</a>)
+<a href="#KibanaPodSpec">KibanaPodSpec</a>)
 
 </p>
 <p>
@@ -15415,11 +15415,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaPodSpec">KibanaPodSpec</h3>
+<h3 id="KibanaPodSpec">KibanaPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaPodTemplateSpec">KibanaPodTemplateSpec</a>)
+<a href="#KibanaPodTemplateSpec">KibanaPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -15438,7 +15438,7 @@ KibanaPodSpec is the Kibana Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaInitContainer">
+<a href="#KibanaInitContainer">
 []KibanaInitContainer
 </a>
 </em>
@@ -15460,7 +15460,7 @@ If omitted, the Kibana Deployment will use its default values for its init conta
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaContainer">
+<a href="#KibanaContainer">
 []KibanaContainer
 </a>
 </em>
@@ -15479,11 +15479,11 @@ If omitted, the Kibana Deployment will use its default values for its containers
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaPodTemplateSpec">KibanaPodTemplateSpec</h3>
+<h3 id="KibanaPodTemplateSpec">KibanaPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaSpec">KibanaSpec</a>)
+<a href="#KibanaSpec">KibanaSpec</a>)
 
 </p>
 <p>
@@ -15502,7 +15502,7 @@ KibanaPodTemplateSpec is the Kibana&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaPodSpec">
+<a href="#KibanaPodSpec">
 KibanaPodSpec
 </a>
 </em>
@@ -15523,11 +15523,11 @@ Spec is the Kibana&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaSpec">KibanaSpec</h3>
+<h3 id="KibanaSpec">KibanaSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Kibana">Kibana</a>)
+<a href="#Kibana">Kibana</a>)
 
 </p>
 <table>
@@ -15543,7 +15543,7 @@ Spec is the Kibana&rsquo;s PodSpec.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaPodTemplateSpec">
+<a href="#KibanaPodTemplateSpec">
 KibanaPodTemplateSpec
 </a>
 </em>
@@ -15560,12 +15560,12 @@ Template describes the Kibana pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
+<h3 id="KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</a>)
+<a href="#NodeAddressAutodetection">NodeAddressAutodetection</a>)
 
 </p>
 <p>
@@ -15574,11 +15574,11 @@ KubernetesAutodetectionMethod is a method of detecting an IP address based on th
 <p>
 One of: NodeInternalIP
 </p>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</h3>
+<h3 id="L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <p>
@@ -15597,7 +15597,7 @@ L7LogCollectorDaemonSet is the configuration for the L7LogCollector DaemonSet.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetSpec">
+<a href="#L7LogCollectorDaemonSetSpec">
 L7LogCollectorDaemonSetSpec
 </a>
 </em>
@@ -15618,11 +15618,11 @@ Spec is the specification of the L7LogCollector DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetContainer">L7LogCollectorDaemonSetContainer</h3>
+<h3 id="L7LogCollectorDaemonSetContainer">L7LogCollectorDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
+<a href="#L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -15678,11 +15678,11 @@ If omitted, the L7LogCollector DaemonSet will use its default value for this con
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetInitContainer">L7LogCollectorDaemonSetInitContainer</h3>
+<h3 id="L7LogCollectorDaemonSetInitContainer">L7LogCollectorDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
+<a href="#L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -15737,11 +15737,11 @@ If omitted, the L7LogCollector DaemonSet will use its default value for this ini
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</h3>
+<h3 id="L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</a>)
+<a href="#L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -15760,7 +15760,7 @@ L7LogCollectorDaemonSetPodSpec is the L7LogCollector DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetInitContainer">
+<a href="#L7LogCollectorDaemonSetInitContainer">
 []L7LogCollectorDaemonSetInitContainer
 </a>
 </em>
@@ -15782,7 +15782,7 @@ If omitted, the L7LogCollector DaemonSet will use its default values for its ini
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetContainer">
+<a href="#L7LogCollectorDaemonSetContainer">
 []L7LogCollectorDaemonSetContainer
 </a>
 </em>
@@ -15801,11 +15801,11 @@ If omitted, the L7LogCollector DaemonSet will use its default values for its con
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</h3>
+<h3 id="L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</a>)
+<a href="#L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -15824,7 +15824,7 @@ L7LogCollectorDaemonSetPodTemplateSpec is the L7LogCollector DaemonSet&rsquo;s P
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">
+<a href="#L7LogCollectorDaemonSetPodSpec">
 L7LogCollectorDaemonSetPodSpec
 </a>
 </em>
@@ -15845,11 +15845,11 @@ Spec is the L7LogCollector DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</h3>
+<h3 id="L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</a>)
+<a href="#L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</a>)
 
 </p>
 <p>
@@ -15868,7 +15868,7 @@ L7LogCollectorDaemonSetSpec defines configuration for the L7LogCollector DaemonS
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodTemplateSpec">
+<a href="#L7LogCollectorDaemonSetPodTemplateSpec">
 L7LogCollectorDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -15885,12 +15885,12 @@ Template describes the L7LogCollector DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeployment">LinseedDeployment</h3>
+<h3 id="LinseedDeployment">LinseedDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>, 
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>, 
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -15909,7 +15909,7 @@ LinseedDeployment is the configuration for the linseed Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentSpec">
+<a href="#LinseedDeploymentSpec">
 LinseedDeploymentSpec
 </a>
 </em>
@@ -15930,11 +15930,11 @@ Spec is the specification of the linseed Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentContainer">LinseedDeploymentContainer</h3>
+<h3 id="LinseedDeploymentContainer">LinseedDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
+<a href="#LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -15990,11 +15990,11 @@ If omitted, the linseed Deployment will use its default value for this container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentInitContainer">LinseedDeploymentInitContainer</h3>
+<h3 id="LinseedDeploymentInitContainer">LinseedDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
+<a href="#LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -16050,11 +16050,11 @@ If omitted, the linseed Deployment will use its default value for this init cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</h3>
+<h3 id="LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</a>)
+<a href="#LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -16073,7 +16073,7 @@ LinseedDeploymentPodSpec is the linseed Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentInitContainer">
+<a href="#LinseedDeploymentInitContainer">
 []LinseedDeploymentInitContainer
 </a>
 </em>
@@ -16095,7 +16095,7 @@ If omitted, the linseed Deployment will use its default values for its init cont
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentContainer">
+<a href="#LinseedDeploymentContainer">
 []LinseedDeploymentContainer
 </a>
 </em>
@@ -16114,11 +16114,11 @@ If omitted, the linseed Deployment will use its default values for its container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</h3>
+<h3 id="LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentSpec">LinseedDeploymentSpec</a>)
+<a href="#LinseedDeploymentSpec">LinseedDeploymentSpec</a>)
 
 </p>
 <p>
@@ -16137,7 +16137,7 @@ LinseedDeploymentPodTemplateSpec is the linseed Deployment&rsquo;s PodTemplateSp
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">
+<a href="#LinseedDeploymentPodSpec">
 LinseedDeploymentPodSpec
 </a>
 </em>
@@ -16158,11 +16158,11 @@ Spec is the linseed Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentSpec">LinseedDeploymentSpec</h3>
+<h3 id="LinseedDeploymentSpec">LinseedDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">LinseedDeployment</a>)
+<a href="#LinseedDeployment">LinseedDeployment</a>)
 
 </p>
 <p>
@@ -16181,7 +16181,7 @@ LinseedDeploymentSpec defines configuration for the linseed Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">
+<a href="#LinseedDeploymentPodTemplateSpec">
 LinseedDeploymentPodTemplateSpec
 </a>
 </em>
@@ -16198,12 +16198,12 @@ Template describes the linseed Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinuxDataplaneOption">LinuxDataplaneOption
+<h3 id="LinuxDataplaneOption">LinuxDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -16212,11 +16212,11 @@ LinuxDataplaneOption controls which dataplane is to be used on Linux nodes.
 <p>
 One of: Iptables, BPF
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</h3>
+<h3 id="LogCollectionSpec">LogCollectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -16232,7 +16232,7 @@ One of: Iptables, BPF
 
 <code>collectLogs</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionStatusType">
+<a href="#LogCollectionStatusType">
 LogCollectionStatusType
 </a>
 </em>
@@ -16290,19 +16290,19 @@ Default: -1
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectionStatusType">LogCollectionStatusType
+<h3 id="LogCollectionStatusType">LogCollectionStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</a>)
+<a href="#LogCollectionSpec">LogCollectionSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</h3>
+<h3 id="LogCollectorSpec">LogCollectorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>)
+<a href="#LogCollector">LogCollector</a>)
 
 </p>
 <p>
@@ -16321,7 +16321,7 @@ LogCollectorSpec defines the desired state of Tigera flow, audit, and DNS log co
 
 <code>additionalStores</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">
+<a href="#AdditionalLogStoreSpec">
 AdditionalLogStoreSpec
 </a>
 </em>
@@ -16341,7 +16341,7 @@ Configuration for exporting flow, audit, and DNS logs to external storage.
 
 <code>additionalSources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">
+<a href="#AdditionalLogSourceSpec">
 AdditionalLogSourceSpec
 </a>
 </em>
@@ -16361,7 +16361,7 @@ Configuration for importing audit logs from managed kubernetes cluster log sourc
 
 <code>collectProcessPath</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CollectProcessPathOption">
+<a href="#CollectProcessPathOption">
 CollectProcessPathOption
 </a>
 </em>
@@ -16402,7 +16402,7 @@ the management cluster&rsquo;s tenant services are running.
 
 <code>fluentdDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSet">
+<a href="#FluentdDaemonSet">
 FluentdDaemonSet
 </a>
 </em>
@@ -16421,7 +16421,7 @@ FluentdDaemonSet configures the Fluentd DaemonSet.
 
 <code>eksLogForwarderDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeployment">
+<a href="#EKSLogForwarderDeployment">
 EKSLogForwarderDeployment
 </a>
 </em>
@@ -16438,11 +16438,11 @@ EKSLogForwarderDeployment configures the EKSLogForwarderDeployment Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectorStatus">LogCollectorStatus</h3>
+<h3 id="LogCollectorStatus">LogCollectorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>)
+<a href="#LogCollector">LogCollector</a>)
 
 </p>
 <p>
@@ -16496,31 +16496,31 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogLevel">LogLevel
+<h3 id="LogLevel">LogLevel
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNILogging">CNILogging</a>, 
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#CNILogging">CNILogging</a>, 
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogStorageComponentName">LogStorageComponentName
+<h3 id="LogStorageComponentName">LogStorageComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">LogStorageComponentResource</a>)
+<a href="#LogStorageComponentResource">LogStorageComponentResource</a>)
 
 </p>
 <p>
 LogStorageComponentName CRD enum
 </p>
-<h3 id="operator.tigera.io/v1.LogStorageComponentResource">LogStorageComponentResource</h3>
+<h3 id="LogStorageComponentResource">LogStorageComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -16539,7 +16539,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentName">
+<a href="#LogStorageComponentName">
 LogStorageComponentName
 </a>
 </em>
@@ -16575,11 +16575,11 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</h3>
+<h3 id="LogStorageSpec">LogStorageSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>)
+<a href="#LogStorage">LogStorage</a>)
 
 </p>
 <p>
@@ -16598,7 +16598,7 @@ LogStorageSpec defines the desired state of Tigera flow and DNS log storage.
 
 <code>nodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Nodes">
+<a href="#Nodes">
 Nodes
 </a>
 </em>
@@ -16617,7 +16617,7 @@ Nodes defines the configuration for a set of identical Elasticsearch cluster nod
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Indices">
+<a href="#Indices">
 Indices
 </a>
 </em>
@@ -16637,7 +16637,7 @@ Index defines the configuration for the indices in the Elasticsearch cluster.
 
 <code>retention</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Retention">
+<a href="#Retention">
 Retention
 </a>
 </em>
@@ -16699,7 +16699,7 @@ each of the indicated key-value pairs as labels as well as access to the specifi
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">
+<a href="#LogStorageComponentResource">
 []LogStorageComponentResource
 </a>
 </em>
@@ -16720,7 +16720,7 @@ Only ECKOperator is supported for this spec.
 
 <code>eckOperatorStatefulSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSet">
+<a href="#ECKOperatorStatefulSet">
 ECKOperatorStatefulSet
 </a>
 </em>
@@ -16741,7 +16741,7 @@ ComponentResources, then these overrides take precedence.
 
 <code>kibana</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Kibana">
+<a href="#Kibana">
 Kibana
 </a>
 </em>
@@ -16761,7 +16761,7 @@ Kibana configures the Kibana Spec.
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -16780,7 +16780,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>elasticsearchMetricsDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeployment">
+<a href="#ElasticsearchMetricsDeployment">
 ElasticsearchMetricsDeployment
 </a>
 </em>
@@ -16796,11 +16796,11 @@ ElasticsearchMetricsDeployment configures the tigera-elasticsearch-metric Deploy
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorageStatus">LogStorageStatus</h3>
+<h3 id="LogStorageStatus">LogStorageStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>)
+<a href="#LogStorage">LogStorage</a>)
 
 </p>
 <p>
@@ -16890,11 +16890,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Logging">Logging</h3>
+<h3 id="Logging">Logging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>
@@ -16910,7 +16910,7 @@ Ready, Progressing, Degraded or other customer types.
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNILogging">
+<a href="#CNILogging">
 CNILogging
 </a>
 </em>
@@ -16927,11 +16927,11 @@ Customized logging specification for calico-cni plugin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</h3>
+<h3 id="ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>)
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>)
 
 </p>
 <p>
@@ -16969,7 +16969,7 @@ should be able to access this address. This field is used by managed clusters on
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">
+<a href="#ManagementClusterTLS">
 ManagementClusterTLS
 </a>
 </em>
@@ -16989,7 +16989,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>guardianDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeployment">
+<a href="#GuardianDeployment">
 GuardianDeployment
 </a>
 </em>
@@ -17005,11 +17005,11 @@ GuardianDeployment configures the guardian Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnectionStatus">ManagementClusterConnectionStatus</h3>
+<h3 id="ManagementClusterConnectionStatus">ManagementClusterConnectionStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>)
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>)
 
 </p>
 <p>
@@ -17046,11 +17046,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterSpec">ManagementClusterSpec</h3>
+<h3 id="ManagementClusterSpec">ManagementClusterSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementCluster">ManagementCluster</a>)
+<a href="#ManagementCluster">ManagementCluster</a>)
 
 </p>
 <p>
@@ -17089,7 +17089,7 @@ Valid examples are: &ldquo;0.0.0.0:31000&rdquo;, &ldquo;example.com:32000&rdquo;
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLS">
+<a href="#TLS">
 TLS
 </a>
 </em>
@@ -17106,11 +17106,11 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterTLS">ManagementClusterTLS</h3>
+<h3 id="ManagementClusterTLS">ManagementClusterTLS</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
+<a href="#ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
 
 </p>
 <table>
@@ -17126,7 +17126,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>ca</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CAType">
+<a href="#CAType">
 CAType
 </a>
 </em>
@@ -17152,11 +17152,11 @@ Default: Tigera
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeployment">ManagerDeployment</h3>
+<h3 id="ManagerDeployment">ManagerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerSpec">ManagerSpec</a>)
+<a href="#ManagerSpec">ManagerSpec</a>)
 
 </p>
 <p>
@@ -17175,7 +17175,7 @@ ManagerDeployment is the configuration for the Manager Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentSpec">
+<a href="#ManagerDeploymentSpec">
 ManagerDeploymentSpec
 </a>
 </em>
@@ -17196,11 +17196,11 @@ Spec is the specification of the Manager Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentContainer">ManagerDeploymentContainer</h3>
+<h3 id="ManagerDeploymentContainer">ManagerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
+<a href="#ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -17256,11 +17256,11 @@ If omitted, the Manager Deployment will use its default value for this container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentInitContainer">ManagerDeploymentInitContainer</h3>
+<h3 id="ManagerDeploymentInitContainer">ManagerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
+<a href="#ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -17317,11 +17317,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</h3>
+<h3 id="ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</a>)
+<a href="#ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -17340,7 +17340,7 @@ ManagerDeploymentPodSpec is the Manager Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentInitContainer">
+<a href="#ManagerDeploymentInitContainer">
 []ManagerDeploymentInitContainer
 </a>
 </em>
@@ -17362,7 +17362,7 @@ If omitted, the Manager Deployment will use its default values for its init cont
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentContainer">
+<a href="#ManagerDeploymentContainer">
 []ManagerDeploymentContainer
 </a>
 </em>
@@ -17381,11 +17381,11 @@ If omitted, the Manager Deployment will use its default values for its container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</h3>
+<h3 id="ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentSpec">ManagerDeploymentSpec</a>)
+<a href="#ManagerDeploymentSpec">ManagerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -17404,7 +17404,7 @@ ManagerDeploymentPodTemplateSpec is the Manager Deployment&rsquo;s PodTemplateSp
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodSpec">
+<a href="#ManagerDeploymentPodSpec">
 ManagerDeploymentPodSpec
 </a>
 </em>
@@ -17425,11 +17425,11 @@ Spec is the Manager Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentSpec">ManagerDeploymentSpec</h3>
+<h3 id="ManagerDeploymentSpec">ManagerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeployment">ManagerDeployment</a>)
+<a href="#ManagerDeployment">ManagerDeployment</a>)
 
 </p>
 <p>
@@ -17448,7 +17448,7 @@ ManagerDeploymentSpec defines configuration for the Manager Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodTemplateSpec">
+<a href="#ManagerDeploymentPodTemplateSpec">
 ManagerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -17465,11 +17465,11 @@ Template describes the Manager Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerSpec">ManagerSpec</h3>
+<h3 id="ManagerSpec">ManagerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>)
+<a href="#Manager">Manager</a>)
 
 </p>
 <p>
@@ -17488,7 +17488,7 @@ ManagerSpec defines configuration for the Calico Enterprise manager GUI.
 
 <code>managerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeployment">
+<a href="#ManagerDeployment">
 ManagerDeployment
 </a>
 </em>
@@ -17505,11 +17505,11 @@ ManagerDeployment configures the Manager Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerStatus">ManagerStatus</h3>
+<h3 id="ManagerStatus">ManagerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>)
+<a href="#Manager">Manager</a>)
 
 </p>
 <p>
@@ -17563,24 +17563,24 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Metadata">Metadata</h3>
+<h3 id="Metadata">Metadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>, 
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>, 
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
+<a href="#TyphaDeployment">TyphaDeployment</a>, 
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -17636,11 +17636,11 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MonitorSpec">MonitorSpec</h3>
+<h3 id="MonitorSpec">MonitorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -17659,7 +17659,7 @@ MonitorSpec defines the desired state of Tigera monitor.
 
 <code>externalPrometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">
+<a href="#ExternalPrometheus">
 ExternalPrometheus
 </a>
 </em>
@@ -17680,7 +17680,7 @@ scraping from git-ops tools without the need of post-installation steps.
 
 <code>prometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Prometheus">
+<a href="#Prometheus">
 Prometheus
 </a>
 </em>
@@ -17700,7 +17700,7 @@ Prometheus is the configuration for the Prometheus.
 
 <code>alertManager</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AlertManager">
+<a href="#AlertManager">
 AlertManager
 </a>
 </em>
@@ -17717,11 +17717,11 @@ AlertManager is the configuration for the AlertManager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MonitorStatus">MonitorStatus</h3>
+<h3 id="MonitorStatus">MonitorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -17775,12 +17775,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MultiInterfaceMode">MultiInterfaceMode
+<h3 id="MultiInterfaceMode">MultiInterfaceMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -17789,12 +17789,12 @@ MultiInterfaceMode describes the method of providing multiple pod interfaces.
 <p>
 One of: None, Multus
 </p>
-<h3 id="operator.tigera.io/v1.NATOutgoingType">NATOutgoingType
+<h3 id="NATOutgoingType">NATOutgoingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -17803,23 +17803,23 @@ NATOutgoingType describe the type of outgoing NAT to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.NativeIP">NativeIP
+<h3 id="NativeIP">NativeIP
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</a>)
+<a href="#AWSEgressGateway">AWSEgressGateway</a>)
 
 </p>
 <p>
 NativeIP defines if Egress Gateway pods should have AWS IPs.
 When NativeIP is enabled, the IPPools should be backed by AWS subnet.
 </p>
-<h3 id="operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</h3>
+<h3 id="NodeAddressAutodetection">NodeAddressAutodetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -17859,7 +17859,7 @@ filtering based on well-known interface names.
 
 <code>kubernetes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KubernetesAutodetectionMethod">
+<a href="#KubernetesAutodetectionMethod">
 KubernetesAutodetectionMethod
 </a>
 </em>
@@ -17950,11 +17950,11 @@ one of the provided CIDRs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeAffinity">NodeAffinity</h3>
+<h3 id="NodeAffinity">NodeAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</a>)
+<a href="#TyphaAffinity">TyphaAffinity</a>)
 
 </p>
 <p>
@@ -18023,11 +18023,11 @@ may or may not try to eventually evict the pod from its node.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeSet">NodeSet</h3>
+<h3 id="NodeSet">NodeSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Nodes">Nodes</a>)
+<a href="#Nodes">Nodes</a>)
 
 </p>
 <p>
@@ -18046,7 +18046,7 @@ NodeSets defines configuration specific to each Elasticsearch Node Set
 
 <code>selectionAttributes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeSetSelectionAttribute">
+<a href="#NodeSetSelectionAttribute">
 []NodeSetSelectionAttribute
 </a>
 </em>
@@ -18064,11 +18064,11 @@ to define Node Affinities and set the node awareness configuration in the runnin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeSetSelectionAttribute">NodeSetSelectionAttribute</h3>
+<h3 id="NodeSetSelectionAttribute">NodeSetSelectionAttribute</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeSet">NodeSet</a>)
+<a href="#NodeSet">NodeSet</a>)
 
 </p>
 <p>
@@ -18128,11 +18128,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Nodes">Nodes</h3>
+<h3 id="Nodes">Nodes</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -18168,7 +18168,7 @@ Count defines the number of nodes in the Elasticsearch cluster.
 
 <code>nodeSets</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeSet">
+<a href="#NodeSet">
 []NodeSet
 </a>
 </em>
@@ -18205,12 +18205,12 @@ ResourceRequirements defines the resource limits and requirements for the Elasti
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NonPrivilegedType">NonPrivilegedType
+<h3 id="NonPrivilegedType">NonPrivilegedType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -18219,12 +18219,12 @@ NonPrivilegedType specifies whether Calico runs as permissioned or not
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.OIDCType">OIDCType
+<h3 id="OIDCType">OIDCType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
 <p>
@@ -18232,11 +18232,11 @@ OIDCType defines how OIDC is configured for Tigera Enterprise. Dex should be the
 The Tigera option can help in specific use-cases, for instance, when you are unable to configure a client secret.
 One of: Dex, Tigera
 </p>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</h3>
+<h3 id="PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPISpec">PacketCaptureAPISpec</a>)
+<a href="#PacketCaptureAPISpec">PacketCaptureAPISpec</a>)
 
 </p>
 <p>
@@ -18255,7 +18255,7 @@ PacketCaptureAPIDeployment is the configuration for the PacketCaptureAPI Deploym
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentSpec">
+<a href="#PacketCaptureAPIDeploymentSpec">
 PacketCaptureAPIDeploymentSpec
 </a>
 </em>
@@ -18276,11 +18276,11 @@ Spec is the specification of the PacketCaptureAPI Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentContainer">PacketCaptureAPIDeploymentContainer</h3>
+<h3 id="PacketCaptureAPIDeploymentContainer">PacketCaptureAPIDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
+<a href="#PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18336,11 +18336,11 @@ If omitted, the PacketCaptureAPI Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentInitContainer">PacketCaptureAPIDeploymentInitContainer</h3>
+<h3 id="PacketCaptureAPIDeploymentInitContainer">PacketCaptureAPIDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
+<a href="#PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18396,11 +18396,11 @@ If omitted, the PacketCaptureAPI Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</h3>
+<h3 id="PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</a>)
+<a href="#PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -18419,7 +18419,7 @@ PacketCaptureAPIDeploymentPodSpec is the PacketCaptureAPI Deployment&rsquo;s Pod
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentInitContainer">
+<a href="#PacketCaptureAPIDeploymentInitContainer">
 []PacketCaptureAPIDeploymentInitContainer
 </a>
 </em>
@@ -18441,7 +18441,7 @@ If omitted, the PacketCaptureAPI Deployment will use its default values for its 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentContainer">
+<a href="#PacketCaptureAPIDeploymentContainer">
 []PacketCaptureAPIDeploymentContainer
 </a>
 </em>
@@ -18460,11 +18460,11 @@ If omitted, the PacketCaptureAPI Deployment will use its default values for its 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</h3>
+<h3 id="PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</a>)
+<a href="#PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</a>)
 
 </p>
 <p>
@@ -18483,7 +18483,7 @@ PacketCaptureAPIDeploymentPodTemplateSpec is the PacketCaptureAPI Deployment&rsq
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">
+<a href="#PacketCaptureAPIDeploymentPodSpec">
 PacketCaptureAPIDeploymentPodSpec
 </a>
 </em>
@@ -18504,11 +18504,11 @@ Spec is the PacketCaptureAPI Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</h3>
+<h3 id="PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</a>)
+<a href="#PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</a>)
 
 </p>
 <p>
@@ -18527,7 +18527,7 @@ PacketCaptureAPIDeploymentSpec defines configuration for the PacketCaptureAPI De
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodTemplateSpec">
+<a href="#PacketCaptureAPIDeploymentPodTemplateSpec">
 PacketCaptureAPIDeploymentPodTemplateSpec
 </a>
 </em>
@@ -18544,11 +18544,11 @@ Template describes the PacketCaptureAPI Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPISpec">PacketCaptureAPISpec</h3>
+<h3 id="PacketCaptureAPISpec">PacketCaptureAPISpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</a>)
+<a href="#PacketCaptureAPI">PacketCaptureAPI</a>)
 
 </p>
 <p>
@@ -18567,7 +18567,7 @@ PacketCaptureAPISpec defines configuration for the Packet Capture API.
 
 <code>packetCaptureAPIDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeployment">
+<a href="#PacketCaptureAPIDeployment">
 PacketCaptureAPIDeployment
 </a>
 </em>
@@ -18584,11 +18584,11 @@ PacketCaptureAPIDeployment configures the PacketCaptureAPI Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIStatus">PacketCaptureAPIStatus</h3>
+<h3 id="PacketCaptureAPIStatus">PacketCaptureAPIStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</a>)
+<a href="#PacketCaptureAPI">PacketCaptureAPI</a>)
 
 </p>
 <p>
@@ -18642,11 +18642,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PathMatch">PathMatch</h3>
+<h3 id="PathMatch">PathMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
+<a href="#TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
 
 </p>
 <table>
@@ -18712,11 +18712,11 @@ PathReplace if not nil will be used to replace PathRegexp matches.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeployment">PolicyRecommendationDeployment</h3>
+<h3 id="PolicyRecommendationDeployment">PolicyRecommendationDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationSpec">PolicyRecommendationSpec</a>)
+<a href="#PolicyRecommendationSpec">PolicyRecommendationSpec</a>)
 
 </p>
 <p>
@@ -18735,7 +18735,7 @@ PolicyRecommendationDeployment is the configuration for the PolicyRecommendation
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentSpec">
+<a href="#PolicyRecommendationDeploymentSpec">
 PolicyRecommendationDeploymentSpec
 </a>
 </em>
@@ -18756,11 +18756,11 @@ Spec is the specification of the PolicyRecommendation Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentContainer">PolicyRecommendationDeploymentContainer</h3>
+<h3 id="PolicyRecommendationDeploymentContainer">PolicyRecommendationDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
+<a href="#PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18816,11 +18816,11 @@ If omitted, the PolicyRecommendation Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentInitContainer">PolicyRecommendationDeploymentInitContainer</h3>
+<h3 id="PolicyRecommendationDeploymentInitContainer">PolicyRecommendationDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
+<a href="#PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18875,11 +18875,11 @@ If omitted, the PolicyRecommendation Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</h3>
+<h3 id="PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</a>)
+<a href="#PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -18898,7 +18898,7 @@ PolicyRecommendationDeploymentPodSpec is the PolicyRecommendation Deployment&rsq
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentInitContainer">
+<a href="#PolicyRecommendationDeploymentInitContainer">
 []PolicyRecommendationDeploymentInitContainer
 </a>
 </em>
@@ -18920,7 +18920,7 @@ If omitted, the PolicyRecommendation Deployment will use its default values for 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentContainer">
+<a href="#PolicyRecommendationDeploymentContainer">
 []PolicyRecommendationDeploymentContainer
 </a>
 </em>
@@ -18939,11 +18939,11 @@ If omitted, the PolicyRecommendation Deployment will use its default values for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</h3>
+<h3 id="PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</a>)
+<a href="#PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</a>)
 
 </p>
 <p>
@@ -18962,7 +18962,7 @@ PolicyRecommendationDeploymentPodTemplateSpec is the PolicyRecommendation Deploy
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">
+<a href="#PolicyRecommendationDeploymentPodSpec">
 PolicyRecommendationDeploymentPodSpec
 </a>
 </em>
@@ -18983,11 +18983,11 @@ Spec is the PolicyRecommendation Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</h3>
+<h3 id="PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeployment">PolicyRecommendationDeployment</a>)
+<a href="#PolicyRecommendationDeployment">PolicyRecommendationDeployment</a>)
 
 </p>
 <p>
@@ -19006,7 +19006,7 @@ PolicyRecommendationDeploymentSpec defines configuration for the PolicyRecommend
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodTemplateSpec">
+<a href="#PolicyRecommendationDeploymentPodTemplateSpec">
 PolicyRecommendationDeploymentPodTemplateSpec
 </a>
 </em>
@@ -19023,11 +19023,11 @@ Template describes the PolicyRecommendation Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
+<h3 id="PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
@@ -19047,7 +19047,7 @@ service.
 
 <code>policyRecommendationDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeployment">
+<a href="#PolicyRecommendationDeployment">
 PolicyRecommendationDeployment
 </a>
 </em>
@@ -19064,11 +19064,11 @@ PolicyRecommendation configures the PolicyRecommendation Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
+<h3 id="PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
@@ -19101,13 +19101,13 @@ State provides user-readable status.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ProductVariant">ProductVariant
+<h3 id="ProductVariant">ProductVariant
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#InstallationSpec">InstallationSpec</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -19116,11 +19116,11 @@ ProductVariant represents the variant of the product.
 <p>
 One of: Calico, TigeraSecureEnterprise
 </p>
-<h3 id="operator.tigera.io/v1.Prometheus">Prometheus</h3>
+<h3 id="Prometheus">Prometheus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.MonitorSpec">MonitorSpec</a>)
+<a href="#MonitorSpec">MonitorSpec</a>)
 
 </p>
 <table>
@@ -19136,7 +19136,7 @@ One of: Calico, TigeraSecureEnterprise
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PrometheusSpec">
+<a href="#PrometheusSpec">
 PrometheusSpec
 </a>
 </em>
@@ -19157,11 +19157,11 @@ Spec is the specification of the Prometheus.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PrometheusContainer">PrometheusContainer</h3>
+<h3 id="PrometheusContainer">PrometheusContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CommonPrometheusFields">CommonPrometheusFields</a>)
+<a href="#CommonPrometheusFields">CommonPrometheusFields</a>)
 
 </p>
 <p>
@@ -19217,11 +19217,11 @@ If omitted, the Prometheus will use its default value for this container&rsquo;s
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PrometheusSpec">PrometheusSpec</h3>
+<h3 id="PrometheusSpec">PrometheusSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Prometheus">Prometheus</a>)
+<a href="#Prometheus">Prometheus</a>)
 
 </p>
 <table>
@@ -19237,7 +19237,7 @@ If omitted, the Prometheus will use its default value for this container&rsquo;s
 
 <code>commonPrometheusFields</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CommonPrometheusFields">
+<a href="#CommonPrometheusFields">
 CommonPrometheusFields
 </a>
 </em>
@@ -19253,12 +19253,12 @@ CommonPrometheusFields are the options available to both the Prometheus server a
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PromptType">PromptType
+<h3 id="PromptType">PromptType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
 <p>
@@ -19266,23 +19266,23 @@ PromptType is a value that specifies whether the identity provider prompts the e
 consent.
 One of: None, Login, Consent, SelectAccount.
 </p>
-<h3 id="operator.tigera.io/v1.Provider">Provider
+<h3 id="Provider">Provider
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
 Provider represents a particular provider or flavor of Kubernetes. Valid options
 are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG.
 </p>
-<h3 id="operator.tigera.io/v1.Retention">Retention</h3>
+<h3 id="Retention">Retention</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -19424,11 +19424,11 @@ Default: 8
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.S3StoreSpec">S3StoreSpec</h3>
+<h3 id="S3StoreSpec">S3StoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -19495,11 +19495,11 @@ Path in the S3 bucket where to send logs
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SNIMatch">SNIMatch</h3>
+<h3 id="SNIMatch">SNIMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>)
+<a href="#TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>)
 
 </p>
 <table>
@@ -19529,11 +19529,11 @@ ServerName is used to match the server name for the request.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ServiceMonitor">ServiceMonitor</h3>
+<h3 id="ServiceMonitor">ServiceMonitor</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">ExternalPrometheus</a>)
+<a href="#ExternalPrometheus">ExternalPrometheus</a>)
 
 </p>
 <table>
@@ -19568,7 +19568,7 @@ Default: k8s-app=tigera-prometheus
 
 <code>endpoints</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Endpoint">
+<a href="#Endpoint">
 []Endpoint
 </a>
 </em>
@@ -19585,11 +19585,11 @@ related to connecting to our Prometheus server are automatically set by the oper
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SplunkStoreSpec">SplunkStoreSpec</h3>
+<h3 id="SplunkStoreSpec">SplunkStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -19622,22 +19622,22 @@ Location for splunk&rsquo;s http event collector end point. example <code>https:
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.StatusConditionType">StatusConditionType
+<h3 id="StatusConditionType">StatusConditionType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 StatusConditionType is a type of condition that may apply to a particular component.
 </p>
-<h3 id="operator.tigera.io/v1.Sysctl">Sysctl</h3>
+<h3 id="Sysctl">Sysctl</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -19678,12 +19678,12 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SyslogLogType">SyslogLogType
+<h3 id="SyslogLogType">SyslogLogType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</a>)
+<a href="#SyslogStoreSpec">SyslogStoreSpec</a>)
 
 </p>
 <p>
@@ -19694,11 +19694,11 @@ Allowable values are Audit, DNS, Flows and IDSEvents.
 * Flows corresponds to flow logs generated by Calico node.
 * IDSEvents corresponds to event logs for the intrusion detection system (anomaly detection, suspicious IPs, suspicious domains and global alerts).
 </p>
-<h3 id="operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</h3>
+<h3 id="SyslogStoreSpec">SyslogStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -19754,7 +19754,7 @@ Default: 1024
 
 <code>logTypes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SyslogLogType">
+<a href="#SyslogLogType">
 []SyslogLogType
 </a>
 </em>
@@ -19774,7 +19774,7 @@ Default: Audit, DNS, Flows
 
 <code>encryption</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncryptionOption">
+<a href="#EncryptionOption">
 EncryptionOption
 </a>
 </em>
@@ -19792,11 +19792,11 @@ Default: None
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLS">TLS</h3>
+<h3 id="TLS">TLS</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterSpec">ManagementClusterSpec</a>)
+<a href="#ManagementClusterSpec">ManagementClusterSpec</a>)
 
 </p>
 <table>
@@ -19846,11 +19846,11 @@ Default: tigera-management-cluster-connection
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</h3>
+<h3 id="TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRoute">TLSPassThroughRoute</a>)
+<a href="#TLSPassThroughRoute">TLSPassThroughRoute</a>)
 
 </p>
 <table>
@@ -19866,7 +19866,7 @@ Default: tigera-management-cluster-connection
 
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -19882,7 +19882,7 @@ TargetType
 
 <code>sniMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SNIMatch">
+<a href="#SNIMatch">
 SNIMatch
 </a>
 </em>
@@ -19916,11 +19916,11 @@ Destination is the destination url to proxy the request to.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</h3>
+<h3 id="TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSTerminatedRoute">TLSTerminatedRoute</a>)
+<a href="#TLSTerminatedRoute">TLSTerminatedRoute</a>)
 
 </p>
 <table>
@@ -19936,7 +19936,7 @@ Destination is the destination url to proxy the request to.
 
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -19952,7 +19952,7 @@ TargetType
 
 <code>pathMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PathMatch">
+<a href="#PathMatch">
 PathMatch
 </a>
 </em>
@@ -20067,20 +20067,20 @@ is UI.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TargetType">TargetType
+<h3 id="TargetType">TargetType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>, 
-<a href="#operator.tigera.io/v1.TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
+<a href="#TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>, 
+<a href="#TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.TenantElasticSpec">TenantElasticSpec</h3>
+<h3 id="TenantElasticSpec">TenantElasticSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <table>
@@ -20135,11 +20135,11 @@ bool
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantSpec">TenantSpec</h3>
+<h3 id="TenantSpec">TenantSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
 <table>
@@ -20189,7 +20189,7 @@ Name is a human readable name for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -20208,7 +20208,7 @@ Indices defines the how to store a tenant&rsquo;s data
 
 <code>elastic</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantElasticSpec">
+<a href="#TenantElasticSpec">
 TenantElasticSpec
 </a>
 </em>
@@ -20247,7 +20247,7 @@ in the Tenant&rsquo;s namespace. Defaults to the controlPlaneReplicas in Install
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -20266,7 +20266,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>dashboardsJob</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJob">
+<a href="#DashboardsJob">
 DashboardsJob
 </a>
 </em>
@@ -20282,18 +20282,18 @@ DashboardsJob configures the Dashboards job
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantStatus">TenantStatus</h3>
+<h3 id="TenantStatus">TenantStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</h3>
+<h3 id="TigeraStatusCondition">TigeraStatusCondition</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</a>)
+<a href="#TigeraStatusStatus">TigeraStatusStatus</a>)
 
 </p>
 <p>
@@ -20312,7 +20312,7 @@ TigeraStatusCondition represents a condition attached to a particular component.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.StatusConditionType">
+<a href="#StatusConditionType">
 StatusConditionType
 </a>
 </em>
@@ -20331,7 +20331,7 @@ The type of condition. May be Available, Progressing, or Degraded.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ConditionStatus">
+<a href="#ConditionStatus">
 ConditionStatus
 </a>
 </em>
@@ -20420,26 +20420,26 @@ with respect to the current state of the instance.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatusReason">TigeraStatusReason
+<h3 id="TigeraStatusReason">TigeraStatusReason
 (<code>string</code> alias)</h3>
 <p>
 TigeraStatusReason represents the reason for a particular condition.
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusSpec">TigeraStatusSpec</h3>
+<h3 id="TigeraStatusSpec">TigeraStatusSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
 TigeraStatusSpec defines the desired state of TigeraStatus
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</h3>
+<h3 id="TigeraStatusStatus">TigeraStatusStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
@@ -20458,7 +20458,7 @@ TigeraStatusStatus defines the observed state of TigeraStatus
 
 <code>conditions</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">
+<a href="#TigeraStatusCondition">
 []TigeraStatusCondition
 </a>
 </em>
@@ -20475,11 +20475,11 @@ Available, Progressing, or Degraded.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</h3>
+<h3 id="TyphaAffinity">TyphaAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -20499,7 +20499,7 @@ TyphaAffinity allows configuration of node affinity characteristics for Typha po
 
 <code>nodeAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAffinity">
+<a href="#NodeAffinity">
 NodeAffinity
 </a>
 </em>
@@ -20516,11 +20516,11 @@ NodeAffinity describes node affinity scheduling rules for typha.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</h3>
+<h3 id="TyphaDeployment">TyphaDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -20539,7 +20539,7 @@ TyphaDeployment is the configuration for the typha Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -20559,7 +20559,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">
+<a href="#TyphaDeploymentSpec">
 TyphaDeploymentSpec
 </a>
 </em>
@@ -20580,11 +20580,11 @@ Spec is the specification of the typha Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
+<h3 id="TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -20641,11 +20641,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
+<h3 id="TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -20702,11 +20702,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
+<h3 id="TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -20725,7 +20725,7 @@ TyphaDeploymentPodSpec is the typha Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentInitContainer">
+<a href="#TyphaDeploymentInitContainer">
 []TyphaDeploymentInitContainer
 </a>
 </em>
@@ -20747,7 +20747,7 @@ If omitted, the typha Deployment will use its default values for its init contai
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentContainer">
+<a href="#TyphaDeploymentContainer">
 []TyphaDeploymentContainer
 </a>
 </em>
@@ -20881,11 +20881,11 @@ WARNING: Please note that this field will override the default calico-typha Depl
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
+<h3 id="TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -20904,7 +20904,7 @@ TyphaDeploymentPodTemplateSpec is the typha Deployment&rsquo;s PodTemplateSpec
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -20925,7 +20925,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">
+<a href="#TyphaDeploymentPodSpec">
 TyphaDeploymentPodSpec
 </a>
 </em>
@@ -20946,11 +20946,11 @@ Spec is the typha Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
+<h3 id="TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>)
+<a href="#TyphaDeployment">TyphaDeployment</a>)
 
 </p>
 <p>
@@ -20990,7 +20990,7 @@ If omitted, the typha Deployment will use its default value for minReadySeconds.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">
+<a href="#TyphaDeploymentPodTemplateSpec">
 TyphaDeploymentPodTemplateSpec
 </a>
 </em>
@@ -21010,7 +21010,7 @@ Template describes the typha Deployment pod that will be created.
 
 <code>strategy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentStrategy">
+<a href="#TyphaDeploymentStrategy">
 TyphaDeploymentStrategy
 </a>
 </em>
@@ -21027,11 +21027,11 @@ The deployment strategy to use to replace existing pods with new ones.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
+<h3 id="TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -21070,11 +21070,11 @@ to be.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.UserMatch">UserMatch</h3>
+<h3 id="UserMatch">UserMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GroupSearch">GroupSearch</a>)
+<a href="#GroupSearch">GroupSearch</a>)
 
 </p>
 <p>
@@ -21124,11 +21124,11 @@ The attribute of a group that links it to a user.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.UserSearch">UserSearch</h3>
+<h3 id="UserSearch">UserSearch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</a>)
+<a href="#AuthenticationLDAP">AuthenticationLDAP</a>)
 
 </p>
 <p>
@@ -21198,27 +21198,27 @@ Default: uid
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.WAFStatusType">WAFStatusType
+<h3 id="WAFStatusType">WAFStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsDataplaneOption">WindowsDataplaneOption
+<h3 id="WindowsDataplaneOption">WindowsDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsNodeSpec">WindowsNodeSpec</h3>
+<h3 id="WindowsNodeSpec">WindowsNodeSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>

--- a/calico-cloud_versioned_docs/version-19-2/release-notes/index.mdx
+++ b/calico-cloud_versioned_docs/version-19-2/release-notes/index.mdx
@@ -282,7 +282,7 @@ For more information, see [Optimize egress networking for workloads with long-li
 
 We've added support for XFF to propagate the original IP address when proxying application layer traffic with Envoy within a Kubernetes cluster.
 
-For more information, see [Installation reference](../reference/installation/api.mdx#operator.tigera.io/v1.EnvoySettings).
+For more information, see [Installation reference](../reference/installation/api.mdx#EnvoySettings.
 
 #### Alert-only mode for workload-based Web Application Firewall (WAF)
 

--- a/calico-cloud_versioned_docs/version-19-2/threat/deeppacketinspection.mdx
+++ b/calico-cloud_versioned_docs/version-19-2/threat/deeppacketinspection.mdx
@@ -76,7 +76,7 @@ spec:
 
 ### Configure resource requirements
 
-Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionComponentResource).
+Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#IntrusionDetectionComponentResource.
 
 For a data transfer rate of 1GB/sec on workload endpoints being monitored, we recommend a minimum of 1 CPU and 1GB RAM.
 

--- a/calico-cloud_versioned_docs/version-19-2/threat/web-application-firewall.mdx
+++ b/calico-cloud_versioned_docs/version-19-2/threat/web-application-firewall.mdx
@@ -352,7 +352,7 @@ kubectl annotate svc <service-name> -n <service-namespace> projectcalico.org/l7-
 
 ### Disable WAF feature from your cluster
 
-To disable WAF, update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the `webApplicationFirewall` field, and ensure it is set to `Disabled`.
+To disable WAF, update the [ApplicationLayer](../reference/installation/api#ApplicationLayer resource to include the `webApplicationFirewall` field, and ensure it is set to `Disabled`.
 
 Example:
 

--- a/calico-cloud_versioned_docs/version-19-2/visibility/elastic/archive-storage.mdx
+++ b/calico-cloud_versioned_docs/version-19-2/visibility/elastic/archive-storage.mdx
@@ -48,8 +48,8 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
     -n tigera-operator
    ```
 
-3. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#operator.tigera.io/v1.S3StoreSpec)
+3. Update the [LogCollector](../../reference/installation/api.mdx#LogCollector
+   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#S3StoreSpec
    with your information noted from above.
    Example:
 
@@ -76,8 +76,8 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
 </TabItem>
 <TabItem label="Syslog" value="Syslog-1">
 
-1. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+1. Update the [LogCollector](../../reference/installation/api.mdx#LogCollector
+   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec
    with your syslog information.
    Example:
    ```yaml
@@ -104,7 +104,7 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    kubectl edit logcollector tigera-secure
    ```
 2. You can control which types of {variables.prodname} log data you would like to send to syslog.
-   The [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+   The [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec
    contains a field called `logTypes` which allows you to list which log types you would like to include.
    The allowable log types are:
 
@@ -113,11 +113,11 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    - Flows
    - IDSEvents
 
-   Refer to the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec) for more details on what data each log type represents.
+   Refer to the [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec for more details on what data each log type represents.
 
    :::note
 
-   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
+   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#LogStorage configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
 
    :::
 
@@ -125,7 +125,7 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
 
 **TLS configuration**
 
-3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec).
+3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec.
 
    ```yaml
    apiVersion: operator.tigera.io/v1
@@ -182,9 +182,9 @@ In this release, only [Splunk Enterprise](https://www.splunk.com/en_us/products/
    ```
 
 3. Update the
-   [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
+   [LogCollector](../../reference/installation/api.mdx#LogCollector
    resource named `tigera-secure` to include
-   a [Splunk section](../../reference/installation/api.mdx#operator.tigera.io/v1.SplunkStoreSpec)
+   a [Splunk section](../../reference/installation/api.mdx#SplunkStoreSpec
    with your Splunk information.
    Example:
 

--- a/calico-cloud_versioned_docs/version-19-2/visibility/elastic/l7/configure.mdx
+++ b/calico-cloud_versioned_docs/version-19-2/visibility/elastic/l7/configure.mdx
@@ -70,7 +70,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
 
 **Configure the ApplicationLayer resource for L7 logs**
 
-1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) resource named, `tigera-secure` to include a logCollection section of the file, `_api.html` [here](../../../reference/installation/api.mdx).
+1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#ApplicationLayer resource named, `tigera-secure` to include a logCollection section of the file, `_api.html` [here](../../../reference/installation/api.mdx).
 
 1. Ensure that the `collectLogs` field is set to `Enabled`.
 

--- a/calico-cloud_versioned_docs/version-19-2/visibility/elastic/overview.mdx
+++ b/calico-cloud_versioned_docs/version-19-2/visibility/elastic/overview.mdx
@@ -93,7 +93,7 @@ verbs: ['get']
 - Global network policies
 - Network sets
 
-{variables.prodname} also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec).
+{variables.prodname} also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#LogCollectorSpec.
 
 ## Additional resources
 
@@ -102,4 +102,4 @@ verbs: ['get']
 - [BGP logs](bgp.mdx)
 - [DNS logs](dns/dns-logs.mdx)
 - [Archive logs](archive-storage.mdx)
-- [Log collection options](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../reference/installation/api.mdx#LogCollectorSpec

--- a/calico-cloud_versioned_docs/version-20-1/networking/configuring/dual-tor.mdx
+++ b/calico-cloud_versioned_docs/version-20-1/networking/configuring/dual-tor.mdx
@@ -640,7 +640,7 @@ The only connections using interface-specific addresses should be BGP.
 If you plan to use [Egress Gateways](../egress/egress-gateway-on-prem.mdx) in your cluster, you must also adjust the {variables.nodecontainer} IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-{variables.prodname} [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+{variables.prodname} [Installation resource](../../reference/installation/api.mdx#NodeAddressAutodetection.
 
 :::
 

--- a/calico-cloud_versioned_docs/version-20-1/networking/configuring/multiple-networks.mdx
+++ b/calico-cloud_versioned_docs/version-20-1/networking/configuring/multiple-networks.mdx
@@ -79,7 +79,7 @@ Although the following {variables.prodname} features are supported for your defa
 
 ### Configure cluster for multiple networks
 
-In the [Installation custom resource](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoNetworkSpec), set the `MultiInterfaceMode` to **Multus**.
+In the [Installation custom resource](../../reference/installation/api.mdx#CalicoNetworkSpec, set the `MultiInterfaceMode` to **Multus**.
 
 ### Create a new network
 

--- a/calico-cloud_versioned_docs/version-20-1/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-cloud_versioned_docs/version-20-1/networking/egress/egress-gateway-on-prem.mdx
@@ -350,7 +350,7 @@ To modify the iptables backend for egress gateways, you must change the `iptable
 If you plan to use Egress Gateways in a [dual-ToR cluster](../configuring/dual-tor.mdx), you must also adjust the {variables.nodecontainer} IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-{variables.prodname} [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+{variables.prodname} [Installation resource](../../reference/installation/api.mdx#NodeAddressAutodetection.
 
 ### Configure namespaces and pods to use egress gateways
 

--- a/calico-cloud_versioned_docs/version-20-1/networking/ipam/initial-ippool.mdx
+++ b/calico-cloud_versioned_docs/version-20-1/networking/ipam/initial-ippool.mdx
@@ -24,7 +24,7 @@ The **Kubernetes pod CIDR** is the expected IP address range for pod IPs. It is 
 
 [Calico IP pools](../../reference/resources/ippool.mdx) are ranges of IP addresses that Calico uses to assign to pods; the ranges must within the Kubernetes pod CIDR.
 
-The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#Installation
 resource and configures the default Calico IP pool. Note the following:
 
 - Default fields for any that are omitted:
@@ -44,7 +44,7 @@ resource and configures the default Calico IP pool. Note the following:
 ## How to
 
 1. Download the custom-resource.yaml file.
-1. Edit the [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation).  
+1. Edit the [Installation resource](../../reference/installation/api.mdx#Installation.  
    **Required values**: `cidr:`  
    **Empty values**: Defaulted
 

--- a/calico-cloud_versioned_docs/version-20-1/networking/ipam/ip-autodetection.mdx
+++ b/calico-cloud_versioned_docs/version-20-1/networking/ipam/ip-autodetection.mdx
@@ -51,7 +51,7 @@ By default, {variables.prodname} uses the **firstFound** method; the first valid
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#NodeAddressAutodetection in the operator Installation reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-cloud_versioned_docs/version-20-1/operations/comms/certificate-management.mdx
+++ b/calico-cloud_versioned_docs/version-20-1/operations/comms/certificate-management.mdx
@@ -21,7 +21,7 @@ certificate issuance, {variables.prodname} provides a simple configuration optio
 **Limitations**
 
 If your cluster is already running {variables.prodname} and you would like to enable certificate management, you need to
-temporarily remove [the logstorage resource](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+temporarily remove [the logstorage resource](../../reference/installation/api.mdx#LogStorage
 before following the steps to enable certificate management and then re-apply afterwards.
 
 <!--TODO-XREFS-CC
@@ -40,7 +40,7 @@ Currently, this feature is not supported in combination with [Multi-cluster mana
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../../reference/installation/api.mdx#Installation
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
 ```yaml

--- a/calico-cloud_versioned_docs/version-20-1/reference/component-resources/configuration.mdx
+++ b/calico-cloud_versioned_docs/version-20-1/reference/component-resources/configuration.mdx
@@ -241,7 +241,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#Installation API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico-cloud_versioned_docs/version-20-1/reference/component-resources/configure-resources.mdx
+++ b/calico-cloud_versioned_docs/version-20-1/reference/component-resources/configure-resources.mdx
@@ -16,11 +16,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../../reference/installation/api.mdx#APIServer CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the installation CR using the below command:
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#APIServerDeployment, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch apiserver tigera-secure  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -68,11 +68,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## ApplicationLayer custom resource
 
-The [ApplicationLayer](../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
+The [ApplicationLayer](../../reference/installation/api.mdx#ApplicationLayer CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
 
 ### L7LogCollectorDaemonSet
 
-To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.L7LogCollectorDaemonSet), patch the ApplicationLayer CR using the below command:
+To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#L7LogCollectorDaemonSet, patch the ApplicationLayer CR using the below command:
 
 ```bash
 $ kubectl patch applicationlayer tigera-secure  --type=merge --patch='{"spec": {"l7LogCollectorDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"l7-collector","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"envoy-proxy","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -121,11 +121,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Compliance custom resource
 
-The [Compliance](../../reference/installation/api.mdx#operator.tigera.io/v1.Compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
+The [Compliance](../../reference/installation/api.mdx#Compliance CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
 
 ### ComplianceControllerDeployment
 
-To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceControllerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#ComplianceControllerDeployment, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -161,7 +161,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceSnapshotterDeployment
 
-To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceSnapshotterDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#ComplianceSnapshotterDeployment, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceSnapshotterDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-snapshotter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -197,7 +197,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceBenchmarkerDaemonSet
 
-To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#ComplianceBenchmarkerDaemonSet, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceBenchmarkerDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-benchmarker","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -232,7 +232,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceServerDeployment
 
-To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceServerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#ComplianceServerDeployment, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -268,7 +268,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceReporterPodTemplate.
 
-To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceReporterPodTemplate), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#ComplianceReporterPodTemplate, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceReporterPodTemplate": {"template": {"spec": {"containers":[{"name":"reporter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}'
@@ -310,7 +310,7 @@ Example Configurations:
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#TyphaDeployment, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -346,7 +346,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#calicoNodeDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -381,7 +381,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#calicoNodeWindowsDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -416,7 +416,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#CalicoKubeControllersDeployment component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -452,7 +452,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#CSINodeDriverDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -500,11 +500,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## IntrusionDetection custom resource
 
-The [IntrusionDetection](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
+The [IntrusionDetection](../../reference/installation/api.mdx#IntrusionDetection CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
 
 ### IntrusionDetectionControllerDeployment.
 
-To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionControllerDeployment), patch the IntrusionDetection CR using the below command:
+To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#IntrusionDetectionControllerDeployment, patch the IntrusionDetection CR using the below command:
 
 ```bash
 $ kubectl patch intrusiondetection tigera-secure  --type=merge --patch='{"spec": {"intrusionDetectionControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"webhooks-processor","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}},{"name":"controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -552,11 +552,11 @@ This command will output the configured resource requests and limits for the Int
 
 ## LogCollector custom resource
 
-The [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
+The [LogCollector](../../reference/installation/api.mdx#LogCollector CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
 
 ### FluentdDaemonSet.
 
-To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.FluentdDaemonSet), patch the LogCollector CR using the below command:
+To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#FluentdDaemonSet, patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"fluentdDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"fluentd","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -592,7 +592,7 @@ This command will output the configured resource requests and limits for the Flu
 
 ### EKSLogForwarderDeployment.
 
-To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.EKSLogForwarderDeployment), patch the LogCollector CR using the below command:
+To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#EKSLogForwarderDeployment, patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"eksLogForwarderDeployment": {"spec": {"template": {"spec": {"containers":[{"name":"eks-log-forwarder","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -627,11 +627,11 @@ This command will output the configured resource requests and limits for the EKS
 
 ## ManagementClusterConnection custom resource
 
-The [ManagementClusterConnection](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
+The [ManagementClusterConnection](../../reference/installation/api.mdx#ManagementClusterConnection CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
 
 ### GuardianDeployment.
 
-To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.GuardianDeployment), patch the ManagementClusterConnection CR using the below command:
+To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#GuardianDeployment, patch the ManagementClusterConnection CR using the below command:
 
 ```bash
 kubectl patch managementclusterconnection tigera-secure  --type=merge --patch='{"spec": {"guardianDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-guardian","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -663,11 +663,11 @@ This command will output the configured resource requests and limits for the Gua
 
 ## PacketCaptureAPI custom resource
 
-The [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
+The [PacketCaptureAPI](../../reference/installation/api.mdx#PacketCaptureAPI CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
 
 ### PacketCaptureAPIDeployment
 
-To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI), patch the PacketCapture CR using the below command:
+To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#PacketCaptureAPI, patch the PacketCapture CR using the below command:
 
 ```bash
 kubectl patch packetcaptureapis tigera-secure  --type=merge --patch='{"spec": {"packetCaptureAPIDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-packetcapture-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'

--- a/calico-cloud_versioned_docs/version-20-1/reference/installation/_api.mdx
+++ b/calico-cloud_versioned_docs/version-20-1/reference/installation/_api.mdx
@@ -15,47 +15,47 @@ API Schema definitions for configuring the installation of Calico and Calico Ent
 </p>
 Resource Types:
 <ul><li>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>
+<a href="#APIServer">APIServer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>
+<a href="#ApplicationLayer">ApplicationLayer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>
+<a href="#Authentication">Authentication</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>
+<a href="#Compliance">Compliance</a>
 </li><li>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>
+<a href="#EgressGateway">EgressGateway</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>
+<a href="#ImageSet">ImageSet</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>
+<a href="#Installation">Installation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>
+<a href="#IntrusionDetection">IntrusionDetection</a>
 </li><li>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>
+<a href="#LogCollector">LogCollector</a>
 </li><li>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>
+<a href="#LogStorage">LogStorage</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ManagementCluster">ManagementCluster</a>
+<a href="#ManagementCluster">ManagementCluster</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>
+<a href="#Manager">Manager</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>
+<a href="#Monitor">Monitor</a>
 </li><li>
-<a href="#operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</a>
+<a href="#PacketCaptureAPI">PacketCaptureAPI</a>
 </li><li>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>
+<a href="#PolicyRecommendation">PolicyRecommendation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TLSPassThroughRoute">TLSPassThroughRoute</a>
+<a href="#TLSPassThroughRoute">TLSPassThroughRoute</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TLSTerminatedRoute">TLSTerminatedRoute</a>
+<a href="#TLSTerminatedRoute">TLSTerminatedRoute</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>
+<a href="#Tenant">Tenant</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>
+<a href="#TigeraStatus">TigeraStatus</a>
 </li></ul>
-<h3 id="operator.tigera.io/v1.APIServer">APIServer</h3>
+<h3 id="APIServer">APIServer</h3>
 <p>
 APIServer installs the Tigera API server and related resources. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo; or &ldquo;tigera-secure&rdquo;.
@@ -116,7 +116,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerSpec">
+<a href="#APIServerSpec">
 APIServerSpec
 </a>
 </em>
@@ -134,7 +134,7 @@ Specification of the desired state for the Tigera API server.
 <td>
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -158,7 +158,7 @@ take precedence.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerStatus">
+<a href="#APIServerStatus">
 APIServerStatus
 </a>
 </em>
@@ -174,7 +174,7 @@ Most recently observed status for the Tigera API server.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</h3>
+<h3 id="ApplicationLayer">ApplicationLayer</h3>
 <p>
 ApplicationLayer is the Schema for the applicationlayers API
 </p>
@@ -234,7 +234,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">
+<a href="#ApplicationLayerSpec">
 ApplicationLayerSpec
 </a>
 </em>
@@ -249,7 +249,7 @@ ApplicationLayerSpec
 <td>
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -269,7 +269,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -288,7 +288,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -308,7 +308,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -327,7 +327,7 @@ User-configurable settings for the Envoy proxy.
 
 <code>l7LogCollectorDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSet">
+<a href="#L7LogCollectorDaemonSet">
 L7LogCollectorDaemonSet
 </a>
 </em>
@@ -350,7 +350,7 @@ L7LogCollectorDaemonSet configures the L7LogCollector DaemonSet.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerStatus">
+<a href="#ApplicationLayerStatus">
 ApplicationLayerStatus
 </a>
 </em>
@@ -363,7 +363,7 @@ ApplicationLayerStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Authentication">Authentication</h3>
+<h3 id="Authentication">Authentication</h3>
 <p>
 Authentication is the Schema for the authentications API
 </p>
@@ -423,7 +423,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">
+<a href="#AuthenticationSpec">
 AuthenticationSpec
 </a>
 </em>
@@ -495,7 +495,7 @@ ClusterRoleBindings into Elastic.
 
 <code>oidc</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">
+<a href="#AuthenticationOIDC">
 AuthenticationOIDC
 </a>
 </em>
@@ -515,7 +515,7 @@ OIDC contains the configuration needed to setup OIDC authentication.
 
 <code>openshift</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOpenshift">
+<a href="#AuthenticationOpenshift">
 AuthenticationOpenshift
 </a>
 </em>
@@ -535,7 +535,7 @@ Openshift contains the configuration needed to setup Openshift OAuth authenticat
 
 <code>ldap</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">
+<a href="#AuthenticationLDAP">
 AuthenticationLDAP
 </a>
 </em>
@@ -555,7 +555,7 @@ LDAP contains the configuration needed to setup LDAP authentication.
 
 <code>dexDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeployment">
+<a href="#DexDeployment">
 DexDeployment
 </a>
 </em>
@@ -578,7 +578,7 @@ DexDeployment configures the Dex Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationStatus">
+<a href="#AuthenticationStatus">
 AuthenticationStatus
 </a>
 </em>
@@ -591,7 +591,7 @@ AuthenticationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Compliance">Compliance</h3>
+<h3 id="Compliance">Compliance</h3>
 <p>
 Compliance installs the components required for Tigera compliance reporting. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -652,7 +652,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">
+<a href="#ComplianceSpec">
 ComplianceSpec
 </a>
 </em>
@@ -670,7 +670,7 @@ Specification of the desired state for Tigera compliance reporting.
 <td>
 <code>complianceControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeployment">
+<a href="#ComplianceControllerDeployment">
 ComplianceControllerDeployment
 </a>
 </em>
@@ -690,7 +690,7 @@ ComplianceControllerDeployment configures the Compliance Controller Deployment.
 
 <code>complianceSnapshotterDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeployment">
+<a href="#ComplianceSnapshotterDeployment">
 ComplianceSnapshotterDeployment
 </a>
 </em>
@@ -710,7 +710,7 @@ ComplianceSnapshotterDeployment configures the Compliance Snapshotter Deployment
 
 <code>complianceBenchmarkerDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">
+<a href="#ComplianceBenchmarkerDaemonSet">
 ComplianceBenchmarkerDaemonSet
 </a>
 </em>
@@ -730,7 +730,7 @@ ComplianceBenchmarkerDaemonSet configures the Compliance Benchmarker DaemonSet.
 
 <code>complianceServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeployment">
+<a href="#ComplianceServerDeployment">
 ComplianceServerDeployment
 </a>
 </em>
@@ -750,7 +750,7 @@ ComplianceServerDeployment configures the Compliance Server Deployment.
 
 <code>complianceReporterPodTemplate</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplate">
+<a href="#ComplianceReporterPodTemplate">
 ComplianceReporterPodTemplate
 </a>
 </em>
@@ -773,7 +773,7 @@ ComplianceReporterPodTemplate configures the Compliance Reporter PodTemplate.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceStatus">
+<a href="#ComplianceStatus">
 ComplianceStatus
 </a>
 </em>
@@ -789,7 +789,7 @@ Most recently observed state for Tigera compliance reporting.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGateway">EgressGateway</h3>
+<h3 id="EgressGateway">EgressGateway</h3>
 <p>
 EgressGateway is the Schema for the egressgateways API
 </p>
@@ -849,7 +849,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">
+<a href="#EgressGatewaySpec">
 EgressGatewaySpec
 </a>
 </em>
@@ -882,7 +882,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -923,7 +923,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -944,7 +944,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -964,7 +964,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -988,7 +988,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -1011,7 +1011,7 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayStatus">
+<a href="#EgressGatewayStatus">
 EgressGatewayStatus
 </a>
 </em>
@@ -1024,7 +1024,7 @@ EgressGatewayStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSet">ImageSet</h3>
+<h3 id="ImageSet">ImageSet</h3>
 <p>
 ImageSet is used to specify image digests for the images that the operator deploys.
 The name of the ImageSet is expected to be in the format <code>&lt;variant&gt;-&lt;release&gt;</code>.
@@ -1089,7 +1089,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">
+<a href="#ImageSetSpec">
 ImageSetSpec
 </a>
 </em>
@@ -1104,7 +1104,7 @@ ImageSetSpec
 <td>
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -1124,7 +1124,7 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Installation">Installation</h3>
+<h3 id="Installation">Installation</h3>
 <p>
 Installation configures an installation of Calico or Calico Enterprise. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo;. The Installation API installs core networking
@@ -1186,7 +1186,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -1204,7 +1204,7 @@ Specification of the desired state for the Calico or Calico Enterprise installat
 <td>
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -1332,7 +1332,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -1355,7 +1355,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -1375,7 +1375,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -1395,7 +1395,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -1574,7 +1574,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -1596,7 +1596,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -1618,7 +1618,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -1638,7 +1638,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -1658,7 +1658,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -1677,7 +1677,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -1697,7 +1697,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -1717,7 +1717,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -1737,7 +1737,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -1756,7 +1756,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -1777,7 +1777,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -1797,7 +1797,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -1838,7 +1838,7 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationStatus">
+<a href="#InstallationStatus">
 InstallationStatus
 </a>
 </em>
@@ -1854,7 +1854,7 @@ Most recently observed state for the Calico or Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</h3>
+<h3 id="IntrusionDetection">IntrusionDetection</h3>
 <p>
 IntrusionDetection installs the components required for Tigera intrusion detection. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -1915,7 +1915,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">
+<a href="#IntrusionDetectionSpec">
 IntrusionDetectionSpec
 </a>
 </em>
@@ -1933,7 +1933,7 @@ Specification of the desired state for Tigera intrusion detection.
 <td>
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">
+<a href="#IntrusionDetectionComponentResource">
 []IntrusionDetectionComponentResource
 </a>
 </em>
@@ -1954,7 +1954,7 @@ Only DeepPacketInspection is supported for this spec.
 
 <code>anomalyDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+<a href="#AnomalyDetectionSpec">
 AnomalyDetectionSpec
 </a>
 </em>
@@ -1974,7 +1974,7 @@ AnomalyDetection is now deprecated, and configuring it has no effect.
 
 <code>intrusionDetectionControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeployment">
+<a href="#IntrusionDetectionControllerDeployment">
 IntrusionDetectionControllerDeployment
 </a>
 </em>
@@ -1997,7 +1997,7 @@ IntrusionDetectionControllerDeployment configures the IntrusionDetection Control
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionStatus">
+<a href="#IntrusionDetectionStatus">
 IntrusionDetectionStatus
 </a>
 </em>
@@ -2013,7 +2013,7 @@ Most recently observed state for Tigera intrusion detection.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollector">LogCollector</h3>
+<h3 id="LogCollector">LogCollector</h3>
 <p>
 LogCollector installs the components required for Tigera flow and DNS log collection. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;. When created, this installs fluentd on all nodes
@@ -2075,7 +2075,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">
+<a href="#LogCollectorSpec">
 LogCollectorSpec
 </a>
 </em>
@@ -2093,7 +2093,7 @@ Specification of the desired state for Tigera log collection.
 <td>
 <code>additionalStores</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">
+<a href="#AdditionalLogStoreSpec">
 AdditionalLogStoreSpec
 </a>
 </em>
@@ -2113,7 +2113,7 @@ Configuration for exporting flow, audit, and DNS logs to external storage.
 
 <code>additionalSources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">
+<a href="#AdditionalLogSourceSpec">
 AdditionalLogSourceSpec
 </a>
 </em>
@@ -2133,7 +2133,7 @@ Configuration for importing audit logs from managed kubernetes cluster log sourc
 
 <code>collectProcessPath</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CollectProcessPathOption">
+<a href="#CollectProcessPathOption">
 CollectProcessPathOption
 </a>
 </em>
@@ -2174,7 +2174,7 @@ the management cluster&rsquo;s tenant services are running.
 
 <code>fluentdDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSet">
+<a href="#FluentdDaemonSet">
 FluentdDaemonSet
 </a>
 </em>
@@ -2193,7 +2193,7 @@ FluentdDaemonSet configures the Fluentd DaemonSet.
 
 <code>eksLogForwarderDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeployment">
+<a href="#EKSLogForwarderDeployment">
 EKSLogForwarderDeployment
 </a>
 </em>
@@ -2216,7 +2216,7 @@ EKSLogForwarderDeployment configures the EKSLogForwarderDeployment Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectorStatus">
+<a href="#LogCollectorStatus">
 LogCollectorStatus
 </a>
 </em>
@@ -2232,7 +2232,7 @@ Most recently observed state for Tigera log collection.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorage">LogStorage</h3>
+<h3 id="LogStorage">LogStorage</h3>
 <p>
 LogStorage installs the components required for Tigera flow and DNS log storage. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;. When created, this installs an Elasticsearch cluster for use by
@@ -2294,7 +2294,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">
+<a href="#LogStorageSpec">
 LogStorageSpec
 </a>
 </em>
@@ -2312,7 +2312,7 @@ Specification of the desired state for Tigera log storage.
 <td>
 <code>nodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Nodes">
+<a href="#Nodes">
 Nodes
 </a>
 </em>
@@ -2331,7 +2331,7 @@ Nodes defines the configuration for a set of identical Elasticsearch cluster nod
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Indices">
+<a href="#Indices">
 Indices
 </a>
 </em>
@@ -2351,7 +2351,7 @@ Index defines the configuration for the indices in the Elasticsearch cluster.
 
 <code>retention</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Retention">
+<a href="#Retention">
 Retention
 </a>
 </em>
@@ -2413,7 +2413,7 @@ each of the indicated key-value pairs as labels as well as access to the specifi
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">
+<a href="#LogStorageComponentResource">
 []LogStorageComponentResource
 </a>
 </em>
@@ -2434,7 +2434,7 @@ Only ECKOperator is supported for this spec.
 
 <code>eckOperatorStatefulSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSet">
+<a href="#ECKOperatorStatefulSet">
 ECKOperatorStatefulSet
 </a>
 </em>
@@ -2455,7 +2455,7 @@ ComponentResources, then these overrides take precedence.
 
 <code>kibana</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Kibana">
+<a href="#Kibana">
 Kibana
 </a>
 </em>
@@ -2475,7 +2475,7 @@ Kibana configures the Kibana Spec.
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -2494,7 +2494,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>elasticsearchMetricsDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeployment">
+<a href="#ElasticsearchMetricsDeployment">
 ElasticsearchMetricsDeployment
 </a>
 </em>
@@ -2516,7 +2516,7 @@ ElasticsearchMetricsDeployment configures the tigera-elasticsearch-metric Deploy
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageStatus">
+<a href="#LogStorageStatus">
 LogStorageStatus
 </a>
 </em>
@@ -2532,7 +2532,7 @@ Most recently observed state for Tigera log storage.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementCluster">ManagementCluster</h3>
+<h3 id="ManagementCluster">ManagementCluster</h3>
 <p>
 The presence of ManagementCluster in your cluster, will configure it to be the management plane to which managed
 clusters can connect. At most one instance of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2593,7 +2593,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterSpec">
+<a href="#ManagementClusterSpec">
 ManagementClusterSpec
 </a>
 </em>
@@ -2628,7 +2628,7 @@ Valid examples are: &ldquo;0.0.0.0:31000&rdquo;, &ldquo;example.com:32000&rdquo;
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLS">
+<a href="#TLS">
 TLS
 </a>
 </em>
@@ -2648,7 +2648,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</h3>
+<h3 id="ManagementClusterConnection">ManagementClusterConnection</h3>
 <p>
 ManagementClusterConnection represents a link between a managed cluster and a management cluster. At most one
 instance of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2709,7 +2709,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">
+<a href="#ManagementClusterConnectionSpec">
 ManagementClusterConnectionSpec
 </a>
 </em>
@@ -2743,7 +2743,7 @@ should be able to access this address. This field is used by managed clusters on
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">
+<a href="#ManagementClusterTLS">
 ManagementClusterTLS
 </a>
 </em>
@@ -2763,7 +2763,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>guardianDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeployment">
+<a href="#GuardianDeployment">
 GuardianDeployment
 </a>
 </em>
@@ -2785,7 +2785,7 @@ GuardianDeployment configures the guardian Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionStatus">
+<a href="#ManagementClusterConnectionStatus">
 ManagementClusterConnectionStatus
 </a>
 </em>
@@ -2798,7 +2798,7 @@ ManagementClusterConnectionStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Manager">Manager</h3>
+<h3 id="Manager">Manager</h3>
 <p>
 Manager installs the Calico Enterprise manager graphical user interface. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2859,7 +2859,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerSpec">
+<a href="#ManagerSpec">
 ManagerSpec
 </a>
 </em>
@@ -2877,7 +2877,7 @@ Specification of the desired state for the Calico Enterprise manager.
 <td>
 <code>managerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeployment">
+<a href="#ManagerDeployment">
 ManagerDeployment
 </a>
 </em>
@@ -2900,7 +2900,7 @@ ManagerDeployment configures the Manager Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerStatus">
+<a href="#ManagerStatus">
 ManagerStatus
 </a>
 </em>
@@ -2916,7 +2916,7 @@ Most recently observed state for the Calico Enterprise manager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Monitor">Monitor</h3>
+<h3 id="Monitor">Monitor</h3>
 <p>
 Monitor is the Schema for the monitor API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2977,7 +2977,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorSpec">
+<a href="#MonitorSpec">
 MonitorSpec
 </a>
 </em>
@@ -2992,7 +2992,7 @@ MonitorSpec
 <td>
 <code>externalPrometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">
+<a href="#ExternalPrometheus">
 ExternalPrometheus
 </a>
 </em>
@@ -3013,7 +3013,7 @@ scraping from git-ops tools without the need of post-installation steps.
 
 <code>prometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Prometheus">
+<a href="#Prometheus">
 Prometheus
 </a>
 </em>
@@ -3033,7 +3033,7 @@ Prometheus is the configuration for the Prometheus.
 
 <code>alertManager</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AlertManager">
+<a href="#AlertManager">
 AlertManager
 </a>
 </em>
@@ -3056,7 +3056,7 @@ AlertManager is the configuration for the AlertManager.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorStatus">
+<a href="#MonitorStatus">
 MonitorStatus
 </a>
 </em>
@@ -3069,7 +3069,7 @@ MonitorStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</h3>
+<h3 id="PacketCaptureAPI">PacketCaptureAPI</h3>
 <p>
 PacketCaptureAPI is used to configure the resource requirement for PacketCaptureAPI deployment. It must be named &ldquo;tigera-secure&rdquo;.
 </p>
@@ -3129,7 +3129,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPISpec">
+<a href="#PacketCaptureAPISpec">
 PacketCaptureAPISpec
 </a>
 </em>
@@ -3147,7 +3147,7 @@ Specification of the desired state for the PacketCaptureAPI.
 <td>
 <code>packetCaptureAPIDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeployment">
+<a href="#PacketCaptureAPIDeployment">
 PacketCaptureAPIDeployment
 </a>
 </em>
@@ -3170,7 +3170,7 @@ PacketCaptureAPIDeployment configures the PacketCaptureAPI Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIStatus">
+<a href="#PacketCaptureAPIStatus">
 PacketCaptureAPIStatus
 </a>
 </em>
@@ -3186,7 +3186,7 @@ Most recently observed state for the PacketCaptureAPI.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</h3>
+<h3 id="PolicyRecommendation">PolicyRecommendation</h3>
 <p>
 PolicyRecommendation is the Schema for the policy recommendation API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -3247,7 +3247,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationSpec">
+<a href="#PolicyRecommendationSpec">
 PolicyRecommendationSpec
 </a>
 </em>
@@ -3262,7 +3262,7 @@ PolicyRecommendationSpec
 <td>
 <code>policyRecommendationDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeployment">
+<a href="#PolicyRecommendationDeployment">
 PolicyRecommendationDeployment
 </a>
 </em>
@@ -3285,7 +3285,7 @@ PolicyRecommendation configures the PolicyRecommendation Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationStatus">
+<a href="#PolicyRecommendationStatus">
 PolicyRecommendationStatus
 </a>
 </em>
@@ -3298,7 +3298,7 @@ PolicyRecommendationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSPassThroughRoute">TLSPassThroughRoute</h3>
+<h3 id="TLSPassThroughRoute">TLSPassThroughRoute</h3>
 <table>
 <thead>
 <tr>
@@ -3355,7 +3355,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRouteSpec">
+<a href="#TLSPassThroughRouteSpec">
 TLSPassThroughRouteSpec
 </a>
 </em>
@@ -3373,7 +3373,7 @@ Dest is the destination URL
 <td>
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -3389,7 +3389,7 @@ TargetType
 
 <code>sniMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SNIMatch">
+<a href="#SNIMatch">
 SNIMatch
 </a>
 </em>
@@ -3426,7 +3426,7 @@ Destination is the destination url to proxy the request to.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSTerminatedRoute">TLSTerminatedRoute</h3>
+<h3 id="TLSTerminatedRoute">TLSTerminatedRoute</h3>
 <table>
 <thead>
 <tr>
@@ -3483,7 +3483,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLSTerminatedRouteSpec">
+<a href="#TLSTerminatedRouteSpec">
 TLSTerminatedRouteSpec
 </a>
 </em>
@@ -3498,7 +3498,7 @@ TLSTerminatedRouteSpec
 <td>
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -3514,7 +3514,7 @@ TargetType
 
 <code>pathMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PathMatch">
+<a href="#PathMatch">
 PathMatch
 </a>
 </em>
@@ -3632,7 +3632,7 @@ is UI.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Tenant">Tenant</h3>
+<h3 id="Tenant">Tenant</h3>
 <p>
 Tenant is the Schema for the tenants API
 </p>
@@ -3692,7 +3692,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantSpec">
+<a href="#TenantSpec">
 TenantSpec
 </a>
 </em>
@@ -3741,7 +3741,7 @@ Name is a human readable name for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -3760,7 +3760,7 @@ Indices defines the how to store a tenant&rsquo;s data
 
 <code>elastic</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantElasticSpec">
+<a href="#TenantElasticSpec">
 TenantElasticSpec
 </a>
 </em>
@@ -3799,7 +3799,7 @@ in the Tenant&rsquo;s namespace. Defaults to the controlPlaneReplicas in Install
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -3818,7 +3818,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>esKubeControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -3837,7 +3837,7 @@ ESKubeControllerDeployment configures the ESKubeController Deployment.
 
 <code>dashboardsJob</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJob">
+<a href="#DashboardsJob">
 DashboardsJob
 </a>
 </em>
@@ -3859,7 +3859,7 @@ DashboardsJob configures the Dashboards job
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantStatus">
+<a href="#TenantStatus">
 TenantStatus
 </a>
 </em>
@@ -3872,7 +3872,7 @@ TenantStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatus">TigeraStatus</h3>
+<h3 id="TigeraStatus">TigeraStatus</h3>
 <p>
 TigeraStatus represents the most recently observed status for Calico or a Calico Enterprise functional area.
 </p>
@@ -3932,7 +3932,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusSpec">
+<a href="#TigeraStatusSpec">
 TigeraStatusSpec
 </a>
 </em>
@@ -3952,7 +3952,7 @@ TigeraStatusSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">
+<a href="#TigeraStatusStatus">
 TigeraStatusStatus
 </a>
 </em>
@@ -3965,11 +3965,11 @@ TigeraStatusStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</h3>
+<h3 id="APIServerDeployment">APIServerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerSpec">APIServerSpec</a>)
+<a href="#APIServerSpec">APIServerSpec</a>)
 
 </p>
 <p>
@@ -3988,7 +3988,7 @@ APIServerDeployment is the configuration for the API server Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4008,7 +4008,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">
+<a href="#APIServerDeploymentSpec">
 APIServerDeploymentSpec
 </a>
 </em>
@@ -4029,11 +4029,11 @@ Spec is the specification of the API server Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
+<h3 id="APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -4090,11 +4090,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
+<h3 id="APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -4150,11 +4150,11 @@ If omitted, the API server Deployment will use its default value for this init c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
+<h3 id="APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -4173,7 +4173,7 @@ APIServerDeploymentDeploymentPodSpec is the API server Deployment&rsquo;s PodSpe
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentInitContainer">
+<a href="#APIServerDeploymentInitContainer">
 []APIServerDeploymentInitContainer
 </a>
 </em>
@@ -4195,7 +4195,7 @@ If omitted, the API server Deployment will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentContainer">
+<a href="#APIServerDeploymentContainer">
 []APIServerDeploymentContainer
 </a>
 </em>
@@ -4306,11 +4306,11 @@ WARNING: Please note that this field will override the default API server Deploy
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
+<h3 id="APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
+<a href="#APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -4329,7 +4329,7 @@ APIServerDeploymentPodTemplateSpec is the API server Deployment&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4350,7 +4350,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">
+<a href="#APIServerDeploymentPodSpec">
 APIServerDeploymentPodSpec
 </a>
 </em>
@@ -4371,11 +4371,11 @@ Spec is the API server Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
+<h3 id="APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>)
 
 </p>
 <p>
@@ -4415,7 +4415,7 @@ If omitted, the API server Deployment will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">
+<a href="#APIServerDeploymentPodTemplateSpec">
 APIServerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -4432,11 +4432,11 @@ Template describes the API server Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerSpec">APIServerSpec</h3>
+<h3 id="APIServerSpec">APIServerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -4455,7 +4455,7 @@ APIServerSpec defines the desired state of Tigera API server.
 
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -4473,11 +4473,11 @@ take precedence.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerStatus">APIServerStatus</h3>
+<h3 id="APIServerStatus">APIServerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -4531,11 +4531,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</h3>
+<h3 id="AWSEgressGateway">AWSEgressGateway</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -4554,7 +4554,7 @@ AWSEgressGateway defines the configurations for deploying EgressGateway in AWS
 
 <code>nativeIP</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NativeIP">
+<a href="#NativeIP">
 NativeIP
 </a>
 </em>
@@ -4591,11 +4591,11 @@ NativeIP must be Enabled if elastic IPs are set.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AdditionalLogSourceSpec">AdditionalLogSourceSpec</h3>
+<h3 id="AdditionalLogSourceSpec">AdditionalLogSourceSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <table>
@@ -4611,7 +4611,7 @@ NativeIP must be Enabled if elastic IPs are set.
 
 <code>eksCloudwatchLog</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EksCloudwatchLogsSpec">
+<a href="#EksCloudwatchLogsSpec">
 EksCloudwatchLogsSpec
 </a>
 </em>
@@ -4629,11 +4629,11 @@ audit logs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</h3>
+<h3 id="AdditionalLogStoreSpec">AdditionalLogStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <table>
@@ -4649,7 +4649,7 @@ audit logs.
 
 <code>s3</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.S3StoreSpec">
+<a href="#S3StoreSpec">
 S3StoreSpec
 </a>
 </em>
@@ -4669,7 +4669,7 @@ If specified, enables exporting of flow, audit, and DNS logs to Amazon S3 storag
 
 <code>syslog</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">
+<a href="#SyslogStoreSpec">
 SyslogStoreSpec
 </a>
 </em>
@@ -4689,7 +4689,7 @@ If specified, enables exporting of flow, audit, and DNS logs to syslog.
 
 <code>splunk</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SplunkStoreSpec">
+<a href="#SplunkStoreSpec">
 SplunkStoreSpec
 </a>
 </em>
@@ -4706,11 +4706,11 @@ If specified, enables exporting of flow, audit, and DNS logs to splunk.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AlertManager">AlertManager</h3>
+<h3 id="AlertManager">AlertManager</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.MonitorSpec">MonitorSpec</a>)
+<a href="#MonitorSpec">MonitorSpec</a>)
 
 </p>
 <table>
@@ -4726,7 +4726,7 @@ If specified, enables exporting of flow, audit, and DNS logs to splunk.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AlertManagerSpec">
+<a href="#AlertManagerSpec">
 AlertManagerSpec
 </a>
 </em>
@@ -4747,11 +4747,11 @@ Spec is the specification of the Alertmanager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AlertManagerSpec">AlertManagerSpec</h3>
+<h3 id="AlertManagerSpec">AlertManagerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AlertManager">AlertManager</a>)
+<a href="#AlertManager">AlertManager</a>)
 
 </p>
 <table>
@@ -4783,11 +4783,11 @@ Define resources requests and limits for single Pods.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
+<h3 id="AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <table>
@@ -4818,19 +4818,19 @@ StorageClassName is now deprecated, and configuring it has no effect.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
+<h3 id="ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</h3>
+<h3 id="ApplicationLayerSpec">ApplicationLayerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -4849,7 +4849,7 @@ ApplicationLayerSpec defines the desired state of ApplicationLayer
 
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -4869,7 +4869,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -4888,7 +4888,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -4908,7 +4908,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -4927,7 +4927,7 @@ User-configurable settings for the Envoy proxy.
 
 <code>l7LogCollectorDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSet">
+<a href="#L7LogCollectorDaemonSet">
 L7LogCollectorDaemonSet
 </a>
 </em>
@@ -4944,11 +4944,11 @@ L7LogCollectorDaemonSet configures the L7LogCollector DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerStatus">ApplicationLayerStatus</h3>
+<h3 id="ApplicationLayerStatus">ApplicationLayerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -5002,13 +5002,13 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthMethod">AuthMethod
+<h3 id="AuthMethod">AuthMethod
 (<code>string</code> alias)</h3>
-<h3 id="operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</h3>
+<h3 id="AuthenticationLDAP">AuthenticationLDAP</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -5064,7 +5064,7 @@ the ldaps:// protocol.
 
 <code>userSearch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.UserSearch">
+<a href="#UserSearch">
 UserSearch
 </a>
 </em>
@@ -5083,7 +5083,7 @@ User entry search configuration to match the credentials with a user.
 
 <code>groupSearch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GroupSearch">
+<a href="#GroupSearch">
 GroupSearch
 </a>
 </em>
@@ -5100,11 +5100,11 @@ Group search configuration to find the groups that a user is in.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</h3>
+<h3 id="AuthenticationOIDC">AuthenticationOIDC</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -5230,7 +5230,7 @@ Deprecated. Please use Authentication.Spec.GroupsPrefix instead.
 
 <code>emailVerification</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EmailVerificationType">
+<a href="#EmailVerificationType">
 EmailVerificationType
 </a>
 </em>
@@ -5253,7 +5253,7 @@ Default: Verify
 
 <code>promptTypes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PromptType">
+<a href="#PromptType">
 []PromptType
 </a>
 </em>
@@ -5276,7 +5276,7 @@ Default: &ldquo;Consent&rdquo;
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.OIDCType">
+<a href="#OIDCType">
 OIDCType
 </a>
 </em>
@@ -5293,11 +5293,11 @@ Default: &ldquo;Dex&rdquo;
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationOpenshift">AuthenticationOpenshift</h3>
+<h3 id="AuthenticationOpenshift">AuthenticationOpenshift</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -5330,11 +5330,11 @@ IssuerURL is the URL to the Openshift OAuth provider. Ex.: <a href="https://api.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</h3>
+<h3 id="AuthenticationSpec">AuthenticationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>)
+<a href="#Authentication">Authentication</a>)
 
 </p>
 <p>
@@ -5410,7 +5410,7 @@ ClusterRoleBindings into Elastic.
 
 <code>oidc</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">
+<a href="#AuthenticationOIDC">
 AuthenticationOIDC
 </a>
 </em>
@@ -5430,7 +5430,7 @@ OIDC contains the configuration needed to setup OIDC authentication.
 
 <code>openshift</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOpenshift">
+<a href="#AuthenticationOpenshift">
 AuthenticationOpenshift
 </a>
 </em>
@@ -5450,7 +5450,7 @@ Openshift contains the configuration needed to setup Openshift OAuth authenticat
 
 <code>ldap</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">
+<a href="#AuthenticationLDAP">
 AuthenticationLDAP
 </a>
 </em>
@@ -5470,7 +5470,7 @@ LDAP contains the configuration needed to setup LDAP authentication.
 
 <code>dexDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeployment">
+<a href="#DexDeployment">
 DexDeployment
 </a>
 </em>
@@ -5487,11 +5487,11 @@ DexDeployment configures the Dex Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationStatus">AuthenticationStatus</h3>
+<h3 id="AuthenticationStatus">AuthenticationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>)
+<a href="#Authentication">Authentication</a>)
 
 </p>
 <p>
@@ -5545,12 +5545,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.BGPOption">BGPOption
+<h3 id="BGPOption">BGPOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -5559,12 +5559,12 @@ BGPOption describes the mode of BGP to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.CAType">CAType
+<h3 id="CAType">CAType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">ManagementClusterTLS</a>)
+<a href="#ManagementClusterTLS">ManagementClusterTLS</a>)
 
 </p>
 <p>
@@ -5573,11 +5573,11 @@ CAType specifies which verification method the tunnel client should use to verif
 <p>
 One of: Tigera, Public
 </p>
-<h3 id="operator.tigera.io/v1.CNILogging">CNILogging</h3>
+<h3 id="CNILogging">CNILogging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Logging">Logging</a>)
+<a href="#Logging">Logging</a>)
 
 </p>
 <table>
@@ -5593,7 +5593,7 @@ One of: Tigera, Public
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -5664,12 +5664,12 @@ Default: 10
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CNIPluginType">CNIPluginType
+<h3 id="CNIPluginType">CNIPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -5678,11 +5678,11 @@ CNIPluginType describes the type of CNI plugin used.
 <p>
 One of: Calico, GKE, AmazonVPC, AzureVNET
 </p>
-<h3 id="operator.tigera.io/v1.CNISpec">CNISpec</h3>
+<h3 id="CNISpec">CNISpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5701,7 +5701,7 @@ CNISpec contains configuration for the CNI plugin.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNIPluginType">
+<a href="#CNIPluginType">
 CNIPluginType
 </a>
 </em>
@@ -5733,7 +5733,7 @@ Default: Calico
 
 <code>ipam</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMSpec">
+<a href="#IPAMSpec">
 IPAMSpec
 </a>
 </em>
@@ -5751,11 +5751,11 @@ Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
+<h3 id="CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5774,7 +5774,7 @@ CSINodeDriverDaemonSet is the configuration for the csi-node-driver DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5794,7 +5794,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">
+<a href="#CSINodeDriverDaemonSetSpec">
 CSINodeDriverDaemonSetSpec
 </a>
 </em>
@@ -5815,11 +5815,11 @@ Spec is the specification of the csi-node-driver DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
+<h3 id="CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -5875,11 +5875,11 @@ If omitted, the csi-node-driver DaemonSet will use its default value for this co
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -5898,7 +5898,7 @@ CSINodeDriverDaemonSetPodSpec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">
+<a href="#CSINodeDriverDaemonSetContainer">
 []CSINodeDriverDaemonSetContainer
 </a>
 </em>
@@ -5985,11 +5985,11 @@ WARNING: Please note that this field will override the default csi-node-driver D
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
+<a href="#CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -6008,7 +6008,7 @@ CSINodeDriverDaemonSetPodTemplateSpec is the csi-node-driver DaemonSet&rsquo;s P
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6029,7 +6029,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">
+<a href="#CSINodeDriverDaemonSetPodSpec">
 CSINodeDriverDaemonSetPodSpec
 </a>
 </em>
@@ -6050,11 +6050,11 @@ Spec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
+<h3 id="CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
 
 </p>
 <p>
@@ -6094,7 +6094,7 @@ If omitted, the csi-node-driver DaemonSet will use its default value for minRead
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">
 CSINodeDriverDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -6111,12 +6111,12 @@ Template describes the csi-node-driver DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
+<h3 id="CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>, 
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -6135,7 +6135,7 @@ CalicoKubeControllersDeployment is the configuration for the calico-kube-control
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6155,7 +6155,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">
+<a href="#CalicoKubeControllersDeploymentSpec">
 CalicoKubeControllersDeploymentSpec
 </a>
 </em>
@@ -6176,11 +6176,11 @@ Spec is the specification of the calico-kube-controllers Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
+<h3 id="CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -6237,11 +6237,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6260,7 +6260,7 @@ CalicoKubeControllersDeploymentPodSpec is the calico-kube-controller Deployment&
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">
+<a href="#CalicoKubeControllersDeploymentContainer">
 []CalicoKubeControllersDeploymentContainer
 </a>
 </em>
@@ -6349,11 +6349,11 @@ WARNING: Please note that this field will override the default calico-kube-contr
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
+<a href="#CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
 
 </p>
 <p>
@@ -6372,7 +6372,7 @@ CalicoKubeControllersDeploymentPodTemplateSpec is the calico-kube-controllers De
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6393,7 +6393,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">
+<a href="#CalicoKubeControllersDeploymentPodSpec">
 CalicoKubeControllersDeploymentPodSpec
 </a>
 </em>
@@ -6414,11 +6414,11 @@ Spec is the calico-kube-controllers Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
 
 </p>
 <p>
@@ -6458,7 +6458,7 @@ If omitted, the calico-kube-controllers Deployment will use its default value fo
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">
 CalicoKubeControllersDeploymentPodTemplateSpec
 </a>
 </em>
@@ -6475,11 +6475,11 @@ Template describes the calico-kube-controllers Deployment pod that will be creat
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</h3>
+<h3 id="CalicoNetworkSpec">CalicoNetworkSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -6498,7 +6498,7 @@ CalicoNetworkSpec specifies configuration options for Calico provided pod networ
 
 <code>linuxDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinuxDataplaneOption">
+<a href="#LinuxDataplaneOption">
 LinuxDataplaneOption
 </a>
 </em>
@@ -6521,7 +6521,7 @@ Default: Iptables
 
 <code>windowsDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsDataplaneOption">
+<a href="#WindowsDataplaneOption">
 WindowsDataplaneOption
 </a>
 </em>
@@ -6544,7 +6544,7 @@ Default: Disabled
 
 <code>bgp</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.BGPOption">
+<a href="#BGPOption">
 BGPOption
 </a>
 </em>
@@ -6564,7 +6564,7 @@ BGP configures whether or not to enable Calico&rsquo;s BGP capabilities.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPPool">
+<a href="#IPPool">
 []IPPool
 </a>
 </em>
@@ -6604,7 +6604,7 @@ If not specified, Calico will perform MTU auto-detection based on the cluster ne
 
 <code>nodeAddressAutodetectionV4</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -6625,7 +6625,7 @@ will use default auto-detection settings to acquire an IPv4 address for each nod
 
 <code>nodeAddressAutodetectionV6</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -6646,7 +6646,7 @@ IPv6 addresses will not be auto-detected.
 
 <code>hostPorts</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HostPortsType">
+<a href="#HostPortsType">
 HostPortsType
 </a>
 </em>
@@ -6667,7 +6667,7 @@ Default: Enabled
 
 <code>multiInterfaceMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MultiInterfaceMode">
+<a href="#MultiInterfaceMode">
 MultiInterfaceMode
 </a>
 </em>
@@ -6689,7 +6689,7 @@ Default: None
 
 <code>containerIPForwarding</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ContainerIPForwardingType">
+<a href="#ContainerIPForwardingType">
 ContainerIPForwardingType
 </a>
 </em>
@@ -6710,7 +6710,7 @@ Default: Disabled
 
 <code>sysctl</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Sysctl">
+<a href="#Sysctl">
 []Sysctl
 </a>
 </em>
@@ -6757,11 +6757,11 @@ Default: 0
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
+<h3 id="CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -6780,7 +6780,7 @@ CalicoNodeDaemonSet is the configuration for the calico-node DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6800,7 +6800,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">
+<a href="#CalicoNodeDaemonSetSpec">
 CalicoNodeDaemonSetSpec
 </a>
 </em>
@@ -6821,11 +6821,11 @@ Spec is the specification of the calico-node DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
+<h3 id="CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6882,11 +6882,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6943,11 +6943,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6966,7 +6966,7 @@ CalicoNodeDaemonSetPodSpec is the calico-node DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">
+<a href="#CalicoNodeDaemonSetInitContainer">
 []CalicoNodeDaemonSetInitContainer
 </a>
 </em>
@@ -6988,7 +6988,7 @@ If omitted, the calico-node DaemonSet will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetContainer">
+<a href="#CalicoNodeDaemonSetContainer">
 []CalicoNodeDaemonSetContainer
 </a>
 </em>
@@ -7075,11 +7075,11 @@ WARNING: Please note that this field will override the default calico-node Daemo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
+<a href="#CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7098,7 +7098,7 @@ CalicoNodeDaemonSetPodTemplateSpec is the calico-node DaemonSet&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7119,7 +7119,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">
+<a href="#CalicoNodeDaemonSetPodSpec">
 CalicoNodeDaemonSetPodSpec
 </a>
 </em>
@@ -7140,11 +7140,11 @@ Spec is the calico-node DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
+<h3 id="CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
 
 </p>
 <p>
@@ -7184,7 +7184,7 @@ If omitted, the calico-node DaemonSet will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">
 CalicoNodeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -7201,11 +7201,11 @@ Template describes the calico-node DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
+<h3 id="CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7224,7 +7224,7 @@ CalicoNodeWindowsDaemonSet is the configuration for the calico-node-windows Daem
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7244,7 +7244,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">
+<a href="#CalicoNodeWindowsDaemonSetSpec">
 CalicoNodeWindowsDaemonSetSpec
 </a>
 </em>
@@ -7265,11 +7265,11 @@ Spec is the specification of the calico-node-windows DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -7326,11 +7326,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -7387,11 +7387,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7410,7 +7410,7 @@ CalicoNodeWindowsDaemonSetPodSpec is the calico-node-windows DaemonSet&rsquo;s P
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">
+<a href="#CalicoNodeWindowsDaemonSetInitContainer">
 []CalicoNodeWindowsDaemonSetInitContainer
 </a>
 </em>
@@ -7432,7 +7432,7 @@ If omitted, the calico-node-windows DaemonSet will use its default values for it
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">
+<a href="#CalicoNodeWindowsDaemonSetContainer">
 []CalicoNodeWindowsDaemonSetContainer
 </a>
 </em>
@@ -7519,11 +7519,11 @@ WARNING: Please note that this field will override the default calico-node-windo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7542,7 +7542,7 @@ CalicoNodeWindowsDaemonSetPodTemplateSpec is the calico-node-windows DaemonSet&r
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7563,7 +7563,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">
 CalicoNodeWindowsDaemonSetPodSpec
 </a>
 </em>
@@ -7584,11 +7584,11 @@ Spec is the calico-node-windows DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
 
 </p>
 <p>
@@ -7628,7 +7628,7 @@ If omitted, the calico-node-windows DaemonSet will use its default value for min
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">
 CalicoNodeWindowsDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -7645,11 +7645,11 @@ Template describes the calico-node-windows DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7669,7 +7669,7 @@ CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrad
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7689,7 +7689,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">
 CalicoWindowsUpgradeDaemonSetSpec
 </a>
 </em>
@@ -7710,11 +7710,11 @@ Spec is the specification of the calico-windows-upgrade DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -7769,11 +7769,11 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7792,7 +7792,7 @@ CalicoWindowsUpgradeDaemonSetPodSpec is the calico-windows-upgrade DaemonSet&rsq
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">
+<a href="#CalicoWindowsUpgradeDaemonSetContainer">
 []CalicoWindowsUpgradeDaemonSetContainer
 </a>
 </em>
@@ -7879,11 +7879,11 @@ WARNING: Please note that this field will override the default calico-windows-up
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7902,7 +7902,7 @@ CalicoWindowsUpgradeDaemonSetPodTemplateSpec is the calico-windows-upgrade Daemo
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7923,7 +7923,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">
 CalicoWindowsUpgradeDaemonSetPodSpec
 </a>
 </em>
@@ -7944,11 +7944,11 @@ Spec is the calico-windows-upgrade DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
 
 </p>
 <p>
@@ -7988,7 +7988,7 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
 CalicoWindowsUpgradeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -8005,11 +8005,11 @@ Template describes the calico-windows-upgrade DaemonSet pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CertificateManagement">CertificateManagement</h3>
+<h3 id="CertificateManagement">CertificateManagement</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -8101,19 +8101,19 @@ Default: SHA256WithRSA
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CollectProcessPathOption">CollectProcessPathOption
+<h3 id="CollectProcessPathOption">CollectProcessPathOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.CommonPrometheusFields">CommonPrometheusFields</h3>
+<h3 id="CommonPrometheusFields">CommonPrometheusFields</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PrometheusSpec">PrometheusSpec</a>)
+<a href="#PrometheusSpec">PrometheusSpec</a>)
 
 </p>
 <table>
@@ -8129,7 +8129,7 @@ Default: SHA256WithRSA
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PrometheusContainer">
+<a href="#PrometheusContainer">
 []PrometheusContainer
 </a>
 </em>
@@ -8167,11 +8167,11 @@ Define resources requests and limits for single Pods.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</h3>
+<h3 id="ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -8190,7 +8190,7 @@ ComplianceBenchmarkerDaemonSet is the configuration for the Compliance Benchmark
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetSpec">
+<a href="#ComplianceBenchmarkerDaemonSetSpec">
 ComplianceBenchmarkerDaemonSetSpec
 </a>
 </em>
@@ -8211,11 +8211,11 @@ Spec is the specification of the Compliance Benchmarker DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetContainer">ComplianceBenchmarkerDaemonSetContainer</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetContainer">ComplianceBenchmarkerDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -8271,11 +8271,11 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetInitContainer">ComplianceBenchmarkerDaemonSetInitContainer</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetInitContainer">ComplianceBenchmarkerDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -8331,11 +8331,11 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8354,7 +8354,7 @@ ComplianceBenchmarkerDaemonSetPodSpec is the Compliance Benchmarker DaemonSet&rs
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetInitContainer">
+<a href="#ComplianceBenchmarkerDaemonSetInitContainer">
 []ComplianceBenchmarkerDaemonSetInitContainer
 </a>
 </em>
@@ -8376,7 +8376,7 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default values for
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetContainer">
+<a href="#ComplianceBenchmarkerDaemonSetContainer">
 []ComplianceBenchmarkerDaemonSetContainer
 </a>
 </em>
@@ -8395,11 +8395,11 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default values for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -8418,7 +8418,7 @@ ComplianceBenchmarkerDaemonSetPodTemplateSpec is the Compliance Benchmarker Daem
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">
+<a href="#ComplianceBenchmarkerDaemonSetPodSpec">
 ComplianceBenchmarkerDaemonSetPodSpec
 </a>
 </em>
@@ -8439,11 +8439,11 @@ Spec is the Compliance Benchmarker DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</a>)
+<a href="#ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</a>)
 
 </p>
 <p>
@@ -8462,7 +8462,7 @@ ComplianceBenchmarkerDaemonSetSpec defines configuration for the Compliance Benc
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodTemplateSpec">
+<a href="#ComplianceBenchmarkerDaemonSetPodTemplateSpec">
 ComplianceBenchmarkerDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -8479,11 +8479,11 @@ Template describes the Compliance Benchmarker DaemonSet pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeployment">ComplianceControllerDeployment</h3>
+<h3 id="ComplianceControllerDeployment">ComplianceControllerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -8502,7 +8502,7 @@ ComplianceControllerDeployment is the configuration for the compliance controlle
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentSpec">
+<a href="#ComplianceControllerDeploymentSpec">
 ComplianceControllerDeploymentSpec
 </a>
 </em>
@@ -8523,11 +8523,11 @@ Spec is the specification of the compliance controller Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentContainer">ComplianceControllerDeploymentContainer</h3>
+<h3 id="ComplianceControllerDeploymentContainer">ComplianceControllerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
+<a href="#ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -8583,11 +8583,11 @@ If omitted, the compliance controller Deployment will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentInitContainer">ComplianceControllerDeploymentInitContainer</h3>
+<h3 id="ComplianceControllerDeploymentInitContainer">ComplianceControllerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
+<a href="#ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -8643,11 +8643,11 @@ If omitted, the compliance controller Deployment will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</h3>
+<h3 id="ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</a>)
+<a href="#ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8666,7 +8666,7 @@ ComplianceControllerDeploymentPodSpec is the compliance controller Deployment&rs
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentInitContainer">
+<a href="#ComplianceControllerDeploymentInitContainer">
 []ComplianceControllerDeploymentInitContainer
 </a>
 </em>
@@ -8688,7 +8688,7 @@ If omitted, the compliance controller Deployment will use its default values for
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentContainer">
+<a href="#ComplianceControllerDeploymentContainer">
 []ComplianceControllerDeploymentContainer
 </a>
 </em>
@@ -8707,11 +8707,11 @@ If omitted, the compliance controller Deployment will use its default values for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</h3>
+<h3 id="ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</a>)
+<a href="#ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -8730,7 +8730,7 @@ ComplianceControllerDeploymentPodTemplateSpec is the compliance controller Deplo
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">
+<a href="#ComplianceControllerDeploymentPodSpec">
 ComplianceControllerDeploymentPodSpec
 </a>
 </em>
@@ -8751,11 +8751,11 @@ Spec is the compliance controller Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</h3>
+<h3 id="ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeployment">ComplianceControllerDeployment</a>)
+<a href="#ComplianceControllerDeployment">ComplianceControllerDeployment</a>)
 
 </p>
 <p>
@@ -8774,7 +8774,7 @@ ComplianceControllerDeploymentSpec defines configuration for the compliance cont
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodTemplateSpec">
+<a href="#ComplianceControllerDeploymentPodTemplateSpec">
 ComplianceControllerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -8791,11 +8791,11 @@ Template describes the compliance controller Deployment pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodSpec">ComplianceReporterPodSpec</h3>
+<h3 id="ComplianceReporterPodSpec">ComplianceReporterPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</a>)
+<a href="#ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8814,7 +8814,7 @@ ComplianceReporterPodSpec is the ComplianceReporter PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateInitContainer">
+<a href="#ComplianceReporterPodTemplateInitContainer">
 []ComplianceReporterPodTemplateInitContainer
 </a>
 </em>
@@ -8836,7 +8836,7 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateContainer">
+<a href="#ComplianceReporterPodTemplateContainer">
 []ComplianceReporterPodTemplateContainer
 </a>
 </em>
@@ -8855,11 +8855,11 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</h3>
+<h3 id="ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -8878,7 +8878,7 @@ ComplianceReporterPodTemplate is the configuration for the ComplianceReporter Po
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateSpec">
+<a href="#ComplianceReporterPodTemplateSpec">
 ComplianceReporterPodTemplateSpec
 </a>
 </em>
@@ -8895,11 +8895,11 @@ Spec is the specification of the ComplianceReporter PodTemplateSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplateContainer">ComplianceReporterPodTemplateContainer</h3>
+<h3 id="ComplianceReporterPodTemplateContainer">ComplianceReporterPodTemplateContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
+<a href="#ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
 
 </p>
 <p>
@@ -8955,11 +8955,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplateInitContainer">ComplianceReporterPodTemplateInitContainer</h3>
+<h3 id="ComplianceReporterPodTemplateInitContainer">ComplianceReporterPodTemplateInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
+<a href="#ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
 
 </p>
 <p>
@@ -9015,11 +9015,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</h3>
+<h3 id="ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</a>)
+<a href="#ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</a>)
 
 </p>
 <p>
@@ -9038,7 +9038,7 @@ ComplianceReporterPodTemplateSpec is the ComplianceReporter PodTemplateSpec.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodSpec">
+<a href="#ComplianceReporterPodSpec">
 ComplianceReporterPodSpec
 </a>
 </em>
@@ -9059,11 +9059,11 @@ Spec is the ComplianceReporter PodTemplate&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeployment">ComplianceServerDeployment</h3>
+<h3 id="ComplianceServerDeployment">ComplianceServerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -9082,7 +9082,7 @@ ComplianceServerDeployment is the configuration for the ComplianceServer Deploym
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentSpec">
+<a href="#ComplianceServerDeploymentSpec">
 ComplianceServerDeploymentSpec
 </a>
 </em>
@@ -9103,11 +9103,11 @@ Spec is the specification of the ComplianceServer Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentContainer">ComplianceServerDeploymentContainer</h3>
+<h3 id="ComplianceServerDeploymentContainer">ComplianceServerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
+<a href="#ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9163,11 +9163,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentInitContainer">ComplianceServerDeploymentInitContainer</h3>
+<h3 id="ComplianceServerDeploymentInitContainer">ComplianceServerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
+<a href="#ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9223,11 +9223,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</h3>
+<h3 id="ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</a>)
+<a href="#ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -9246,7 +9246,7 @@ ComplianceServerDeploymentPodSpec is the ComplianceServer Deployment&rsquo;s Pod
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentInitContainer">
+<a href="#ComplianceServerDeploymentInitContainer">
 []ComplianceServerDeploymentInitContainer
 </a>
 </em>
@@ -9268,7 +9268,7 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentContainer">
+<a href="#ComplianceServerDeploymentContainer">
 []ComplianceServerDeploymentContainer
 </a>
 </em>
@@ -9287,11 +9287,11 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</h3>
+<h3 id="ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</a>)
+<a href="#ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -9310,7 +9310,7 @@ ComplianceServerDeploymentPodTemplateSpec is the ComplianceServer Deployment&rsq
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">
+<a href="#ComplianceServerDeploymentPodSpec">
 ComplianceServerDeploymentPodSpec
 </a>
 </em>
@@ -9331,11 +9331,11 @@ Spec is the ComplianceServer Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</h3>
+<h3 id="ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeployment">ComplianceServerDeployment</a>)
+<a href="#ComplianceServerDeployment">ComplianceServerDeployment</a>)
 
 </p>
 <p>
@@ -9354,7 +9354,7 @@ ComplianceServerDeploymentSpec defines configuration for the ComplianceServer De
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodTemplateSpec">
+<a href="#ComplianceServerDeploymentPodTemplateSpec">
 ComplianceServerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -9371,11 +9371,11 @@ Template describes the ComplianceServer Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</h3>
+<h3 id="ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -9394,7 +9394,7 @@ ComplianceSnapshotterDeployment is the configuration for the compliance snapshot
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentSpec">
+<a href="#ComplianceSnapshotterDeploymentSpec">
 ComplianceSnapshotterDeploymentSpec
 </a>
 </em>
@@ -9415,11 +9415,11 @@ Spec is the specification of the compliance snapshotter Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentContainer">ComplianceSnapshotterDeploymentContainer</h3>
+<h3 id="ComplianceSnapshotterDeploymentContainer">ComplianceSnapshotterDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9475,11 +9475,11 @@ If omitted, the compliance snapshotter Deployment will use its default value for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentInitContainer">ComplianceSnapshotterDeploymentInitContainer</h3>
+<h3 id="ComplianceSnapshotterDeploymentInitContainer">ComplianceSnapshotterDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9535,11 +9535,11 @@ If omitted, the compliance snapshotter Deployment will use its default value for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</h3>
+<h3 id="ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -9558,7 +9558,7 @@ ComplianceSnapshotterDeploymentPodSpec is the compliance snapshotter Deployment&
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentInitContainer">
+<a href="#ComplianceSnapshotterDeploymentInitContainer">
 []ComplianceSnapshotterDeploymentInitContainer
 </a>
 </em>
@@ -9580,7 +9580,7 @@ If omitted, the compliance snapshotter Deployment will use its default values fo
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentContainer">
+<a href="#ComplianceSnapshotterDeploymentContainer">
 []ComplianceSnapshotterDeploymentContainer
 </a>
 </em>
@@ -9599,11 +9599,11 @@ If omitted, the compliance snapshotter Deployment will use its default values fo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</h3>
+<h3 id="ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</a>)
 
 </p>
 <p>
@@ -9622,7 +9622,7 @@ ComplianceSnapshotterDeploymentPodTemplateSpec is the compliance snapshotter Dep
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">
+<a href="#ComplianceSnapshotterDeploymentPodSpec">
 ComplianceSnapshotterDeploymentPodSpec
 </a>
 </em>
@@ -9643,11 +9643,11 @@ Spec is the compliance snapshotter Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</h3>
+<h3 id="ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</a>)
+<a href="#ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</a>)
 
 </p>
 <p>
@@ -9666,7 +9666,7 @@ ComplianceSnapshotterDeploymentSpec defines configuration for the compliance sna
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodTemplateSpec">
+<a href="#ComplianceSnapshotterDeploymentPodTemplateSpec">
 ComplianceSnapshotterDeploymentPodTemplateSpec
 </a>
 </em>
@@ -9683,11 +9683,11 @@ Template describes the compliance snapshotter Deployment pod that will be create
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</h3>
+<h3 id="ComplianceSpec">ComplianceSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>)
+<a href="#Compliance">Compliance</a>)
 
 </p>
 <p>
@@ -9706,7 +9706,7 @@ ComplianceSpec defines the desired state of Tigera compliance reporting capabili
 
 <code>complianceControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeployment">
+<a href="#ComplianceControllerDeployment">
 ComplianceControllerDeployment
 </a>
 </em>
@@ -9726,7 +9726,7 @@ ComplianceControllerDeployment configures the Compliance Controller Deployment.
 
 <code>complianceSnapshotterDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeployment">
+<a href="#ComplianceSnapshotterDeployment">
 ComplianceSnapshotterDeployment
 </a>
 </em>
@@ -9746,7 +9746,7 @@ ComplianceSnapshotterDeployment configures the Compliance Snapshotter Deployment
 
 <code>complianceBenchmarkerDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">
+<a href="#ComplianceBenchmarkerDaemonSet">
 ComplianceBenchmarkerDaemonSet
 </a>
 </em>
@@ -9766,7 +9766,7 @@ ComplianceBenchmarkerDaemonSet configures the Compliance Benchmarker DaemonSet.
 
 <code>complianceServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeployment">
+<a href="#ComplianceServerDeployment">
 ComplianceServerDeployment
 </a>
 </em>
@@ -9786,7 +9786,7 @@ ComplianceServerDeployment configures the Compliance Server Deployment.
 
 <code>complianceReporterPodTemplate</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplate">
+<a href="#ComplianceReporterPodTemplate">
 ComplianceReporterPodTemplate
 </a>
 </em>
@@ -9803,11 +9803,11 @@ ComplianceReporterPodTemplate configures the Compliance Reporter PodTemplate.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceStatus">ComplianceStatus</h3>
+<h3 id="ComplianceStatus">ComplianceStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>)
+<a href="#Compliance">Compliance</a>)
 
 </p>
 <p>
@@ -9861,12 +9861,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComponentName">ComponentName
+<h3 id="ComponentName">ComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComponentResource">ComponentResource</a>)
+<a href="#ComponentResource">ComponentResource</a>)
 
 </p>
 <p>
@@ -9875,11 +9875,11 @@ ComponentName represents a single component.
 <p>
 One of: Node, Typha, KubeControllers
 </p>
-<h3 id="operator.tigera.io/v1.ComponentResource">ComponentResource</h3>
+<h3 id="ComponentResource">ComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -9899,7 +9899,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentName">
+<a href="#ComponentName">
 ComponentName
 </a>
 </em>
@@ -9934,33 +9934,33 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ConditionStatus">ConditionStatus
+<h3 id="ConditionStatus">ConditionStatus
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 ConditionStatus represents the status of a particular condition. A condition may be one of: True, False, Unknown.
 </p>
-<h3 id="operator.tigera.io/v1.ContainerIPForwardingType">ContainerIPForwardingType
+<h3 id="ContainerIPForwardingType">ContainerIPForwardingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
 ContainerIPForwardingType specifies whether the CNI config for container ip forwarding is enabled.
 </p>
-<h3 id="operator.tigera.io/v1.DashboardsJob">DashboardsJob</h3>
+<h3 id="DashboardsJob">DashboardsJob</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -9979,7 +9979,7 @@ DashboardsJob is the configuration for the Dashboards job.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobSpec">
+<a href="#DashboardsJobSpec">
 DashboardsJobSpec
 </a>
 </em>
@@ -10000,11 +10000,11 @@ Spec is the specification of the dashboards job.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobContainer">DashboardsJobContainer</h3>
+<h3 id="DashboardsJobContainer">DashboardsJobContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodSpec">DashboardsJobPodSpec</a>)
+<a href="#DashboardsJobPodSpec">DashboardsJobPodSpec</a>)
 
 </p>
 <p>
@@ -10060,11 +10060,11 @@ If omitted, the Dashboard Job will use its default value for this container&rsqu
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobPodSpec">DashboardsJobPodSpec</h3>
+<h3 id="DashboardsJobPodSpec">DashboardsJobPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</a>)
+<a href="#DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -10083,7 +10083,7 @@ DashboardsJobPodSpec is the Dashboards job&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobContainer">
+<a href="#DashboardsJobContainer">
 []DashboardsJobContainer
 </a>
 </em>
@@ -10102,11 +10102,11 @@ If omitted, the Dashboard job will use its default values for its containers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</h3>
+<h3 id="DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobSpec">DashboardsJobSpec</a>)
+<a href="#DashboardsJobSpec">DashboardsJobSpec</a>)
 
 </p>
 <p>
@@ -10125,7 +10125,7 @@ DashboardsJobPodTemplateSpec is the Dashboards job&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodSpec">
+<a href="#DashboardsJobPodSpec">
 DashboardsJobPodSpec
 </a>
 </em>
@@ -10146,11 +10146,11 @@ Spec is the Dashboard job&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobSpec">DashboardsJobSpec</h3>
+<h3 id="DashboardsJobSpec">DashboardsJobSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJob">DashboardsJob</a>)
+<a href="#DashboardsJob">DashboardsJob</a>)
 
 </p>
 <p>
@@ -10169,7 +10169,7 @@ DashboardsJobSpec defines configuration for the Dashboards job.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodTemplateSpec">
+<a href="#DashboardsJobPodTemplateSpec">
 DashboardsJobPodTemplateSpec
 </a>
 </em>
@@ -10186,22 +10186,22 @@ Template describes the Dashboards job pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DataType">DataType
+<h3 id="DataType">DataType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Index">Index</a>)
+<a href="#Index">Index</a>)
 
 </p>
 <p>
 DataType represent the type of data stored
 </p>
-<h3 id="operator.tigera.io/v1.DexDeployment">DexDeployment</h3>
+<h3 id="DexDeployment">DexDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -10220,7 +10220,7 @@ DexDeployment is the configuration for the Dex Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentSpec">
+<a href="#DexDeploymentSpec">
 DexDeploymentSpec
 </a>
 </em>
@@ -10241,11 +10241,11 @@ Spec is the specification of the Dex Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentContainer">DexDeploymentContainer</h3>
+<h3 id="DexDeploymentContainer">DexDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
+<a href="#DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10301,11 +10301,11 @@ If omitted, the Dex Deployment will use its default value for this container&rsq
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentInitContainer">DexDeploymentInitContainer</h3>
+<h3 id="DexDeploymentInitContainer">DexDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
+<a href="#DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10361,11 +10361,11 @@ If omitted, the Dex Deployment will use its default value for this init containe
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentPodSpec">DexDeploymentPodSpec</h3>
+<h3 id="DexDeploymentPodSpec">DexDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</a>)
+<a href="#DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -10384,7 +10384,7 @@ DexDeploymentPodSpec is the Dex Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentInitContainer">
+<a href="#DexDeploymentInitContainer">
 []DexDeploymentInitContainer
 </a>
 </em>
@@ -10406,7 +10406,7 @@ If omitted, the Dex Deployment will use its default values for its init containe
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentContainer">
+<a href="#DexDeploymentContainer">
 []DexDeploymentContainer
 </a>
 </em>
@@ -10425,11 +10425,11 @@ If omitted, the Dex Deployment will use its default values for its containers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</h3>
+<h3 id="DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentSpec">DexDeploymentSpec</a>)
+<a href="#DexDeploymentSpec">DexDeploymentSpec</a>)
 
 </p>
 <p>
@@ -10448,7 +10448,7 @@ DexDeploymentPodTemplateSpec is the Dex Deployment&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodSpec">
+<a href="#DexDeploymentPodSpec">
 DexDeploymentPodSpec
 </a>
 </em>
@@ -10469,11 +10469,11 @@ Spec is the Dex Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentSpec">DexDeploymentSpec</h3>
+<h3 id="DexDeploymentSpec">DexDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeployment">DexDeployment</a>)
+<a href="#DexDeployment">DexDeployment</a>)
 
 </p>
 <p>
@@ -10492,7 +10492,7 @@ DexDeploymentSpec defines configuration for the Dex Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodTemplateSpec">
+<a href="#DexDeploymentPodTemplateSpec">
 DexDeploymentPodTemplateSpec
 </a>
 </em>
@@ -10509,11 +10509,11 @@ Template describes the Dex Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSet">ECKOperatorStatefulSet</h3>
+<h3 id="ECKOperatorStatefulSet">ECKOperatorStatefulSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -10532,7 +10532,7 @@ ECKOperatorStatefulSet is the configuration for the ECKOperator StatefulSet.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetSpec">
+<a href="#ECKOperatorStatefulSetSpec">
 ECKOperatorStatefulSetSpec
 </a>
 </em>
@@ -10553,11 +10553,11 @@ Spec is the specification of the ECKOperator StatefulSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetContainer">ECKOperatorStatefulSetContainer</h3>
+<h3 id="ECKOperatorStatefulSetContainer">ECKOperatorStatefulSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
+<a href="#ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
 
 </p>
 <p>
@@ -10613,11 +10613,11 @@ If omitted, the ECKOperator StatefulSet will use its default value for this cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetInitContainer">ECKOperatorStatefulSetInitContainer</h3>
+<h3 id="ECKOperatorStatefulSetInitContainer">ECKOperatorStatefulSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
+<a href="#ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
 
 </p>
 <p>
@@ -10672,11 +10672,11 @@ If omitted, the ECKOperator StatefulSet will use its default value for this init
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</h3>
+<h3 id="ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</a>)
+<a href="#ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -10695,7 +10695,7 @@ ECKOperatorStatefulSetPodSpec is the ECKOperator StatefulSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetInitContainer">
+<a href="#ECKOperatorStatefulSetInitContainer">
 []ECKOperatorStatefulSetInitContainer
 </a>
 </em>
@@ -10717,7 +10717,7 @@ If omitted, the ECKOperator StatefulSet will use its default values for its init
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetContainer">
+<a href="#ECKOperatorStatefulSetContainer">
 []ECKOperatorStatefulSetContainer
 </a>
 </em>
@@ -10736,11 +10736,11 @@ If omitted, the ECKOperator StatefulSet will use its default values for its cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</h3>
+<h3 id="ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</a>)
+<a href="#ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</a>)
 
 </p>
 <p>
@@ -10759,7 +10759,7 @@ ECKOperatorStatefulSetPodTemplateSpec is the ECKOperator StatefulSet&rsquo;s Pod
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">
+<a href="#ECKOperatorStatefulSetPodSpec">
 ECKOperatorStatefulSetPodSpec
 </a>
 </em>
@@ -10780,11 +10780,11 @@ Spec is the ECKOperator StatefulSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</h3>
+<h3 id="ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSet">ECKOperatorStatefulSet</a>)
+<a href="#ECKOperatorStatefulSet">ECKOperatorStatefulSet</a>)
 
 </p>
 <p>
@@ -10803,7 +10803,7 @@ ECKOperatorStatefulSetSpec defines configuration for the ECKOperator StatefulSet
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodTemplateSpec">
+<a href="#ECKOperatorStatefulSetPodTemplateSpec">
 ECKOperatorStatefulSetPodTemplateSpec
 </a>
 </em>
@@ -10820,11 +10820,11 @@ Template describes the ECKOperator StatefulSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentContainer">EGWDeploymentContainer</h3>
+<h3 id="EGWDeploymentContainer">EGWDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10881,11 +10881,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
+<h3 id="EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10942,11 +10942,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeployment">EKSLogForwarderDeployment</h3>
+<h3 id="EKSLogForwarderDeployment">EKSLogForwarderDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <p>
@@ -10965,7 +10965,7 @@ EKSLogForwarderDeployment is the configuration for the EKSLogForwarder Deploymen
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentSpec">
+<a href="#EKSLogForwarderDeploymentSpec">
 EKSLogForwarderDeploymentSpec
 </a>
 </em>
@@ -10986,11 +10986,11 @@ Spec is the specification of the EKSLogForwarder Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentContainer">EKSLogForwarderDeploymentContainer</h3>
+<h3 id="EKSLogForwarderDeploymentContainer">EKSLogForwarderDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
+<a href="#EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -11046,11 +11046,11 @@ If omitted, the EKSLogForwarder Deployment will use its default value for this c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentInitContainer">EKSLogForwarderDeploymentInitContainer</h3>
+<h3 id="EKSLogForwarderDeploymentInitContainer">EKSLogForwarderDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
+<a href="#EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -11106,11 +11106,11 @@ If omitted, the EKSLogForwarder Deployment will use its default value for this i
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</h3>
+<h3 id="EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</a>)
+<a href="#EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11129,7 +11129,7 @@ EKSLogForwarderDeploymentPodSpec is the EKSLogForwarder Deployment&rsquo;s PodSp
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentInitContainer">
+<a href="#EKSLogForwarderDeploymentInitContainer">
 []EKSLogForwarderDeploymentInitContainer
 </a>
 </em>
@@ -11151,7 +11151,7 @@ If omitted, the EKSLogForwarder Deployment will use its default values for its i
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentContainer">
+<a href="#EKSLogForwarderDeploymentContainer">
 []EKSLogForwarderDeploymentContainer
 </a>
 </em>
@@ -11170,11 +11170,11 @@ If omitted, the EKSLogForwarder Deployment will use its default values for its c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</h3>
+<h3 id="EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</a>)
+<a href="#EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</a>)
 
 </p>
 <p>
@@ -11193,7 +11193,7 @@ EKSLogForwarderDeploymentPodTemplateSpec is the EKSLogForwarder Deployment&rsquo
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">
+<a href="#EKSLogForwarderDeploymentPodSpec">
 EKSLogForwarderDeploymentPodSpec
 </a>
 </em>
@@ -11214,11 +11214,11 @@ Spec is the EKSLogForwarder Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</h3>
+<h3 id="EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeployment">EKSLogForwarderDeployment</a>)
+<a href="#EKSLogForwarderDeployment">EKSLogForwarderDeployment</a>)
 
 </p>
 <p>
@@ -11237,7 +11237,7 @@ EKSLogForwarderDeploymentSpec defines configuration for the EKSLogForwarder Depl
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodTemplateSpec">
+<a href="#EKSLogForwarderDeploymentPodTemplateSpec">
 EKSLogForwarderDeploymentPodTemplateSpec
 </a>
 </em>
@@ -11254,11 +11254,11 @@ Template describes the EKSLogForwarder Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
+<h3 id="EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11277,7 +11277,7 @@ EgressGatewayDeploymentPodSpec is the Egress Gateway Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentInitContainer">
+<a href="#EGWDeploymentInitContainer">
 []EGWDeploymentInitContainer
 </a>
 </em>
@@ -11299,7 +11299,7 @@ If omitted, the EGW Deployment will use its default values for its init containe
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentContainer">
+<a href="#EGWDeploymentContainer">
 []EGWDeploymentContainer
 </a>
 </em>
@@ -11434,11 +11434,11 @@ PriorityClassName allows to specify a PriorityClass resource to be used.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
+<h3 id="EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -11457,7 +11457,7 @@ EgressGatewayDeploymentPodTemplateSpec is the EGW Deployment&rsquo;s PodTemplate
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayMetadata">
+<a href="#EgressGatewayMetadata">
 EgressGatewayMetadata
 </a>
 </em>
@@ -11478,7 +11478,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">
+<a href="#EgressGatewayDeploymentPodSpec">
 EgressGatewayDeploymentPodSpec
 </a>
 </em>
@@ -11499,11 +11499,11 @@ Spec is the EGW Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
+<h3 id="EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -11544,7 +11544,7 @@ Default: 90
 
 <code>icmpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ICMPProbe">
+<a href="#ICMPProbe">
 ICMPProbe
 </a>
 </em>
@@ -11566,7 +11566,7 @@ fail. Timeout must be greater than interval.
 
 <code>httpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HTTPProbe">
+<a href="#HTTPProbe">
 HTTPProbe
 </a>
 </em>
@@ -11585,11 +11585,11 @@ fail. Timeout must be greater than interval.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayIPPool">EgressGatewayIPPool</h3>
+<h3 id="EgressGatewayIPPool">EgressGatewayIPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <table>
@@ -11638,11 +11638,11 @@ CIDR is the IPPool CIDR that the Egress Gateways can use.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayMetadata">EgressGatewayMetadata</h3>
+<h3 id="EgressGatewayMetadata">EgressGatewayMetadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11700,11 +11700,11 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</h3>
+<h3 id="EgressGatewaySpec">EgressGatewaySpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -11741,7 +11741,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -11782,7 +11782,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -11803,7 +11803,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -11823,7 +11823,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -11847,7 +11847,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -11864,11 +11864,11 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayStatus">EgressGatewayStatus</h3>
+<h3 id="EgressGatewayStatus">EgressGatewayStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -11922,11 +11922,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EksCloudwatchLogsSpec">EksCloudwatchLogsSpec</h3>
+<h3 id="EksCloudwatchLogsSpec">EksCloudwatchLogsSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">AdditionalLogSourceSpec</a>)
+<a href="#AdditionalLogSourceSpec">AdditionalLogSourceSpec</a>)
 
 </p>
 <p>
@@ -12014,11 +12014,11 @@ Default: 60
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</h3>
+<h3 id="ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -12037,7 +12037,7 @@ ElasticsearchMetricsDeployment is the configuration for the tigera-elasticsearch
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentSpec">
+<a href="#ElasticsearchMetricsDeploymentSpec">
 ElasticsearchMetricsDeploymentSpec
 </a>
 </em>
@@ -12058,11 +12058,11 @@ Spec is the specification of the ElasticsearchMetrics Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentContainer">ElasticsearchMetricsDeploymentContainer</h3>
+<h3 id="ElasticsearchMetricsDeploymentContainer">ElasticsearchMetricsDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -12118,11 +12118,11 @@ If omitted, the ElasticsearchMetrics Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentInitContainer">ElasticsearchMetricsDeploymentInitContainer</h3>
+<h3 id="ElasticsearchMetricsDeploymentInitContainer">ElasticsearchMetricsDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -12178,11 +12178,11 @@ If omitted, the ElasticsearchMetrics Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</h3>
+<h3 id="ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -12201,7 +12201,7 @@ ElasticsearchMetricsDeploymentPodSpec is the tElasticsearchMetricsDeployment&rsq
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentInitContainer">
+<a href="#ElasticsearchMetricsDeploymentInitContainer">
 []ElasticsearchMetricsDeploymentInitContainer
 </a>
 </em>
@@ -12223,7 +12223,7 @@ If omitted, the ElasticsearchMetrics Deployment will use its default values for 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentContainer">
+<a href="#ElasticsearchMetricsDeploymentContainer">
 []ElasticsearchMetricsDeploymentContainer
 </a>
 </em>
@@ -12242,11 +12242,11 @@ If omitted, the ElasticsearchMetrics Deployment will use its default values for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</h3>
+<h3 id="ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</a>)
 
 </p>
 <p>
@@ -12265,7 +12265,7 @@ ElasticsearchMetricsDeploymentPodTemplateSpec is the ElasticsearchMetricsDeploym
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">
+<a href="#ElasticsearchMetricsDeploymentPodSpec">
 ElasticsearchMetricsDeploymentPodSpec
 </a>
 </em>
@@ -12286,11 +12286,11 @@ Spec is the ElasticsearchMetrics Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</h3>
+<h3 id="ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</a>)
+<a href="#ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</a>)
 
 </p>
 <p>
@@ -12309,7 +12309,7 @@ ElasticsearchMetricsDeploymentSpec defines configuration for the ElasticsearchMe
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodTemplateSpec">
+<a href="#ElasticsearchMetricsDeploymentPodTemplateSpec">
 ElasticsearchMetricsDeploymentPodTemplateSpec
 </a>
 </em>
@@ -12326,20 +12326,20 @@ Template describes the ElasticsearchMetrics Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EmailVerificationType">EmailVerificationType
+<h3 id="EmailVerificationType">EmailVerificationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.EncapsulationType">EncapsulationType
+<h3 id="EncapsulationType">EncapsulationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -12348,12 +12348,12 @@ EncapsulationType is the type of encapsulation to use on an IP pool.
 <p>
 One of: IPIP, VXLAN, IPIPCrossSubnet, VXLANCrossSubnet, None
 </p>
-<h3 id="operator.tigera.io/v1.EncryptionOption">EncryptionOption
+<h3 id="EncryptionOption">EncryptionOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</a>)
+<a href="#SyslogStoreSpec">SyslogStoreSpec</a>)
 
 </p>
 <p>
@@ -12362,11 +12362,11 @@ EncryptionOption specifies the traffic encryption mode when connecting to a Sysl
 <p>
 One of: None, TLS
 </p>
-<h3 id="operator.tigera.io/v1.Endpoint">Endpoint</h3>
+<h3 id="Endpoint">Endpoint</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ServiceMonitor">ServiceMonitor</a>)
+<a href="#ServiceMonitor">ServiceMonitor</a>)
 
 </p>
 <p>
@@ -12527,11 +12527,11 @@ More info: <a href="https://prometheus.io/docs/prometheus/latest/configuration/c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EnvoySettings">EnvoySettings</h3>
+<h3 id="EnvoySettings">EnvoySettings</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -12584,11 +12584,11 @@ manipulating various headers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ExternalPrometheus">ExternalPrometheus</h3>
+<h3 id="ExternalPrometheus">ExternalPrometheus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.MonitorSpec">MonitorSpec</a>)
+<a href="#MonitorSpec">MonitorSpec</a>)
 
 </p>
 <table>
@@ -12604,7 +12604,7 @@ manipulating various headers.
 
 <code>serviceMonitor</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ServiceMonitor">
+<a href="#ServiceMonitor">
 ServiceMonitor
 </a>
 </em>
@@ -12644,19 +12644,19 @@ must be created before the operator will create Prometheus resources.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FIPSMode">FIPSMode
+<h3 id="FIPSMode">FIPSMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSet">FluentdDaemonSet</h3>
+<h3 id="FluentdDaemonSet">FluentdDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <p>
@@ -12675,7 +12675,7 @@ FluentdDaemonSet is the configuration for the Fluentd DaemonSet.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetSpec">
+<a href="#FluentdDaemonSetSpec">
 FluentdDaemonSetSpec
 </a>
 </em>
@@ -12696,11 +12696,11 @@ Spec is the specification of the Fluentd DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetContainer">FluentdDaemonSetContainer</h3>
+<h3 id="FluentdDaemonSetContainer">FluentdDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
+<a href="#FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -12756,11 +12756,11 @@ If omitted, the Fluentd DaemonSet will use its default value for this container&
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetInitContainer">FluentdDaemonSetInitContainer</h3>
+<h3 id="FluentdDaemonSetInitContainer">FluentdDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
+<a href="#FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -12816,11 +12816,11 @@ If omitted, the Fluentd DaemonSet will use its default value for this init conta
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</h3>
+<h3 id="FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</a>)
+<a href="#FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -12839,7 +12839,7 @@ FluentdDaemonSetPodSpec is the Fluentd DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetInitContainer">
+<a href="#FluentdDaemonSetInitContainer">
 []FluentdDaemonSetInitContainer
 </a>
 </em>
@@ -12861,7 +12861,7 @@ If omitted, the Fluentd DaemonSet will use its default values for its init conta
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetContainer">
+<a href="#FluentdDaemonSetContainer">
 []FluentdDaemonSetContainer
 </a>
 </em>
@@ -12880,11 +12880,11 @@ If omitted, the Fluentd DaemonSet will use its default values for its containers
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</h3>
+<h3 id="FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetSpec">FluentdDaemonSetSpec</a>)
+<a href="#FluentdDaemonSetSpec">FluentdDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -12903,7 +12903,7 @@ FluentdDaemonSetPodTemplateSpec is the Fluentd DaemonSet&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodSpec">
+<a href="#FluentdDaemonSetPodSpec">
 FluentdDaemonSetPodSpec
 </a>
 </em>
@@ -12924,11 +12924,11 @@ Spec is the Fluentd DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetSpec">FluentdDaemonSetSpec</h3>
+<h3 id="FluentdDaemonSetSpec">FluentdDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSet">FluentdDaemonSet</a>)
+<a href="#FluentdDaemonSet">FluentdDaemonSet</a>)
 
 </p>
 <p>
@@ -12947,7 +12947,7 @@ FluentdDaemonSetSpec defines configuration for the Fluentd DaemonSet.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodTemplateSpec">
+<a href="#FluentdDaemonSetPodTemplateSpec">
 FluentdDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -12964,11 +12964,11 @@ Template describes the Fluentd DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GroupSearch">GroupSearch</h3>
+<h3 id="GroupSearch">GroupSearch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</a>)
+<a href="#AuthenticationLDAP">AuthenticationLDAP</a>)
 
 </p>
 <p>
@@ -13040,7 +13040,7 @@ The attribute of the group that represents its name. This attribute can be used 
 
 <code>userMatchers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.UserMatch">
+<a href="#UserMatch">
 []UserMatch
 </a>
 </em>
@@ -13058,11 +13058,11 @@ attribute value.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeployment">GuardianDeployment</h3>
+<h3 id="GuardianDeployment">GuardianDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
+<a href="#ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
 
 </p>
 <p>
@@ -13081,7 +13081,7 @@ GuardianDeployment is the configuration for the guardian Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentSpec">
+<a href="#GuardianDeploymentSpec">
 GuardianDeploymentSpec
 </a>
 </em>
@@ -13102,11 +13102,11 @@ Spec is the specification of the guardian Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentContainer">GuardianDeploymentContainer</h3>
+<h3 id="GuardianDeploymentContainer">GuardianDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
+<a href="#GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -13162,11 +13162,11 @@ If omitted, the guardian Deployment will use its default value for this containe
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentInitContainer">GuardianDeploymentInitContainer</h3>
+<h3 id="GuardianDeploymentInitContainer">GuardianDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
+<a href="#GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -13221,11 +13221,11 @@ If omitted, the guardian Deployment will use its default value for this init con
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</h3>
+<h3 id="GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</a>)
+<a href="#GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -13244,7 +13244,7 @@ GuardianDeploymentPodSpec is the guardian Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentInitContainer">
+<a href="#GuardianDeploymentInitContainer">
 []GuardianDeploymentInitContainer
 </a>
 </em>
@@ -13266,7 +13266,7 @@ If omitted, the guardian Deployment will use its default values for its init con
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentContainer">
+<a href="#GuardianDeploymentContainer">
 []GuardianDeploymentContainer
 </a>
 </em>
@@ -13285,11 +13285,11 @@ If omitted, the guardian Deployment will use its default values for its containe
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</h3>
+<h3 id="GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentSpec">GuardianDeploymentSpec</a>)
+<a href="#GuardianDeploymentSpec">GuardianDeploymentSpec</a>)
 
 </p>
 <p>
@@ -13308,7 +13308,7 @@ GuardianDeploymentPodTemplateSpec is the guardian Deployment&rsquo;s PodTemplate
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodSpec">
+<a href="#GuardianDeploymentPodSpec">
 GuardianDeploymentPodSpec
 </a>
 </em>
@@ -13329,11 +13329,11 @@ Spec is the guardian Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentSpec">GuardianDeploymentSpec</h3>
+<h3 id="GuardianDeploymentSpec">GuardianDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeployment">GuardianDeployment</a>)
+<a href="#GuardianDeployment">GuardianDeployment</a>)
 
 </p>
 <p>
@@ -13352,7 +13352,7 @@ GuardianDeploymentSpec defines configuration for the guardian Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodTemplateSpec">
+<a href="#GuardianDeploymentPodTemplateSpec">
 GuardianDeploymentPodTemplateSpec
 </a>
 </em>
@@ -13369,11 +13369,11 @@ Template describes the guardian Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HTTPProbe">HTTPProbe</h3>
+<h3 id="HTTPProbe">HTTPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -13445,12 +13445,12 @@ Default: 30
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HostPortsType">HostPortsType
+<h3 id="HostPortsType">HostPortsType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -13459,11 +13459,11 @@ HostPortsType specifies host port support.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.ICMPProbe">ICMPProbe</h3>
+<h3 id="ICMPProbe">ICMPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -13535,19 +13535,19 @@ Default: 15
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPAMPluginType">IPAMPluginType
+<h3 id="IPAMPluginType">IPAMPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPAMSpec">IPAMSpec</a>)
+<a href="#IPAMSpec">IPAMSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IPAMSpec">IPAMSpec</h3>
+<h3 id="IPAMSpec">IPAMSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -13566,7 +13566,7 @@ IPAMSpec contains configuration for pod IP address management.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMPluginType">
+<a href="#IPAMPluginType">
 IPAMPluginType
 </a>
 </em>
@@ -13594,11 +13594,11 @@ Default: Calico
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPPool">IPPool</h3>
+<h3 id="IPPool">IPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -13648,7 +13648,7 @@ CIDR contains the address range for the IP Pool in classless inter-domain routin
 
 <code>encapsulation</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncapsulationType">
+<a href="#EncapsulationType">
 EncapsulationType
 </a>
 </em>
@@ -13670,7 +13670,7 @@ Default: IPIP
 
 <code>natOutgoing</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NATOutgoingType">
+<a href="#NATOutgoingType">
 NATOutgoingType
 </a>
 </em>
@@ -13749,7 +13749,7 @@ Default: false
 
 <code>allowedUses</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPPoolAllowedUse">
+<a href="#IPPoolAllowedUse">
 []IPPoolAllowedUse
 </a>
 </em>
@@ -13766,19 +13766,19 @@ AllowedUse controls what the IP pool will be used for.  If not specified or empt
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPPoolAllowedUse">IPPoolAllowedUse
+<h3 id="IPPoolAllowedUse">IPPoolAllowedUse
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.Image">Image</h3>
+<h3 id="Image">Image</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</a>)
+<a href="#ImageSetSpec">ImageSetSpec</a>)
 
 </p>
 <table>
@@ -13829,11 +13829,11 @@ The field should not include a leading <code>@</code> and must be prefixed with 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</h3>
+<h3 id="ImageSetSpec">ImageSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>)
+<a href="#ImageSet">ImageSet</a>)
 
 </p>
 <p>
@@ -13852,7 +13852,7 @@ ImageSetSpec defines the desired state of ImageSet.
 
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -13869,11 +13869,11 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Index">Index</h3>
+<h3 id="Index">Index</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -13911,7 +13911,7 @@ excludes the numerical identifier suffix)
 
 <code>dataType</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DataType">
+<a href="#DataType">
 DataType
 </a>
 </em>
@@ -13927,11 +13927,11 @@ DataType represents the type of data stored in the defined index
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Indices">Indices</h3>
+<h3 id="Indices">Indices</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -13965,12 +13965,12 @@ Replicas defines how many replicas each index will have. See <a href="https://ww
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationSpec">InstallationSpec</h3>
+<h3 id="InstallationSpec">InstallationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#Installation">Installation</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -13989,7 +13989,7 @@ InstallationSpec defines configuration for a Calico or Calico Enterprise install
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -14117,7 +14117,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -14140,7 +14140,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -14160,7 +14160,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -14180,7 +14180,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -14359,7 +14359,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -14381,7 +14381,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -14403,7 +14403,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -14423,7 +14423,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -14443,7 +14443,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -14462,7 +14462,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -14482,7 +14482,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -14502,7 +14502,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -14522,7 +14522,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -14541,7 +14541,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -14562,7 +14562,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -14582,7 +14582,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -14617,11 +14617,11 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationStatus">InstallationStatus</h3>
+<h3 id="InstallationStatus">InstallationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>)
+<a href="#Installation">Installation</a>)
 
 </p>
 <p>
@@ -14640,7 +14640,7 @@ InstallationStatus defines the observed state of the Calico or Calico Enterprise
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -14696,7 +14696,7 @@ that is being used. If an ImageSet is not being used then this will not be set.
 
 <code>computed</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -14753,19 +14753,19 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionComponentName">IntrusionDetectionComponentName
+<h3 id="IntrusionDetectionComponentName">IntrusionDetectionComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</a>)
+<a href="#IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</h3>
+<h3 id="IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <p>
@@ -14784,7 +14784,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentName">
+<a href="#IntrusionDetectionComponentName">
 IntrusionDetectionComponentName
 </a>
 </em>
@@ -14819,11 +14819,11 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</h3>
+<h3 id="IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <p>
@@ -14842,7 +14842,7 @@ IntrusionDetectionControllerDeployment is the configuration for the IntrusionDet
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentSpec">
+<a href="#IntrusionDetectionControllerDeploymentSpec">
 IntrusionDetectionControllerDeploymentSpec
 </a>
 </em>
@@ -14863,11 +14863,11 @@ Spec is the specification of the IntrusionDetectionController Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentContainer">IntrusionDetectionControllerDeploymentContainer</h3>
+<h3 id="IntrusionDetectionControllerDeploymentContainer">IntrusionDetectionControllerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -14923,11 +14923,11 @@ If omitted, the IntrusionDetection Deployment will use its default value for thi
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentInitContainer">IntrusionDetectionControllerDeploymentInitContainer</h3>
+<h3 id="IntrusionDetectionControllerDeploymentInitContainer">IntrusionDetectionControllerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -14983,11 +14983,11 @@ If omitted, the IntrusionDetectionController Deployment will use its default val
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</h3>
+<h3 id="IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -15006,7 +15006,7 @@ IntrusionDetectionControllerDeploymentPodSpec is the IntrusionDetectionControlle
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentInitContainer">
+<a href="#IntrusionDetectionControllerDeploymentInitContainer">
 []IntrusionDetectionControllerDeploymentInitContainer
 </a>
 </em>
@@ -15028,7 +15028,7 @@ If omitted, the IntrusionDetectionController Deployment will use its default val
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentContainer">
+<a href="#IntrusionDetectionControllerDeploymentContainer">
 []IntrusionDetectionControllerDeploymentContainer
 </a>
 </em>
@@ -15047,11 +15047,11 @@ If omitted, the IntrusionDetectionController Deployment will use its default val
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</h3>
+<h3 id="IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -15070,7 +15070,7 @@ IntrusionDetectionControllerDeploymentPodTemplateSpec is the IntrusionDetectionC
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">
+<a href="#IntrusionDetectionControllerDeploymentPodSpec">
 IntrusionDetectionControllerDeploymentPodSpec
 </a>
 </em>
@@ -15091,11 +15091,11 @@ Spec is the IntrusionDetectionController Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</h3>
+<h3 id="IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</a>)
+<a href="#IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</a>)
 
 </p>
 <p>
@@ -15114,7 +15114,7 @@ IntrusionDetectionControllerDeploymentSpec defines configuration for the Intrusi
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodTemplateSpec">
+<a href="#IntrusionDetectionControllerDeploymentPodTemplateSpec">
 IntrusionDetectionControllerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -15131,11 +15131,11 @@ Template describes the IntrusionDetectionController Deployment pod that will be 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</h3>
+<h3 id="IntrusionDetectionSpec">IntrusionDetectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>)
+<a href="#IntrusionDetection">IntrusionDetection</a>)
 
 </p>
 <p>
@@ -15154,7 +15154,7 @@ IntrusionDetectionSpec defines the desired state of Tigera intrusion detection c
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">
+<a href="#IntrusionDetectionComponentResource">
 []IntrusionDetectionComponentResource
 </a>
 </em>
@@ -15175,7 +15175,7 @@ Only DeepPacketInspection is supported for this spec.
 
 <code>anomalyDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+<a href="#AnomalyDetectionSpec">
 AnomalyDetectionSpec
 </a>
 </em>
@@ -15195,7 +15195,7 @@ AnomalyDetection is now deprecated, and configuring it has no effect.
 
 <code>intrusionDetectionControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeployment">
+<a href="#IntrusionDetectionControllerDeployment">
 IntrusionDetectionControllerDeployment
 </a>
 </em>
@@ -15212,11 +15212,11 @@ IntrusionDetectionControllerDeployment configures the IntrusionDetection Control
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionStatus">IntrusionDetectionStatus</h3>
+<h3 id="IntrusionDetectionStatus">IntrusionDetectionStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>)
+<a href="#IntrusionDetection">IntrusionDetection</a>)
 
 </p>
 <p>
@@ -15270,11 +15270,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Kibana">Kibana</h3>
+<h3 id="Kibana">Kibana</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -15293,7 +15293,7 @@ Kibana is the configuration for the Kibana.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaSpec">
+<a href="#KibanaSpec">
 KibanaSpec
 </a>
 </em>
@@ -15314,11 +15314,11 @@ Spec is the specification of the Kibana.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaContainer">KibanaContainer</h3>
+<h3 id="KibanaContainer">KibanaContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaPodSpec">KibanaPodSpec</a>)
+<a href="#KibanaPodSpec">KibanaPodSpec</a>)
 
 </p>
 <p>
@@ -15374,11 +15374,11 @@ If omitted, the Kibana will use its default value for this container&rsquo;s res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaInitContainer">KibanaInitContainer</h3>
+<h3 id="KibanaInitContainer">KibanaInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaPodSpec">KibanaPodSpec</a>)
+<a href="#KibanaPodSpec">KibanaPodSpec</a>)
 
 </p>
 <p>
@@ -15435,11 +15435,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaPodSpec">KibanaPodSpec</h3>
+<h3 id="KibanaPodSpec">KibanaPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaPodTemplateSpec">KibanaPodTemplateSpec</a>)
+<a href="#KibanaPodTemplateSpec">KibanaPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -15458,7 +15458,7 @@ KibanaPodSpec is the Kibana Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaInitContainer">
+<a href="#KibanaInitContainer">
 []KibanaInitContainer
 </a>
 </em>
@@ -15480,7 +15480,7 @@ If omitted, the Kibana Deployment will use its default values for its init conta
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaContainer">
+<a href="#KibanaContainer">
 []KibanaContainer
 </a>
 </em>
@@ -15499,11 +15499,11 @@ If omitted, the Kibana Deployment will use its default values for its containers
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaPodTemplateSpec">KibanaPodTemplateSpec</h3>
+<h3 id="KibanaPodTemplateSpec">KibanaPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaSpec">KibanaSpec</a>)
+<a href="#KibanaSpec">KibanaSpec</a>)
 
 </p>
 <p>
@@ -15522,7 +15522,7 @@ KibanaPodTemplateSpec is the Kibana&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaPodSpec">
+<a href="#KibanaPodSpec">
 KibanaPodSpec
 </a>
 </em>
@@ -15543,11 +15543,11 @@ Spec is the Kibana&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaSpec">KibanaSpec</h3>
+<h3 id="KibanaSpec">KibanaSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Kibana">Kibana</a>)
+<a href="#Kibana">Kibana</a>)
 
 </p>
 <table>
@@ -15563,7 +15563,7 @@ Spec is the Kibana&rsquo;s PodSpec.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaPodTemplateSpec">
+<a href="#KibanaPodTemplateSpec">
 KibanaPodTemplateSpec
 </a>
 </em>
@@ -15580,12 +15580,12 @@ Template describes the Kibana pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
+<h3 id="KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</a>)
+<a href="#NodeAddressAutodetection">NodeAddressAutodetection</a>)
 
 </p>
 <p>
@@ -15594,11 +15594,11 @@ KubernetesAutodetectionMethod is a method of detecting an IP address based on th
 <p>
 One of: NodeInternalIP
 </p>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</h3>
+<h3 id="L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <p>
@@ -15617,7 +15617,7 @@ L7LogCollectorDaemonSet is the configuration for the L7LogCollector DaemonSet.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetSpec">
+<a href="#L7LogCollectorDaemonSetSpec">
 L7LogCollectorDaemonSetSpec
 </a>
 </em>
@@ -15638,11 +15638,11 @@ Spec is the specification of the L7LogCollector DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetContainer">L7LogCollectorDaemonSetContainer</h3>
+<h3 id="L7LogCollectorDaemonSetContainer">L7LogCollectorDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
+<a href="#L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -15698,11 +15698,11 @@ If omitted, the L7LogCollector DaemonSet will use its default value for this con
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetInitContainer">L7LogCollectorDaemonSetInitContainer</h3>
+<h3 id="L7LogCollectorDaemonSetInitContainer">L7LogCollectorDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
+<a href="#L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -15757,11 +15757,11 @@ If omitted, the L7LogCollector DaemonSet will use its default value for this ini
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</h3>
+<h3 id="L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</a>)
+<a href="#L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -15780,7 +15780,7 @@ L7LogCollectorDaemonSetPodSpec is the L7LogCollector DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetInitContainer">
+<a href="#L7LogCollectorDaemonSetInitContainer">
 []L7LogCollectorDaemonSetInitContainer
 </a>
 </em>
@@ -15802,7 +15802,7 @@ If omitted, the L7LogCollector DaemonSet will use its default values for its ini
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetContainer">
+<a href="#L7LogCollectorDaemonSetContainer">
 []L7LogCollectorDaemonSetContainer
 </a>
 </em>
@@ -15821,11 +15821,11 @@ If omitted, the L7LogCollector DaemonSet will use its default values for its con
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</h3>
+<h3 id="L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</a>)
+<a href="#L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -15844,7 +15844,7 @@ L7LogCollectorDaemonSetPodTemplateSpec is the L7LogCollector DaemonSet&rsquo;s P
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">
+<a href="#L7LogCollectorDaemonSetPodSpec">
 L7LogCollectorDaemonSetPodSpec
 </a>
 </em>
@@ -15865,11 +15865,11 @@ Spec is the L7LogCollector DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</h3>
+<h3 id="L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</a>)
+<a href="#L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</a>)
 
 </p>
 <p>
@@ -15888,7 +15888,7 @@ L7LogCollectorDaemonSetSpec defines configuration for the L7LogCollector DaemonS
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodTemplateSpec">
+<a href="#L7LogCollectorDaemonSetPodTemplateSpec">
 L7LogCollectorDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -15905,12 +15905,12 @@ Template describes the L7LogCollector DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeployment">LinseedDeployment</h3>
+<h3 id="LinseedDeployment">LinseedDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>, 
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>, 
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -15929,7 +15929,7 @@ LinseedDeployment is the configuration for the linseed Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentSpec">
+<a href="#LinseedDeploymentSpec">
 LinseedDeploymentSpec
 </a>
 </em>
@@ -15950,11 +15950,11 @@ Spec is the specification of the linseed Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentContainer">LinseedDeploymentContainer</h3>
+<h3 id="LinseedDeploymentContainer">LinseedDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
+<a href="#LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -16010,11 +16010,11 @@ If omitted, the linseed Deployment will use its default value for this container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentInitContainer">LinseedDeploymentInitContainer</h3>
+<h3 id="LinseedDeploymentInitContainer">LinseedDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
+<a href="#LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -16070,11 +16070,11 @@ If omitted, the linseed Deployment will use its default value for this init cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</h3>
+<h3 id="LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</a>)
+<a href="#LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -16093,7 +16093,7 @@ LinseedDeploymentPodSpec is the linseed Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentInitContainer">
+<a href="#LinseedDeploymentInitContainer">
 []LinseedDeploymentInitContainer
 </a>
 </em>
@@ -16115,7 +16115,7 @@ If omitted, the linseed Deployment will use its default values for its init cont
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentContainer">
+<a href="#LinseedDeploymentContainer">
 []LinseedDeploymentContainer
 </a>
 </em>
@@ -16134,11 +16134,11 @@ If omitted, the linseed Deployment will use its default values for its container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</h3>
+<h3 id="LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentSpec">LinseedDeploymentSpec</a>)
+<a href="#LinseedDeploymentSpec">LinseedDeploymentSpec</a>)
 
 </p>
 <p>
@@ -16157,7 +16157,7 @@ LinseedDeploymentPodTemplateSpec is the linseed Deployment&rsquo;s PodTemplateSp
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">
+<a href="#LinseedDeploymentPodSpec">
 LinseedDeploymentPodSpec
 </a>
 </em>
@@ -16178,11 +16178,11 @@ Spec is the linseed Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentSpec">LinseedDeploymentSpec</h3>
+<h3 id="LinseedDeploymentSpec">LinseedDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">LinseedDeployment</a>)
+<a href="#LinseedDeployment">LinseedDeployment</a>)
 
 </p>
 <p>
@@ -16201,7 +16201,7 @@ LinseedDeploymentSpec defines configuration for the linseed Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">
+<a href="#LinseedDeploymentPodTemplateSpec">
 LinseedDeploymentPodTemplateSpec
 </a>
 </em>
@@ -16218,12 +16218,12 @@ Template describes the linseed Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinuxDataplaneOption">LinuxDataplaneOption
+<h3 id="LinuxDataplaneOption">LinuxDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -16232,11 +16232,11 @@ LinuxDataplaneOption controls which dataplane is to be used on Linux nodes.
 <p>
 One of: Iptables, BPF
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</h3>
+<h3 id="LogCollectionSpec">LogCollectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -16252,7 +16252,7 @@ One of: Iptables, BPF
 
 <code>collectLogs</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionStatusType">
+<a href="#LogCollectionStatusType">
 LogCollectionStatusType
 </a>
 </em>
@@ -16310,19 +16310,19 @@ Default: -1
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectionStatusType">LogCollectionStatusType
+<h3 id="LogCollectionStatusType">LogCollectionStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</a>)
+<a href="#LogCollectionSpec">LogCollectionSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</h3>
+<h3 id="LogCollectorSpec">LogCollectorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>)
+<a href="#LogCollector">LogCollector</a>)
 
 </p>
 <p>
@@ -16341,7 +16341,7 @@ LogCollectorSpec defines the desired state of Tigera flow, audit, and DNS log co
 
 <code>additionalStores</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">
+<a href="#AdditionalLogStoreSpec">
 AdditionalLogStoreSpec
 </a>
 </em>
@@ -16361,7 +16361,7 @@ Configuration for exporting flow, audit, and DNS logs to external storage.
 
 <code>additionalSources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">
+<a href="#AdditionalLogSourceSpec">
 AdditionalLogSourceSpec
 </a>
 </em>
@@ -16381,7 +16381,7 @@ Configuration for importing audit logs from managed kubernetes cluster log sourc
 
 <code>collectProcessPath</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CollectProcessPathOption">
+<a href="#CollectProcessPathOption">
 CollectProcessPathOption
 </a>
 </em>
@@ -16422,7 +16422,7 @@ the management cluster&rsquo;s tenant services are running.
 
 <code>fluentdDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSet">
+<a href="#FluentdDaemonSet">
 FluentdDaemonSet
 </a>
 </em>
@@ -16441,7 +16441,7 @@ FluentdDaemonSet configures the Fluentd DaemonSet.
 
 <code>eksLogForwarderDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeployment">
+<a href="#EKSLogForwarderDeployment">
 EKSLogForwarderDeployment
 </a>
 </em>
@@ -16458,11 +16458,11 @@ EKSLogForwarderDeployment configures the EKSLogForwarderDeployment Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectorStatus">LogCollectorStatus</h3>
+<h3 id="LogCollectorStatus">LogCollectorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>)
+<a href="#LogCollector">LogCollector</a>)
 
 </p>
 <p>
@@ -16516,31 +16516,31 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogLevel">LogLevel
+<h3 id="LogLevel">LogLevel
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNILogging">CNILogging</a>, 
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#CNILogging">CNILogging</a>, 
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogStorageComponentName">LogStorageComponentName
+<h3 id="LogStorageComponentName">LogStorageComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">LogStorageComponentResource</a>)
+<a href="#LogStorageComponentResource">LogStorageComponentResource</a>)
 
 </p>
 <p>
 LogStorageComponentName CRD enum
 </p>
-<h3 id="operator.tigera.io/v1.LogStorageComponentResource">LogStorageComponentResource</h3>
+<h3 id="LogStorageComponentResource">LogStorageComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -16559,7 +16559,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentName">
+<a href="#LogStorageComponentName">
 LogStorageComponentName
 </a>
 </em>
@@ -16595,11 +16595,11 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</h3>
+<h3 id="LogStorageSpec">LogStorageSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>)
+<a href="#LogStorage">LogStorage</a>)
 
 </p>
 <p>
@@ -16618,7 +16618,7 @@ LogStorageSpec defines the desired state of Tigera flow and DNS log storage.
 
 <code>nodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Nodes">
+<a href="#Nodes">
 Nodes
 </a>
 </em>
@@ -16637,7 +16637,7 @@ Nodes defines the configuration for a set of identical Elasticsearch cluster nod
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Indices">
+<a href="#Indices">
 Indices
 </a>
 </em>
@@ -16657,7 +16657,7 @@ Index defines the configuration for the indices in the Elasticsearch cluster.
 
 <code>retention</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Retention">
+<a href="#Retention">
 Retention
 </a>
 </em>
@@ -16719,7 +16719,7 @@ each of the indicated key-value pairs as labels as well as access to the specifi
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">
+<a href="#LogStorageComponentResource">
 []LogStorageComponentResource
 </a>
 </em>
@@ -16740,7 +16740,7 @@ Only ECKOperator is supported for this spec.
 
 <code>eckOperatorStatefulSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSet">
+<a href="#ECKOperatorStatefulSet">
 ECKOperatorStatefulSet
 </a>
 </em>
@@ -16761,7 +16761,7 @@ ComponentResources, then these overrides take precedence.
 
 <code>kibana</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Kibana">
+<a href="#Kibana">
 Kibana
 </a>
 </em>
@@ -16781,7 +16781,7 @@ Kibana configures the Kibana Spec.
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -16800,7 +16800,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>elasticsearchMetricsDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeployment">
+<a href="#ElasticsearchMetricsDeployment">
 ElasticsearchMetricsDeployment
 </a>
 </em>
@@ -16816,11 +16816,11 @@ ElasticsearchMetricsDeployment configures the tigera-elasticsearch-metric Deploy
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorageStatus">LogStorageStatus</h3>
+<h3 id="LogStorageStatus">LogStorageStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>)
+<a href="#LogStorage">LogStorage</a>)
 
 </p>
 <p>
@@ -16910,11 +16910,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Logging">Logging</h3>
+<h3 id="Logging">Logging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>
@@ -16930,7 +16930,7 @@ Ready, Progressing, Degraded or other customer types.
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNILogging">
+<a href="#CNILogging">
 CNILogging
 </a>
 </em>
@@ -16947,11 +16947,11 @@ Customized logging specification for calico-cni plugin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</h3>
+<h3 id="ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>)
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>)
 
 </p>
 <p>
@@ -16989,7 +16989,7 @@ should be able to access this address. This field is used by managed clusters on
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">
+<a href="#ManagementClusterTLS">
 ManagementClusterTLS
 </a>
 </em>
@@ -17009,7 +17009,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>guardianDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeployment">
+<a href="#GuardianDeployment">
 GuardianDeployment
 </a>
 </em>
@@ -17025,11 +17025,11 @@ GuardianDeployment configures the guardian Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnectionStatus">ManagementClusterConnectionStatus</h3>
+<h3 id="ManagementClusterConnectionStatus">ManagementClusterConnectionStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>)
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>)
 
 </p>
 <p>
@@ -17066,11 +17066,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterSpec">ManagementClusterSpec</h3>
+<h3 id="ManagementClusterSpec">ManagementClusterSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementCluster">ManagementCluster</a>)
+<a href="#ManagementCluster">ManagementCluster</a>)
 
 </p>
 <p>
@@ -17109,7 +17109,7 @@ Valid examples are: &ldquo;0.0.0.0:31000&rdquo;, &ldquo;example.com:32000&rdquo;
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLS">
+<a href="#TLS">
 TLS
 </a>
 </em>
@@ -17126,11 +17126,11 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterTLS">ManagementClusterTLS</h3>
+<h3 id="ManagementClusterTLS">ManagementClusterTLS</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
+<a href="#ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
 
 </p>
 <table>
@@ -17146,7 +17146,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>ca</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CAType">
+<a href="#CAType">
 CAType
 </a>
 </em>
@@ -17172,11 +17172,11 @@ Default: Tigera
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeployment">ManagerDeployment</h3>
+<h3 id="ManagerDeployment">ManagerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerSpec">ManagerSpec</a>)
+<a href="#ManagerSpec">ManagerSpec</a>)
 
 </p>
 <p>
@@ -17195,7 +17195,7 @@ ManagerDeployment is the configuration for the Manager Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentSpec">
+<a href="#ManagerDeploymentSpec">
 ManagerDeploymentSpec
 </a>
 </em>
@@ -17216,11 +17216,11 @@ Spec is the specification of the Manager Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentContainer">ManagerDeploymentContainer</h3>
+<h3 id="ManagerDeploymentContainer">ManagerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
+<a href="#ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -17276,11 +17276,11 @@ If omitted, the Manager Deployment will use its default value for this container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentInitContainer">ManagerDeploymentInitContainer</h3>
+<h3 id="ManagerDeploymentInitContainer">ManagerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
+<a href="#ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -17337,11 +17337,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</h3>
+<h3 id="ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</a>)
+<a href="#ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -17360,7 +17360,7 @@ ManagerDeploymentPodSpec is the Manager Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentInitContainer">
+<a href="#ManagerDeploymentInitContainer">
 []ManagerDeploymentInitContainer
 </a>
 </em>
@@ -17382,7 +17382,7 @@ If omitted, the Manager Deployment will use its default values for its init cont
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentContainer">
+<a href="#ManagerDeploymentContainer">
 []ManagerDeploymentContainer
 </a>
 </em>
@@ -17401,11 +17401,11 @@ If omitted, the Manager Deployment will use its default values for its container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</h3>
+<h3 id="ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentSpec">ManagerDeploymentSpec</a>)
+<a href="#ManagerDeploymentSpec">ManagerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -17424,7 +17424,7 @@ ManagerDeploymentPodTemplateSpec is the Manager Deployment&rsquo;s PodTemplateSp
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodSpec">
+<a href="#ManagerDeploymentPodSpec">
 ManagerDeploymentPodSpec
 </a>
 </em>
@@ -17445,11 +17445,11 @@ Spec is the Manager Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentSpec">ManagerDeploymentSpec</h3>
+<h3 id="ManagerDeploymentSpec">ManagerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeployment">ManagerDeployment</a>)
+<a href="#ManagerDeployment">ManagerDeployment</a>)
 
 </p>
 <p>
@@ -17468,7 +17468,7 @@ ManagerDeploymentSpec defines configuration for the Manager Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodTemplateSpec">
+<a href="#ManagerDeploymentPodTemplateSpec">
 ManagerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -17485,11 +17485,11 @@ Template describes the Manager Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerSpec">ManagerSpec</h3>
+<h3 id="ManagerSpec">ManagerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>)
+<a href="#Manager">Manager</a>)
 
 </p>
 <p>
@@ -17508,7 +17508,7 @@ ManagerSpec defines configuration for the Calico Enterprise manager GUI.
 
 <code>managerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeployment">
+<a href="#ManagerDeployment">
 ManagerDeployment
 </a>
 </em>
@@ -17525,11 +17525,11 @@ ManagerDeployment configures the Manager Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerStatus">ManagerStatus</h3>
+<h3 id="ManagerStatus">ManagerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>)
+<a href="#Manager">Manager</a>)
 
 </p>
 <p>
@@ -17583,24 +17583,24 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Metadata">Metadata</h3>
+<h3 id="Metadata">Metadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>, 
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>, 
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
+<a href="#TyphaDeployment">TyphaDeployment</a>, 
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -17656,11 +17656,11 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MonitorSpec">MonitorSpec</h3>
+<h3 id="MonitorSpec">MonitorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -17679,7 +17679,7 @@ MonitorSpec defines the desired state of Tigera monitor.
 
 <code>externalPrometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">
+<a href="#ExternalPrometheus">
 ExternalPrometheus
 </a>
 </em>
@@ -17700,7 +17700,7 @@ scraping from git-ops tools without the need of post-installation steps.
 
 <code>prometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Prometheus">
+<a href="#Prometheus">
 Prometheus
 </a>
 </em>
@@ -17720,7 +17720,7 @@ Prometheus is the configuration for the Prometheus.
 
 <code>alertManager</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AlertManager">
+<a href="#AlertManager">
 AlertManager
 </a>
 </em>
@@ -17737,11 +17737,11 @@ AlertManager is the configuration for the AlertManager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MonitorStatus">MonitorStatus</h3>
+<h3 id="MonitorStatus">MonitorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -17795,12 +17795,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MultiInterfaceMode">MultiInterfaceMode
+<h3 id="MultiInterfaceMode">MultiInterfaceMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -17809,12 +17809,12 @@ MultiInterfaceMode describes the method of providing multiple pod interfaces.
 <p>
 One of: None, Multus
 </p>
-<h3 id="operator.tigera.io/v1.NATOutgoingType">NATOutgoingType
+<h3 id="NATOutgoingType">NATOutgoingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -17823,23 +17823,23 @@ NATOutgoingType describe the type of outgoing NAT to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.NativeIP">NativeIP
+<h3 id="NativeIP">NativeIP
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</a>)
+<a href="#AWSEgressGateway">AWSEgressGateway</a>)
 
 </p>
 <p>
 NativeIP defines if Egress Gateway pods should have AWS IPs.
 When NativeIP is enabled, the IPPools should be backed by AWS subnet.
 </p>
-<h3 id="operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</h3>
+<h3 id="NodeAddressAutodetection">NodeAddressAutodetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -17879,7 +17879,7 @@ filtering based on well-known interface names.
 
 <code>kubernetes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KubernetesAutodetectionMethod">
+<a href="#KubernetesAutodetectionMethod">
 KubernetesAutodetectionMethod
 </a>
 </em>
@@ -17970,11 +17970,11 @@ one of the provided CIDRs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeAffinity">NodeAffinity</h3>
+<h3 id="NodeAffinity">NodeAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</a>)
+<a href="#TyphaAffinity">TyphaAffinity</a>)
 
 </p>
 <p>
@@ -18043,11 +18043,11 @@ may or may not try to eventually evict the pod from its node.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeSet">NodeSet</h3>
+<h3 id="NodeSet">NodeSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Nodes">Nodes</a>)
+<a href="#Nodes">Nodes</a>)
 
 </p>
 <p>
@@ -18066,7 +18066,7 @@ NodeSets defines configuration specific to each Elasticsearch Node Set
 
 <code>selectionAttributes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeSetSelectionAttribute">
+<a href="#NodeSetSelectionAttribute">
 []NodeSetSelectionAttribute
 </a>
 </em>
@@ -18084,11 +18084,11 @@ to define Node Affinities and set the node awareness configuration in the runnin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeSetSelectionAttribute">NodeSetSelectionAttribute</h3>
+<h3 id="NodeSetSelectionAttribute">NodeSetSelectionAttribute</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeSet">NodeSet</a>)
+<a href="#NodeSet">NodeSet</a>)
 
 </p>
 <p>
@@ -18148,11 +18148,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Nodes">Nodes</h3>
+<h3 id="Nodes">Nodes</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -18188,7 +18188,7 @@ Count defines the number of nodes in the Elasticsearch cluster.
 
 <code>nodeSets</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeSet">
+<a href="#NodeSet">
 []NodeSet
 </a>
 </em>
@@ -18225,12 +18225,12 @@ ResourceRequirements defines the resource limits and requirements for the Elasti
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NonPrivilegedType">NonPrivilegedType
+<h3 id="NonPrivilegedType">NonPrivilegedType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -18239,12 +18239,12 @@ NonPrivilegedType specifies whether Calico runs as permissioned or not
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.OIDCType">OIDCType
+<h3 id="OIDCType">OIDCType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
 <p>
@@ -18252,11 +18252,11 @@ OIDCType defines how OIDC is configured for Tigera Enterprise. Dex should be the
 The Tigera option can help in specific use-cases, for instance, when you are unable to configure a client secret.
 One of: Dex, Tigera
 </p>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</h3>
+<h3 id="PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPISpec">PacketCaptureAPISpec</a>)
+<a href="#PacketCaptureAPISpec">PacketCaptureAPISpec</a>)
 
 </p>
 <p>
@@ -18275,7 +18275,7 @@ PacketCaptureAPIDeployment is the configuration for the PacketCaptureAPI Deploym
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentSpec">
+<a href="#PacketCaptureAPIDeploymentSpec">
 PacketCaptureAPIDeploymentSpec
 </a>
 </em>
@@ -18296,11 +18296,11 @@ Spec is the specification of the PacketCaptureAPI Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentContainer">PacketCaptureAPIDeploymentContainer</h3>
+<h3 id="PacketCaptureAPIDeploymentContainer">PacketCaptureAPIDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
+<a href="#PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18356,11 +18356,11 @@ If omitted, the PacketCaptureAPI Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentInitContainer">PacketCaptureAPIDeploymentInitContainer</h3>
+<h3 id="PacketCaptureAPIDeploymentInitContainer">PacketCaptureAPIDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
+<a href="#PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18416,11 +18416,11 @@ If omitted, the PacketCaptureAPI Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</h3>
+<h3 id="PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</a>)
+<a href="#PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -18439,7 +18439,7 @@ PacketCaptureAPIDeploymentPodSpec is the PacketCaptureAPI Deployment&rsquo;s Pod
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentInitContainer">
+<a href="#PacketCaptureAPIDeploymentInitContainer">
 []PacketCaptureAPIDeploymentInitContainer
 </a>
 </em>
@@ -18461,7 +18461,7 @@ If omitted, the PacketCaptureAPI Deployment will use its default values for its 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentContainer">
+<a href="#PacketCaptureAPIDeploymentContainer">
 []PacketCaptureAPIDeploymentContainer
 </a>
 </em>
@@ -18480,11 +18480,11 @@ If omitted, the PacketCaptureAPI Deployment will use its default values for its 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</h3>
+<h3 id="PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</a>)
+<a href="#PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</a>)
 
 </p>
 <p>
@@ -18503,7 +18503,7 @@ PacketCaptureAPIDeploymentPodTemplateSpec is the PacketCaptureAPI Deployment&rsq
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">
+<a href="#PacketCaptureAPIDeploymentPodSpec">
 PacketCaptureAPIDeploymentPodSpec
 </a>
 </em>
@@ -18524,11 +18524,11 @@ Spec is the PacketCaptureAPI Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</h3>
+<h3 id="PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</a>)
+<a href="#PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</a>)
 
 </p>
 <p>
@@ -18547,7 +18547,7 @@ PacketCaptureAPIDeploymentSpec defines configuration for the PacketCaptureAPI De
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodTemplateSpec">
+<a href="#PacketCaptureAPIDeploymentPodTemplateSpec">
 PacketCaptureAPIDeploymentPodTemplateSpec
 </a>
 </em>
@@ -18564,11 +18564,11 @@ Template describes the PacketCaptureAPI Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPISpec">PacketCaptureAPISpec</h3>
+<h3 id="PacketCaptureAPISpec">PacketCaptureAPISpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</a>)
+<a href="#PacketCaptureAPI">PacketCaptureAPI</a>)
 
 </p>
 <p>
@@ -18587,7 +18587,7 @@ PacketCaptureAPISpec defines configuration for the Packet Capture API.
 
 <code>packetCaptureAPIDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeployment">
+<a href="#PacketCaptureAPIDeployment">
 PacketCaptureAPIDeployment
 </a>
 </em>
@@ -18604,11 +18604,11 @@ PacketCaptureAPIDeployment configures the PacketCaptureAPI Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIStatus">PacketCaptureAPIStatus</h3>
+<h3 id="PacketCaptureAPIStatus">PacketCaptureAPIStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</a>)
+<a href="#PacketCaptureAPI">PacketCaptureAPI</a>)
 
 </p>
 <p>
@@ -18662,11 +18662,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PathMatch">PathMatch</h3>
+<h3 id="PathMatch">PathMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
+<a href="#TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
 
 </p>
 <table>
@@ -18732,11 +18732,11 @@ PathReplace if not nil will be used to replace PathRegexp matches.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeployment">PolicyRecommendationDeployment</h3>
+<h3 id="PolicyRecommendationDeployment">PolicyRecommendationDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationSpec">PolicyRecommendationSpec</a>)
+<a href="#PolicyRecommendationSpec">PolicyRecommendationSpec</a>)
 
 </p>
 <p>
@@ -18755,7 +18755,7 @@ PolicyRecommendationDeployment is the configuration for the PolicyRecommendation
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentSpec">
+<a href="#PolicyRecommendationDeploymentSpec">
 PolicyRecommendationDeploymentSpec
 </a>
 </em>
@@ -18776,11 +18776,11 @@ Spec is the specification of the PolicyRecommendation Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentContainer">PolicyRecommendationDeploymentContainer</h3>
+<h3 id="PolicyRecommendationDeploymentContainer">PolicyRecommendationDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
+<a href="#PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18836,11 +18836,11 @@ If omitted, the PolicyRecommendation Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentInitContainer">PolicyRecommendationDeploymentInitContainer</h3>
+<h3 id="PolicyRecommendationDeploymentInitContainer">PolicyRecommendationDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
+<a href="#PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18895,11 +18895,11 @@ If omitted, the PolicyRecommendation Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</h3>
+<h3 id="PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</a>)
+<a href="#PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -18918,7 +18918,7 @@ PolicyRecommendationDeploymentPodSpec is the PolicyRecommendation Deployment&rsq
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentInitContainer">
+<a href="#PolicyRecommendationDeploymentInitContainer">
 []PolicyRecommendationDeploymentInitContainer
 </a>
 </em>
@@ -18940,7 +18940,7 @@ If omitted, the PolicyRecommendation Deployment will use its default values for 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentContainer">
+<a href="#PolicyRecommendationDeploymentContainer">
 []PolicyRecommendationDeploymentContainer
 </a>
 </em>
@@ -18959,11 +18959,11 @@ If omitted, the PolicyRecommendation Deployment will use its default values for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</h3>
+<h3 id="PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</a>)
+<a href="#PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</a>)
 
 </p>
 <p>
@@ -18982,7 +18982,7 @@ PolicyRecommendationDeploymentPodTemplateSpec is the PolicyRecommendation Deploy
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">
+<a href="#PolicyRecommendationDeploymentPodSpec">
 PolicyRecommendationDeploymentPodSpec
 </a>
 </em>
@@ -19003,11 +19003,11 @@ Spec is the PolicyRecommendation Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</h3>
+<h3 id="PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeployment">PolicyRecommendationDeployment</a>)
+<a href="#PolicyRecommendationDeployment">PolicyRecommendationDeployment</a>)
 
 </p>
 <p>
@@ -19026,7 +19026,7 @@ PolicyRecommendationDeploymentSpec defines configuration for the PolicyRecommend
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodTemplateSpec">
+<a href="#PolicyRecommendationDeploymentPodTemplateSpec">
 PolicyRecommendationDeploymentPodTemplateSpec
 </a>
 </em>
@@ -19043,11 +19043,11 @@ Template describes the PolicyRecommendation Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
+<h3 id="PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
@@ -19067,7 +19067,7 @@ service.
 
 <code>policyRecommendationDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeployment">
+<a href="#PolicyRecommendationDeployment">
 PolicyRecommendationDeployment
 </a>
 </em>
@@ -19084,11 +19084,11 @@ PolicyRecommendation configures the PolicyRecommendation Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
+<h3 id="PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
@@ -19121,13 +19121,13 @@ State provides user-readable status.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ProductVariant">ProductVariant
+<h3 id="ProductVariant">ProductVariant
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#InstallationSpec">InstallationSpec</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -19136,11 +19136,11 @@ ProductVariant represents the variant of the product.
 <p>
 One of: Calico, TigeraSecureEnterprise
 </p>
-<h3 id="operator.tigera.io/v1.Prometheus">Prometheus</h3>
+<h3 id="Prometheus">Prometheus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.MonitorSpec">MonitorSpec</a>)
+<a href="#MonitorSpec">MonitorSpec</a>)
 
 </p>
 <table>
@@ -19156,7 +19156,7 @@ One of: Calico, TigeraSecureEnterprise
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PrometheusSpec">
+<a href="#PrometheusSpec">
 PrometheusSpec
 </a>
 </em>
@@ -19177,11 +19177,11 @@ Spec is the specification of the Prometheus.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PrometheusContainer">PrometheusContainer</h3>
+<h3 id="PrometheusContainer">PrometheusContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CommonPrometheusFields">CommonPrometheusFields</a>)
+<a href="#CommonPrometheusFields">CommonPrometheusFields</a>)
 
 </p>
 <p>
@@ -19237,11 +19237,11 @@ If omitted, the Prometheus will use its default value for this container&rsquo;s
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PrometheusSpec">PrometheusSpec</h3>
+<h3 id="PrometheusSpec">PrometheusSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Prometheus">Prometheus</a>)
+<a href="#Prometheus">Prometheus</a>)
 
 </p>
 <table>
@@ -19257,7 +19257,7 @@ If omitted, the Prometheus will use its default value for this container&rsquo;s
 
 <code>commonPrometheusFields</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CommonPrometheusFields">
+<a href="#CommonPrometheusFields">
 CommonPrometheusFields
 </a>
 </em>
@@ -19273,12 +19273,12 @@ CommonPrometheusFields are the options available to both the Prometheus server a
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PromptType">PromptType
+<h3 id="PromptType">PromptType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
 <p>
@@ -19286,23 +19286,23 @@ PromptType is a value that specifies whether the identity provider prompts the e
 consent.
 One of: None, Login, Consent, SelectAccount.
 </p>
-<h3 id="operator.tigera.io/v1.Provider">Provider
+<h3 id="Provider">Provider
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
 Provider represents a particular provider or flavor of Kubernetes. Valid options
 are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG.
 </p>
-<h3 id="operator.tigera.io/v1.Retention">Retention</h3>
+<h3 id="Retention">Retention</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -19444,11 +19444,11 @@ Default: 8
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.S3StoreSpec">S3StoreSpec</h3>
+<h3 id="S3StoreSpec">S3StoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -19515,11 +19515,11 @@ Path in the S3 bucket where to send logs
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SNIMatch">SNIMatch</h3>
+<h3 id="SNIMatch">SNIMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>)
+<a href="#TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>)
 
 </p>
 <table>
@@ -19549,11 +19549,11 @@ ServerName is used to match the server name for the request.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ServiceMonitor">ServiceMonitor</h3>
+<h3 id="ServiceMonitor">ServiceMonitor</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">ExternalPrometheus</a>)
+<a href="#ExternalPrometheus">ExternalPrometheus</a>)
 
 </p>
 <table>
@@ -19588,7 +19588,7 @@ Default: k8s-app=tigera-prometheus
 
 <code>endpoints</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Endpoint">
+<a href="#Endpoint">
 []Endpoint
 </a>
 </em>
@@ -19605,11 +19605,11 @@ related to connecting to our Prometheus server are automatically set by the oper
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SplunkStoreSpec">SplunkStoreSpec</h3>
+<h3 id="SplunkStoreSpec">SplunkStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -19642,22 +19642,22 @@ Location for splunk&rsquo;s http event collector end point. example <code>https:
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.StatusConditionType">StatusConditionType
+<h3 id="StatusConditionType">StatusConditionType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 StatusConditionType is a type of condition that may apply to a particular component.
 </p>
-<h3 id="operator.tigera.io/v1.Sysctl">Sysctl</h3>
+<h3 id="Sysctl">Sysctl</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -19698,12 +19698,12 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SyslogLogType">SyslogLogType
+<h3 id="SyslogLogType">SyslogLogType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</a>)
+<a href="#SyslogStoreSpec">SyslogStoreSpec</a>)
 
 </p>
 <p>
@@ -19714,11 +19714,11 @@ Allowable values are Audit, DNS, Flows and IDSEvents.
 * Flows corresponds to flow logs generated by Calico node.
 * IDSEvents corresponds to event logs for the intrusion detection system (anomaly detection, suspicious IPs, suspicious domains and global alerts).
 </p>
-<h3 id="operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</h3>
+<h3 id="SyslogStoreSpec">SyslogStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -19774,7 +19774,7 @@ Default: 1024
 
 <code>logTypes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SyslogLogType">
+<a href="#SyslogLogType">
 []SyslogLogType
 </a>
 </em>
@@ -19794,7 +19794,7 @@ Default: Audit, DNS, Flows
 
 <code>encryption</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncryptionOption">
+<a href="#EncryptionOption">
 EncryptionOption
 </a>
 </em>
@@ -19812,11 +19812,11 @@ Default: None
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLS">TLS</h3>
+<h3 id="TLS">TLS</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterSpec">ManagementClusterSpec</a>)
+<a href="#ManagementClusterSpec">ManagementClusterSpec</a>)
 
 </p>
 <table>
@@ -19866,11 +19866,11 @@ Default: tigera-management-cluster-connection
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</h3>
+<h3 id="TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRoute">TLSPassThroughRoute</a>)
+<a href="#TLSPassThroughRoute">TLSPassThroughRoute</a>)
 
 </p>
 <table>
@@ -19886,7 +19886,7 @@ Default: tigera-management-cluster-connection
 
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -19902,7 +19902,7 @@ TargetType
 
 <code>sniMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SNIMatch">
+<a href="#SNIMatch">
 SNIMatch
 </a>
 </em>
@@ -19936,11 +19936,11 @@ Destination is the destination url to proxy the request to.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</h3>
+<h3 id="TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSTerminatedRoute">TLSTerminatedRoute</a>)
+<a href="#TLSTerminatedRoute">TLSTerminatedRoute</a>)
 
 </p>
 <table>
@@ -19956,7 +19956,7 @@ Destination is the destination url to proxy the request to.
 
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -19972,7 +19972,7 @@ TargetType
 
 <code>pathMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PathMatch">
+<a href="#PathMatch">
 PathMatch
 </a>
 </em>
@@ -20087,20 +20087,20 @@ is UI.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TargetType">TargetType
+<h3 id="TargetType">TargetType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>, 
-<a href="#operator.tigera.io/v1.TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
+<a href="#TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>, 
+<a href="#TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.TenantElasticSpec">TenantElasticSpec</h3>
+<h3 id="TenantElasticSpec">TenantElasticSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <table>
@@ -20155,11 +20155,11 @@ bool
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantSpec">TenantSpec</h3>
+<h3 id="TenantSpec">TenantSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
 <table>
@@ -20209,7 +20209,7 @@ Name is a human readable name for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -20228,7 +20228,7 @@ Indices defines the how to store a tenant&rsquo;s data
 
 <code>elastic</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantElasticSpec">
+<a href="#TenantElasticSpec">
 TenantElasticSpec
 </a>
 </em>
@@ -20267,7 +20267,7 @@ in the Tenant&rsquo;s namespace. Defaults to the controlPlaneReplicas in Install
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -20286,7 +20286,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>esKubeControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -20305,7 +20305,7 @@ ESKubeControllerDeployment configures the ESKubeController Deployment.
 
 <code>dashboardsJob</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJob">
+<a href="#DashboardsJob">
 DashboardsJob
 </a>
 </em>
@@ -20321,18 +20321,18 @@ DashboardsJob configures the Dashboards job
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantStatus">TenantStatus</h3>
+<h3 id="TenantStatus">TenantStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</h3>
+<h3 id="TigeraStatusCondition">TigeraStatusCondition</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</a>)
+<a href="#TigeraStatusStatus">TigeraStatusStatus</a>)
 
 </p>
 <p>
@@ -20351,7 +20351,7 @@ TigeraStatusCondition represents a condition attached to a particular component.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.StatusConditionType">
+<a href="#StatusConditionType">
 StatusConditionType
 </a>
 </em>
@@ -20370,7 +20370,7 @@ The type of condition. May be Available, Progressing, or Degraded.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ConditionStatus">
+<a href="#ConditionStatus">
 ConditionStatus
 </a>
 </em>
@@ -20459,26 +20459,26 @@ with respect to the current state of the instance.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatusReason">TigeraStatusReason
+<h3 id="TigeraStatusReason">TigeraStatusReason
 (<code>string</code> alias)</h3>
 <p>
 TigeraStatusReason represents the reason for a particular condition.
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusSpec">TigeraStatusSpec</h3>
+<h3 id="TigeraStatusSpec">TigeraStatusSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
 TigeraStatusSpec defines the desired state of TigeraStatus
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</h3>
+<h3 id="TigeraStatusStatus">TigeraStatusStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
@@ -20497,7 +20497,7 @@ TigeraStatusStatus defines the observed state of TigeraStatus
 
 <code>conditions</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">
+<a href="#TigeraStatusCondition">
 []TigeraStatusCondition
 </a>
 </em>
@@ -20514,11 +20514,11 @@ Available, Progressing, or Degraded.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</h3>
+<h3 id="TyphaAffinity">TyphaAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -20538,7 +20538,7 @@ TyphaAffinity allows configuration of node affinity characteristics for Typha po
 
 <code>nodeAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAffinity">
+<a href="#NodeAffinity">
 NodeAffinity
 </a>
 </em>
@@ -20555,11 +20555,11 @@ NodeAffinity describes node affinity scheduling rules for typha.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</h3>
+<h3 id="TyphaDeployment">TyphaDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -20578,7 +20578,7 @@ TyphaDeployment is the configuration for the typha Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -20598,7 +20598,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">
+<a href="#TyphaDeploymentSpec">
 TyphaDeploymentSpec
 </a>
 </em>
@@ -20619,11 +20619,11 @@ Spec is the specification of the typha Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
+<h3 id="TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -20680,11 +20680,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
+<h3 id="TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -20741,11 +20741,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
+<h3 id="TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -20764,7 +20764,7 @@ TyphaDeploymentPodSpec is the typha Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentInitContainer">
+<a href="#TyphaDeploymentInitContainer">
 []TyphaDeploymentInitContainer
 </a>
 </em>
@@ -20786,7 +20786,7 @@ If omitted, the typha Deployment will use its default values for its init contai
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentContainer">
+<a href="#TyphaDeploymentContainer">
 []TyphaDeploymentContainer
 </a>
 </em>
@@ -20920,11 +20920,11 @@ WARNING: Please note that this field will override the default calico-typha Depl
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
+<h3 id="TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -20943,7 +20943,7 @@ TyphaDeploymentPodTemplateSpec is the typha Deployment&rsquo;s PodTemplateSpec
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -20964,7 +20964,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">
+<a href="#TyphaDeploymentPodSpec">
 TyphaDeploymentPodSpec
 </a>
 </em>
@@ -20985,11 +20985,11 @@ Spec is the typha Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
+<h3 id="TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>)
+<a href="#TyphaDeployment">TyphaDeployment</a>)
 
 </p>
 <p>
@@ -21029,7 +21029,7 @@ If omitted, the typha Deployment will use its default value for minReadySeconds.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">
+<a href="#TyphaDeploymentPodTemplateSpec">
 TyphaDeploymentPodTemplateSpec
 </a>
 </em>
@@ -21049,7 +21049,7 @@ Template describes the typha Deployment pod that will be created.
 
 <code>strategy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentStrategy">
+<a href="#TyphaDeploymentStrategy">
 TyphaDeploymentStrategy
 </a>
 </em>
@@ -21066,11 +21066,11 @@ The deployment strategy to use to replace existing pods with new ones.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
+<h3 id="TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -21109,11 +21109,11 @@ to be.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.UserMatch">UserMatch</h3>
+<h3 id="UserMatch">UserMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GroupSearch">GroupSearch</a>)
+<a href="#GroupSearch">GroupSearch</a>)
 
 </p>
 <p>
@@ -21163,11 +21163,11 @@ The attribute of a group that links it to a user.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.UserSearch">UserSearch</h3>
+<h3 id="UserSearch">UserSearch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</a>)
+<a href="#AuthenticationLDAP">AuthenticationLDAP</a>)
 
 </p>
 <p>
@@ -21237,27 +21237,27 @@ Default: uid
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.WAFStatusType">WAFStatusType
+<h3 id="WAFStatusType">WAFStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsDataplaneOption">WindowsDataplaneOption
+<h3 id="WindowsDataplaneOption">WindowsDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsNodeSpec">WindowsNodeSpec</h3>
+<h3 id="WindowsNodeSpec">WindowsNodeSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>

--- a/calico-cloud_versioned_docs/version-20-1/release-notes/index.mdx
+++ b/calico-cloud_versioned_docs/version-20-1/release-notes/index.mdx
@@ -320,7 +320,7 @@ For more information, see [Optimize egress networking for workloads with long-li
 
 We've added support for XFF to propagate the original IP address when proxying application layer traffic with Envoy within a Kubernetes cluster.
 
-For more information, see [Installation reference](../reference/installation/api.mdx#operator.tigera.io/v1.EnvoySettings).
+For more information, see [Installation reference](../reference/installation/api.mdx#EnvoySettings.
 
 #### Alert-only mode for workload-based Web Application Firewall (WAF)
 

--- a/calico-cloud_versioned_docs/version-20-1/threat/deeppacketinspection.mdx
+++ b/calico-cloud_versioned_docs/version-20-1/threat/deeppacketinspection.mdx
@@ -76,7 +76,7 @@ spec:
 
 ### Configure resource requirements
 
-Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionComponentResource).
+Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#IntrusionDetectionComponentResource.
 
 For a data transfer rate of 1GB/sec on workload endpoints being monitored, we recommend a minimum of 1 CPU and 1GB RAM.
 

--- a/calico-cloud_versioned_docs/version-20-1/threat/web-application-firewall.mdx
+++ b/calico-cloud_versioned_docs/version-20-1/threat/web-application-firewall.mdx
@@ -352,7 +352,7 @@ kubectl annotate svc <service-name> -n <service-namespace> projectcalico.org/l7-
 
 ### Disable WAF feature from your cluster
 
-To disable WAF, update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) resource to include the `webApplicationFirewall` field, and ensure it is set to `Disabled`.
+To disable WAF, update the [ApplicationLayer](../reference/installation/api#ApplicationLayer resource to include the `webApplicationFirewall` field, and ensure it is set to `Disabled`.
 
 Example:
 

--- a/calico-cloud_versioned_docs/version-20-1/visibility/elastic/archive-storage.mdx
+++ b/calico-cloud_versioned_docs/version-20-1/visibility/elastic/archive-storage.mdx
@@ -48,8 +48,8 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
     -n tigera-operator
    ```
 
-3. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#operator.tigera.io/v1.S3StoreSpec)
+3. Update the [LogCollector](../../reference/installation/api.mdx#LogCollector
+   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#S3StoreSpec
    with your information noted from above.
    Example:
 
@@ -76,8 +76,8 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
 </TabItem>
 <TabItem label="Syslog" value="Syslog-1">
 
-1. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+1. Update the [LogCollector](../../reference/installation/api.mdx#LogCollector
+   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec
    with your syslog information.
    Example:
    ```yaml
@@ -104,7 +104,7 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    kubectl edit logcollector tigera-secure
    ```
 2. You can control which types of {variables.prodname} log data you would like to send to syslog.
-   The [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+   The [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec
    contains a field called `logTypes` which allows you to list which log types you would like to include.
    The allowable log types are:
 
@@ -113,11 +113,11 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    - Flows
    - IDSEvents
 
-   Refer to the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec) for more details on what data each log type represents.
+   Refer to the [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec for more details on what data each log type represents.
 
    :::note
 
-   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
+   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#LogStorage configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
 
    :::
 
@@ -125,7 +125,7 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
 
 **TLS configuration**
 
-3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec).
+3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec.
 
    ```yaml
    apiVersion: operator.tigera.io/v1
@@ -182,9 +182,9 @@ In this release, only [Splunk Enterprise](https://www.splunk.com/en_us/products/
    ```
 
 3. Update the
-   [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
+   [LogCollector](../../reference/installation/api.mdx#LogCollector
    resource named `tigera-secure` to include
-   a [Splunk section](../../reference/installation/api.mdx#operator.tigera.io/v1.SplunkStoreSpec)
+   a [Splunk section](../../reference/installation/api.mdx#SplunkStoreSpec
    with your Splunk information.
    Example:
 

--- a/calico-cloud_versioned_docs/version-20-1/visibility/elastic/l7/configure.mdx
+++ b/calico-cloud_versioned_docs/version-20-1/visibility/elastic/l7/configure.mdx
@@ -70,7 +70,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
 
 **Configure the ApplicationLayer resource for L7 logs**
 
-1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) resource named, `tigera-secure` to include a logCollection section of the file, `_api.html` [here](../../../reference/installation/api.mdx).
+1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#ApplicationLayer resource named, `tigera-secure` to include a logCollection section of the file, `_api.html` [here](../../../reference/installation/api.mdx).
 
 1. Ensure that the `collectLogs` field is set to `Enabled`.
 

--- a/calico-cloud_versioned_docs/version-20-1/visibility/elastic/overview.mdx
+++ b/calico-cloud_versioned_docs/version-20-1/visibility/elastic/overview.mdx
@@ -93,7 +93,7 @@ verbs: ['get']
 - Global network policies
 - Network sets
 
-{variables.prodname} also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec).
+{variables.prodname} also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#LogCollectorSpec.
 
 ## Additional resources
 
@@ -102,4 +102,4 @@ verbs: ['get']
 - [BGP logs](bgp.mdx)
 - [DNS logs](dns/dns-logs.mdx)
 - [Archive logs](archive-storage.mdx)
-- [Log collection options](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../reference/installation/api.mdx#LogCollectorSpec

--- a/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -49,7 +49,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#Provider
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
@@ -46,4 +46,4 @@ key features like Flow Visualizer, metrics in the dashboard and Policy Board, po
 - [Configure flow log aggregation](../../../visibility/elastic/flow/aggregation.mdx)
 - [Log storage recommendations](../../../operations/logstorage/log-storage-recommendations.mdx)
 - [Archive logs](../../../visibility/elastic/archive-storage.mdx)
-- [Log collection options](../../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../../reference/installation/api.mdx#LogCollectorSpec

--- a/calico-enterprise/getting-started/install-on-clusters/windows-calico/requirements.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/windows-calico/requirements.mdx
@@ -38,7 +38,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#BGPOption.
 
 :::
 

--- a/calico-enterprise/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
@@ -116,7 +116,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
 
 1. <OpenShiftPrometheusOperator operation='upgrade' />
 
-1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster)
+1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#ManagementCluster
    CR to your cluster.
 
    ```bash
@@ -128,7 +128,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#operator.tigera.io/v1.Monitor)
+1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#Monitor
    CR to your cluster.
 
    ```bash
@@ -140,7 +140,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendation)
+1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#PolicyRecommendation
    CR to your cluster.
 
    ```bash
@@ -152,7 +152,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster was at one time v3.18 or older, remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#operator.tigera.io/v1.Manager).
+1. If your cluster was at one time v3.18 or older, remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#Manager.
 
    ```bash
    oc apply -f - <<EOF
@@ -163,7 +163,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.19 or older, apply a new [PacketCaptureAPI](../../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI)
+1. If your cluster is v3.19 or older, apply a new [PacketCaptureAPI](../../../reference/installation/api.mdx#PacketCaptureAPI
     CR to your cluster.
 
    ```bash

--- a/calico-enterprise/multicluster/fine-tune-deployment.mdx
+++ b/calico-enterprise/multicluster/fine-tune-deployment.mdx
@@ -153,4 +153,4 @@ To filter log data by a given managed cluster you can include the filter criteri
 
 # Additional resources
 
-- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection)
+- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#ManagementClusterConnection

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -49,7 +49,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#Provider
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -51,7 +51,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#Provider
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
@@ -54,7 +54,7 @@ To control managed clusters from your central management plane, you must ensure 
     ```bash
     export MANAGEMENT_CLUSTER_ADDR=<your-management-cluster-addr>
     ```
-1.  Apply the [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) CR.
+1.  Apply the [ManagementCluster](../../../reference/installation/api.mdx#ManagementCluster CR.
 
     ```bash
     kubectl apply -f - <<EOF

--- a/calico-enterprise/networking/configuring/dual-tor.mdx
+++ b/calico-enterprise/networking/configuring/dual-tor.mdx
@@ -637,7 +637,7 @@ The only connections using interface-specific addresses should be BGP.
 If you plan to use [Egress Gateways](../egress/egress-gateway-on-prem.mdx) in your cluster, you must also adjust the {variables.nodecontainer} IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-{variables.prodname} [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+{variables.prodname} [Installation resource](../../reference/installation/api.mdx#NodeAddressAutodetection.
 
 :::
 

--- a/calico-enterprise/networking/configuring/multiple-networks.mdx
+++ b/calico-enterprise/networking/configuring/multiple-networks.mdx
@@ -79,7 +79,7 @@ Although the following {variables.prodname} features are supported for your defa
 
 ### Configure cluster for multiple networks
 
-In the [Installation custom resource](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoNetworkSpec), set the `MultiInterfaceMode` to **Multus**.
+In the [Installation custom resource](../../reference/installation/api.mdx#CalicoNetworkSpec, set the `MultiInterfaceMode` to **Multus**.
 
 ### Create a new network
 

--- a/calico-enterprise/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-on-prem.mdx
@@ -350,7 +350,7 @@ To modify the iptables backend for egress gateways, you must change the `iptable
 If you plan to use Egress Gateways in a [dual-ToR cluster](../configuring/dual-tor.mdx), you must also adjust the {variables.nodecontainer} IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-{variables.prodname} [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+{variables.prodname} [Installation resource](../../reference/installation/api.mdx#NodeAddressAutodetection.
 
 ### Configure namespaces and pods to use egress gateways
 

--- a/calico-enterprise/networking/ipam/initial-ippool.mdx
+++ b/calico-enterprise/networking/ipam/initial-ippool.mdx
@@ -24,7 +24,7 @@ The **Kubernetes pod CIDR** is the expected IP address range for pod IPs. It is 
 
 [Calico IP pools](../../reference/resources/ippool.mdx) are ranges of IP addresses that Calico uses to assign to pods; the ranges must within the Kubernetes pod CIDR.
 
-The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#Installation
 resource and configures the default Calico IP pool. Note the following:
 
 - Default fields for any that are omitted:
@@ -44,7 +44,7 @@ resource and configures the default Calico IP pool. Note the following:
 ## How to
 
 1. Download the custom-resource.yaml file.
-1. Edit the [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation).
+1. Edit the [Installation resource](../../reference/installation/api.mdx#Installation.
    **Required values**: `cidr:`
    **Empty values**: Defaulted
 

--- a/calico-enterprise/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise/networking/ipam/ip-autodetection.mdx
@@ -51,7 +51,7 @@ By default, {variables.prodname} uses the **firstFound** method; the first valid
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#NodeAddressAutodetection in the operator Installation reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-enterprise/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise/operations/cnx/configure-identity-provider.mdx
@@ -17,7 +17,7 @@ Configure an external identity provider (IdP), create a user, and log in to {var
 
 ## Concepts
 
-The {variables.prodname} authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Authentication) named, `tigera-secure`.
+The {variables.prodname} authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#Authentication named, `tigera-secure`.
 
 When configuring your cluster, you may be asked for the following inputs:
 

--- a/calico-enterprise/operations/cnx/roles-and-permissions.mdx
+++ b/calico-enterprise/operations/cnx/roles-and-permissions.mdx
@@ -18,7 +18,7 @@ Self-service is an important part of your Kubernetes platform networking and net
 
 ### Kubernetes RBAC authorization
 
-The [Calico Enterprise API server](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) is an extension to the standard [Kubernetes RBAC Authorization APIs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
+The [Calico Enterprise API server](../../reference/installation/api.mdx#APIServer is an extension to the standard [Kubernetes RBAC Authorization APIs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
 
 | Features                       | RBAC controls for...                                                                                                                                                                                                                            |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/calico-enterprise/operations/comms/certificate-management.mdx
+++ b/calico-enterprise/operations/comms/certificate-management.mdx
@@ -21,7 +21,7 @@ certificate issuance, {variables.prodname} provides a simple configuration optio
 **Limitations**
 
 If your cluster is already running {variables.prodname} and you would like to enable certificate management, you need to
-temporarily remove [the logstorage resource](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+temporarily remove [the logstorage resource](../../reference/installation/api.mdx#LogStorage
 before following the steps to enable certificate management and then re-apply afterwards. For detailed steps on
 re-creating logstorage, read more on [how to create a new Elasticsearch cluster](../../visibility/elastic/troubleshoot.mdx#how-to-create-a-new-cluster).
 
@@ -40,7 +40,7 @@ Currently, this feature is not supported in combination with [Multi-cluster mana
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../../reference/installation/api.mdx#Installation
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
    ```yaml

--- a/calico-enterprise/operations/logstorage/log-storage-recommendations.mdx
+++ b/calico-enterprise/operations/logstorage/log-storage-recommendations.mdx
@@ -82,4 +82,4 @@ is no tolerance for removing/restarting a node.
 
 - Read the [LogStorage overview page](../logstorage/index.mdx)
 - [Troubleshooting Elasticsearch](../../visibility/elastic/troubleshoot.mdx)
-- [LogStorage Specification](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+- [LogStorage Specification](../../reference/installation/api.mdx#LogStorage

--- a/calico-enterprise/reference/architecture/overview.mdx
+++ b/calico-enterprise/reference/architecture/overview.mdx
@@ -124,7 +124,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### Manager
 
-**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#operator.tigera.io/v1.Manager).
+**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#Manager.
 
 ### Packet capture API
 
@@ -152,7 +152,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### API server
 
-**Main task**: Allows users to manage {variables.prodname} resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#operator.tigera.io/v1.APIServer).
+**Main task**: Allows users to manage {variables.prodname} resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#APIServer.
 
 ### BIRD
 

--- a/calico-enterprise/reference/component-resources/configuration.mdx
+++ b/calico-enterprise/reference/component-resources/configuration.mdx
@@ -241,7 +241,7 @@ By enabling this feature, you can avoid errors that can occur when a pod tries t
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](../installation/api#operator.tigera.io/v1.CalicoNetworkSpec) of the default `operator.tigera.io/v1/installation` resource.
+The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](../installation/api#CalicoNetworkSpec of the default `operator.tigera.io/v1/installation` resource.
 
 The following example configures the CNI to delay a pod from starting its containers for up to 10 seconds, or until the pod's dataplane has been programmed:
 
@@ -311,7 +311,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-2">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#Installation API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico-enterprise/reference/component-resources/configure-resources.mdx
+++ b/calico-enterprise/reference/component-resources/configure-resources.mdx
@@ -16,11 +16,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../../reference/installation/api.mdx#APIServer CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the APIServer CR using the below command:
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#APIServerDeployment, patch the APIServer CR using the below command:
 
 ```bash
 kubectl patch apiserver tigera-secure  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -68,11 +68,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## ApplicationLayer custom resource
 
-The [ApplicationLayer](../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
+The [ApplicationLayer](../../reference/installation/api.mdx#ApplicationLayer CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
 
 ### L7LogCollectorDaemonSet
 
-To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.L7LogCollectorDaemonSet), patch the ApplicationLayer CR using the below command:
+To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#L7LogCollectorDaemonSet, patch the ApplicationLayer CR using the below command:
 
 ```bash
 kubectl patch applicationlayer tigera-secure  --type=merge --patch='{"spec": {"l7LogCollectorDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"l7-collector","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"envoy-proxy","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -120,11 +120,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Authentication custom resource
 
-The [Authentication](../../reference/installation/api.mdx#operator.tigera.io/v1.Authentication) CR provides a way to configure resources for DexDeployment. The following sections provide example configurations for this CR.
+The [Authentication](../../reference/installation/api.mdx#Authentication CR provides a way to configure resources for DexDeployment. The following sections provide example configurations for this CR.
 
 ### DexDeployment
 
-To configure resource specification for the [DexDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.DexDeployment), patch the Authentication CR using the below command:
+To configure resource specification for the [DexDeployment](../../reference/installation/api.mdx#DexDeployment, patch the Authentication CR using the below command:
 
 ```bash
 kubectl patch authentication tigera-secure  --type=merge --patch='{"spec": {"dexDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-dex","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -159,13 +159,13 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Compliance custom resource
 
-The [Compliance](../../reference/installation/api.mdx#operator.tigera.io/v1.Compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
+The [Compliance](../../reference/installation/api.mdx#Compliance CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
 
 Example Configurations:
 
 ### ComplianceControllerDeployment
 
-To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceControllerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#ComplianceControllerDeployment, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -200,7 +200,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceSnapshotterDeployment
 
-To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceSnapshotterDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#ComplianceSnapshotterDeployment, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceSnapshotterDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-snapshotter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -235,7 +235,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceBenchmarkerDaemonSet
 
-To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#ComplianceBenchmarkerDaemonSet, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceBenchmarkerDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-benchmarker","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -270,7 +270,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceServerDeployment
 
-To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceServerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#ComplianceServerDeployment, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -305,7 +305,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceReporterPodTemplate.
 
-To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceReporterPodTemplate), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#ComplianceReporterPodTemplate, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceReporterPodTemplate": {"template": {"spec": {"containers":[{"name":"reporter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}'
@@ -344,7 +344,7 @@ The [Installation CR](../../reference/installation/api.mdx) provides a way to co
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#TyphaDeployment, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -379,7 +379,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#calicoNodeDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -414,7 +414,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#calicoNodeWindowsDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -449,7 +449,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#CalicoKubeControllersDeployment component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -485,7 +485,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#CSINodeDriverDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -533,11 +533,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## IntrusionDetection custom resource
 
-The [IntrusionDetection](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
+The [IntrusionDetection](../../reference/installation/api.mdx#IntrusionDetection CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
 
 ### IntrusionDetectionControllerDeployment.
 
-To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionControllerDeployment), patch the IntrusionDetection CR using the below command:
+To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#IntrusionDetectionControllerDeployment, patch the IntrusionDetection CR using the below command:
 
 ```bash
 kubectl patch intrusiondetection tigera-secure  --type=merge --patch='{"spec": {"intrusionDetectionControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"webhooks-processor","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}},{"name":"controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -585,11 +585,11 @@ This command will output the configured resource requests and limits for the Int
 
 ## LogCollector custom resource
 
-The [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
+The [LogCollector](../../reference/installation/api.mdx#LogCollector CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
 
 ### FluentdDaemonSet.
 
-To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.FluentdDaemonSet), patch the LogCollector CR using the below command:
+To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#FluentdDaemonSet, patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"fluentdDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"fluentd","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -624,7 +624,7 @@ This command will output the configured resource requests and limits for the Flu
 
 ### EKSLogForwarderDeployment.
 
-To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.EKSLogForwarderDeployment), patch the LogCollector CR using the below command:
+To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#EKSLogForwarderDeployment, patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"eksLogForwarderDeployment": {"spec": {"template": {"spec": {"containers":[{"name":"eks-log-forwarder","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -659,11 +659,11 @@ This command will output the configured resource requests and limits for the EKS
 
 ## LogStorage custom resource
 
-The [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) CR provides a way to configure resources for ECKOperatorStatefulSet, Kibana, LinseedDeployment, ElasticsearchMetricsDeployment. The following sections provide example configurations for this CR.
+The [LogStorage](../../reference/installation/api.mdx#LogStorage CR provides a way to configure resources for ECKOperatorStatefulSet, Kibana, LinseedDeployment, ElasticsearchMetricsDeployment. The following sections provide example configurations for this CR.
 
 ### ECKOperatorStatefulSet.
 
-To configure resource specification for the [ECKOperatorStatefulSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ECKOperatorStatefulSet), patch the LogStorage CR using the below command:
+To configure resource specification for the [ECKOperatorStatefulSet](../../reference/installation/api.mdx#ECKOperatorStatefulSet, patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"eckOperatorStatefulSet":{"spec": {"template": {"spec": {"containers":[{"name":"manager","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -698,7 +698,7 @@ This command will output the configured resource requests and limits for the ECK
 
 ### Kibana
 
-To configure resource specification for the [Kibana](../../reference/installation/api.mdx#operator.tigera.io/v1.Kibana), patch the LogStorage CR using the below command:
+To configure resource specification for the [Kibana](../../reference/installation/api.mdx#Kibana, patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"kibana":{"spec": {"template": {"spec": {"containers":[{"name":"kibana","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -733,7 +733,7 @@ This command will output the configured resource requests and limits for the Kib
 
 ### LinseedDeployment
 
-To configure resource specification for the [LinseedDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.LinseedDeployment), patch the LogStorage CR using the below command:
+To configure resource specification for the [LinseedDeployment](../../reference/installation/api.mdx#LinseedDeployment, patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"linseedDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-linseed","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -768,7 +768,7 @@ This command will output the configured resource requests and limits for the Lin
 
 ### ElasticsearchMetricsDeployment
 
-To configure resource specification for the [ElasticsearchMetricsDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ElasticsearchMetricsDeployment), patch the LogStorage CR using the below command:
+To configure resource specification for the [ElasticsearchMetricsDeployment](../../reference/installation/api.mdx#ElasticsearchMetricsDeployment, patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"elasticsearchMetricsDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-elasticsearch-metrics","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -803,11 +803,11 @@ This command will output the configured resource requests and limits for the Ela
 
 ## ManagementClusterConnection custom resource
 
-The [ManagementClusterConnection](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
+The [ManagementClusterConnection](../../reference/installation/api.mdx#ManagementClusterConnection CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
 
 ### GuardianDeployment
 
-To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.GuardianDeployment), patch the ManagementClusterConnection CR using the below command:
+To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#GuardianDeployment, patch the ManagementClusterConnection CR using the below command:
 
 ```bash
 kubectl patch managementclusterconnection tigera-secure  --type=merge --patch='{"spec": {"guardianDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-guardian","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -842,11 +842,11 @@ This command will output the configured resource requests and limits for the Gua
 
 ## Manager custom resource
 
-The [Manager](../../reference/installation/api.mdx#operator.tigera.io/v1.Manager) CR provides a way to configure resources for ManagerDeployment. The following sections provide example configurations for this CR.
+The [Manager](../../reference/installation/api.mdx#Manager CR provides a way to configure resources for ManagerDeployment. The following sections provide example configurations for this CR.
 
 ### ManagerDeployment
 
-To configure resource specification for the [ManagerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagerDeployment), patch the Manager CR using the below command:
+To configure resource specification for the [ManagerDeployment](../../reference/installation/api.mdx#ManagerDeployment, patch the Manager CR using the below command:
 
 ```bash
 kubectl patch manager tigera-secure  --type=merge --patch='{"spec": {"managerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-voltron","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-es-proxy","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-manager","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -908,11 +908,11 @@ This command will output the configured resource requests and limits for the Man
 
 ## Monitor custom resource
 
-The [Monitor](../../reference/installation/api.mdx#operator.tigera.io/v1.Monitor) CR provides a way to configure resources for Prometheus, AlertManager. The following sections provide example configurations for this CR.
+The [Monitor](../../reference/installation/api.mdx#Monitor CR provides a way to configure resources for Prometheus, AlertManager. The following sections provide example configurations for this CR.
 
 ### Prometheus
 
-To configure resource specification for the [Prometheus](../../reference/installation/api.mdx#operator.tigera.io/v1.Prometheus), Resources for the default container "prometheus" can be configured using the "resources" field under "commonPrometheusFields". For all other injected containers, such as "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
+To configure resource specification for the [Prometheus](../../reference/installation/api.mdx#Prometheus, Resources for the default container "prometheus" can be configured using the "resources" field under "commonPrometheusFields". For all other injected containers, such as "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
 
 ```bash
 kubectl patch monitor tigera-secure --type=merge --patch='{"spec": {"prometheus": {"spec":{ "commonPrometheusFields": {"resources": {"limits": {"cpu":"500m","memory":"500Mi"}, "requests": {"cpu":"50m", "memory":"50Mi"}}, "containers":[{"name":"authn-proxy","resources":{"limits": {"cpu":"250m","memory":"500Mi"},"requests": {"cpu":"25m","memory":"50Mi"}}}]}}}}}'
@@ -977,7 +977,7 @@ The "config-reloader" container has default resource values set based by the Pro
 
 ### AlertManager
 
-To configure resource specification for the [AlertManager](../../reference/installation/api.mdx#operator.tigera.io/v1.AlertManager),  you can set resources for the default container "prometheus" using the "resources" field under "commonPrometheusFields". For all other injected containers, like "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
+To configure resource specification for the [AlertManager](../../reference/installation/api.mdx#AlertManager,  you can set resources for the default container "prometheus" using the "resources" field under "commonPrometheusFields". For all other injected containers, like "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
 
 ```bash
 kubectl patch monitor tigera-secure  --type=merge --patch='{"spec": {"alertManager": {"spec": {"resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}}}}'
@@ -1029,11 +1029,11 @@ The "config-reloader" container has default resource values set by the AlertMana
 
 ## PacketCaptureAPI custom resource
 
-The [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
+The [PacketCaptureAPI](../../reference/installation/api.mdx#PacketCaptureAPI CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
 
 ### PacketCaptureAPIDeployment
 
-To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI), patch the PacketCapture CR using the below command:
+To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#PacketCaptureAPI, patch the PacketCapture CR using the below command:
 
 ```bash
 kubectl patch packetcaptureapis tigera-secure  --type=merge --patch='{"spec": {"packetCaptureAPIDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-packetcapture-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -1068,11 +1068,11 @@ This command will output the configured resource requests and limits for the Pac
 
 ## PolicyRecommendation custom resource
 
-The [PolicyRecommendation](../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendation) CR provides a way to configure resources for PolicyRecommendation. The following sections provide example configurations for this CR.
+The [PolicyRecommendation](../../reference/installation/api.mdx#PolicyRecommendation CR provides a way to configure resources for PolicyRecommendation. The following sections provide example configurations for this CR.
 
 ### PolicyRecommendationDeployment
 
-To configure resource specification for the [PolicyRecommendationDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendationDeployment), patch the PolicyRecommendation CR using the below command:
+To configure resource specification for the [PolicyRecommendationDeployment](../../reference/installation/api.mdx#PolicyRecommendationDeployment, patch the PolicyRecommendation CR using the below command:
 
 ```bash
 kubectl patch policyrecommendation tigera-secure  --type=merge --patch='{"spec": {"policyRecommendationDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"policy-recommendation-controller","resources":{"requests":{"cpu":"100m", "memory":"100Mi"},"limits":{"cpu":"1", "memory":"512Mi"}}}]}}}}}}'
@@ -1116,11 +1116,11 @@ The provided example illustrates configuring the apiserver component. Follow a s
 
 ### APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
+The [APIServer](../../reference/installation/api.mdx#APIServer CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
 
 #### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), update values.yaml with the appropriate resource values.
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#APIServerDeployment, update values.yaml with the appropriate resource values.
 
 ```bash
 apiServer:

--- a/calico-enterprise/reference/component-resources/typha/prometheus.mdx
+++ b/calico-enterprise/reference/component-resources/typha/prometheus.mdx
@@ -7,7 +7,7 @@ import variables from '@site/calico-enterprise/variables';
 # Prometheus metrics
 
 Typha can be configured to report a number of metrics through Prometheus. The Prometheus port can be controlled
-via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#operator.tigera.io/v1.Installation).
+via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#Installation.
 
 ## Metric reference
 

--- a/calico-enterprise/reference/installation/_api.mdx
+++ b/calico-enterprise/reference/installation/_api.mdx
@@ -15,47 +15,47 @@ API Schema definitions for configuring the installation of Calico and Calico Ent
 </p>
 Resource Types:
 <ul><li>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>
+<a href="#APIServer">APIServer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>
+<a href="#ApplicationLayer">ApplicationLayer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>
+<a href="#Authentication">Authentication</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>
+<a href="#Compliance">Compliance</a>
 </li><li>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>
+<a href="#EgressGateway">EgressGateway</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>
+<a href="#ImageSet">ImageSet</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>
+<a href="#Installation">Installation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>
+<a href="#IntrusionDetection">IntrusionDetection</a>
 </li><li>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>
+<a href="#LogCollector">LogCollector</a>
 </li><li>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>
+<a href="#LogStorage">LogStorage</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ManagementCluster">ManagementCluster</a>
+<a href="#ManagementCluster">ManagementCluster</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>
+<a href="#Manager">Manager</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>
+<a href="#Monitor">Monitor</a>
 </li><li>
-<a href="#operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</a>
+<a href="#PacketCaptureAPI">PacketCaptureAPI</a>
 </li><li>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>
+<a href="#PolicyRecommendation">PolicyRecommendation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TLSPassThroughRoute">TLSPassThroughRoute</a>
+<a href="#TLSPassThroughRoute">TLSPassThroughRoute</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TLSTerminatedRoute">TLSTerminatedRoute</a>
+<a href="#TLSTerminatedRoute">TLSTerminatedRoute</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>
+<a href="#Tenant">Tenant</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>
+<a href="#TigeraStatus">TigeraStatus</a>
 </li></ul>
-<h3 id="operator.tigera.io/v1.APIServer">APIServer</h3>
+<h3 id="APIServer">APIServer</h3>
 <p>
 APIServer installs the Tigera API server and related resources. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo; or &ldquo;tigera-secure&rdquo;.
@@ -116,7 +116,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerSpec">
+<a href="#APIServerSpec">
 APIServerSpec
 </a>
 </em>
@@ -134,7 +134,7 @@ Specification of the desired state for the Tigera API server.
 <td>
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -158,7 +158,7 @@ take precedence.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerStatus">
+<a href="#APIServerStatus">
 APIServerStatus
 </a>
 </em>
@@ -174,7 +174,7 @@ Most recently observed status for the Tigera API server.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</h3>
+<h3 id="ApplicationLayer">ApplicationLayer</h3>
 <p>
 ApplicationLayer is the Schema for the applicationlayers API
 </p>
@@ -234,7 +234,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">
+<a href="#ApplicationLayerSpec">
 ApplicationLayerSpec
 </a>
 </em>
@@ -249,7 +249,7 @@ ApplicationLayerSpec
 <td>
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -269,7 +269,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -288,7 +288,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -308,7 +308,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -327,7 +327,7 @@ User-configurable settings for the Envoy proxy.
 
 <code>l7LogCollectorDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSet">
+<a href="#L7LogCollectorDaemonSet">
 L7LogCollectorDaemonSet
 </a>
 </em>
@@ -350,7 +350,7 @@ L7LogCollectorDaemonSet configures the L7LogCollector DaemonSet.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerStatus">
+<a href="#ApplicationLayerStatus">
 ApplicationLayerStatus
 </a>
 </em>
@@ -363,7 +363,7 @@ ApplicationLayerStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Authentication">Authentication</h3>
+<h3 id="Authentication">Authentication</h3>
 <p>
 Authentication is the Schema for the authentications API
 </p>
@@ -423,7 +423,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">
+<a href="#AuthenticationSpec">
 AuthenticationSpec
 </a>
 </em>
@@ -495,7 +495,7 @@ ClusterRoleBindings into Elastic.
 
 <code>oidc</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">
+<a href="#AuthenticationOIDC">
 AuthenticationOIDC
 </a>
 </em>
@@ -515,7 +515,7 @@ OIDC contains the configuration needed to setup OIDC authentication.
 
 <code>openshift</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOpenshift">
+<a href="#AuthenticationOpenshift">
 AuthenticationOpenshift
 </a>
 </em>
@@ -535,7 +535,7 @@ Openshift contains the configuration needed to setup Openshift OAuth authenticat
 
 <code>ldap</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">
+<a href="#AuthenticationLDAP">
 AuthenticationLDAP
 </a>
 </em>
@@ -555,7 +555,7 @@ LDAP contains the configuration needed to setup LDAP authentication.
 
 <code>dexDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeployment">
+<a href="#DexDeployment">
 DexDeployment
 </a>
 </em>
@@ -578,7 +578,7 @@ DexDeployment configures the Dex Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationStatus">
+<a href="#AuthenticationStatus">
 AuthenticationStatus
 </a>
 </em>
@@ -591,7 +591,7 @@ AuthenticationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Compliance">Compliance</h3>
+<h3 id="Compliance">Compliance</h3>
 <p>
 Compliance installs the components required for Tigera compliance reporting. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -652,7 +652,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">
+<a href="#ComplianceSpec">
 ComplianceSpec
 </a>
 </em>
@@ -670,7 +670,7 @@ Specification of the desired state for Tigera compliance reporting.
 <td>
 <code>complianceControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeployment">
+<a href="#ComplianceControllerDeployment">
 ComplianceControllerDeployment
 </a>
 </em>
@@ -690,7 +690,7 @@ ComplianceControllerDeployment configures the Compliance Controller Deployment.
 
 <code>complianceSnapshotterDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeployment">
+<a href="#ComplianceSnapshotterDeployment">
 ComplianceSnapshotterDeployment
 </a>
 </em>
@@ -710,7 +710,7 @@ ComplianceSnapshotterDeployment configures the Compliance Snapshotter Deployment
 
 <code>complianceBenchmarkerDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">
+<a href="#ComplianceBenchmarkerDaemonSet">
 ComplianceBenchmarkerDaemonSet
 </a>
 </em>
@@ -730,7 +730,7 @@ ComplianceBenchmarkerDaemonSet configures the Compliance Benchmarker DaemonSet.
 
 <code>complianceServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeployment">
+<a href="#ComplianceServerDeployment">
 ComplianceServerDeployment
 </a>
 </em>
@@ -750,7 +750,7 @@ ComplianceServerDeployment configures the Compliance Server Deployment.
 
 <code>complianceReporterPodTemplate</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplate">
+<a href="#ComplianceReporterPodTemplate">
 ComplianceReporterPodTemplate
 </a>
 </em>
@@ -773,7 +773,7 @@ ComplianceReporterPodTemplate configures the Compliance Reporter PodTemplate.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceStatus">
+<a href="#ComplianceStatus">
 ComplianceStatus
 </a>
 </em>
@@ -789,7 +789,7 @@ Most recently observed state for Tigera compliance reporting.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGateway">EgressGateway</h3>
+<h3 id="EgressGateway">EgressGateway</h3>
 <p>
 EgressGateway is the Schema for the egressgateways API
 </p>
@@ -849,7 +849,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">
+<a href="#EgressGatewaySpec">
 EgressGatewaySpec
 </a>
 </em>
@@ -882,7 +882,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -923,7 +923,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -944,7 +944,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -964,7 +964,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -988,7 +988,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -1011,7 +1011,7 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayStatus">
+<a href="#EgressGatewayStatus">
 EgressGatewayStatus
 </a>
 </em>
@@ -1024,7 +1024,7 @@ EgressGatewayStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSet">ImageSet</h3>
+<h3 id="ImageSet">ImageSet</h3>
 <p>
 ImageSet is used to specify image digests for the images that the operator deploys.
 The name of the ImageSet is expected to be in the format <code>&lt;variant&gt;-&lt;release&gt;</code>.
@@ -1089,7 +1089,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">
+<a href="#ImageSetSpec">
 ImageSetSpec
 </a>
 </em>
@@ -1104,7 +1104,7 @@ ImageSetSpec
 <td>
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -1124,7 +1124,7 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Installation">Installation</h3>
+<h3 id="Installation">Installation</h3>
 <p>
 Installation configures an installation of Calico or Calico Enterprise. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo;. The Installation API installs core networking
@@ -1186,7 +1186,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -1204,7 +1204,7 @@ Specification of the desired state for the Calico or Calico Enterprise installat
 <td>
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -1332,7 +1332,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -1355,7 +1355,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -1375,7 +1375,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -1395,7 +1395,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -1574,7 +1574,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -1596,7 +1596,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -1618,7 +1618,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -1638,7 +1638,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -1658,7 +1658,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -1677,7 +1677,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -1697,7 +1697,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -1717,7 +1717,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -1737,7 +1737,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -1756,7 +1756,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -1777,7 +1777,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -1797,7 +1797,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -1838,7 +1838,7 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationStatus">
+<a href="#InstallationStatus">
 InstallationStatus
 </a>
 </em>
@@ -1854,7 +1854,7 @@ Most recently observed state for the Calico or Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</h3>
+<h3 id="IntrusionDetection">IntrusionDetection</h3>
 <p>
 IntrusionDetection installs the components required for Tigera intrusion detection. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -1915,7 +1915,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">
+<a href="#IntrusionDetectionSpec">
 IntrusionDetectionSpec
 </a>
 </em>
@@ -1933,7 +1933,7 @@ Specification of the desired state for Tigera intrusion detection.
 <td>
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">
+<a href="#IntrusionDetectionComponentResource">
 []IntrusionDetectionComponentResource
 </a>
 </em>
@@ -1954,7 +1954,7 @@ Only DeepPacketInspection is supported for this spec.
 
 <code>anomalyDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+<a href="#AnomalyDetectionSpec">
 AnomalyDetectionSpec
 </a>
 </em>
@@ -1974,7 +1974,7 @@ AnomalyDetection is now deprecated, and configuring it has no effect.
 
 <code>intrusionDetectionControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeployment">
+<a href="#IntrusionDetectionControllerDeployment">
 IntrusionDetectionControllerDeployment
 </a>
 </em>
@@ -1997,7 +1997,7 @@ IntrusionDetectionControllerDeployment configures the IntrusionDetection Control
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionStatus">
+<a href="#IntrusionDetectionStatus">
 IntrusionDetectionStatus
 </a>
 </em>
@@ -2013,7 +2013,7 @@ Most recently observed state for Tigera intrusion detection.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollector">LogCollector</h3>
+<h3 id="LogCollector">LogCollector</h3>
 <p>
 LogCollector installs the components required for Tigera flow and DNS log collection. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;. When created, this installs fluentd on all nodes
@@ -2075,7 +2075,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">
+<a href="#LogCollectorSpec">
 LogCollectorSpec
 </a>
 </em>
@@ -2093,7 +2093,7 @@ Specification of the desired state for Tigera log collection.
 <td>
 <code>additionalStores</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">
+<a href="#AdditionalLogStoreSpec">
 AdditionalLogStoreSpec
 </a>
 </em>
@@ -2113,7 +2113,7 @@ Configuration for exporting flow, audit, and DNS logs to external storage.
 
 <code>additionalSources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">
+<a href="#AdditionalLogSourceSpec">
 AdditionalLogSourceSpec
 </a>
 </em>
@@ -2133,7 +2133,7 @@ Configuration for importing audit logs from managed kubernetes cluster log sourc
 
 <code>collectProcessPath</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CollectProcessPathOption">
+<a href="#CollectProcessPathOption">
 CollectProcessPathOption
 </a>
 </em>
@@ -2174,7 +2174,7 @@ the management cluster&rsquo;s tenant services are running.
 
 <code>fluentdDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSet">
+<a href="#FluentdDaemonSet">
 FluentdDaemonSet
 </a>
 </em>
@@ -2193,7 +2193,7 @@ FluentdDaemonSet configures the Fluentd DaemonSet.
 
 <code>eksLogForwarderDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeployment">
+<a href="#EKSLogForwarderDeployment">
 EKSLogForwarderDeployment
 </a>
 </em>
@@ -2216,7 +2216,7 @@ EKSLogForwarderDeployment configures the EKSLogForwarderDeployment Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectorStatus">
+<a href="#LogCollectorStatus">
 LogCollectorStatus
 </a>
 </em>
@@ -2232,7 +2232,7 @@ Most recently observed state for Tigera log collection.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorage">LogStorage</h3>
+<h3 id="LogStorage">LogStorage</h3>
 <p>
 LogStorage installs the components required for Tigera flow and DNS log storage. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;. When created, this installs an Elasticsearch cluster for use by
@@ -2294,7 +2294,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">
+<a href="#LogStorageSpec">
 LogStorageSpec
 </a>
 </em>
@@ -2312,7 +2312,7 @@ Specification of the desired state for Tigera log storage.
 <td>
 <code>nodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Nodes">
+<a href="#Nodes">
 Nodes
 </a>
 </em>
@@ -2331,7 +2331,7 @@ Nodes defines the configuration for a set of identical Elasticsearch cluster nod
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Indices">
+<a href="#Indices">
 Indices
 </a>
 </em>
@@ -2351,7 +2351,7 @@ Index defines the configuration for the indices in the Elasticsearch cluster.
 
 <code>retention</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Retention">
+<a href="#Retention">
 Retention
 </a>
 </em>
@@ -2413,7 +2413,7 @@ each of the indicated key-value pairs as labels as well as access to the specifi
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">
+<a href="#LogStorageComponentResource">
 []LogStorageComponentResource
 </a>
 </em>
@@ -2434,7 +2434,7 @@ Only ECKOperator is supported for this spec.
 
 <code>eckOperatorStatefulSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSet">
+<a href="#ECKOperatorStatefulSet">
 ECKOperatorStatefulSet
 </a>
 </em>
@@ -2455,7 +2455,7 @@ ComponentResources, then these overrides take precedence.
 
 <code>kibana</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Kibana">
+<a href="#Kibana">
 Kibana
 </a>
 </em>
@@ -2475,7 +2475,7 @@ Kibana configures the Kibana Spec.
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -2494,7 +2494,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>elasticsearchMetricsDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeployment">
+<a href="#ElasticsearchMetricsDeployment">
 ElasticsearchMetricsDeployment
 </a>
 </em>
@@ -2516,7 +2516,7 @@ ElasticsearchMetricsDeployment configures the tigera-elasticsearch-metric Deploy
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageStatus">
+<a href="#LogStorageStatus">
 LogStorageStatus
 </a>
 </em>
@@ -2532,7 +2532,7 @@ Most recently observed state for Tigera log storage.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementCluster">ManagementCluster</h3>
+<h3 id="ManagementCluster">ManagementCluster</h3>
 <p>
 The presence of ManagementCluster in your cluster, will configure it to be the management plane to which managed
 clusters can connect. At most one instance of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2593,7 +2593,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterSpec">
+<a href="#ManagementClusterSpec">
 ManagementClusterSpec
 </a>
 </em>
@@ -2628,7 +2628,7 @@ Valid examples are: &ldquo;0.0.0.0:31000&rdquo;, &ldquo;example.com:32000&rdquo;
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLS">
+<a href="#TLS">
 TLS
 </a>
 </em>
@@ -2648,7 +2648,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</h3>
+<h3 id="ManagementClusterConnection">ManagementClusterConnection</h3>
 <p>
 ManagementClusterConnection represents a link between a managed cluster and a management cluster. At most one
 instance of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2709,7 +2709,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">
+<a href="#ManagementClusterConnectionSpec">
 ManagementClusterConnectionSpec
 </a>
 </em>
@@ -2743,7 +2743,7 @@ should be able to access this address. This field is used by managed clusters on
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">
+<a href="#ManagementClusterTLS">
 ManagementClusterTLS
 </a>
 </em>
@@ -2763,7 +2763,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>guardianDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeployment">
+<a href="#GuardianDeployment">
 GuardianDeployment
 </a>
 </em>
@@ -2785,7 +2785,7 @@ GuardianDeployment configures the guardian Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionStatus">
+<a href="#ManagementClusterConnectionStatus">
 ManagementClusterConnectionStatus
 </a>
 </em>
@@ -2798,7 +2798,7 @@ ManagementClusterConnectionStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Manager">Manager</h3>
+<h3 id="Manager">Manager</h3>
 <p>
 Manager installs the Calico Enterprise manager graphical user interface. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2859,7 +2859,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerSpec">
+<a href="#ManagerSpec">
 ManagerSpec
 </a>
 </em>
@@ -2877,7 +2877,7 @@ Specification of the desired state for the Calico Enterprise manager.
 <td>
 <code>managerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeployment">
+<a href="#ManagerDeployment">
 ManagerDeployment
 </a>
 </em>
@@ -2900,7 +2900,7 @@ ManagerDeployment configures the Manager Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerStatus">
+<a href="#ManagerStatus">
 ManagerStatus
 </a>
 </em>
@@ -2916,7 +2916,7 @@ Most recently observed state for the Calico Enterprise manager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Monitor">Monitor</h3>
+<h3 id="Monitor">Monitor</h3>
 <p>
 Monitor is the Schema for the monitor API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2977,7 +2977,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorSpec">
+<a href="#MonitorSpec">
 MonitorSpec
 </a>
 </em>
@@ -2992,7 +2992,7 @@ MonitorSpec
 <td>
 <code>externalPrometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">
+<a href="#ExternalPrometheus">
 ExternalPrometheus
 </a>
 </em>
@@ -3013,7 +3013,7 @@ scraping from git-ops tools without the need of post-installation steps.
 
 <code>prometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Prometheus">
+<a href="#Prometheus">
 Prometheus
 </a>
 </em>
@@ -3033,7 +3033,7 @@ Prometheus is the configuration for the Prometheus.
 
 <code>alertManager</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AlertManager">
+<a href="#AlertManager">
 AlertManager
 </a>
 </em>
@@ -3056,7 +3056,7 @@ AlertManager is the configuration for the AlertManager.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorStatus">
+<a href="#MonitorStatus">
 MonitorStatus
 </a>
 </em>
@@ -3069,7 +3069,7 @@ MonitorStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</h3>
+<h3 id="PacketCaptureAPI">PacketCaptureAPI</h3>
 <p>
 PacketCaptureAPI is used to configure the resource requirement for PacketCaptureAPI deployment. It must be named &ldquo;tigera-secure&rdquo;.
 </p>
@@ -3129,7 +3129,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPISpec">
+<a href="#PacketCaptureAPISpec">
 PacketCaptureAPISpec
 </a>
 </em>
@@ -3147,7 +3147,7 @@ Specification of the desired state for the PacketCaptureAPI.
 <td>
 <code>packetCaptureAPIDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeployment">
+<a href="#PacketCaptureAPIDeployment">
 PacketCaptureAPIDeployment
 </a>
 </em>
@@ -3170,7 +3170,7 @@ PacketCaptureAPIDeployment configures the PacketCaptureAPI Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIStatus">
+<a href="#PacketCaptureAPIStatus">
 PacketCaptureAPIStatus
 </a>
 </em>
@@ -3186,7 +3186,7 @@ Most recently observed state for the PacketCaptureAPI.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</h3>
+<h3 id="PolicyRecommendation">PolicyRecommendation</h3>
 <p>
 PolicyRecommendation is the Schema for the policy recommendation API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -3247,7 +3247,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationSpec">
+<a href="#PolicyRecommendationSpec">
 PolicyRecommendationSpec
 </a>
 </em>
@@ -3262,7 +3262,7 @@ PolicyRecommendationSpec
 <td>
 <code>policyRecommendationDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeployment">
+<a href="#PolicyRecommendationDeployment">
 PolicyRecommendationDeployment
 </a>
 </em>
@@ -3285,7 +3285,7 @@ PolicyRecommendation configures the PolicyRecommendation Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationStatus">
+<a href="#PolicyRecommendationStatus">
 PolicyRecommendationStatus
 </a>
 </em>
@@ -3298,7 +3298,7 @@ PolicyRecommendationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSPassThroughRoute">TLSPassThroughRoute</h3>
+<h3 id="TLSPassThroughRoute">TLSPassThroughRoute</h3>
 <table>
 <thead>
 <tr>
@@ -3355,7 +3355,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRouteSpec">
+<a href="#TLSPassThroughRouteSpec">
 TLSPassThroughRouteSpec
 </a>
 </em>
@@ -3373,7 +3373,7 @@ Dest is the destination URL
 <td>
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -3389,7 +3389,7 @@ TargetType
 
 <code>sniMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SNIMatch">
+<a href="#SNIMatch">
 SNIMatch
 </a>
 </em>
@@ -3426,7 +3426,7 @@ Destination is the destination url to proxy the request to.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSTerminatedRoute">TLSTerminatedRoute</h3>
+<h3 id="TLSTerminatedRoute">TLSTerminatedRoute</h3>
 <table>
 <thead>
 <tr>
@@ -3483,7 +3483,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLSTerminatedRouteSpec">
+<a href="#TLSTerminatedRouteSpec">
 TLSTerminatedRouteSpec
 </a>
 </em>
@@ -3498,7 +3498,7 @@ TLSTerminatedRouteSpec
 <td>
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -3514,7 +3514,7 @@ TargetType
 
 <code>pathMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PathMatch">
+<a href="#PathMatch">
 PathMatch
 </a>
 </em>
@@ -3632,7 +3632,7 @@ is UI.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Tenant">Tenant</h3>
+<h3 id="Tenant">Tenant</h3>
 <p>
 Tenant is the Schema for the tenants API
 </p>
@@ -3692,7 +3692,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantSpec">
+<a href="#TenantSpec">
 TenantSpec
 </a>
 </em>
@@ -3741,7 +3741,7 @@ Name is a human readable name for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -3760,7 +3760,7 @@ Indices defines the how to store a tenant&rsquo;s data
 
 <code>elastic</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantElasticSpec">
+<a href="#TenantElasticSpec">
 TenantElasticSpec
 </a>
 </em>
@@ -3799,7 +3799,7 @@ in the Tenant&rsquo;s namespace. Defaults to the controlPlaneReplicas in Install
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -3818,7 +3818,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>esKubeControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -3837,7 +3837,7 @@ ESKubeControllerDeployment configures the ESKubeController Deployment.
 
 <code>dashboardsJob</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJob">
+<a href="#DashboardsJob">
 DashboardsJob
 </a>
 </em>
@@ -3859,7 +3859,7 @@ DashboardsJob configures the Dashboards job
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantStatus">
+<a href="#TenantStatus">
 TenantStatus
 </a>
 </em>
@@ -3872,7 +3872,7 @@ TenantStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatus">TigeraStatus</h3>
+<h3 id="TigeraStatus">TigeraStatus</h3>
 <p>
 TigeraStatus represents the most recently observed status for Calico or a Calico Enterprise functional area.
 </p>
@@ -3932,7 +3932,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusSpec">
+<a href="#TigeraStatusSpec">
 TigeraStatusSpec
 </a>
 </em>
@@ -3952,7 +3952,7 @@ TigeraStatusSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">
+<a href="#TigeraStatusStatus">
 TigeraStatusStatus
 </a>
 </em>
@@ -3965,11 +3965,11 @@ TigeraStatusStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</h3>
+<h3 id="APIServerDeployment">APIServerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerSpec">APIServerSpec</a>)
+<a href="#APIServerSpec">APIServerSpec</a>)
 
 </p>
 <p>
@@ -3988,7 +3988,7 @@ APIServerDeployment is the configuration for the API server Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4008,7 +4008,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">
+<a href="#APIServerDeploymentSpec">
 APIServerDeploymentSpec
 </a>
 </em>
@@ -4029,11 +4029,11 @@ Spec is the specification of the API server Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
+<h3 id="APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -4090,11 +4090,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
+<h3 id="APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -4150,11 +4150,11 @@ If omitted, the API server Deployment will use its default value for this init c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
+<h3 id="APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -4173,7 +4173,7 @@ APIServerDeploymentDeploymentPodSpec is the API server Deployment&rsquo;s PodSpe
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentInitContainer">
+<a href="#APIServerDeploymentInitContainer">
 []APIServerDeploymentInitContainer
 </a>
 </em>
@@ -4195,7 +4195,7 @@ If omitted, the API server Deployment will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentContainer">
+<a href="#APIServerDeploymentContainer">
 []APIServerDeploymentContainer
 </a>
 </em>
@@ -4306,11 +4306,11 @@ WARNING: Please note that this field will override the default API server Deploy
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
+<h3 id="APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
+<a href="#APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -4329,7 +4329,7 @@ APIServerDeploymentPodTemplateSpec is the API server Deployment&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4350,7 +4350,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">
+<a href="#APIServerDeploymentPodSpec">
 APIServerDeploymentPodSpec
 </a>
 </em>
@@ -4371,11 +4371,11 @@ Spec is the API server Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
+<h3 id="APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>)
 
 </p>
 <p>
@@ -4415,7 +4415,7 @@ If omitted, the API server Deployment will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">
+<a href="#APIServerDeploymentPodTemplateSpec">
 APIServerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -4432,11 +4432,11 @@ Template describes the API server Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerSpec">APIServerSpec</h3>
+<h3 id="APIServerSpec">APIServerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -4455,7 +4455,7 @@ APIServerSpec defines the desired state of Tigera API server.
 
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -4473,11 +4473,11 @@ take precedence.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerStatus">APIServerStatus</h3>
+<h3 id="APIServerStatus">APIServerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -4531,11 +4531,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</h3>
+<h3 id="AWSEgressGateway">AWSEgressGateway</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -4554,7 +4554,7 @@ AWSEgressGateway defines the configurations for deploying EgressGateway in AWS
 
 <code>nativeIP</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NativeIP">
+<a href="#NativeIP">
 NativeIP
 </a>
 </em>
@@ -4591,11 +4591,11 @@ NativeIP must be Enabled if elastic IPs are set.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AdditionalLogSourceSpec">AdditionalLogSourceSpec</h3>
+<h3 id="AdditionalLogSourceSpec">AdditionalLogSourceSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <table>
@@ -4611,7 +4611,7 @@ NativeIP must be Enabled if elastic IPs are set.
 
 <code>eksCloudwatchLog</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EksCloudwatchLogsSpec">
+<a href="#EksCloudwatchLogsSpec">
 EksCloudwatchLogsSpec
 </a>
 </em>
@@ -4629,11 +4629,11 @@ audit logs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</h3>
+<h3 id="AdditionalLogStoreSpec">AdditionalLogStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <table>
@@ -4649,7 +4649,7 @@ audit logs.
 
 <code>s3</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.S3StoreSpec">
+<a href="#S3StoreSpec">
 S3StoreSpec
 </a>
 </em>
@@ -4669,7 +4669,7 @@ If specified, enables exporting of flow, audit, and DNS logs to Amazon S3 storag
 
 <code>syslog</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">
+<a href="#SyslogStoreSpec">
 SyslogStoreSpec
 </a>
 </em>
@@ -4689,7 +4689,7 @@ If specified, enables exporting of flow, audit, and DNS logs to syslog.
 
 <code>splunk</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SplunkStoreSpec">
+<a href="#SplunkStoreSpec">
 SplunkStoreSpec
 </a>
 </em>
@@ -4706,11 +4706,11 @@ If specified, enables exporting of flow, audit, and DNS logs to splunk.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AlertManager">AlertManager</h3>
+<h3 id="AlertManager">AlertManager</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.MonitorSpec">MonitorSpec</a>)
+<a href="#MonitorSpec">MonitorSpec</a>)
 
 </p>
 <table>
@@ -4726,7 +4726,7 @@ If specified, enables exporting of flow, audit, and DNS logs to splunk.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AlertManagerSpec">
+<a href="#AlertManagerSpec">
 AlertManagerSpec
 </a>
 </em>
@@ -4747,11 +4747,11 @@ Spec is the specification of the Alertmanager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AlertManagerSpec">AlertManagerSpec</h3>
+<h3 id="AlertManagerSpec">AlertManagerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AlertManager">AlertManager</a>)
+<a href="#AlertManager">AlertManager</a>)
 
 </p>
 <table>
@@ -4783,11 +4783,11 @@ Define resources requests and limits for single Pods.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
+<h3 id="AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <table>
@@ -4818,19 +4818,19 @@ StorageClassName is now deprecated, and configuring it has no effect.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
+<h3 id="ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</h3>
+<h3 id="ApplicationLayerSpec">ApplicationLayerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -4849,7 +4849,7 @@ ApplicationLayerSpec defines the desired state of ApplicationLayer
 
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -4869,7 +4869,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -4888,7 +4888,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -4908,7 +4908,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -4927,7 +4927,7 @@ User-configurable settings for the Envoy proxy.
 
 <code>l7LogCollectorDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSet">
+<a href="#L7LogCollectorDaemonSet">
 L7LogCollectorDaemonSet
 </a>
 </em>
@@ -4944,11 +4944,11 @@ L7LogCollectorDaemonSet configures the L7LogCollector DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerStatus">ApplicationLayerStatus</h3>
+<h3 id="ApplicationLayerStatus">ApplicationLayerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -5002,13 +5002,13 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthMethod">AuthMethod
+<h3 id="AuthMethod">AuthMethod
 (<code>string</code> alias)</h3>
-<h3 id="operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</h3>
+<h3 id="AuthenticationLDAP">AuthenticationLDAP</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -5064,7 +5064,7 @@ the ldaps:// protocol.
 
 <code>userSearch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.UserSearch">
+<a href="#UserSearch">
 UserSearch
 </a>
 </em>
@@ -5083,7 +5083,7 @@ User entry search configuration to match the credentials with a user.
 
 <code>groupSearch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GroupSearch">
+<a href="#GroupSearch">
 GroupSearch
 </a>
 </em>
@@ -5100,11 +5100,11 @@ Group search configuration to find the groups that a user is in.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</h3>
+<h3 id="AuthenticationOIDC">AuthenticationOIDC</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -5230,7 +5230,7 @@ Deprecated. Please use Authentication.Spec.GroupsPrefix instead.
 
 <code>emailVerification</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EmailVerificationType">
+<a href="#EmailVerificationType">
 EmailVerificationType
 </a>
 </em>
@@ -5253,7 +5253,7 @@ Default: Verify
 
 <code>promptTypes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PromptType">
+<a href="#PromptType">
 []PromptType
 </a>
 </em>
@@ -5276,7 +5276,7 @@ Default: &ldquo;Consent&rdquo;
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.OIDCType">
+<a href="#OIDCType">
 OIDCType
 </a>
 </em>
@@ -5293,11 +5293,11 @@ Default: &ldquo;Dex&rdquo;
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationOpenshift">AuthenticationOpenshift</h3>
+<h3 id="AuthenticationOpenshift">AuthenticationOpenshift</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -5330,11 +5330,11 @@ IssuerURL is the URL to the Openshift OAuth provider. Ex.: <a href="https://api.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</h3>
+<h3 id="AuthenticationSpec">AuthenticationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>)
+<a href="#Authentication">Authentication</a>)
 
 </p>
 <p>
@@ -5410,7 +5410,7 @@ ClusterRoleBindings into Elastic.
 
 <code>oidc</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">
+<a href="#AuthenticationOIDC">
 AuthenticationOIDC
 </a>
 </em>
@@ -5430,7 +5430,7 @@ OIDC contains the configuration needed to setup OIDC authentication.
 
 <code>openshift</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOpenshift">
+<a href="#AuthenticationOpenshift">
 AuthenticationOpenshift
 </a>
 </em>
@@ -5450,7 +5450,7 @@ Openshift contains the configuration needed to setup Openshift OAuth authenticat
 
 <code>ldap</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">
+<a href="#AuthenticationLDAP">
 AuthenticationLDAP
 </a>
 </em>
@@ -5470,7 +5470,7 @@ LDAP contains the configuration needed to setup LDAP authentication.
 
 <code>dexDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeployment">
+<a href="#DexDeployment">
 DexDeployment
 </a>
 </em>
@@ -5487,11 +5487,11 @@ DexDeployment configures the Dex Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationStatus">AuthenticationStatus</h3>
+<h3 id="AuthenticationStatus">AuthenticationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>)
+<a href="#Authentication">Authentication</a>)
 
 </p>
 <p>
@@ -5545,12 +5545,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.BGPOption">BGPOption
+<h3 id="BGPOption">BGPOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -5559,12 +5559,12 @@ BGPOption describes the mode of BGP to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.CAType">CAType
+<h3 id="CAType">CAType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">ManagementClusterTLS</a>)
+<a href="#ManagementClusterTLS">ManagementClusterTLS</a>)
 
 </p>
 <p>
@@ -5573,11 +5573,11 @@ CAType specifies which verification method the tunnel client should use to verif
 <p>
 One of: Tigera, Public
 </p>
-<h3 id="operator.tigera.io/v1.CNILogging">CNILogging</h3>
+<h3 id="CNILogging">CNILogging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Logging">Logging</a>)
+<a href="#Logging">Logging</a>)
 
 </p>
 <table>
@@ -5593,7 +5593,7 @@ One of: Tigera, Public
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -5664,12 +5664,12 @@ Default: 10
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CNIPluginType">CNIPluginType
+<h3 id="CNIPluginType">CNIPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -5678,11 +5678,11 @@ CNIPluginType describes the type of CNI plugin used.
 <p>
 One of: Calico, GKE, AmazonVPC, AzureVNET
 </p>
-<h3 id="operator.tigera.io/v1.CNISpec">CNISpec</h3>
+<h3 id="CNISpec">CNISpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5701,7 +5701,7 @@ CNISpec contains configuration for the CNI plugin.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNIPluginType">
+<a href="#CNIPluginType">
 CNIPluginType
 </a>
 </em>
@@ -5733,7 +5733,7 @@ Default: Calico
 
 <code>ipam</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMSpec">
+<a href="#IPAMSpec">
 IPAMSpec
 </a>
 </em>
@@ -5751,11 +5751,11 @@ Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
+<h3 id="CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5774,7 +5774,7 @@ CSINodeDriverDaemonSet is the configuration for the csi-node-driver DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5794,7 +5794,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">
+<a href="#CSINodeDriverDaemonSetSpec">
 CSINodeDriverDaemonSetSpec
 </a>
 </em>
@@ -5815,11 +5815,11 @@ Spec is the specification of the csi-node-driver DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
+<h3 id="CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -5875,11 +5875,11 @@ If omitted, the csi-node-driver DaemonSet will use its default value for this co
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -5898,7 +5898,7 @@ CSINodeDriverDaemonSetPodSpec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">
+<a href="#CSINodeDriverDaemonSetContainer">
 []CSINodeDriverDaemonSetContainer
 </a>
 </em>
@@ -5985,11 +5985,11 @@ WARNING: Please note that this field will override the default csi-node-driver D
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
+<a href="#CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -6008,7 +6008,7 @@ CSINodeDriverDaemonSetPodTemplateSpec is the csi-node-driver DaemonSet&rsquo;s P
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6029,7 +6029,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">
+<a href="#CSINodeDriverDaemonSetPodSpec">
 CSINodeDriverDaemonSetPodSpec
 </a>
 </em>
@@ -6050,11 +6050,11 @@ Spec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
+<h3 id="CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
 
 </p>
 <p>
@@ -6094,7 +6094,7 @@ If omitted, the csi-node-driver DaemonSet will use its default value for minRead
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">
 CSINodeDriverDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -6111,12 +6111,12 @@ Template describes the csi-node-driver DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
+<h3 id="CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>, 
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -6135,7 +6135,7 @@ CalicoKubeControllersDeployment is the configuration for the calico-kube-control
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6155,7 +6155,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">
+<a href="#CalicoKubeControllersDeploymentSpec">
 CalicoKubeControllersDeploymentSpec
 </a>
 </em>
@@ -6176,11 +6176,11 @@ Spec is the specification of the calico-kube-controllers Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
+<h3 id="CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -6237,11 +6237,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6260,7 +6260,7 @@ CalicoKubeControllersDeploymentPodSpec is the calico-kube-controller Deployment&
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">
+<a href="#CalicoKubeControllersDeploymentContainer">
 []CalicoKubeControllersDeploymentContainer
 </a>
 </em>
@@ -6349,11 +6349,11 @@ WARNING: Please note that this field will override the default calico-kube-contr
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
+<a href="#CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
 
 </p>
 <p>
@@ -6372,7 +6372,7 @@ CalicoKubeControllersDeploymentPodTemplateSpec is the calico-kube-controllers De
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6393,7 +6393,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">
+<a href="#CalicoKubeControllersDeploymentPodSpec">
 CalicoKubeControllersDeploymentPodSpec
 </a>
 </em>
@@ -6414,11 +6414,11 @@ Spec is the calico-kube-controllers Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
 
 </p>
 <p>
@@ -6458,7 +6458,7 @@ If omitted, the calico-kube-controllers Deployment will use its default value fo
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">
 CalicoKubeControllersDeploymentPodTemplateSpec
 </a>
 </em>
@@ -6475,11 +6475,11 @@ Template describes the calico-kube-controllers Deployment pod that will be creat
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</h3>
+<h3 id="CalicoNetworkSpec">CalicoNetworkSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -6498,7 +6498,7 @@ CalicoNetworkSpec specifies configuration options for Calico provided pod networ
 
 <code>linuxDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinuxDataplaneOption">
+<a href="#LinuxDataplaneOption">
 LinuxDataplaneOption
 </a>
 </em>
@@ -6521,7 +6521,7 @@ Default: Iptables
 
 <code>windowsDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsDataplaneOption">
+<a href="#WindowsDataplaneOption">
 WindowsDataplaneOption
 </a>
 </em>
@@ -6544,7 +6544,7 @@ Default: Disabled
 
 <code>bgp</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.BGPOption">
+<a href="#BGPOption">
 BGPOption
 </a>
 </em>
@@ -6564,7 +6564,7 @@ BGP configures whether or not to enable Calico&rsquo;s BGP capabilities.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPPool">
+<a href="#IPPool">
 []IPPool
 </a>
 </em>
@@ -6604,7 +6604,7 @@ If not specified, Calico will perform MTU auto-detection based on the cluster ne
 
 <code>nodeAddressAutodetectionV4</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -6625,7 +6625,7 @@ will use default auto-detection settings to acquire an IPv4 address for each nod
 
 <code>nodeAddressAutodetectionV6</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -6646,7 +6646,7 @@ IPv6 addresses will not be auto-detected.
 
 <code>hostPorts</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HostPortsType">
+<a href="#HostPortsType">
 HostPortsType
 </a>
 </em>
@@ -6667,7 +6667,7 @@ Default: Enabled
 
 <code>multiInterfaceMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MultiInterfaceMode">
+<a href="#MultiInterfaceMode">
 MultiInterfaceMode
 </a>
 </em>
@@ -6689,7 +6689,7 @@ Default: None
 
 <code>containerIPForwarding</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ContainerIPForwardingType">
+<a href="#ContainerIPForwardingType">
 ContainerIPForwardingType
 </a>
 </em>
@@ -6710,7 +6710,7 @@ Default: Disabled
 
 <code>sysctl</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Sysctl">
+<a href="#Sysctl">
 []Sysctl
 </a>
 </em>
@@ -6757,11 +6757,11 @@ Default: 0
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
+<h3 id="CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -6780,7 +6780,7 @@ CalicoNodeDaemonSet is the configuration for the calico-node DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6800,7 +6800,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">
+<a href="#CalicoNodeDaemonSetSpec">
 CalicoNodeDaemonSetSpec
 </a>
 </em>
@@ -6821,11 +6821,11 @@ Spec is the specification of the calico-node DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
+<h3 id="CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6882,11 +6882,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6943,11 +6943,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6966,7 +6966,7 @@ CalicoNodeDaemonSetPodSpec is the calico-node DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">
+<a href="#CalicoNodeDaemonSetInitContainer">
 []CalicoNodeDaemonSetInitContainer
 </a>
 </em>
@@ -6988,7 +6988,7 @@ If omitted, the calico-node DaemonSet will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetContainer">
+<a href="#CalicoNodeDaemonSetContainer">
 []CalicoNodeDaemonSetContainer
 </a>
 </em>
@@ -7075,11 +7075,11 @@ WARNING: Please note that this field will override the default calico-node Daemo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
+<a href="#CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7098,7 +7098,7 @@ CalicoNodeDaemonSetPodTemplateSpec is the calico-node DaemonSet&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7119,7 +7119,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">
+<a href="#CalicoNodeDaemonSetPodSpec">
 CalicoNodeDaemonSetPodSpec
 </a>
 </em>
@@ -7140,11 +7140,11 @@ Spec is the calico-node DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
+<h3 id="CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
 
 </p>
 <p>
@@ -7184,7 +7184,7 @@ If omitted, the calico-node DaemonSet will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">
 CalicoNodeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -7201,11 +7201,11 @@ Template describes the calico-node DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
+<h3 id="CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7224,7 +7224,7 @@ CalicoNodeWindowsDaemonSet is the configuration for the calico-node-windows Daem
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7244,7 +7244,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">
+<a href="#CalicoNodeWindowsDaemonSetSpec">
 CalicoNodeWindowsDaemonSetSpec
 </a>
 </em>
@@ -7265,11 +7265,11 @@ Spec is the specification of the calico-node-windows DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -7326,11 +7326,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -7387,11 +7387,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7410,7 +7410,7 @@ CalicoNodeWindowsDaemonSetPodSpec is the calico-node-windows DaemonSet&rsquo;s P
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">
+<a href="#CalicoNodeWindowsDaemonSetInitContainer">
 []CalicoNodeWindowsDaemonSetInitContainer
 </a>
 </em>
@@ -7432,7 +7432,7 @@ If omitted, the calico-node-windows DaemonSet will use its default values for it
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">
+<a href="#CalicoNodeWindowsDaemonSetContainer">
 []CalicoNodeWindowsDaemonSetContainer
 </a>
 </em>
@@ -7519,11 +7519,11 @@ WARNING: Please note that this field will override the default calico-node-windo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7542,7 +7542,7 @@ CalicoNodeWindowsDaemonSetPodTemplateSpec is the calico-node-windows DaemonSet&r
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7563,7 +7563,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">
 CalicoNodeWindowsDaemonSetPodSpec
 </a>
 </em>
@@ -7584,11 +7584,11 @@ Spec is the calico-node-windows DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
 
 </p>
 <p>
@@ -7628,7 +7628,7 @@ If omitted, the calico-node-windows DaemonSet will use its default value for min
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">
 CalicoNodeWindowsDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -7645,11 +7645,11 @@ Template describes the calico-node-windows DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7669,7 +7669,7 @@ CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrad
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7689,7 +7689,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">
 CalicoWindowsUpgradeDaemonSetSpec
 </a>
 </em>
@@ -7710,11 +7710,11 @@ Spec is the specification of the calico-windows-upgrade DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -7769,11 +7769,11 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7792,7 +7792,7 @@ CalicoWindowsUpgradeDaemonSetPodSpec is the calico-windows-upgrade DaemonSet&rsq
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">
+<a href="#CalicoWindowsUpgradeDaemonSetContainer">
 []CalicoWindowsUpgradeDaemonSetContainer
 </a>
 </em>
@@ -7879,11 +7879,11 @@ WARNING: Please note that this field will override the default calico-windows-up
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7902,7 +7902,7 @@ CalicoWindowsUpgradeDaemonSetPodTemplateSpec is the calico-windows-upgrade Daemo
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7923,7 +7923,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">
 CalicoWindowsUpgradeDaemonSetPodSpec
 </a>
 </em>
@@ -7944,11 +7944,11 @@ Spec is the calico-windows-upgrade DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
 
 </p>
 <p>
@@ -7988,7 +7988,7 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
 CalicoWindowsUpgradeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -8005,11 +8005,11 @@ Template describes the calico-windows-upgrade DaemonSet pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CertificateManagement">CertificateManagement</h3>
+<h3 id="CertificateManagement">CertificateManagement</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -8101,19 +8101,19 @@ Default: SHA256WithRSA
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CollectProcessPathOption">CollectProcessPathOption
+<h3 id="CollectProcessPathOption">CollectProcessPathOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.CommonPrometheusFields">CommonPrometheusFields</h3>
+<h3 id="CommonPrometheusFields">CommonPrometheusFields</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PrometheusSpec">PrometheusSpec</a>)
+<a href="#PrometheusSpec">PrometheusSpec</a>)
 
 </p>
 <table>
@@ -8129,7 +8129,7 @@ Default: SHA256WithRSA
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PrometheusContainer">
+<a href="#PrometheusContainer">
 []PrometheusContainer
 </a>
 </em>
@@ -8167,11 +8167,11 @@ Define resources requests and limits for single Pods.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</h3>
+<h3 id="ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -8190,7 +8190,7 @@ ComplianceBenchmarkerDaemonSet is the configuration for the Compliance Benchmark
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetSpec">
+<a href="#ComplianceBenchmarkerDaemonSetSpec">
 ComplianceBenchmarkerDaemonSetSpec
 </a>
 </em>
@@ -8211,11 +8211,11 @@ Spec is the specification of the Compliance Benchmarker DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetContainer">ComplianceBenchmarkerDaemonSetContainer</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetContainer">ComplianceBenchmarkerDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -8271,11 +8271,11 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetInitContainer">ComplianceBenchmarkerDaemonSetInitContainer</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetInitContainer">ComplianceBenchmarkerDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -8331,11 +8331,11 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8354,7 +8354,7 @@ ComplianceBenchmarkerDaemonSetPodSpec is the Compliance Benchmarker DaemonSet&rs
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetInitContainer">
+<a href="#ComplianceBenchmarkerDaemonSetInitContainer">
 []ComplianceBenchmarkerDaemonSetInitContainer
 </a>
 </em>
@@ -8376,7 +8376,7 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default values for
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetContainer">
+<a href="#ComplianceBenchmarkerDaemonSetContainer">
 []ComplianceBenchmarkerDaemonSetContainer
 </a>
 </em>
@@ -8395,11 +8395,11 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default values for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -8418,7 +8418,7 @@ ComplianceBenchmarkerDaemonSetPodTemplateSpec is the Compliance Benchmarker Daem
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">
+<a href="#ComplianceBenchmarkerDaemonSetPodSpec">
 ComplianceBenchmarkerDaemonSetPodSpec
 </a>
 </em>
@@ -8439,11 +8439,11 @@ Spec is the Compliance Benchmarker DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</a>)
+<a href="#ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</a>)
 
 </p>
 <p>
@@ -8462,7 +8462,7 @@ ComplianceBenchmarkerDaemonSetSpec defines configuration for the Compliance Benc
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodTemplateSpec">
+<a href="#ComplianceBenchmarkerDaemonSetPodTemplateSpec">
 ComplianceBenchmarkerDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -8479,11 +8479,11 @@ Template describes the Compliance Benchmarker DaemonSet pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeployment">ComplianceControllerDeployment</h3>
+<h3 id="ComplianceControllerDeployment">ComplianceControllerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -8502,7 +8502,7 @@ ComplianceControllerDeployment is the configuration for the compliance controlle
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentSpec">
+<a href="#ComplianceControllerDeploymentSpec">
 ComplianceControllerDeploymentSpec
 </a>
 </em>
@@ -8523,11 +8523,11 @@ Spec is the specification of the compliance controller Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentContainer">ComplianceControllerDeploymentContainer</h3>
+<h3 id="ComplianceControllerDeploymentContainer">ComplianceControllerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
+<a href="#ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -8583,11 +8583,11 @@ If omitted, the compliance controller Deployment will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentInitContainer">ComplianceControllerDeploymentInitContainer</h3>
+<h3 id="ComplianceControllerDeploymentInitContainer">ComplianceControllerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
+<a href="#ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -8643,11 +8643,11 @@ If omitted, the compliance controller Deployment will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</h3>
+<h3 id="ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</a>)
+<a href="#ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8666,7 +8666,7 @@ ComplianceControllerDeploymentPodSpec is the compliance controller Deployment&rs
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentInitContainer">
+<a href="#ComplianceControllerDeploymentInitContainer">
 []ComplianceControllerDeploymentInitContainer
 </a>
 </em>
@@ -8688,7 +8688,7 @@ If omitted, the compliance controller Deployment will use its default values for
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentContainer">
+<a href="#ComplianceControllerDeploymentContainer">
 []ComplianceControllerDeploymentContainer
 </a>
 </em>
@@ -8707,11 +8707,11 @@ If omitted, the compliance controller Deployment will use its default values for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</h3>
+<h3 id="ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</a>)
+<a href="#ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -8730,7 +8730,7 @@ ComplianceControllerDeploymentPodTemplateSpec is the compliance controller Deplo
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">
+<a href="#ComplianceControllerDeploymentPodSpec">
 ComplianceControllerDeploymentPodSpec
 </a>
 </em>
@@ -8751,11 +8751,11 @@ Spec is the compliance controller Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</h3>
+<h3 id="ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeployment">ComplianceControllerDeployment</a>)
+<a href="#ComplianceControllerDeployment">ComplianceControllerDeployment</a>)
 
 </p>
 <p>
@@ -8774,7 +8774,7 @@ ComplianceControllerDeploymentSpec defines configuration for the compliance cont
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodTemplateSpec">
+<a href="#ComplianceControllerDeploymentPodTemplateSpec">
 ComplianceControllerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -8791,11 +8791,11 @@ Template describes the compliance controller Deployment pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodSpec">ComplianceReporterPodSpec</h3>
+<h3 id="ComplianceReporterPodSpec">ComplianceReporterPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</a>)
+<a href="#ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8814,7 +8814,7 @@ ComplianceReporterPodSpec is the ComplianceReporter PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateInitContainer">
+<a href="#ComplianceReporterPodTemplateInitContainer">
 []ComplianceReporterPodTemplateInitContainer
 </a>
 </em>
@@ -8836,7 +8836,7 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateContainer">
+<a href="#ComplianceReporterPodTemplateContainer">
 []ComplianceReporterPodTemplateContainer
 </a>
 </em>
@@ -8855,11 +8855,11 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</h3>
+<h3 id="ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -8878,7 +8878,7 @@ ComplianceReporterPodTemplate is the configuration for the ComplianceReporter Po
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateSpec">
+<a href="#ComplianceReporterPodTemplateSpec">
 ComplianceReporterPodTemplateSpec
 </a>
 </em>
@@ -8895,11 +8895,11 @@ Spec is the specification of the ComplianceReporter PodTemplateSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplateContainer">ComplianceReporterPodTemplateContainer</h3>
+<h3 id="ComplianceReporterPodTemplateContainer">ComplianceReporterPodTemplateContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
+<a href="#ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
 
 </p>
 <p>
@@ -8955,11 +8955,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplateInitContainer">ComplianceReporterPodTemplateInitContainer</h3>
+<h3 id="ComplianceReporterPodTemplateInitContainer">ComplianceReporterPodTemplateInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
+<a href="#ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
 
 </p>
 <p>
@@ -9015,11 +9015,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</h3>
+<h3 id="ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</a>)
+<a href="#ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</a>)
 
 </p>
 <p>
@@ -9038,7 +9038,7 @@ ComplianceReporterPodTemplateSpec is the ComplianceReporter PodTemplateSpec.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodSpec">
+<a href="#ComplianceReporterPodSpec">
 ComplianceReporterPodSpec
 </a>
 </em>
@@ -9059,11 +9059,11 @@ Spec is the ComplianceReporter PodTemplate&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeployment">ComplianceServerDeployment</h3>
+<h3 id="ComplianceServerDeployment">ComplianceServerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -9082,7 +9082,7 @@ ComplianceServerDeployment is the configuration for the ComplianceServer Deploym
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentSpec">
+<a href="#ComplianceServerDeploymentSpec">
 ComplianceServerDeploymentSpec
 </a>
 </em>
@@ -9103,11 +9103,11 @@ Spec is the specification of the ComplianceServer Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentContainer">ComplianceServerDeploymentContainer</h3>
+<h3 id="ComplianceServerDeploymentContainer">ComplianceServerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
+<a href="#ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9163,11 +9163,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentInitContainer">ComplianceServerDeploymentInitContainer</h3>
+<h3 id="ComplianceServerDeploymentInitContainer">ComplianceServerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
+<a href="#ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9223,11 +9223,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</h3>
+<h3 id="ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</a>)
+<a href="#ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -9246,7 +9246,7 @@ ComplianceServerDeploymentPodSpec is the ComplianceServer Deployment&rsquo;s Pod
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentInitContainer">
+<a href="#ComplianceServerDeploymentInitContainer">
 []ComplianceServerDeploymentInitContainer
 </a>
 </em>
@@ -9268,7 +9268,7 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentContainer">
+<a href="#ComplianceServerDeploymentContainer">
 []ComplianceServerDeploymentContainer
 </a>
 </em>
@@ -9287,11 +9287,11 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</h3>
+<h3 id="ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</a>)
+<a href="#ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -9310,7 +9310,7 @@ ComplianceServerDeploymentPodTemplateSpec is the ComplianceServer Deployment&rsq
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">
+<a href="#ComplianceServerDeploymentPodSpec">
 ComplianceServerDeploymentPodSpec
 </a>
 </em>
@@ -9331,11 +9331,11 @@ Spec is the ComplianceServer Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</h3>
+<h3 id="ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeployment">ComplianceServerDeployment</a>)
+<a href="#ComplianceServerDeployment">ComplianceServerDeployment</a>)
 
 </p>
 <p>
@@ -9354,7 +9354,7 @@ ComplianceServerDeploymentSpec defines configuration for the ComplianceServer De
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodTemplateSpec">
+<a href="#ComplianceServerDeploymentPodTemplateSpec">
 ComplianceServerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -9371,11 +9371,11 @@ Template describes the ComplianceServer Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</h3>
+<h3 id="ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -9394,7 +9394,7 @@ ComplianceSnapshotterDeployment is the configuration for the compliance snapshot
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentSpec">
+<a href="#ComplianceSnapshotterDeploymentSpec">
 ComplianceSnapshotterDeploymentSpec
 </a>
 </em>
@@ -9415,11 +9415,11 @@ Spec is the specification of the compliance snapshotter Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentContainer">ComplianceSnapshotterDeploymentContainer</h3>
+<h3 id="ComplianceSnapshotterDeploymentContainer">ComplianceSnapshotterDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9475,11 +9475,11 @@ If omitted, the compliance snapshotter Deployment will use its default value for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentInitContainer">ComplianceSnapshotterDeploymentInitContainer</h3>
+<h3 id="ComplianceSnapshotterDeploymentInitContainer">ComplianceSnapshotterDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9535,11 +9535,11 @@ If omitted, the compliance snapshotter Deployment will use its default value for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</h3>
+<h3 id="ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -9558,7 +9558,7 @@ ComplianceSnapshotterDeploymentPodSpec is the compliance snapshotter Deployment&
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentInitContainer">
+<a href="#ComplianceSnapshotterDeploymentInitContainer">
 []ComplianceSnapshotterDeploymentInitContainer
 </a>
 </em>
@@ -9580,7 +9580,7 @@ If omitted, the compliance snapshotter Deployment will use its default values fo
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentContainer">
+<a href="#ComplianceSnapshotterDeploymentContainer">
 []ComplianceSnapshotterDeploymentContainer
 </a>
 </em>
@@ -9599,11 +9599,11 @@ If omitted, the compliance snapshotter Deployment will use its default values fo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</h3>
+<h3 id="ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</a>)
 
 </p>
 <p>
@@ -9622,7 +9622,7 @@ ComplianceSnapshotterDeploymentPodTemplateSpec is the compliance snapshotter Dep
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">
+<a href="#ComplianceSnapshotterDeploymentPodSpec">
 ComplianceSnapshotterDeploymentPodSpec
 </a>
 </em>
@@ -9643,11 +9643,11 @@ Spec is the compliance snapshotter Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</h3>
+<h3 id="ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</a>)
+<a href="#ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</a>)
 
 </p>
 <p>
@@ -9666,7 +9666,7 @@ ComplianceSnapshotterDeploymentSpec defines configuration for the compliance sna
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodTemplateSpec">
+<a href="#ComplianceSnapshotterDeploymentPodTemplateSpec">
 ComplianceSnapshotterDeploymentPodTemplateSpec
 </a>
 </em>
@@ -9683,11 +9683,11 @@ Template describes the compliance snapshotter Deployment pod that will be create
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</h3>
+<h3 id="ComplianceSpec">ComplianceSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>)
+<a href="#Compliance">Compliance</a>)
 
 </p>
 <p>
@@ -9706,7 +9706,7 @@ ComplianceSpec defines the desired state of Tigera compliance reporting capabili
 
 <code>complianceControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeployment">
+<a href="#ComplianceControllerDeployment">
 ComplianceControllerDeployment
 </a>
 </em>
@@ -9726,7 +9726,7 @@ ComplianceControllerDeployment configures the Compliance Controller Deployment.
 
 <code>complianceSnapshotterDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeployment">
+<a href="#ComplianceSnapshotterDeployment">
 ComplianceSnapshotterDeployment
 </a>
 </em>
@@ -9746,7 +9746,7 @@ ComplianceSnapshotterDeployment configures the Compliance Snapshotter Deployment
 
 <code>complianceBenchmarkerDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">
+<a href="#ComplianceBenchmarkerDaemonSet">
 ComplianceBenchmarkerDaemonSet
 </a>
 </em>
@@ -9766,7 +9766,7 @@ ComplianceBenchmarkerDaemonSet configures the Compliance Benchmarker DaemonSet.
 
 <code>complianceServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeployment">
+<a href="#ComplianceServerDeployment">
 ComplianceServerDeployment
 </a>
 </em>
@@ -9786,7 +9786,7 @@ ComplianceServerDeployment configures the Compliance Server Deployment.
 
 <code>complianceReporterPodTemplate</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplate">
+<a href="#ComplianceReporterPodTemplate">
 ComplianceReporterPodTemplate
 </a>
 </em>
@@ -9803,11 +9803,11 @@ ComplianceReporterPodTemplate configures the Compliance Reporter PodTemplate.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceStatus">ComplianceStatus</h3>
+<h3 id="ComplianceStatus">ComplianceStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>)
+<a href="#Compliance">Compliance</a>)
 
 </p>
 <p>
@@ -9861,12 +9861,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComponentName">ComponentName
+<h3 id="ComponentName">ComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComponentResource">ComponentResource</a>)
+<a href="#ComponentResource">ComponentResource</a>)
 
 </p>
 <p>
@@ -9875,11 +9875,11 @@ ComponentName represents a single component.
 <p>
 One of: Node, Typha, KubeControllers
 </p>
-<h3 id="operator.tigera.io/v1.ComponentResource">ComponentResource</h3>
+<h3 id="ComponentResource">ComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -9899,7 +9899,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentName">
+<a href="#ComponentName">
 ComponentName
 </a>
 </em>
@@ -9934,33 +9934,33 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ConditionStatus">ConditionStatus
+<h3 id="ConditionStatus">ConditionStatus
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 ConditionStatus represents the status of a particular condition. A condition may be one of: True, False, Unknown.
 </p>
-<h3 id="operator.tigera.io/v1.ContainerIPForwardingType">ContainerIPForwardingType
+<h3 id="ContainerIPForwardingType">ContainerIPForwardingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
 ContainerIPForwardingType specifies whether the CNI config for container ip forwarding is enabled.
 </p>
-<h3 id="operator.tigera.io/v1.DashboardsJob">DashboardsJob</h3>
+<h3 id="DashboardsJob">DashboardsJob</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -9979,7 +9979,7 @@ DashboardsJob is the configuration for the Dashboards job.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobSpec">
+<a href="#DashboardsJobSpec">
 DashboardsJobSpec
 </a>
 </em>
@@ -10000,11 +10000,11 @@ Spec is the specification of the dashboards job.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobContainer">DashboardsJobContainer</h3>
+<h3 id="DashboardsJobContainer">DashboardsJobContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodSpec">DashboardsJobPodSpec</a>)
+<a href="#DashboardsJobPodSpec">DashboardsJobPodSpec</a>)
 
 </p>
 <p>
@@ -10060,11 +10060,11 @@ If omitted, the Dashboard Job will use its default value for this container&rsqu
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobPodSpec">DashboardsJobPodSpec</h3>
+<h3 id="DashboardsJobPodSpec">DashboardsJobPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</a>)
+<a href="#DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -10083,7 +10083,7 @@ DashboardsJobPodSpec is the Dashboards job&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobContainer">
+<a href="#DashboardsJobContainer">
 []DashboardsJobContainer
 </a>
 </em>
@@ -10102,11 +10102,11 @@ If omitted, the Dashboard job will use its default values for its containers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</h3>
+<h3 id="DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobSpec">DashboardsJobSpec</a>)
+<a href="#DashboardsJobSpec">DashboardsJobSpec</a>)
 
 </p>
 <p>
@@ -10125,7 +10125,7 @@ DashboardsJobPodTemplateSpec is the Dashboards job&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodSpec">
+<a href="#DashboardsJobPodSpec">
 DashboardsJobPodSpec
 </a>
 </em>
@@ -10146,11 +10146,11 @@ Spec is the Dashboard job&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobSpec">DashboardsJobSpec</h3>
+<h3 id="DashboardsJobSpec">DashboardsJobSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJob">DashboardsJob</a>)
+<a href="#DashboardsJob">DashboardsJob</a>)
 
 </p>
 <p>
@@ -10169,7 +10169,7 @@ DashboardsJobSpec defines configuration for the Dashboards job.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodTemplateSpec">
+<a href="#DashboardsJobPodTemplateSpec">
 DashboardsJobPodTemplateSpec
 </a>
 </em>
@@ -10186,22 +10186,22 @@ Template describes the Dashboards job pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DataType">DataType
+<h3 id="DataType">DataType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Index">Index</a>)
+<a href="#Index">Index</a>)
 
 </p>
 <p>
 DataType represent the type of data stored
 </p>
-<h3 id="operator.tigera.io/v1.DexDeployment">DexDeployment</h3>
+<h3 id="DexDeployment">DexDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -10220,7 +10220,7 @@ DexDeployment is the configuration for the Dex Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentSpec">
+<a href="#DexDeploymentSpec">
 DexDeploymentSpec
 </a>
 </em>
@@ -10241,11 +10241,11 @@ Spec is the specification of the Dex Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentContainer">DexDeploymentContainer</h3>
+<h3 id="DexDeploymentContainer">DexDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
+<a href="#DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10301,11 +10301,11 @@ If omitted, the Dex Deployment will use its default value for this container&rsq
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentInitContainer">DexDeploymentInitContainer</h3>
+<h3 id="DexDeploymentInitContainer">DexDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
+<a href="#DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10361,11 +10361,11 @@ If omitted, the Dex Deployment will use its default value for this init containe
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentPodSpec">DexDeploymentPodSpec</h3>
+<h3 id="DexDeploymentPodSpec">DexDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</a>)
+<a href="#DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -10384,7 +10384,7 @@ DexDeploymentPodSpec is the Dex Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentInitContainer">
+<a href="#DexDeploymentInitContainer">
 []DexDeploymentInitContainer
 </a>
 </em>
@@ -10406,7 +10406,7 @@ If omitted, the Dex Deployment will use its default values for its init containe
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentContainer">
+<a href="#DexDeploymentContainer">
 []DexDeploymentContainer
 </a>
 </em>
@@ -10425,11 +10425,11 @@ If omitted, the Dex Deployment will use its default values for its containers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</h3>
+<h3 id="DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentSpec">DexDeploymentSpec</a>)
+<a href="#DexDeploymentSpec">DexDeploymentSpec</a>)
 
 </p>
 <p>
@@ -10448,7 +10448,7 @@ DexDeploymentPodTemplateSpec is the Dex Deployment&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodSpec">
+<a href="#DexDeploymentPodSpec">
 DexDeploymentPodSpec
 </a>
 </em>
@@ -10469,11 +10469,11 @@ Spec is the Dex Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentSpec">DexDeploymentSpec</h3>
+<h3 id="DexDeploymentSpec">DexDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeployment">DexDeployment</a>)
+<a href="#DexDeployment">DexDeployment</a>)
 
 </p>
 <p>
@@ -10492,7 +10492,7 @@ DexDeploymentSpec defines configuration for the Dex Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodTemplateSpec">
+<a href="#DexDeploymentPodTemplateSpec">
 DexDeploymentPodTemplateSpec
 </a>
 </em>
@@ -10509,11 +10509,11 @@ Template describes the Dex Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSet">ECKOperatorStatefulSet</h3>
+<h3 id="ECKOperatorStatefulSet">ECKOperatorStatefulSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -10532,7 +10532,7 @@ ECKOperatorStatefulSet is the configuration for the ECKOperator StatefulSet.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetSpec">
+<a href="#ECKOperatorStatefulSetSpec">
 ECKOperatorStatefulSetSpec
 </a>
 </em>
@@ -10553,11 +10553,11 @@ Spec is the specification of the ECKOperator StatefulSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetContainer">ECKOperatorStatefulSetContainer</h3>
+<h3 id="ECKOperatorStatefulSetContainer">ECKOperatorStatefulSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
+<a href="#ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
 
 </p>
 <p>
@@ -10613,11 +10613,11 @@ If omitted, the ECKOperator StatefulSet will use its default value for this cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetInitContainer">ECKOperatorStatefulSetInitContainer</h3>
+<h3 id="ECKOperatorStatefulSetInitContainer">ECKOperatorStatefulSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
+<a href="#ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
 
 </p>
 <p>
@@ -10672,11 +10672,11 @@ If omitted, the ECKOperator StatefulSet will use its default value for this init
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</h3>
+<h3 id="ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</a>)
+<a href="#ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -10695,7 +10695,7 @@ ECKOperatorStatefulSetPodSpec is the ECKOperator StatefulSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetInitContainer">
+<a href="#ECKOperatorStatefulSetInitContainer">
 []ECKOperatorStatefulSetInitContainer
 </a>
 </em>
@@ -10717,7 +10717,7 @@ If omitted, the ECKOperator StatefulSet will use its default values for its init
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetContainer">
+<a href="#ECKOperatorStatefulSetContainer">
 []ECKOperatorStatefulSetContainer
 </a>
 </em>
@@ -10736,11 +10736,11 @@ If omitted, the ECKOperator StatefulSet will use its default values for its cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</h3>
+<h3 id="ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</a>)
+<a href="#ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</a>)
 
 </p>
 <p>
@@ -10759,7 +10759,7 @@ ECKOperatorStatefulSetPodTemplateSpec is the ECKOperator StatefulSet&rsquo;s Pod
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">
+<a href="#ECKOperatorStatefulSetPodSpec">
 ECKOperatorStatefulSetPodSpec
 </a>
 </em>
@@ -10780,11 +10780,11 @@ Spec is the ECKOperator StatefulSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</h3>
+<h3 id="ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSet">ECKOperatorStatefulSet</a>)
+<a href="#ECKOperatorStatefulSet">ECKOperatorStatefulSet</a>)
 
 </p>
 <p>
@@ -10803,7 +10803,7 @@ ECKOperatorStatefulSetSpec defines configuration for the ECKOperator StatefulSet
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodTemplateSpec">
+<a href="#ECKOperatorStatefulSetPodTemplateSpec">
 ECKOperatorStatefulSetPodTemplateSpec
 </a>
 </em>
@@ -10820,11 +10820,11 @@ Template describes the ECKOperator StatefulSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentContainer">EGWDeploymentContainer</h3>
+<h3 id="EGWDeploymentContainer">EGWDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10881,11 +10881,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
+<h3 id="EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10942,11 +10942,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeployment">EKSLogForwarderDeployment</h3>
+<h3 id="EKSLogForwarderDeployment">EKSLogForwarderDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <p>
@@ -10965,7 +10965,7 @@ EKSLogForwarderDeployment is the configuration for the EKSLogForwarder Deploymen
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentSpec">
+<a href="#EKSLogForwarderDeploymentSpec">
 EKSLogForwarderDeploymentSpec
 </a>
 </em>
@@ -10986,11 +10986,11 @@ Spec is the specification of the EKSLogForwarder Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentContainer">EKSLogForwarderDeploymentContainer</h3>
+<h3 id="EKSLogForwarderDeploymentContainer">EKSLogForwarderDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
+<a href="#EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -11046,11 +11046,11 @@ If omitted, the EKSLogForwarder Deployment will use its default value for this c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentInitContainer">EKSLogForwarderDeploymentInitContainer</h3>
+<h3 id="EKSLogForwarderDeploymentInitContainer">EKSLogForwarderDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
+<a href="#EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -11106,11 +11106,11 @@ If omitted, the EKSLogForwarder Deployment will use its default value for this i
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</h3>
+<h3 id="EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</a>)
+<a href="#EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11129,7 +11129,7 @@ EKSLogForwarderDeploymentPodSpec is the EKSLogForwarder Deployment&rsquo;s PodSp
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentInitContainer">
+<a href="#EKSLogForwarderDeploymentInitContainer">
 []EKSLogForwarderDeploymentInitContainer
 </a>
 </em>
@@ -11151,7 +11151,7 @@ If omitted, the EKSLogForwarder Deployment will use its default values for its i
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentContainer">
+<a href="#EKSLogForwarderDeploymentContainer">
 []EKSLogForwarderDeploymentContainer
 </a>
 </em>
@@ -11170,11 +11170,11 @@ If omitted, the EKSLogForwarder Deployment will use its default values for its c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</h3>
+<h3 id="EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</a>)
+<a href="#EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</a>)
 
 </p>
 <p>
@@ -11193,7 +11193,7 @@ EKSLogForwarderDeploymentPodTemplateSpec is the EKSLogForwarder Deployment&rsquo
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">
+<a href="#EKSLogForwarderDeploymentPodSpec">
 EKSLogForwarderDeploymentPodSpec
 </a>
 </em>
@@ -11214,11 +11214,11 @@ Spec is the EKSLogForwarder Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</h3>
+<h3 id="EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeployment">EKSLogForwarderDeployment</a>)
+<a href="#EKSLogForwarderDeployment">EKSLogForwarderDeployment</a>)
 
 </p>
 <p>
@@ -11237,7 +11237,7 @@ EKSLogForwarderDeploymentSpec defines configuration for the EKSLogForwarder Depl
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodTemplateSpec">
+<a href="#EKSLogForwarderDeploymentPodTemplateSpec">
 EKSLogForwarderDeploymentPodTemplateSpec
 </a>
 </em>
@@ -11254,11 +11254,11 @@ Template describes the EKSLogForwarder Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
+<h3 id="EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11277,7 +11277,7 @@ EgressGatewayDeploymentPodSpec is the Egress Gateway Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentInitContainer">
+<a href="#EGWDeploymentInitContainer">
 []EGWDeploymentInitContainer
 </a>
 </em>
@@ -11299,7 +11299,7 @@ If omitted, the EGW Deployment will use its default values for its init containe
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentContainer">
+<a href="#EGWDeploymentContainer">
 []EGWDeploymentContainer
 </a>
 </em>
@@ -11434,11 +11434,11 @@ PriorityClassName allows to specify a PriorityClass resource to be used.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
+<h3 id="EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -11457,7 +11457,7 @@ EgressGatewayDeploymentPodTemplateSpec is the EGW Deployment&rsquo;s PodTemplate
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayMetadata">
+<a href="#EgressGatewayMetadata">
 EgressGatewayMetadata
 </a>
 </em>
@@ -11478,7 +11478,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">
+<a href="#EgressGatewayDeploymentPodSpec">
 EgressGatewayDeploymentPodSpec
 </a>
 </em>
@@ -11499,11 +11499,11 @@ Spec is the EGW Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
+<h3 id="EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -11544,7 +11544,7 @@ Default: 90
 
 <code>icmpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ICMPProbe">
+<a href="#ICMPProbe">
 ICMPProbe
 </a>
 </em>
@@ -11566,7 +11566,7 @@ fail. Timeout must be greater than interval.
 
 <code>httpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HTTPProbe">
+<a href="#HTTPProbe">
 HTTPProbe
 </a>
 </em>
@@ -11585,11 +11585,11 @@ fail. Timeout must be greater than interval.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayIPPool">EgressGatewayIPPool</h3>
+<h3 id="EgressGatewayIPPool">EgressGatewayIPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <table>
@@ -11638,11 +11638,11 @@ CIDR is the IPPool CIDR that the Egress Gateways can use.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayMetadata">EgressGatewayMetadata</h3>
+<h3 id="EgressGatewayMetadata">EgressGatewayMetadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11700,11 +11700,11 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</h3>
+<h3 id="EgressGatewaySpec">EgressGatewaySpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -11741,7 +11741,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -11782,7 +11782,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -11803,7 +11803,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -11823,7 +11823,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -11847,7 +11847,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -11864,11 +11864,11 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayStatus">EgressGatewayStatus</h3>
+<h3 id="EgressGatewayStatus">EgressGatewayStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -11922,11 +11922,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EksCloudwatchLogsSpec">EksCloudwatchLogsSpec</h3>
+<h3 id="EksCloudwatchLogsSpec">EksCloudwatchLogsSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">AdditionalLogSourceSpec</a>)
+<a href="#AdditionalLogSourceSpec">AdditionalLogSourceSpec</a>)
 
 </p>
 <p>
@@ -12014,11 +12014,11 @@ Default: 60
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</h3>
+<h3 id="ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -12037,7 +12037,7 @@ ElasticsearchMetricsDeployment is the configuration for the tigera-elasticsearch
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentSpec">
+<a href="#ElasticsearchMetricsDeploymentSpec">
 ElasticsearchMetricsDeploymentSpec
 </a>
 </em>
@@ -12058,11 +12058,11 @@ Spec is the specification of the ElasticsearchMetrics Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentContainer">ElasticsearchMetricsDeploymentContainer</h3>
+<h3 id="ElasticsearchMetricsDeploymentContainer">ElasticsearchMetricsDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -12118,11 +12118,11 @@ If omitted, the ElasticsearchMetrics Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentInitContainer">ElasticsearchMetricsDeploymentInitContainer</h3>
+<h3 id="ElasticsearchMetricsDeploymentInitContainer">ElasticsearchMetricsDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -12178,11 +12178,11 @@ If omitted, the ElasticsearchMetrics Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</h3>
+<h3 id="ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -12201,7 +12201,7 @@ ElasticsearchMetricsDeploymentPodSpec is the tElasticsearchMetricsDeployment&rsq
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentInitContainer">
+<a href="#ElasticsearchMetricsDeploymentInitContainer">
 []ElasticsearchMetricsDeploymentInitContainer
 </a>
 </em>
@@ -12223,7 +12223,7 @@ If omitted, the ElasticsearchMetrics Deployment will use its default values for 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentContainer">
+<a href="#ElasticsearchMetricsDeploymentContainer">
 []ElasticsearchMetricsDeploymentContainer
 </a>
 </em>
@@ -12242,11 +12242,11 @@ If omitted, the ElasticsearchMetrics Deployment will use its default values for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</h3>
+<h3 id="ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</a>)
 
 </p>
 <p>
@@ -12265,7 +12265,7 @@ ElasticsearchMetricsDeploymentPodTemplateSpec is the ElasticsearchMetricsDeploym
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">
+<a href="#ElasticsearchMetricsDeploymentPodSpec">
 ElasticsearchMetricsDeploymentPodSpec
 </a>
 </em>
@@ -12286,11 +12286,11 @@ Spec is the ElasticsearchMetrics Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</h3>
+<h3 id="ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</a>)
+<a href="#ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</a>)
 
 </p>
 <p>
@@ -12309,7 +12309,7 @@ ElasticsearchMetricsDeploymentSpec defines configuration for the ElasticsearchMe
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodTemplateSpec">
+<a href="#ElasticsearchMetricsDeploymentPodTemplateSpec">
 ElasticsearchMetricsDeploymentPodTemplateSpec
 </a>
 </em>
@@ -12326,20 +12326,20 @@ Template describes the ElasticsearchMetrics Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EmailVerificationType">EmailVerificationType
+<h3 id="EmailVerificationType">EmailVerificationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.EncapsulationType">EncapsulationType
+<h3 id="EncapsulationType">EncapsulationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -12348,12 +12348,12 @@ EncapsulationType is the type of encapsulation to use on an IP pool.
 <p>
 One of: IPIP, VXLAN, IPIPCrossSubnet, VXLANCrossSubnet, None
 </p>
-<h3 id="operator.tigera.io/v1.EncryptionOption">EncryptionOption
+<h3 id="EncryptionOption">EncryptionOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</a>)
+<a href="#SyslogStoreSpec">SyslogStoreSpec</a>)
 
 </p>
 <p>
@@ -12362,11 +12362,11 @@ EncryptionOption specifies the traffic encryption mode when connecting to a Sysl
 <p>
 One of: None, TLS
 </p>
-<h3 id="operator.tigera.io/v1.Endpoint">Endpoint</h3>
+<h3 id="Endpoint">Endpoint</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ServiceMonitor">ServiceMonitor</a>)
+<a href="#ServiceMonitor">ServiceMonitor</a>)
 
 </p>
 <p>
@@ -12527,11 +12527,11 @@ More info: <a href="https://prometheus.io/docs/prometheus/latest/configuration/c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EnvoySettings">EnvoySettings</h3>
+<h3 id="EnvoySettings">EnvoySettings</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -12584,11 +12584,11 @@ manipulating various headers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ExternalPrometheus">ExternalPrometheus</h3>
+<h3 id="ExternalPrometheus">ExternalPrometheus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.MonitorSpec">MonitorSpec</a>)
+<a href="#MonitorSpec">MonitorSpec</a>)
 
 </p>
 <table>
@@ -12604,7 +12604,7 @@ manipulating various headers.
 
 <code>serviceMonitor</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ServiceMonitor">
+<a href="#ServiceMonitor">
 ServiceMonitor
 </a>
 </em>
@@ -12644,19 +12644,19 @@ must be created before the operator will create Prometheus resources.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FIPSMode">FIPSMode
+<h3 id="FIPSMode">FIPSMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSet">FluentdDaemonSet</h3>
+<h3 id="FluentdDaemonSet">FluentdDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <p>
@@ -12675,7 +12675,7 @@ FluentdDaemonSet is the configuration for the Fluentd DaemonSet.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetSpec">
+<a href="#FluentdDaemonSetSpec">
 FluentdDaemonSetSpec
 </a>
 </em>
@@ -12696,11 +12696,11 @@ Spec is the specification of the Fluentd DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetContainer">FluentdDaemonSetContainer</h3>
+<h3 id="FluentdDaemonSetContainer">FluentdDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
+<a href="#FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -12756,11 +12756,11 @@ If omitted, the Fluentd DaemonSet will use its default value for this container&
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetInitContainer">FluentdDaemonSetInitContainer</h3>
+<h3 id="FluentdDaemonSetInitContainer">FluentdDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
+<a href="#FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -12816,11 +12816,11 @@ If omitted, the Fluentd DaemonSet will use its default value for this init conta
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</h3>
+<h3 id="FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</a>)
+<a href="#FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -12839,7 +12839,7 @@ FluentdDaemonSetPodSpec is the Fluentd DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetInitContainer">
+<a href="#FluentdDaemonSetInitContainer">
 []FluentdDaemonSetInitContainer
 </a>
 </em>
@@ -12861,7 +12861,7 @@ If omitted, the Fluentd DaemonSet will use its default values for its init conta
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetContainer">
+<a href="#FluentdDaemonSetContainer">
 []FluentdDaemonSetContainer
 </a>
 </em>
@@ -12880,11 +12880,11 @@ If omitted, the Fluentd DaemonSet will use its default values for its containers
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</h3>
+<h3 id="FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetSpec">FluentdDaemonSetSpec</a>)
+<a href="#FluentdDaemonSetSpec">FluentdDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -12903,7 +12903,7 @@ FluentdDaemonSetPodTemplateSpec is the Fluentd DaemonSet&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodSpec">
+<a href="#FluentdDaemonSetPodSpec">
 FluentdDaemonSetPodSpec
 </a>
 </em>
@@ -12924,11 +12924,11 @@ Spec is the Fluentd DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetSpec">FluentdDaemonSetSpec</h3>
+<h3 id="FluentdDaemonSetSpec">FluentdDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSet">FluentdDaemonSet</a>)
+<a href="#FluentdDaemonSet">FluentdDaemonSet</a>)
 
 </p>
 <p>
@@ -12947,7 +12947,7 @@ FluentdDaemonSetSpec defines configuration for the Fluentd DaemonSet.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodTemplateSpec">
+<a href="#FluentdDaemonSetPodTemplateSpec">
 FluentdDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -12964,11 +12964,11 @@ Template describes the Fluentd DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GroupSearch">GroupSearch</h3>
+<h3 id="GroupSearch">GroupSearch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</a>)
+<a href="#AuthenticationLDAP">AuthenticationLDAP</a>)
 
 </p>
 <p>
@@ -13040,7 +13040,7 @@ The attribute of the group that represents its name. This attribute can be used 
 
 <code>userMatchers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.UserMatch">
+<a href="#UserMatch">
 []UserMatch
 </a>
 </em>
@@ -13058,11 +13058,11 @@ attribute value.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeployment">GuardianDeployment</h3>
+<h3 id="GuardianDeployment">GuardianDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
+<a href="#ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
 
 </p>
 <p>
@@ -13081,7 +13081,7 @@ GuardianDeployment is the configuration for the guardian Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentSpec">
+<a href="#GuardianDeploymentSpec">
 GuardianDeploymentSpec
 </a>
 </em>
@@ -13102,11 +13102,11 @@ Spec is the specification of the guardian Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentContainer">GuardianDeploymentContainer</h3>
+<h3 id="GuardianDeploymentContainer">GuardianDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
+<a href="#GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -13162,11 +13162,11 @@ If omitted, the guardian Deployment will use its default value for this containe
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentInitContainer">GuardianDeploymentInitContainer</h3>
+<h3 id="GuardianDeploymentInitContainer">GuardianDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
+<a href="#GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -13221,11 +13221,11 @@ If omitted, the guardian Deployment will use its default value for this init con
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</h3>
+<h3 id="GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</a>)
+<a href="#GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -13244,7 +13244,7 @@ GuardianDeploymentPodSpec is the guardian Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentInitContainer">
+<a href="#GuardianDeploymentInitContainer">
 []GuardianDeploymentInitContainer
 </a>
 </em>
@@ -13266,7 +13266,7 @@ If omitted, the guardian Deployment will use its default values for its init con
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentContainer">
+<a href="#GuardianDeploymentContainer">
 []GuardianDeploymentContainer
 </a>
 </em>
@@ -13285,11 +13285,11 @@ If omitted, the guardian Deployment will use its default values for its containe
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</h3>
+<h3 id="GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentSpec">GuardianDeploymentSpec</a>)
+<a href="#GuardianDeploymentSpec">GuardianDeploymentSpec</a>)
 
 </p>
 <p>
@@ -13308,7 +13308,7 @@ GuardianDeploymentPodTemplateSpec is the guardian Deployment&rsquo;s PodTemplate
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodSpec">
+<a href="#GuardianDeploymentPodSpec">
 GuardianDeploymentPodSpec
 </a>
 </em>
@@ -13329,11 +13329,11 @@ Spec is the guardian Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentSpec">GuardianDeploymentSpec</h3>
+<h3 id="GuardianDeploymentSpec">GuardianDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeployment">GuardianDeployment</a>)
+<a href="#GuardianDeployment">GuardianDeployment</a>)
 
 </p>
 <p>
@@ -13352,7 +13352,7 @@ GuardianDeploymentSpec defines configuration for the guardian Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodTemplateSpec">
+<a href="#GuardianDeploymentPodTemplateSpec">
 GuardianDeploymentPodTemplateSpec
 </a>
 </em>
@@ -13369,11 +13369,11 @@ Template describes the guardian Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HTTPProbe">HTTPProbe</h3>
+<h3 id="HTTPProbe">HTTPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -13445,12 +13445,12 @@ Default: 30
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HostPortsType">HostPortsType
+<h3 id="HostPortsType">HostPortsType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -13459,11 +13459,11 @@ HostPortsType specifies host port support.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.ICMPProbe">ICMPProbe</h3>
+<h3 id="ICMPProbe">ICMPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -13535,19 +13535,19 @@ Default: 15
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPAMPluginType">IPAMPluginType
+<h3 id="IPAMPluginType">IPAMPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPAMSpec">IPAMSpec</a>)
+<a href="#IPAMSpec">IPAMSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IPAMSpec">IPAMSpec</h3>
+<h3 id="IPAMSpec">IPAMSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -13566,7 +13566,7 @@ IPAMSpec contains configuration for pod IP address management.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMPluginType">
+<a href="#IPAMPluginType">
 IPAMPluginType
 </a>
 </em>
@@ -13594,11 +13594,11 @@ Default: Calico
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPPool">IPPool</h3>
+<h3 id="IPPool">IPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -13648,7 +13648,7 @@ CIDR contains the address range for the IP Pool in classless inter-domain routin
 
 <code>encapsulation</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncapsulationType">
+<a href="#EncapsulationType">
 EncapsulationType
 </a>
 </em>
@@ -13670,7 +13670,7 @@ Default: IPIP
 
 <code>natOutgoing</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NATOutgoingType">
+<a href="#NATOutgoingType">
 NATOutgoingType
 </a>
 </em>
@@ -13768,7 +13768,7 @@ impacting any existing pods that have already been assigned addresses from this 
 
 <code>allowedUses</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPPoolAllowedUse">
+<a href="#IPPoolAllowedUse">
 []IPPoolAllowedUse
 </a>
 </em>
@@ -13785,19 +13785,19 @@ AllowedUse controls what the IP pool will be used for.  If not specified or empt
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPPoolAllowedUse">IPPoolAllowedUse
+<h3 id="IPPoolAllowedUse">IPPoolAllowedUse
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.Image">Image</h3>
+<h3 id="Image">Image</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</a>)
+<a href="#ImageSetSpec">ImageSetSpec</a>)
 
 </p>
 <table>
@@ -13848,11 +13848,11 @@ The field should not include a leading <code>@</code> and must be prefixed with 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</h3>
+<h3 id="ImageSetSpec">ImageSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>)
+<a href="#ImageSet">ImageSet</a>)
 
 </p>
 <p>
@@ -13871,7 +13871,7 @@ ImageSetSpec defines the desired state of ImageSet.
 
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -13888,11 +13888,11 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Index">Index</h3>
+<h3 id="Index">Index</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -13930,7 +13930,7 @@ excludes the numerical identifier suffix)
 
 <code>dataType</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DataType">
+<a href="#DataType">
 DataType
 </a>
 </em>
@@ -13946,11 +13946,11 @@ DataType represents the type of data stored in the defined index
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Indices">Indices</h3>
+<h3 id="Indices">Indices</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -13984,12 +13984,12 @@ Replicas defines how many replicas each index will have. See <a href="https://ww
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationSpec">InstallationSpec</h3>
+<h3 id="InstallationSpec">InstallationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#Installation">Installation</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -14008,7 +14008,7 @@ InstallationSpec defines configuration for a Calico or Calico Enterprise install
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -14136,7 +14136,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -14159,7 +14159,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -14179,7 +14179,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -14199,7 +14199,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -14378,7 +14378,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -14400,7 +14400,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -14422,7 +14422,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -14442,7 +14442,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -14462,7 +14462,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -14481,7 +14481,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -14501,7 +14501,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -14521,7 +14521,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -14541,7 +14541,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -14560,7 +14560,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -14581,7 +14581,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -14601,7 +14601,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -14636,11 +14636,11 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationStatus">InstallationStatus</h3>
+<h3 id="InstallationStatus">InstallationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>)
+<a href="#Installation">Installation</a>)
 
 </p>
 <p>
@@ -14659,7 +14659,7 @@ InstallationStatus defines the observed state of the Calico or Calico Enterprise
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -14715,7 +14715,7 @@ that is being used. If an ImageSet is not being used then this will not be set.
 
 <code>computed</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -14772,19 +14772,19 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionComponentName">IntrusionDetectionComponentName
+<h3 id="IntrusionDetectionComponentName">IntrusionDetectionComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</a>)
+<a href="#IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</h3>
+<h3 id="IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <p>
@@ -14803,7 +14803,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentName">
+<a href="#IntrusionDetectionComponentName">
 IntrusionDetectionComponentName
 </a>
 </em>
@@ -14838,11 +14838,11 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</h3>
+<h3 id="IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <p>
@@ -14861,7 +14861,7 @@ IntrusionDetectionControllerDeployment is the configuration for the IntrusionDet
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentSpec">
+<a href="#IntrusionDetectionControllerDeploymentSpec">
 IntrusionDetectionControllerDeploymentSpec
 </a>
 </em>
@@ -14882,11 +14882,11 @@ Spec is the specification of the IntrusionDetectionController Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentContainer">IntrusionDetectionControllerDeploymentContainer</h3>
+<h3 id="IntrusionDetectionControllerDeploymentContainer">IntrusionDetectionControllerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -14942,11 +14942,11 @@ If omitted, the IntrusionDetection Deployment will use its default value for thi
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentInitContainer">IntrusionDetectionControllerDeploymentInitContainer</h3>
+<h3 id="IntrusionDetectionControllerDeploymentInitContainer">IntrusionDetectionControllerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -15002,11 +15002,11 @@ If omitted, the IntrusionDetectionController Deployment will use its default val
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</h3>
+<h3 id="IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -15025,7 +15025,7 @@ IntrusionDetectionControllerDeploymentPodSpec is the IntrusionDetectionControlle
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentInitContainer">
+<a href="#IntrusionDetectionControllerDeploymentInitContainer">
 []IntrusionDetectionControllerDeploymentInitContainer
 </a>
 </em>
@@ -15047,7 +15047,7 @@ If omitted, the IntrusionDetectionController Deployment will use its default val
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentContainer">
+<a href="#IntrusionDetectionControllerDeploymentContainer">
 []IntrusionDetectionControllerDeploymentContainer
 </a>
 </em>
@@ -15066,11 +15066,11 @@ If omitted, the IntrusionDetectionController Deployment will use its default val
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</h3>
+<h3 id="IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -15089,7 +15089,7 @@ IntrusionDetectionControllerDeploymentPodTemplateSpec is the IntrusionDetectionC
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">
+<a href="#IntrusionDetectionControllerDeploymentPodSpec">
 IntrusionDetectionControllerDeploymentPodSpec
 </a>
 </em>
@@ -15110,11 +15110,11 @@ Spec is the IntrusionDetectionController Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</h3>
+<h3 id="IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</a>)
+<a href="#IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</a>)
 
 </p>
 <p>
@@ -15133,7 +15133,7 @@ IntrusionDetectionControllerDeploymentSpec defines configuration for the Intrusi
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodTemplateSpec">
+<a href="#IntrusionDetectionControllerDeploymentPodTemplateSpec">
 IntrusionDetectionControllerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -15150,11 +15150,11 @@ Template describes the IntrusionDetectionController Deployment pod that will be 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</h3>
+<h3 id="IntrusionDetectionSpec">IntrusionDetectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>)
+<a href="#IntrusionDetection">IntrusionDetection</a>)
 
 </p>
 <p>
@@ -15173,7 +15173,7 @@ IntrusionDetectionSpec defines the desired state of Tigera intrusion detection c
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">
+<a href="#IntrusionDetectionComponentResource">
 []IntrusionDetectionComponentResource
 </a>
 </em>
@@ -15194,7 +15194,7 @@ Only DeepPacketInspection is supported for this spec.
 
 <code>anomalyDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+<a href="#AnomalyDetectionSpec">
 AnomalyDetectionSpec
 </a>
 </em>
@@ -15214,7 +15214,7 @@ AnomalyDetection is now deprecated, and configuring it has no effect.
 
 <code>intrusionDetectionControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeployment">
+<a href="#IntrusionDetectionControllerDeployment">
 IntrusionDetectionControllerDeployment
 </a>
 </em>
@@ -15231,11 +15231,11 @@ IntrusionDetectionControllerDeployment configures the IntrusionDetection Control
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionStatus">IntrusionDetectionStatus</h3>
+<h3 id="IntrusionDetectionStatus">IntrusionDetectionStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>)
+<a href="#IntrusionDetection">IntrusionDetection</a>)
 
 </p>
 <p>
@@ -15289,11 +15289,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Kibana">Kibana</h3>
+<h3 id="Kibana">Kibana</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -15312,7 +15312,7 @@ Kibana is the configuration for the Kibana.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaSpec">
+<a href="#KibanaSpec">
 KibanaSpec
 </a>
 </em>
@@ -15333,11 +15333,11 @@ Spec is the specification of the Kibana.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaContainer">KibanaContainer</h3>
+<h3 id="KibanaContainer">KibanaContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaPodSpec">KibanaPodSpec</a>)
+<a href="#KibanaPodSpec">KibanaPodSpec</a>)
 
 </p>
 <p>
@@ -15393,11 +15393,11 @@ If omitted, the Kibana will use its default value for this container&rsquo;s res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaInitContainer">KibanaInitContainer</h3>
+<h3 id="KibanaInitContainer">KibanaInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaPodSpec">KibanaPodSpec</a>)
+<a href="#KibanaPodSpec">KibanaPodSpec</a>)
 
 </p>
 <p>
@@ -15454,11 +15454,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaPodSpec">KibanaPodSpec</h3>
+<h3 id="KibanaPodSpec">KibanaPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaPodTemplateSpec">KibanaPodTemplateSpec</a>)
+<a href="#KibanaPodTemplateSpec">KibanaPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -15477,7 +15477,7 @@ KibanaPodSpec is the Kibana Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaInitContainer">
+<a href="#KibanaInitContainer">
 []KibanaInitContainer
 </a>
 </em>
@@ -15499,7 +15499,7 @@ If omitted, the Kibana Deployment will use its default values for its init conta
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaContainer">
+<a href="#KibanaContainer">
 []KibanaContainer
 </a>
 </em>
@@ -15518,11 +15518,11 @@ If omitted, the Kibana Deployment will use its default values for its containers
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaPodTemplateSpec">KibanaPodTemplateSpec</h3>
+<h3 id="KibanaPodTemplateSpec">KibanaPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaSpec">KibanaSpec</a>)
+<a href="#KibanaSpec">KibanaSpec</a>)
 
 </p>
 <p>
@@ -15541,7 +15541,7 @@ KibanaPodTemplateSpec is the Kibana&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaPodSpec">
+<a href="#KibanaPodSpec">
 KibanaPodSpec
 </a>
 </em>
@@ -15562,11 +15562,11 @@ Spec is the Kibana&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaSpec">KibanaSpec</h3>
+<h3 id="KibanaSpec">KibanaSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Kibana">Kibana</a>)
+<a href="#Kibana">Kibana</a>)
 
 </p>
 <table>
@@ -15582,7 +15582,7 @@ Spec is the Kibana&rsquo;s PodSpec.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaPodTemplateSpec">
+<a href="#KibanaPodTemplateSpec">
 KibanaPodTemplateSpec
 </a>
 </em>
@@ -15599,12 +15599,12 @@ Template describes the Kibana pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
+<h3 id="KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</a>)
+<a href="#NodeAddressAutodetection">NodeAddressAutodetection</a>)
 
 </p>
 <p>
@@ -15613,11 +15613,11 @@ KubernetesAutodetectionMethod is a method of detecting an IP address based on th
 <p>
 One of: NodeInternalIP
 </p>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</h3>
+<h3 id="L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <p>
@@ -15636,7 +15636,7 @@ L7LogCollectorDaemonSet is the configuration for the L7LogCollector DaemonSet.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetSpec">
+<a href="#L7LogCollectorDaemonSetSpec">
 L7LogCollectorDaemonSetSpec
 </a>
 </em>
@@ -15657,11 +15657,11 @@ Spec is the specification of the L7LogCollector DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetContainer">L7LogCollectorDaemonSetContainer</h3>
+<h3 id="L7LogCollectorDaemonSetContainer">L7LogCollectorDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
+<a href="#L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -15717,11 +15717,11 @@ If omitted, the L7LogCollector DaemonSet will use its default value for this con
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetInitContainer">L7LogCollectorDaemonSetInitContainer</h3>
+<h3 id="L7LogCollectorDaemonSetInitContainer">L7LogCollectorDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
+<a href="#L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -15776,11 +15776,11 @@ If omitted, the L7LogCollector DaemonSet will use its default value for this ini
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</h3>
+<h3 id="L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</a>)
+<a href="#L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -15799,7 +15799,7 @@ L7LogCollectorDaemonSetPodSpec is the L7LogCollector DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetInitContainer">
+<a href="#L7LogCollectorDaemonSetInitContainer">
 []L7LogCollectorDaemonSetInitContainer
 </a>
 </em>
@@ -15821,7 +15821,7 @@ If omitted, the L7LogCollector DaemonSet will use its default values for its ini
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetContainer">
+<a href="#L7LogCollectorDaemonSetContainer">
 []L7LogCollectorDaemonSetContainer
 </a>
 </em>
@@ -15840,11 +15840,11 @@ If omitted, the L7LogCollector DaemonSet will use its default values for its con
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</h3>
+<h3 id="L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</a>)
+<a href="#L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -15863,7 +15863,7 @@ L7LogCollectorDaemonSetPodTemplateSpec is the L7LogCollector DaemonSet&rsquo;s P
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">
+<a href="#L7LogCollectorDaemonSetPodSpec">
 L7LogCollectorDaemonSetPodSpec
 </a>
 </em>
@@ -15884,11 +15884,11 @@ Spec is the L7LogCollector DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</h3>
+<h3 id="L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</a>)
+<a href="#L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</a>)
 
 </p>
 <p>
@@ -15907,7 +15907,7 @@ L7LogCollectorDaemonSetSpec defines configuration for the L7LogCollector DaemonS
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodTemplateSpec">
+<a href="#L7LogCollectorDaemonSetPodTemplateSpec">
 L7LogCollectorDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -15924,12 +15924,12 @@ Template describes the L7LogCollector DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeployment">LinseedDeployment</h3>
+<h3 id="LinseedDeployment">LinseedDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>, 
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>, 
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -15948,7 +15948,7 @@ LinseedDeployment is the configuration for the linseed Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentSpec">
+<a href="#LinseedDeploymentSpec">
 LinseedDeploymentSpec
 </a>
 </em>
@@ -15969,11 +15969,11 @@ Spec is the specification of the linseed Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentContainer">LinseedDeploymentContainer</h3>
+<h3 id="LinseedDeploymentContainer">LinseedDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
+<a href="#LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -16029,11 +16029,11 @@ If omitted, the linseed Deployment will use its default value for this container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentInitContainer">LinseedDeploymentInitContainer</h3>
+<h3 id="LinseedDeploymentInitContainer">LinseedDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
+<a href="#LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -16089,11 +16089,11 @@ If omitted, the linseed Deployment will use its default value for this init cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</h3>
+<h3 id="LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</a>)
+<a href="#LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -16112,7 +16112,7 @@ LinseedDeploymentPodSpec is the linseed Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentInitContainer">
+<a href="#LinseedDeploymentInitContainer">
 []LinseedDeploymentInitContainer
 </a>
 </em>
@@ -16134,7 +16134,7 @@ If omitted, the linseed Deployment will use its default values for its init cont
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentContainer">
+<a href="#LinseedDeploymentContainer">
 []LinseedDeploymentContainer
 </a>
 </em>
@@ -16153,11 +16153,11 @@ If omitted, the linseed Deployment will use its default values for its container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</h3>
+<h3 id="LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentSpec">LinseedDeploymentSpec</a>)
+<a href="#LinseedDeploymentSpec">LinseedDeploymentSpec</a>)
 
 </p>
 <p>
@@ -16176,7 +16176,7 @@ LinseedDeploymentPodTemplateSpec is the linseed Deployment&rsquo;s PodTemplateSp
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">
+<a href="#LinseedDeploymentPodSpec">
 LinseedDeploymentPodSpec
 </a>
 </em>
@@ -16197,11 +16197,11 @@ Spec is the linseed Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentSpec">LinseedDeploymentSpec</h3>
+<h3 id="LinseedDeploymentSpec">LinseedDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">LinseedDeployment</a>)
+<a href="#LinseedDeployment">LinseedDeployment</a>)
 
 </p>
 <p>
@@ -16220,7 +16220,7 @@ LinseedDeploymentSpec defines configuration for the linseed Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">
+<a href="#LinseedDeploymentPodTemplateSpec">
 LinseedDeploymentPodTemplateSpec
 </a>
 </em>
@@ -16237,12 +16237,12 @@ Template describes the linseed Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinuxDataplaneOption">LinuxDataplaneOption
+<h3 id="LinuxDataplaneOption">LinuxDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -16251,11 +16251,11 @@ LinuxDataplaneOption controls which dataplane is to be used on Linux nodes.
 <p>
 One of: Iptables, BPF, VPP, Nftables
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</h3>
+<h3 id="LogCollectionSpec">LogCollectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -16271,7 +16271,7 @@ One of: Iptables, BPF, VPP, Nftables
 
 <code>collectLogs</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionStatusType">
+<a href="#LogCollectionStatusType">
 LogCollectionStatusType
 </a>
 </em>
@@ -16329,19 +16329,19 @@ Default: -1
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectionStatusType">LogCollectionStatusType
+<h3 id="LogCollectionStatusType">LogCollectionStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</a>)
+<a href="#LogCollectionSpec">LogCollectionSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</h3>
+<h3 id="LogCollectorSpec">LogCollectorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>)
+<a href="#LogCollector">LogCollector</a>)
 
 </p>
 <p>
@@ -16360,7 +16360,7 @@ LogCollectorSpec defines the desired state of Tigera flow, audit, and DNS log co
 
 <code>additionalStores</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">
+<a href="#AdditionalLogStoreSpec">
 AdditionalLogStoreSpec
 </a>
 </em>
@@ -16380,7 +16380,7 @@ Configuration for exporting flow, audit, and DNS logs to external storage.
 
 <code>additionalSources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">
+<a href="#AdditionalLogSourceSpec">
 AdditionalLogSourceSpec
 </a>
 </em>
@@ -16400,7 +16400,7 @@ Configuration for importing audit logs from managed kubernetes cluster log sourc
 
 <code>collectProcessPath</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CollectProcessPathOption">
+<a href="#CollectProcessPathOption">
 CollectProcessPathOption
 </a>
 </em>
@@ -16441,7 +16441,7 @@ the management cluster&rsquo;s tenant services are running.
 
 <code>fluentdDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSet">
+<a href="#FluentdDaemonSet">
 FluentdDaemonSet
 </a>
 </em>
@@ -16460,7 +16460,7 @@ FluentdDaemonSet configures the Fluentd DaemonSet.
 
 <code>eksLogForwarderDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeployment">
+<a href="#EKSLogForwarderDeployment">
 EKSLogForwarderDeployment
 </a>
 </em>
@@ -16477,11 +16477,11 @@ EKSLogForwarderDeployment configures the EKSLogForwarderDeployment Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectorStatus">LogCollectorStatus</h3>
+<h3 id="LogCollectorStatus">LogCollectorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>)
+<a href="#LogCollector">LogCollector</a>)
 
 </p>
 <p>
@@ -16535,31 +16535,31 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogLevel">LogLevel
+<h3 id="LogLevel">LogLevel
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNILogging">CNILogging</a>, 
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#CNILogging">CNILogging</a>, 
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogStorageComponentName">LogStorageComponentName
+<h3 id="LogStorageComponentName">LogStorageComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">LogStorageComponentResource</a>)
+<a href="#LogStorageComponentResource">LogStorageComponentResource</a>)
 
 </p>
 <p>
 LogStorageComponentName CRD enum
 </p>
-<h3 id="operator.tigera.io/v1.LogStorageComponentResource">LogStorageComponentResource</h3>
+<h3 id="LogStorageComponentResource">LogStorageComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -16578,7 +16578,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentName">
+<a href="#LogStorageComponentName">
 LogStorageComponentName
 </a>
 </em>
@@ -16614,11 +16614,11 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</h3>
+<h3 id="LogStorageSpec">LogStorageSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>)
+<a href="#LogStorage">LogStorage</a>)
 
 </p>
 <p>
@@ -16637,7 +16637,7 @@ LogStorageSpec defines the desired state of Tigera flow and DNS log storage.
 
 <code>nodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Nodes">
+<a href="#Nodes">
 Nodes
 </a>
 </em>
@@ -16656,7 +16656,7 @@ Nodes defines the configuration for a set of identical Elasticsearch cluster nod
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Indices">
+<a href="#Indices">
 Indices
 </a>
 </em>
@@ -16676,7 +16676,7 @@ Index defines the configuration for the indices in the Elasticsearch cluster.
 
 <code>retention</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Retention">
+<a href="#Retention">
 Retention
 </a>
 </em>
@@ -16738,7 +16738,7 @@ each of the indicated key-value pairs as labels as well as access to the specifi
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">
+<a href="#LogStorageComponentResource">
 []LogStorageComponentResource
 </a>
 </em>
@@ -16759,7 +16759,7 @@ Only ECKOperator is supported for this spec.
 
 <code>eckOperatorStatefulSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSet">
+<a href="#ECKOperatorStatefulSet">
 ECKOperatorStatefulSet
 </a>
 </em>
@@ -16780,7 +16780,7 @@ ComponentResources, then these overrides take precedence.
 
 <code>kibana</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Kibana">
+<a href="#Kibana">
 Kibana
 </a>
 </em>
@@ -16800,7 +16800,7 @@ Kibana configures the Kibana Spec.
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -16819,7 +16819,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>elasticsearchMetricsDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeployment">
+<a href="#ElasticsearchMetricsDeployment">
 ElasticsearchMetricsDeployment
 </a>
 </em>
@@ -16835,11 +16835,11 @@ ElasticsearchMetricsDeployment configures the tigera-elasticsearch-metric Deploy
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorageStatus">LogStorageStatus</h3>
+<h3 id="LogStorageStatus">LogStorageStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>)
+<a href="#LogStorage">LogStorage</a>)
 
 </p>
 <p>
@@ -16929,11 +16929,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Logging">Logging</h3>
+<h3 id="Logging">Logging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>
@@ -16949,7 +16949,7 @@ Ready, Progressing, Degraded or other customer types.
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNILogging">
+<a href="#CNILogging">
 CNILogging
 </a>
 </em>
@@ -16966,11 +16966,11 @@ Customized logging specification for calico-cni plugin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</h3>
+<h3 id="ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>)
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>)
 
 </p>
 <p>
@@ -17008,7 +17008,7 @@ should be able to access this address. This field is used by managed clusters on
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">
+<a href="#ManagementClusterTLS">
 ManagementClusterTLS
 </a>
 </em>
@@ -17028,7 +17028,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>guardianDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeployment">
+<a href="#GuardianDeployment">
 GuardianDeployment
 </a>
 </em>
@@ -17044,11 +17044,11 @@ GuardianDeployment configures the guardian Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnectionStatus">ManagementClusterConnectionStatus</h3>
+<h3 id="ManagementClusterConnectionStatus">ManagementClusterConnectionStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>)
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>)
 
 </p>
 <p>
@@ -17085,11 +17085,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterSpec">ManagementClusterSpec</h3>
+<h3 id="ManagementClusterSpec">ManagementClusterSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementCluster">ManagementCluster</a>)
+<a href="#ManagementCluster">ManagementCluster</a>)
 
 </p>
 <p>
@@ -17128,7 +17128,7 @@ Valid examples are: &ldquo;0.0.0.0:31000&rdquo;, &ldquo;example.com:32000&rdquo;
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLS">
+<a href="#TLS">
 TLS
 </a>
 </em>
@@ -17145,11 +17145,11 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterTLS">ManagementClusterTLS</h3>
+<h3 id="ManagementClusterTLS">ManagementClusterTLS</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
+<a href="#ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
 
 </p>
 <table>
@@ -17165,7 +17165,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>ca</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CAType">
+<a href="#CAType">
 CAType
 </a>
 </em>
@@ -17191,11 +17191,11 @@ Default: Tigera
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeployment">ManagerDeployment</h3>
+<h3 id="ManagerDeployment">ManagerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerSpec">ManagerSpec</a>)
+<a href="#ManagerSpec">ManagerSpec</a>)
 
 </p>
 <p>
@@ -17214,7 +17214,7 @@ ManagerDeployment is the configuration for the Manager Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentSpec">
+<a href="#ManagerDeploymentSpec">
 ManagerDeploymentSpec
 </a>
 </em>
@@ -17235,11 +17235,11 @@ Spec is the specification of the Manager Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentContainer">ManagerDeploymentContainer</h3>
+<h3 id="ManagerDeploymentContainer">ManagerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
+<a href="#ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -17295,11 +17295,11 @@ If omitted, the Manager Deployment will use its default value for this container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentInitContainer">ManagerDeploymentInitContainer</h3>
+<h3 id="ManagerDeploymentInitContainer">ManagerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
+<a href="#ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -17356,11 +17356,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</h3>
+<h3 id="ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</a>)
+<a href="#ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -17379,7 +17379,7 @@ ManagerDeploymentPodSpec is the Manager Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentInitContainer">
+<a href="#ManagerDeploymentInitContainer">
 []ManagerDeploymentInitContainer
 </a>
 </em>
@@ -17401,7 +17401,7 @@ If omitted, the Manager Deployment will use its default values for its init cont
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentContainer">
+<a href="#ManagerDeploymentContainer">
 []ManagerDeploymentContainer
 </a>
 </em>
@@ -17420,11 +17420,11 @@ If omitted, the Manager Deployment will use its default values for its container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</h3>
+<h3 id="ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentSpec">ManagerDeploymentSpec</a>)
+<a href="#ManagerDeploymentSpec">ManagerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -17443,7 +17443,7 @@ ManagerDeploymentPodTemplateSpec is the Manager Deployment&rsquo;s PodTemplateSp
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodSpec">
+<a href="#ManagerDeploymentPodSpec">
 ManagerDeploymentPodSpec
 </a>
 </em>
@@ -17464,11 +17464,11 @@ Spec is the Manager Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentSpec">ManagerDeploymentSpec</h3>
+<h3 id="ManagerDeploymentSpec">ManagerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeployment">ManagerDeployment</a>)
+<a href="#ManagerDeployment">ManagerDeployment</a>)
 
 </p>
 <p>
@@ -17487,7 +17487,7 @@ ManagerDeploymentSpec defines configuration for the Manager Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodTemplateSpec">
+<a href="#ManagerDeploymentPodTemplateSpec">
 ManagerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -17504,11 +17504,11 @@ Template describes the Manager Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerSpec">ManagerSpec</h3>
+<h3 id="ManagerSpec">ManagerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>)
+<a href="#Manager">Manager</a>)
 
 </p>
 <p>
@@ -17527,7 +17527,7 @@ ManagerSpec defines configuration for the Calico Enterprise manager GUI.
 
 <code>managerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeployment">
+<a href="#ManagerDeployment">
 ManagerDeployment
 </a>
 </em>
@@ -17544,11 +17544,11 @@ ManagerDeployment configures the Manager Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerStatus">ManagerStatus</h3>
+<h3 id="ManagerStatus">ManagerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>)
+<a href="#Manager">Manager</a>)
 
 </p>
 <p>
@@ -17602,24 +17602,24 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Metadata">Metadata</h3>
+<h3 id="Metadata">Metadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>, 
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>, 
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
+<a href="#TyphaDeployment">TyphaDeployment</a>, 
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -17675,11 +17675,11 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MonitorSpec">MonitorSpec</h3>
+<h3 id="MonitorSpec">MonitorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -17698,7 +17698,7 @@ MonitorSpec defines the desired state of Tigera monitor.
 
 <code>externalPrometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">
+<a href="#ExternalPrometheus">
 ExternalPrometheus
 </a>
 </em>
@@ -17719,7 +17719,7 @@ scraping from git-ops tools without the need of post-installation steps.
 
 <code>prometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Prometheus">
+<a href="#Prometheus">
 Prometheus
 </a>
 </em>
@@ -17739,7 +17739,7 @@ Prometheus is the configuration for the Prometheus.
 
 <code>alertManager</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AlertManager">
+<a href="#AlertManager">
 AlertManager
 </a>
 </em>
@@ -17756,11 +17756,11 @@ AlertManager is the configuration for the AlertManager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MonitorStatus">MonitorStatus</h3>
+<h3 id="MonitorStatus">MonitorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -17814,12 +17814,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MultiInterfaceMode">MultiInterfaceMode
+<h3 id="MultiInterfaceMode">MultiInterfaceMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -17828,12 +17828,12 @@ MultiInterfaceMode describes the method of providing multiple pod interfaces.
 <p>
 One of: None, Multus
 </p>
-<h3 id="operator.tigera.io/v1.NATOutgoingType">NATOutgoingType
+<h3 id="NATOutgoingType">NATOutgoingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -17842,23 +17842,23 @@ NATOutgoingType describe the type of outgoing NAT to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.NativeIP">NativeIP
+<h3 id="NativeIP">NativeIP
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</a>)
+<a href="#AWSEgressGateway">AWSEgressGateway</a>)
 
 </p>
 <p>
 NativeIP defines if Egress Gateway pods should have AWS IPs.
 When NativeIP is enabled, the IPPools should be backed by AWS subnet.
 </p>
-<h3 id="operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</h3>
+<h3 id="NodeAddressAutodetection">NodeAddressAutodetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -17898,7 +17898,7 @@ filtering based on well-known interface names.
 
 <code>kubernetes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KubernetesAutodetectionMethod">
+<a href="#KubernetesAutodetectionMethod">
 KubernetesAutodetectionMethod
 </a>
 </em>
@@ -17989,11 +17989,11 @@ one of the provided CIDRs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeAffinity">NodeAffinity</h3>
+<h3 id="NodeAffinity">NodeAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</a>)
+<a href="#TyphaAffinity">TyphaAffinity</a>)
 
 </p>
 <p>
@@ -18062,11 +18062,11 @@ may or may not try to eventually evict the pod from its node.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeSet">NodeSet</h3>
+<h3 id="NodeSet">NodeSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Nodes">Nodes</a>)
+<a href="#Nodes">Nodes</a>)
 
 </p>
 <p>
@@ -18085,7 +18085,7 @@ NodeSets defines configuration specific to each Elasticsearch Node Set
 
 <code>selectionAttributes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeSetSelectionAttribute">
+<a href="#NodeSetSelectionAttribute">
 []NodeSetSelectionAttribute
 </a>
 </em>
@@ -18103,11 +18103,11 @@ to define Node Affinities and set the node awareness configuration in the runnin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeSetSelectionAttribute">NodeSetSelectionAttribute</h3>
+<h3 id="NodeSetSelectionAttribute">NodeSetSelectionAttribute</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeSet">NodeSet</a>)
+<a href="#NodeSet">NodeSet</a>)
 
 </p>
 <p>
@@ -18167,11 +18167,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Nodes">Nodes</h3>
+<h3 id="Nodes">Nodes</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -18207,7 +18207,7 @@ Count defines the number of nodes in the Elasticsearch cluster.
 
 <code>nodeSets</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeSet">
+<a href="#NodeSet">
 []NodeSet
 </a>
 </em>
@@ -18244,12 +18244,12 @@ ResourceRequirements defines the resource limits and requirements for the Elasti
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NonPrivilegedType">NonPrivilegedType
+<h3 id="NonPrivilegedType">NonPrivilegedType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -18258,12 +18258,12 @@ NonPrivilegedType specifies whether Calico runs as permissioned or not
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.OIDCType">OIDCType
+<h3 id="OIDCType">OIDCType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
 <p>
@@ -18271,11 +18271,11 @@ OIDCType defines how OIDC is configured for Tigera Enterprise. Dex should be the
 The Tigera option can help in specific use-cases, for instance, when you are unable to configure a client secret.
 One of: Dex, Tigera
 </p>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</h3>
+<h3 id="PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPISpec">PacketCaptureAPISpec</a>)
+<a href="#PacketCaptureAPISpec">PacketCaptureAPISpec</a>)
 
 </p>
 <p>
@@ -18294,7 +18294,7 @@ PacketCaptureAPIDeployment is the configuration for the PacketCaptureAPI Deploym
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentSpec">
+<a href="#PacketCaptureAPIDeploymentSpec">
 PacketCaptureAPIDeploymentSpec
 </a>
 </em>
@@ -18315,11 +18315,11 @@ Spec is the specification of the PacketCaptureAPI Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentContainer">PacketCaptureAPIDeploymentContainer</h3>
+<h3 id="PacketCaptureAPIDeploymentContainer">PacketCaptureAPIDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
+<a href="#PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18375,11 +18375,11 @@ If omitted, the PacketCaptureAPI Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentInitContainer">PacketCaptureAPIDeploymentInitContainer</h3>
+<h3 id="PacketCaptureAPIDeploymentInitContainer">PacketCaptureAPIDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
+<a href="#PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18435,11 +18435,11 @@ If omitted, the PacketCaptureAPI Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</h3>
+<h3 id="PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</a>)
+<a href="#PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -18458,7 +18458,7 @@ PacketCaptureAPIDeploymentPodSpec is the PacketCaptureAPI Deployment&rsquo;s Pod
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentInitContainer">
+<a href="#PacketCaptureAPIDeploymentInitContainer">
 []PacketCaptureAPIDeploymentInitContainer
 </a>
 </em>
@@ -18480,7 +18480,7 @@ If omitted, the PacketCaptureAPI Deployment will use its default values for its 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentContainer">
+<a href="#PacketCaptureAPIDeploymentContainer">
 []PacketCaptureAPIDeploymentContainer
 </a>
 </em>
@@ -18499,11 +18499,11 @@ If omitted, the PacketCaptureAPI Deployment will use its default values for its 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</h3>
+<h3 id="PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</a>)
+<a href="#PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</a>)
 
 </p>
 <p>
@@ -18522,7 +18522,7 @@ PacketCaptureAPIDeploymentPodTemplateSpec is the PacketCaptureAPI Deployment&rsq
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">
+<a href="#PacketCaptureAPIDeploymentPodSpec">
 PacketCaptureAPIDeploymentPodSpec
 </a>
 </em>
@@ -18543,11 +18543,11 @@ Spec is the PacketCaptureAPI Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</h3>
+<h3 id="PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</a>)
+<a href="#PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</a>)
 
 </p>
 <p>
@@ -18566,7 +18566,7 @@ PacketCaptureAPIDeploymentSpec defines configuration for the PacketCaptureAPI De
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodTemplateSpec">
+<a href="#PacketCaptureAPIDeploymentPodTemplateSpec">
 PacketCaptureAPIDeploymentPodTemplateSpec
 </a>
 </em>
@@ -18583,11 +18583,11 @@ Template describes the PacketCaptureAPI Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPISpec">PacketCaptureAPISpec</h3>
+<h3 id="PacketCaptureAPISpec">PacketCaptureAPISpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</a>)
+<a href="#PacketCaptureAPI">PacketCaptureAPI</a>)
 
 </p>
 <p>
@@ -18606,7 +18606,7 @@ PacketCaptureAPISpec defines configuration for the Packet Capture API.
 
 <code>packetCaptureAPIDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeployment">
+<a href="#PacketCaptureAPIDeployment">
 PacketCaptureAPIDeployment
 </a>
 </em>
@@ -18623,11 +18623,11 @@ PacketCaptureAPIDeployment configures the PacketCaptureAPI Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIStatus">PacketCaptureAPIStatus</h3>
+<h3 id="PacketCaptureAPIStatus">PacketCaptureAPIStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</a>)
+<a href="#PacketCaptureAPI">PacketCaptureAPI</a>)
 
 </p>
 <p>
@@ -18681,11 +18681,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PathMatch">PathMatch</h3>
+<h3 id="PathMatch">PathMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
+<a href="#TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
 
 </p>
 <table>
@@ -18751,11 +18751,11 @@ PathReplace if not nil will be used to replace PathRegexp matches.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeployment">PolicyRecommendationDeployment</h3>
+<h3 id="PolicyRecommendationDeployment">PolicyRecommendationDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationSpec">PolicyRecommendationSpec</a>)
+<a href="#PolicyRecommendationSpec">PolicyRecommendationSpec</a>)
 
 </p>
 <p>
@@ -18774,7 +18774,7 @@ PolicyRecommendationDeployment is the configuration for the PolicyRecommendation
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentSpec">
+<a href="#PolicyRecommendationDeploymentSpec">
 PolicyRecommendationDeploymentSpec
 </a>
 </em>
@@ -18795,11 +18795,11 @@ Spec is the specification of the PolicyRecommendation Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentContainer">PolicyRecommendationDeploymentContainer</h3>
+<h3 id="PolicyRecommendationDeploymentContainer">PolicyRecommendationDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
+<a href="#PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18855,11 +18855,11 @@ If omitted, the PolicyRecommendation Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentInitContainer">PolicyRecommendationDeploymentInitContainer</h3>
+<h3 id="PolicyRecommendationDeploymentInitContainer">PolicyRecommendationDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
+<a href="#PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18914,11 +18914,11 @@ If omitted, the PolicyRecommendation Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</h3>
+<h3 id="PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</a>)
+<a href="#PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -18937,7 +18937,7 @@ PolicyRecommendationDeploymentPodSpec is the PolicyRecommendation Deployment&rsq
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentInitContainer">
+<a href="#PolicyRecommendationDeploymentInitContainer">
 []PolicyRecommendationDeploymentInitContainer
 </a>
 </em>
@@ -18959,7 +18959,7 @@ If omitted, the PolicyRecommendation Deployment will use its default values for 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentContainer">
+<a href="#PolicyRecommendationDeploymentContainer">
 []PolicyRecommendationDeploymentContainer
 </a>
 </em>
@@ -18978,11 +18978,11 @@ If omitted, the PolicyRecommendation Deployment will use its default values for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</h3>
+<h3 id="PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</a>)
+<a href="#PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</a>)
 
 </p>
 <p>
@@ -19001,7 +19001,7 @@ PolicyRecommendationDeploymentPodTemplateSpec is the PolicyRecommendation Deploy
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">
+<a href="#PolicyRecommendationDeploymentPodSpec">
 PolicyRecommendationDeploymentPodSpec
 </a>
 </em>
@@ -19022,11 +19022,11 @@ Spec is the PolicyRecommendation Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</h3>
+<h3 id="PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeployment">PolicyRecommendationDeployment</a>)
+<a href="#PolicyRecommendationDeployment">PolicyRecommendationDeployment</a>)
 
 </p>
 <p>
@@ -19045,7 +19045,7 @@ PolicyRecommendationDeploymentSpec defines configuration for the PolicyRecommend
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodTemplateSpec">
+<a href="#PolicyRecommendationDeploymentPodTemplateSpec">
 PolicyRecommendationDeploymentPodTemplateSpec
 </a>
 </em>
@@ -19062,11 +19062,11 @@ Template describes the PolicyRecommendation Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
+<h3 id="PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
@@ -19086,7 +19086,7 @@ service.
 
 <code>policyRecommendationDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeployment">
+<a href="#PolicyRecommendationDeployment">
 PolicyRecommendationDeployment
 </a>
 </em>
@@ -19103,11 +19103,11 @@ PolicyRecommendation configures the PolicyRecommendation Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
+<h3 id="PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
@@ -19140,13 +19140,13 @@ State provides user-readable status.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ProductVariant">ProductVariant
+<h3 id="ProductVariant">ProductVariant
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#InstallationSpec">InstallationSpec</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -19155,11 +19155,11 @@ ProductVariant represents the variant of the product.
 <p>
 One of: Calico, TigeraSecureEnterprise
 </p>
-<h3 id="operator.tigera.io/v1.Prometheus">Prometheus</h3>
+<h3 id="Prometheus">Prometheus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.MonitorSpec">MonitorSpec</a>)
+<a href="#MonitorSpec">MonitorSpec</a>)
 
 </p>
 <table>
@@ -19175,7 +19175,7 @@ One of: Calico, TigeraSecureEnterprise
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PrometheusSpec">
+<a href="#PrometheusSpec">
 PrometheusSpec
 </a>
 </em>
@@ -19196,11 +19196,11 @@ Spec is the specification of the Prometheus.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PrometheusContainer">PrometheusContainer</h3>
+<h3 id="PrometheusContainer">PrometheusContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CommonPrometheusFields">CommonPrometheusFields</a>)
+<a href="#CommonPrometheusFields">CommonPrometheusFields</a>)
 
 </p>
 <p>
@@ -19256,11 +19256,11 @@ If omitted, the Prometheus will use its default value for this container&rsquo;s
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PrometheusSpec">PrometheusSpec</h3>
+<h3 id="PrometheusSpec">PrometheusSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Prometheus">Prometheus</a>)
+<a href="#Prometheus">Prometheus</a>)
 
 </p>
 <table>
@@ -19276,7 +19276,7 @@ If omitted, the Prometheus will use its default value for this container&rsquo;s
 
 <code>commonPrometheusFields</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CommonPrometheusFields">
+<a href="#CommonPrometheusFields">
 CommonPrometheusFields
 </a>
 </em>
@@ -19292,12 +19292,12 @@ CommonPrometheusFields are the options available to both the Prometheus server a
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PromptType">PromptType
+<h3 id="PromptType">PromptType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
 <p>
@@ -19305,23 +19305,23 @@ PromptType is a value that specifies whether the identity provider prompts the e
 consent.
 One of: None, Login, Consent, SelectAccount.
 </p>
-<h3 id="operator.tigera.io/v1.Provider">Provider
+<h3 id="Provider">Provider
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
 Provider represents a particular provider or flavor of Kubernetes. Valid options
 are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG.
 </p>
-<h3 id="operator.tigera.io/v1.Retention">Retention</h3>
+<h3 id="Retention">Retention</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -19463,11 +19463,11 @@ Default: 8
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.S3StoreSpec">S3StoreSpec</h3>
+<h3 id="S3StoreSpec">S3StoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -19534,11 +19534,11 @@ Path in the S3 bucket where to send logs
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SNIMatch">SNIMatch</h3>
+<h3 id="SNIMatch">SNIMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>)
+<a href="#TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>)
 
 </p>
 <table>
@@ -19568,11 +19568,11 @@ ServerName is used to match the server name for the request.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ServiceMonitor">ServiceMonitor</h3>
+<h3 id="ServiceMonitor">ServiceMonitor</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">ExternalPrometheus</a>)
+<a href="#ExternalPrometheus">ExternalPrometheus</a>)
 
 </p>
 <table>
@@ -19607,7 +19607,7 @@ Default: k8s-app=tigera-prometheus
 
 <code>endpoints</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Endpoint">
+<a href="#Endpoint">
 []Endpoint
 </a>
 </em>
@@ -19624,11 +19624,11 @@ related to connecting to our Prometheus server are automatically set by the oper
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SplunkStoreSpec">SplunkStoreSpec</h3>
+<h3 id="SplunkStoreSpec">SplunkStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -19661,22 +19661,22 @@ Location for splunk&rsquo;s http event collector end point. example <code>https:
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.StatusConditionType">StatusConditionType
+<h3 id="StatusConditionType">StatusConditionType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 StatusConditionType is a type of condition that may apply to a particular component.
 </p>
-<h3 id="operator.tigera.io/v1.Sysctl">Sysctl</h3>
+<h3 id="Sysctl">Sysctl</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -19717,12 +19717,12 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SyslogLogType">SyslogLogType
+<h3 id="SyslogLogType">SyslogLogType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</a>)
+<a href="#SyslogStoreSpec">SyslogStoreSpec</a>)
 
 </p>
 <p>
@@ -19733,11 +19733,11 @@ Allowable values are Audit, DNS, Flows and IDSEvents.
 * Flows corresponds to flow logs generated by Calico node.
 * IDSEvents corresponds to event logs for the intrusion detection system (anomaly detection, suspicious IPs, suspicious domains and global alerts).
 </p>
-<h3 id="operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</h3>
+<h3 id="SyslogStoreSpec">SyslogStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -19793,7 +19793,7 @@ Default: 1024
 
 <code>logTypes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SyslogLogType">
+<a href="#SyslogLogType">
 []SyslogLogType
 </a>
 </em>
@@ -19813,7 +19813,7 @@ Default: Audit, DNS, Flows
 
 <code>encryption</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncryptionOption">
+<a href="#EncryptionOption">
 EncryptionOption
 </a>
 </em>
@@ -19831,11 +19831,11 @@ Default: None
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLS">TLS</h3>
+<h3 id="TLS">TLS</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterSpec">ManagementClusterSpec</a>)
+<a href="#ManagementClusterSpec">ManagementClusterSpec</a>)
 
 </p>
 <table>
@@ -19885,11 +19885,11 @@ Default: tigera-management-cluster-connection
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</h3>
+<h3 id="TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRoute">TLSPassThroughRoute</a>)
+<a href="#TLSPassThroughRoute">TLSPassThroughRoute</a>)
 
 </p>
 <table>
@@ -19905,7 +19905,7 @@ Default: tigera-management-cluster-connection
 
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -19921,7 +19921,7 @@ TargetType
 
 <code>sniMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SNIMatch">
+<a href="#SNIMatch">
 SNIMatch
 </a>
 </em>
@@ -19955,11 +19955,11 @@ Destination is the destination url to proxy the request to.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</h3>
+<h3 id="TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSTerminatedRoute">TLSTerminatedRoute</a>)
+<a href="#TLSTerminatedRoute">TLSTerminatedRoute</a>)
 
 </p>
 <table>
@@ -19975,7 +19975,7 @@ Destination is the destination url to proxy the request to.
 
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -19991,7 +19991,7 @@ TargetType
 
 <code>pathMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PathMatch">
+<a href="#PathMatch">
 PathMatch
 </a>
 </em>
@@ -20106,20 +20106,20 @@ is UI.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TargetType">TargetType
+<h3 id="TargetType">TargetType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>, 
-<a href="#operator.tigera.io/v1.TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
+<a href="#TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>, 
+<a href="#TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.TenantElasticSpec">TenantElasticSpec</h3>
+<h3 id="TenantElasticSpec">TenantElasticSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <table>
@@ -20174,11 +20174,11 @@ bool
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantSpec">TenantSpec</h3>
+<h3 id="TenantSpec">TenantSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
 <table>
@@ -20228,7 +20228,7 @@ Name is a human readable name for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -20247,7 +20247,7 @@ Indices defines the how to store a tenant&rsquo;s data
 
 <code>elastic</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantElasticSpec">
+<a href="#TenantElasticSpec">
 TenantElasticSpec
 </a>
 </em>
@@ -20286,7 +20286,7 @@ in the Tenant&rsquo;s namespace. Defaults to the controlPlaneReplicas in Install
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -20305,7 +20305,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>esKubeControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -20324,7 +20324,7 @@ ESKubeControllerDeployment configures the ESKubeController Deployment.
 
 <code>dashboardsJob</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJob">
+<a href="#DashboardsJob">
 DashboardsJob
 </a>
 </em>
@@ -20340,18 +20340,18 @@ DashboardsJob configures the Dashboards job
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantStatus">TenantStatus</h3>
+<h3 id="TenantStatus">TenantStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</h3>
+<h3 id="TigeraStatusCondition">TigeraStatusCondition</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</a>)
+<a href="#TigeraStatusStatus">TigeraStatusStatus</a>)
 
 </p>
 <p>
@@ -20370,7 +20370,7 @@ TigeraStatusCondition represents a condition attached to a particular component.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.StatusConditionType">
+<a href="#StatusConditionType">
 StatusConditionType
 </a>
 </em>
@@ -20389,7 +20389,7 @@ The type of condition. May be Available, Progressing, or Degraded.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ConditionStatus">
+<a href="#ConditionStatus">
 ConditionStatus
 </a>
 </em>
@@ -20478,26 +20478,26 @@ with respect to the current state of the instance.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatusReason">TigeraStatusReason
+<h3 id="TigeraStatusReason">TigeraStatusReason
 (<code>string</code> alias)</h3>
 <p>
 TigeraStatusReason represents the reason for a particular condition.
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusSpec">TigeraStatusSpec</h3>
+<h3 id="TigeraStatusSpec">TigeraStatusSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
 TigeraStatusSpec defines the desired state of TigeraStatus
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</h3>
+<h3 id="TigeraStatusStatus">TigeraStatusStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
@@ -20516,7 +20516,7 @@ TigeraStatusStatus defines the observed state of TigeraStatus
 
 <code>conditions</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">
+<a href="#TigeraStatusCondition">
 []TigeraStatusCondition
 </a>
 </em>
@@ -20533,11 +20533,11 @@ Available, Progressing, or Degraded.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</h3>
+<h3 id="TyphaAffinity">TyphaAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -20557,7 +20557,7 @@ TyphaAffinity allows configuration of node affinity characteristics for Typha po
 
 <code>nodeAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAffinity">
+<a href="#NodeAffinity">
 NodeAffinity
 </a>
 </em>
@@ -20574,11 +20574,11 @@ NodeAffinity describes node affinity scheduling rules for typha.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</h3>
+<h3 id="TyphaDeployment">TyphaDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -20597,7 +20597,7 @@ TyphaDeployment is the configuration for the typha Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -20617,7 +20617,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">
+<a href="#TyphaDeploymentSpec">
 TyphaDeploymentSpec
 </a>
 </em>
@@ -20638,11 +20638,11 @@ Spec is the specification of the typha Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
+<h3 id="TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -20699,11 +20699,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
+<h3 id="TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -20760,11 +20760,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
+<h3 id="TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -20783,7 +20783,7 @@ TyphaDeploymentPodSpec is the typha Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentInitContainer">
+<a href="#TyphaDeploymentInitContainer">
 []TyphaDeploymentInitContainer
 </a>
 </em>
@@ -20805,7 +20805,7 @@ If omitted, the typha Deployment will use its default values for its init contai
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentContainer">
+<a href="#TyphaDeploymentContainer">
 []TyphaDeploymentContainer
 </a>
 </em>
@@ -20939,11 +20939,11 @@ WARNING: Please note that this field will override the default calico-typha Depl
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
+<h3 id="TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -20962,7 +20962,7 @@ TyphaDeploymentPodTemplateSpec is the typha Deployment&rsquo;s PodTemplateSpec
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -20983,7 +20983,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">
+<a href="#TyphaDeploymentPodSpec">
 TyphaDeploymentPodSpec
 </a>
 </em>
@@ -21004,11 +21004,11 @@ Spec is the typha Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
+<h3 id="TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>)
+<a href="#TyphaDeployment">TyphaDeployment</a>)
 
 </p>
 <p>
@@ -21048,7 +21048,7 @@ If omitted, the typha Deployment will use its default value for minReadySeconds.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">
+<a href="#TyphaDeploymentPodTemplateSpec">
 TyphaDeploymentPodTemplateSpec
 </a>
 </em>
@@ -21068,7 +21068,7 @@ Template describes the typha Deployment pod that will be created.
 
 <code>strategy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentStrategy">
+<a href="#TyphaDeploymentStrategy">
 TyphaDeploymentStrategy
 </a>
 </em>
@@ -21085,11 +21085,11 @@ The deployment strategy to use to replace existing pods with new ones.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
+<h3 id="TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -21128,11 +21128,11 @@ to be.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.UserMatch">UserMatch</h3>
+<h3 id="UserMatch">UserMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GroupSearch">GroupSearch</a>)
+<a href="#GroupSearch">GroupSearch</a>)
 
 </p>
 <p>
@@ -21182,11 +21182,11 @@ The attribute of a group that links it to a user.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.UserSearch">UserSearch</h3>
+<h3 id="UserSearch">UserSearch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</a>)
+<a href="#AuthenticationLDAP">AuthenticationLDAP</a>)
 
 </p>
 <p>
@@ -21256,27 +21256,27 @@ Default: uid
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.WAFStatusType">WAFStatusType
+<h3 id="WAFStatusType">WAFStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsDataplaneOption">WindowsDataplaneOption
+<h3 id="WindowsDataplaneOption">WindowsDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsNodeSpec">WindowsNodeSpec</h3>
+<h3 id="WindowsNodeSpec">WindowsNodeSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>

--- a/calico-enterprise/reference/installation/helm_customization.mdx
+++ b/calico-enterprise/reference/installation/helm_customization.mdx
@@ -8,18 +8,18 @@ import variables from '@site/calico-enterprise/variables';
 
 You can customize the following resources and settings during {variables.prodname} Helm-based installation using the file, `values.yaml`.
 
-- [Installation](api.mdx#operator.tigera.io/v1.InstallationSpec)
-- [Api server](api.mdx#operator.tigera.io/v1.APIServerSpec)
-- [Compliance](api.mdx#operator.tigera.io/v1.ComplianceSpec)
-- [Intrusion detection](api.mdx#operator.tigera.io/v1.IntrusionDetectionSpec)
-- [Log collector](api.mdx#operator.tigera.io/v1.LogCollectorSpec)
-- [Log storage](api.mdx#operator.tigera.io/v1.LogStorageSpec)
-- [Manager](api.mdx#operator.tigera.io/v1.ManagerSpec)
-- [Monitor](api.mdx#operator.tigera.io/v1.MonitorSpec)
-- [Policy recommendation](api.mdx#operator.tigera.io/v1.PolicyRecommendationSpec)
-- [Authentication](api.mdx#operator.tigera.io/v1.AuthenticationSpec)
-- [Application layer](api.mdx#operator.tigera.io/v1.ApplicationLayerSpec)
-- [Amazon cloud integration](api.mdx#operator.tigera.io/v1.AmazonCloudIntegrationSpec)
+- [Installation](api.mdx#InstallationSpec
+- [Api server](api.mdx#APIServerSpec
+- [Compliance](api.mdx#ComplianceSpec
+- [Intrusion detection](api.mdx#IntrusionDetectionSpec
+- [Log collector](api.mdx#LogCollectorSpec
+- [Log storage](api.mdx#LogStorageSpec
+- [Manager](api.mdx#ManagerSpec
+- [Monitor](api.mdx#MonitorSpec
+- [Policy recommendation](api.mdx#PolicyRecommendationSpec
+- [Authentication](api.mdx#AuthenticationSpec
+- [Application layer](api.mdx#ApplicationLayerSpec
+- [Amazon cloud integration](api.mdx#AmazonCloudIntegrationSpec
 - [Default felix configuration](../resources/felixconfig.mdx#spec)
 
 :::note
@@ -94,7 +94,7 @@ Common customizations that you might want to configure are number of replicas, p
 
 ### Number of replicas
 This setting defines the number of replicas for {variables.prodname} components that can run simultaneously in multiple instances.
-To configure this setting, see [controlPlaneReplicas](api.mdx#operator.tigera.io/v1.InstallationSpec).
+To configure this setting, see [controlPlaneReplicas](api.mdx#InstallationSpec.
 The components for the replicas are:
 
 - tigera-manager

--- a/calico-enterprise/threat/deeppacketinspection.mdx
+++ b/calico-enterprise/threat/deeppacketinspection.mdx
@@ -76,7 +76,7 @@ spec:
 
 ### Configure resource requirements
 
-Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionComponentResource).
+Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#IntrusionDetectionComponentResource.
 
 For a data transfer rate of 1GB/sec on workload endpoints being monitored, we recommend a minimum of 1 CPU and 1GB RAM.
 

--- a/calico-enterprise/threat/web-application-firewall.mdx
+++ b/calico-enterprise/threat/web-application-firewall.mdx
@@ -359,9 +359,9 @@ kubectl delete applicationlayer tigera-secure
 
 #### Keep some ApplicationLayer features enabled
 
-To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) custom resource.
+To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#ApplicationLayer custom resource.
 
-Note that the [ApplicationLayer Specification](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerSpec) can specify configuration for [Application Logging](../reference/installation/api#operator.tigera.io/v1.LogCollectionSpec) and [Application Layer Policy](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerPolicyStatusType) also. 
+Note that the [ApplicationLayer Specification](../reference/installation/api#ApplicationLayerSpec can specify configuration for [Application Logging](../reference/installation/api#LogCollectionSpec and [Application Layer Policy](../reference/installation/api#ApplicationLayerPolicyStatusType also. 
 
 For the ApplicationLayer custom resource to be valid, at least one of these features have to be enabled, for example:
 

--- a/calico-enterprise/visibility/elastic/archive-storage.mdx
+++ b/calico-enterprise/visibility/elastic/archive-storage.mdx
@@ -48,8 +48,8 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
     -n tigera-operator
    ```
 
-3. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#operator.tigera.io/v1.S3StoreSpec)
+3. Update the [LogCollector](../../reference/installation/api.mdx#LogCollector
+   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#S3StoreSpec
    with your information noted from above.
    Example:
 
@@ -76,8 +76,8 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
 </TabItem>
 <TabItem label="Syslog" value="Syslog-1">
 
-1. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+1. Update the [LogCollector](../../reference/installation/api.mdx#LogCollector
+   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec
    with your syslog information.
    Example:
    ```yaml
@@ -104,7 +104,7 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    kubectl edit logcollector tigera-secure
    ```
 2. You can control which types of {variables.prodname} log data you would like to send to syslog.
-   The [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+   The [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec
    contains a field called `logTypes` which allows you to list which log types you would like to include.
    The allowable log types are:
 
@@ -113,11 +113,11 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    - Flows
    - IDSEvents
 
-   Refer to the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec) for more details on what data each log type represents.
+   Refer to the [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec for more details on what data each log type represents.
 
    :::note
 
-   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
+   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#LogStorage configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
 
    :::
 
@@ -125,7 +125,7 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
 
 **TLS configuration**
 
-3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec).
+3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec.
 
    ```yaml
    apiVersion: operator.tigera.io/v1
@@ -180,9 +180,9 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    ```
 
 3. Update the
-   [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
+   [LogCollector](../../reference/installation/api.mdx#LogCollector
    resource named `tigera-secure` to include
-   a [Splunk section](../../reference/installation/api.mdx#operator.tigera.io/v1.SplunkStoreSpec)
+   a [Splunk section](../../reference/installation/api.mdx#SplunkStoreSpec
    with your Splunk information.
    Example:
 

--- a/calico-enterprise/visibility/elastic/l7/configure.mdx
+++ b/calico-enterprise/visibility/elastic/l7/configure.mdx
@@ -73,7 +73,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
 
 **Configure the ApplicationLayer resource for L7 logs**
 
-1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) resource named, `tigera-secure` to include a logCollection section of the file, `_api.html` [here](../../../reference/installation/api.mdx).
+1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#ApplicationLayer resource named, `tigera-secure` to include a logCollection section of the file, `_api.html` [here](../../../reference/installation/api.mdx).
 
 1. Ensure that the `collectLogs` field is set to `Enabled`.
 

--- a/calico-enterprise/visibility/elastic/overview.mdx
+++ b/calico-enterprise/visibility/elastic/overview.mdx
@@ -93,7 +93,7 @@ verbs: ['get']
 - Global network policies
 - Network sets
 
-{variables.prodname} also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec).
+{variables.prodname} also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#LogCollectorSpec.
 
 ## Additional resources
 
@@ -104,4 +104,4 @@ verbs: ['get']
 - [BGP logs](bgp.mdx)
 - [DNS logs](dns/dns-logs.mdx)
 - [Archive logs](archive-storage.mdx)
-- [Log collection options](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../reference/installation/api.mdx#LogCollectorSpec

--- a/calico-enterprise/visibility/elastic/rbac-elasticsearch.mdx
+++ b/calico-enterprise/visibility/elastic/rbac-elasticsearch.mdx
@@ -213,4 +213,4 @@ status:
 ## Additional resources
 
 - Configure [RBAC for tiered policies](../../network-policy/policy-tiers/rbac-tiered-policies.mdx).
-- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) resource.
+- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#ManagementCluster resource.

--- a/calico-enterprise/visibility/elastic/retention.mdx
+++ b/calico-enterprise/visibility/elastic/retention.mdx
@@ -12,7 +12,7 @@ Configure how long to retain logs and compliance reports.
 
 ## Before you begin...
 
-Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#operator.tigera.io/v1.Retention) and determine the appropriate values for your deployment.
+Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#Retention and determine the appropriate values for your deployment.
 
 :::note
 

--- a/calico-enterprise/visibility/elastic/troubleshoot.mdx
+++ b/calico-enterprise/visibility/elastic/troubleshoot.mdx
@@ -10,7 +10,7 @@ import variables from '@site/calico-enterprise/variables';
 
 The following user-configured resources are related to Elasticsearch:
 
-- [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage). It has settings for:
+- [LogStorage](../../reference/installation/api.mdx#LogStorage. It has settings for:
 
   - Elasticsearch (for example, nodeCount and replicas)
   - Kubernetes (for example, resourceRequirements, storage and nodeSelectors)
@@ -113,7 +113,7 @@ As a last resort, create a new [Elasticsearch cluster](#how-to-create-a-new-clus
 
 ### Elasticsearch is slow
 
-**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorageSpec).
+**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#LogStorageSpec.
 
 ### Elasticsearch crashes during booting
 

--- a/calico-enterprise_versioned_docs/version-3.17/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
@@ -46,4 +46,4 @@ key features like Flow Visualizer, metrics in the dashboard and Policy Board, po
 - [Configure flow log aggregation](../../../visibility/elastic/flow/aggregation.mdx)
 - [Log storage recommendations](../../../operations/logstorage/log-storage-recommendations.mdx)
 - [Archive logs](../../../visibility/elastic/archive-storage.mdx)
-- [Log collection options](../../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../../reference/installation/api.mdx#LogCollectorSpec

--- a/calico-enterprise_versioned_docs/version-3.17/getting-started/install-on-clusters/windows-calico/kubernetes/requirements.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/getting-started/install-on-clusters/windows-calico/kubernetes/requirements.mdx
@@ -38,7 +38,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../../reference/installation/api.mdx#BGPOption.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.17/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
@@ -89,7 +89,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
 
 1. <OpenShiftPrometheusOperator operation='upgrade' />
 
-1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster)
+1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#ManagementCluster
    CR to your cluster.
 
    ```bash
@@ -101,7 +101,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#operator.tigera.io/v1.Monitor)
+1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#Monitor
    CR to your cluster.
 
    ```bash
@@ -113,7 +113,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendation)
+1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#PolicyRecommendation
    CR to your cluster.
 
    ```bash

--- a/calico-enterprise_versioned_docs/version-3.17/multicluster/create-a-management-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/multicluster/create-a-management-cluster.mdx
@@ -54,7 +54,7 @@ To control managed clusters from your central management plane, you must ensure 
     ```bash
     export MANAGEMENT_CLUSTER_ADDR=<your-management-cluster-addr>
     ```
-1.  Apply the [ManagementCluster](../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) CR.
+1.  Apply the [ManagementCluster](../reference/installation/api.mdx#ManagementCluster CR.
 
     ```bash
     kubectl apply -f - <<EOF

--- a/calico-enterprise_versioned_docs/version-3.17/multicluster/fine-tune-deployment.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/multicluster/fine-tune-deployment.mdx
@@ -153,4 +153,4 @@ To filter log data by a given managed cluster you can include the filter criteri
 
 # Additional resources
 
-- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection)
+- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#ManagementClusterConnection

--- a/calico-enterprise_versioned_docs/version-3.17/network-policy/policy-firewalls/aws-integration/metadata-access.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/network-policy/policy-firewalls/aws-integration/metadata-access.mdx
@@ -33,7 +33,7 @@ kubectl label pods <pod-name> aws.tigera.io/allow-metadata-access=true
 
 If the number of pods you need to allow exceeds the number that you need to block, it may be more convenient to change the default to _allow_ access and then deny access to individual pods that do not need it.
 
-- Edit the [AmazonCloudIntegration resource](../../../reference/installation/api.mdx#operator.tigera.io/v1.AmazonCloudIntegration).
+- Edit the [AmazonCloudIntegration resource](../../../reference/installation/api.mdx#AmazonCloudIntegration.
 
   ```
   kubectl edit amazoncloudintegration tigera-secure

--- a/calico-enterprise_versioned_docs/version-3.17/networking/configuring/dual-tor.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/networking/configuring/dual-tor.mdx
@@ -637,7 +637,7 @@ The only connections using interface-specific addresses should be BGP.
 If you plan to use [Egress Gateways](../egress/egress-gateway-on-prem.mdx) in your cluster, you must also adjust the {variables.nodecontainer} IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-{variables.prodname} [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+{variables.prodname} [Installation resource](../../reference/installation/api.mdx#NodeAddressAutodetection.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.17/networking/configuring/multiple-networks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/networking/configuring/multiple-networks.mdx
@@ -79,7 +79,7 @@ Although the following {variables.prodname} features are supported for your defa
 
 ### Configure cluster for multiple networks
 
-In the [Installation custom resource](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoNetworkSpec), set the `MultiInterfaceMode` to **Multus**.
+In the [Installation custom resource](../../reference/installation/api.mdx#CalicoNetworkSpec, set the `MultiInterfaceMode` to **Multus**.
 
 ### Create a new network
 

--- a/calico-enterprise_versioned_docs/version-3.17/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/networking/egress/egress-gateway-on-prem.mdx
@@ -334,7 +334,7 @@ To modify the iptables backend for egress gateways, you must change the `iptable
 If you plan to use Egress Gateways in a [dual-ToR cluster](../configuring/dual-tor.mdx), you must also adjust the {variables.nodecontainer} IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-{variables.prodname} [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+{variables.prodname} [Installation resource](../../reference/installation/api.mdx#NodeAddressAutodetection.
 
 ### Configure namespaces and pods to use egress gateways
 

--- a/calico-enterprise_versioned_docs/version-3.17/networking/ipam/initial-ippool.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/networking/ipam/initial-ippool.mdx
@@ -24,7 +24,7 @@ The **Kubernetes pod CIDR** is the expected IP address range for pod IPs. It is 
 
 [Calico IP pools](../../reference/resources/ippool.mdx) are ranges of IP addresses that Calico uses to assign to pods; the ranges must within the Kubernetes pod CIDR.
 
-The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#Installation
 resource and configures the default Calico IP pool. Note the following:
 
 - Default fields for any that are omitted:
@@ -44,7 +44,7 @@ resource and configures the default Calico IP pool. Note the following:
 ## How to
 
 1. Download the custom-resource.yaml file.
-1. Edit the [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation).  
+1. Edit the [Installation resource](../../reference/installation/api.mdx#Installation.  
    **Required values**: `cidr:`  
    **Empty values**: Defaulted
 

--- a/calico-enterprise_versioned_docs/version-3.17/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/networking/ipam/ip-autodetection.mdx
@@ -51,7 +51,7 @@ By default, {variables.prodname} uses the **firstFound** method; the first valid
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#NodeAddressAutodetection in the operator Installation reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-enterprise_versioned_docs/version-3.17/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/operations/cnx/configure-identity-provider.mdx
@@ -17,7 +17,7 @@ Configure an external identity provider (IdP), create a user, and log in to {var
 
 ## Concepts
 
-The {variables.prodname} authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Authentication) named, `tigera-secure`.
+The {variables.prodname} authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#Authentication named, `tigera-secure`.
 
 When configuring your cluster, you may be asked for the following inputs:
 

--- a/calico-enterprise_versioned_docs/version-3.17/operations/cnx/roles-and-permissions.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/operations/cnx/roles-and-permissions.mdx
@@ -18,7 +18,7 @@ Self-service is an important part of your Kubernetes platform networking and net
 
 ### Kubernetes RBAC authorization
 
-The [Calico Enterprise API server](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) is an extension to the standard [Kubernetes RBAC Authorization APIs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
+The [Calico Enterprise API server](../../reference/installation/api.mdx#APIServer is an extension to the standard [Kubernetes RBAC Authorization APIs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
 
 | Features                       | RBAC controls for...                                                                                                                                                                                                                            |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/calico-enterprise_versioned_docs/version-3.17/operations/comms/certificate-management.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/operations/comms/certificate-management.mdx
@@ -21,7 +21,7 @@ certificate issuance, {variables.prodname} provides a simple configuration optio
 **Limitations**
 
 If your cluster is already running {variables.prodname} and you would like to enable certificate management, you need to
-temporarily remove [the logstorage resource](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+temporarily remove [the logstorage resource](../../reference/installation/api.mdx#LogStorage
 before following the steps to enable certificate management and then re-apply afterwards. For detailed steps on
 re-creating logstorage, read more on [how to create a new Elasticsearch cluster](../../visibility/elastic/troubleshoot.mdx#how-to-create-a-new-cluster).
 
@@ -40,7 +40,7 @@ Currently, this feature is not supported in combination with [Multi-cluster mana
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../../reference/installation/api.mdx#Installation
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
    ```yaml

--- a/calico-enterprise_versioned_docs/version-3.17/operations/logstorage/log-storage-recommendations.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/operations/logstorage/log-storage-recommendations.mdx
@@ -82,4 +82,4 @@ is no tolerance for removing/restarting a node.
 
 - Read the [LogStorage overview page](../logstorage/index.mdx)
 - [Troubleshooting Elasticsearch](../../visibility/elastic/troubleshoot.mdx)
-- [LogStorage Specification](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+- [LogStorage Specification](../../reference/installation/api.mdx#LogStorage

--- a/calico-enterprise_versioned_docs/version-3.17/reference/architecture/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/reference/architecture/overview.mdx
@@ -124,7 +124,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### Manager
 
-**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#operator.tigera.io/v1.Manager).
+**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#Manager.
 
 ### Packet capture API
 
@@ -152,7 +152,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### API server
 
-**Main task**: Allows users to manage {variables.prodname} resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#operator.tigera.io/v1.APIServer).
+**Main task**: Allows users to manage {variables.prodname} resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#APIServer.
 
 ### BIRD
 

--- a/calico-enterprise_versioned_docs/version-3.17/reference/component-resources/configuration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/reference/component-resources/configuration.mdx
@@ -244,7 +244,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-2">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#Installation API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico-enterprise_versioned_docs/version-3.17/reference/component-resources/typha/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/reference/component-resources/typha/prometheus.mdx
@@ -7,7 +7,7 @@ import variables from '@site/calico-enterprise_versioned_docs/version-3.17/varia
 # Prometheus metrics
 
 Typha can be configured to report a number of metrics through Prometheus. The Prometheus port can be controlled
-via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#operator.tigera.io/v1.Installation).
+via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#Installation.
 
 ## Metric reference
 

--- a/calico-enterprise_versioned_docs/version-3.17/reference/installation/_api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/reference/installation/_api.mdx
@@ -15,41 +15,41 @@ API Schema definitions for configuring the installation of Calico and Calico Ent
 </p>
 Resource Types:
 <ul><li>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>
+<a href="#APIServer">APIServer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.AmazonCloudIntegration">AmazonCloudIntegration</a>
+<a href="#AmazonCloudIntegration">AmazonCloudIntegration</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>
+<a href="#ApplicationLayer">ApplicationLayer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>
+<a href="#Authentication">Authentication</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>
+<a href="#Compliance">Compliance</a>
 </li><li>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>
+<a href="#EgressGateway">EgressGateway</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>
+<a href="#ImageSet">ImageSet</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>
+<a href="#Installation">Installation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>
+<a href="#IntrusionDetection">IntrusionDetection</a>
 </li><li>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>
+<a href="#LogCollector">LogCollector</a>
 </li><li>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>
+<a href="#LogStorage">LogStorage</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ManagementCluster">ManagementCluster</a>
+<a href="#ManagementCluster">ManagementCluster</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>
+<a href="#Manager">Manager</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>
+<a href="#Monitor">Monitor</a>
 </li><li>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>
+<a href="#PolicyRecommendation">PolicyRecommendation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>
+<a href="#TigeraStatus">TigeraStatus</a>
 </li></ul>
-<h3 id="operator.tigera.io/v1.APIServer">APIServer</h3>
+<h3 id="APIServer">APIServer</h3>
 <p>
 APIServer installs the Tigera API server and related resources. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo; or &ldquo;tigera-secure&rdquo;.
@@ -110,7 +110,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerSpec">
+<a href="#APIServerSpec">
 APIServerSpec
 </a>
 </em>
@@ -128,7 +128,7 @@ Specification of the desired state for the Tigera API server.
 <td>
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -152,7 +152,7 @@ take precedence.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerStatus">
+<a href="#APIServerStatus">
 APIServerStatus
 </a>
 </em>
@@ -168,7 +168,7 @@ Most recently observed status for the Tigera API server.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AmazonCloudIntegration">AmazonCloudIntegration</h3>
+<h3 id="AmazonCloudIntegration">AmazonCloudIntegration</h3>
 <p>
 AmazonCloudIntegration is the Schema for the amazoncloudintegrations API
 </p>
@@ -228,7 +228,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AmazonCloudIntegrationSpec">
+<a href="#AmazonCloudIntegrationSpec">
 AmazonCloudIntegrationSpec
 </a>
 </em>
@@ -243,7 +243,7 @@ AmazonCloudIntegrationSpec
 <td>
 <code>defaultPodMetadataAccess</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MetadataAccessAllowedType">
+<a href="#MetadataAccessAllowedType">
 MetadataAccessAllowedType
 </a>
 </em>
@@ -391,7 +391,7 @@ to all ENIs in the VPC.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AmazonCloudIntegrationStatus">
+<a href="#AmazonCloudIntegrationStatus">
 AmazonCloudIntegrationStatus
 </a>
 </em>
@@ -404,7 +404,7 @@ AmazonCloudIntegrationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</h3>
+<h3 id="ApplicationLayer">ApplicationLayer</h3>
 <p>
 ApplicationLayer is the Schema for the applicationlayers API
 </p>
@@ -464,7 +464,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">
+<a href="#ApplicationLayerSpec">
 ApplicationLayerSpec
 </a>
 </em>
@@ -479,7 +479,7 @@ ApplicationLayerSpec
 <td>
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -499,7 +499,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -518,7 +518,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -538,7 +538,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -560,7 +560,7 @@ User-configurable settings for the Envoy proxy.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerStatus">
+<a href="#ApplicationLayerStatus">
 ApplicationLayerStatus
 </a>
 </em>
@@ -573,7 +573,7 @@ ApplicationLayerStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Authentication">Authentication</h3>
+<h3 id="Authentication">Authentication</h3>
 <p>
 Authentication is the Schema for the authentications API
 </p>
@@ -633,7 +633,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">
+<a href="#AuthenticationSpec">
 AuthenticationSpec
 </a>
 </em>
@@ -705,7 +705,7 @@ ClusterRoleBindings into Elastic.
 
 <code>oidc</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">
+<a href="#AuthenticationOIDC">
 AuthenticationOIDC
 </a>
 </em>
@@ -725,7 +725,7 @@ OIDC contains the configuration needed to setup OIDC authentication.
 
 <code>openshift</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOpenshift">
+<a href="#AuthenticationOpenshift">
 AuthenticationOpenshift
 </a>
 </em>
@@ -745,7 +745,7 @@ Openshift contains the configuration needed to setup Openshift OAuth authenticat
 
 <code>ldap</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">
+<a href="#AuthenticationLDAP">
 AuthenticationLDAP
 </a>
 </em>
@@ -768,7 +768,7 @@ LDAP contains the configuration needed to setup LDAP authentication.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationStatus">
+<a href="#AuthenticationStatus">
 AuthenticationStatus
 </a>
 </em>
@@ -781,7 +781,7 @@ AuthenticationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Compliance">Compliance</h3>
+<h3 id="Compliance">Compliance</h3>
 <p>
 Compliance installs the components required for Tigera compliance reporting. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -842,7 +842,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">
+<a href="#ComplianceSpec">
 ComplianceSpec
 </a>
 </em>
@@ -865,7 +865,7 @@ Specification of the desired state for Tigera compliance reporting.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceStatus">
+<a href="#ComplianceStatus">
 ComplianceStatus
 </a>
 </em>
@@ -881,7 +881,7 @@ Most recently observed state for Tigera compliance reporting.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGateway">EgressGateway</h3>
+<h3 id="EgressGateway">EgressGateway</h3>
 <p>
 EgressGateway is the Schema for the egressgateways API
 </p>
@@ -941,7 +941,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">
+<a href="#EgressGatewaySpec">
 EgressGatewaySpec
 </a>
 </em>
@@ -974,7 +974,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -1015,7 +1015,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -1036,7 +1036,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -1056,7 +1056,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -1080,7 +1080,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -1103,7 +1103,7 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayStatus">
+<a href="#EgressGatewayStatus">
 EgressGatewayStatus
 </a>
 </em>
@@ -1116,7 +1116,7 @@ EgressGatewayStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSet">ImageSet</h3>
+<h3 id="ImageSet">ImageSet</h3>
 <p>
 ImageSet is used to specify image digests for the images that the operator deploys.
 The name of the ImageSet is expected to be in the format <code>&lt;variant&gt;-&lt;release&gt;</code>.
@@ -1181,7 +1181,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">
+<a href="#ImageSetSpec">
 ImageSetSpec
 </a>
 </em>
@@ -1196,7 +1196,7 @@ ImageSetSpec
 <td>
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -1216,7 +1216,7 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Installation">Installation</h3>
+<h3 id="Installation">Installation</h3>
 <p>
 Installation configures an installation of Calico or Calico Enterprise. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo;. The Installation API installs core networking
@@ -1278,7 +1278,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -1296,7 +1296,7 @@ Specification of the desired state for the Calico or Calico Enterprise installat
 <td>
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -1424,7 +1424,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -1447,7 +1447,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -1467,7 +1467,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -1487,7 +1487,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -1666,7 +1666,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -1688,7 +1688,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -1710,7 +1710,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -1730,7 +1730,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -1750,7 +1750,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -1769,7 +1769,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -1789,7 +1789,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -1809,7 +1809,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -1828,7 +1828,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -1849,7 +1849,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -1872,7 +1872,7 @@ Logging Configuration for Components
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationStatus">
+<a href="#InstallationStatus">
 InstallationStatus
 </a>
 </em>
@@ -1888,7 +1888,7 @@ Most recently observed state for the Calico or Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</h3>
+<h3 id="IntrusionDetection">IntrusionDetection</h3>
 <p>
 IntrusionDetection installs the components required for Tigera intrusion detection. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -1949,7 +1949,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">
+<a href="#IntrusionDetectionSpec">
 IntrusionDetectionSpec
 </a>
 </em>
@@ -1967,7 +1967,7 @@ Specification of the desired state for Tigera intrusion detection.
 <td>
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">
+<a href="#IntrusionDetectionComponentResource">
 []IntrusionDetectionComponentResource
 </a>
 </em>
@@ -1988,7 +1988,7 @@ Only DeepPacketInspection is supported for this spec.
 
 <code>anomalyDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+<a href="#AnomalyDetectionSpec">
 AnomalyDetectionSpec
 </a>
 </em>
@@ -2013,7 +2013,7 @@ management clusters.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionStatus">
+<a href="#IntrusionDetectionStatus">
 IntrusionDetectionStatus
 </a>
 </em>
@@ -2029,7 +2029,7 @@ Most recently observed state for Tigera intrusion detection.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollector">LogCollector</h3>
+<h3 id="LogCollector">LogCollector</h3>
 <p>
 LogCollector installs the components required for Tigera flow and DNS log collection. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;. When created, this installs fluentd on all nodes
@@ -2091,7 +2091,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">
+<a href="#LogCollectorSpec">
 LogCollectorSpec
 </a>
 </em>
@@ -2109,7 +2109,7 @@ Specification of the desired state for Tigera log collection.
 <td>
 <code>additionalStores</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">
+<a href="#AdditionalLogStoreSpec">
 AdditionalLogStoreSpec
 </a>
 </em>
@@ -2129,7 +2129,7 @@ Configuration for exporting flow, audit, and DNS logs to external storage.
 
 <code>additionalSources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">
+<a href="#AdditionalLogSourceSpec">
 AdditionalLogSourceSpec
 </a>
 </em>
@@ -2149,7 +2149,7 @@ Configuration for importing audit logs from managed kubernetes cluster log sourc
 
 <code>collectProcessPath</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CollectProcessPathOption">
+<a href="#CollectProcessPathOption">
 CollectProcessPathOption
 </a>
 </em>
@@ -2174,7 +2174,7 @@ Default: Enabled
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectorStatus">
+<a href="#LogCollectorStatus">
 LogCollectorStatus
 </a>
 </em>
@@ -2190,7 +2190,7 @@ Most recently observed state for Tigera log collection.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorage">LogStorage</h3>
+<h3 id="LogStorage">LogStorage</h3>
 <p>
 LogStorage installs the components required for Tigera flow and DNS log storage. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;. When created, this installs an Elasticsearch cluster for use by
@@ -2252,7 +2252,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">
+<a href="#LogStorageSpec">
 LogStorageSpec
 </a>
 </em>
@@ -2270,7 +2270,7 @@ Specification of the desired state for Tigera log storage.
 <td>
 <code>nodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Nodes">
+<a href="#Nodes">
 Nodes
 </a>
 </em>
@@ -2289,7 +2289,7 @@ Nodes defines the configuration for a set of identical Elasticsearch cluster nod
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Indices">
+<a href="#Indices">
 Indices
 </a>
 </em>
@@ -2309,7 +2309,7 @@ Index defines the configuration for the indices in the Elasticsearch cluster.
 
 <code>retention</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Retention">
+<a href="#Retention">
 Retention
 </a>
 </em>
@@ -2371,7 +2371,7 @@ each of the indicated key-value pairs as labels as well as access to the specifi
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">
+<a href="#LogStorageComponentResource">
 []LogStorageComponentResource
 </a>
 </em>
@@ -2395,7 +2395,7 @@ Only ECKOperator is supported for this spec.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageStatus">
+<a href="#LogStorageStatus">
 LogStorageStatus
 </a>
 </em>
@@ -2411,7 +2411,7 @@ Most recently observed state for Tigera log storage.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementCluster">ManagementCluster</h3>
+<h3 id="ManagementCluster">ManagementCluster</h3>
 <p>
 The presence of ManagementCluster in your cluster, will configure it to be the management plane to which managed
 clusters can connect. At most one instance of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2472,7 +2472,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterSpec">
+<a href="#ManagementClusterSpec">
 ManagementClusterSpec
 </a>
 </em>
@@ -2507,7 +2507,7 @@ Valid examples are: &ldquo;0.0.0.0:31000&rdquo;, &ldquo;example.com:32000&rdquo;
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLS">
+<a href="#TLS">
 TLS
 </a>
 </em>
@@ -2527,7 +2527,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</h3>
+<h3 id="ManagementClusterConnection">ManagementClusterConnection</h3>
 <p>
 ManagementClusterConnection represents a link between a managed cluster and a management cluster. At most one
 instance of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2588,7 +2588,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">
+<a href="#ManagementClusterConnectionSpec">
 ManagementClusterConnectionSpec
 </a>
 </em>
@@ -2622,7 +2622,7 @@ should be able to access this address. This field is used by managed clusters on
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">
+<a href="#ManagementClusterTLS">
 ManagementClusterTLS
 </a>
 </em>
@@ -2645,7 +2645,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionStatus">
+<a href="#ManagementClusterConnectionStatus">
 ManagementClusterConnectionStatus
 </a>
 </em>
@@ -2658,7 +2658,7 @@ ManagementClusterConnectionStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Manager">Manager</h3>
+<h3 id="Manager">Manager</h3>
 <p>
 Manager installs the Calico Enterprise manager graphical user interface. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2719,7 +2719,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerSpec">
+<a href="#ManagerSpec">
 ManagerSpec
 </a>
 </em>
@@ -2737,7 +2737,7 @@ Specification of the desired state for the Calico Enterprise manager.
 <td>
 <code>auth</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Auth">
+<a href="#Auth">
 Auth
 </a>
 </em>
@@ -2760,7 +2760,7 @@ Deprecated. Please use the Authentication CR for configuring authentication.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerStatus">
+<a href="#ManagerStatus">
 ManagerStatus
 </a>
 </em>
@@ -2776,7 +2776,7 @@ Most recently observed state for the Calico Enterprise manager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Monitor">Monitor</h3>
+<h3 id="Monitor">Monitor</h3>
 <p>
 Monitor is the Schema for the monitor API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2837,7 +2837,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorSpec">
+<a href="#MonitorSpec">
 MonitorSpec
 </a>
 </em>
@@ -2857,7 +2857,7 @@ MonitorSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorStatus">
+<a href="#MonitorStatus">
 MonitorStatus
 </a>
 </em>
@@ -2870,7 +2870,7 @@ MonitorStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</h3>
+<h3 id="PolicyRecommendation">PolicyRecommendation</h3>
 <p>
 PolicyRecommendation is the Schema for the policy recommendation API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2931,7 +2931,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationSpec">
+<a href="#PolicyRecommendationSpec">
 PolicyRecommendationSpec
 </a>
 </em>
@@ -2951,7 +2951,7 @@ PolicyRecommendationSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationStatus">
+<a href="#PolicyRecommendationStatus">
 PolicyRecommendationStatus
 </a>
 </em>
@@ -2964,7 +2964,7 @@ PolicyRecommendationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatus">TigeraStatus</h3>
+<h3 id="TigeraStatus">TigeraStatus</h3>
 <p>
 TigeraStatus represents the most recently observed status for Calico or a Calico Enterprise functional area.
 </p>
@@ -3024,7 +3024,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusSpec">
+<a href="#TigeraStatusSpec">
 TigeraStatusSpec
 </a>
 </em>
@@ -3044,7 +3044,7 @@ TigeraStatusSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">
+<a href="#TigeraStatusStatus">
 TigeraStatusStatus
 </a>
 </em>
@@ -3057,11 +3057,11 @@ TigeraStatusStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</h3>
+<h3 id="APIServerDeployment">APIServerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerSpec">APIServerSpec</a>)
+<a href="#APIServerSpec">APIServerSpec</a>)
 
 </p>
 <p>
@@ -3080,7 +3080,7 @@ APIServerDeployment is the configuration for the API server Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3100,7 +3100,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">
+<a href="#APIServerDeploymentSpec">
 APIServerDeploymentSpec
 </a>
 </em>
@@ -3121,11 +3121,11 @@ Spec is the specification of the API server Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
+<h3 id="APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -3181,11 +3181,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
+<h3 id="APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -3240,11 +3240,11 @@ If omitted, the API server Deployment will use its default value for this init c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
+<h3 id="APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -3263,7 +3263,7 @@ APIServerDeploymentDeploymentPodSpec is the API server Deployment&rsquo;s PodSpe
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentInitContainer">
+<a href="#APIServerDeploymentInitContainer">
 []APIServerDeploymentInitContainer
 </a>
 </em>
@@ -3285,7 +3285,7 @@ If omitted, the API server Deployment will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentContainer">
+<a href="#APIServerDeploymentContainer">
 []APIServerDeploymentContainer
 </a>
 </em>
@@ -3396,11 +3396,11 @@ WARNING: Please note that this field will override the default API server Deploy
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
+<h3 id="APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
+<a href="#APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -3419,7 +3419,7 @@ APIServerDeploymentPodTemplateSpec is the API server Deployment&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3440,7 +3440,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">
+<a href="#APIServerDeploymentPodSpec">
 APIServerDeploymentPodSpec
 </a>
 </em>
@@ -3461,11 +3461,11 @@ Spec is the API server Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
+<h3 id="APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>)
 
 </p>
 <p>
@@ -3505,7 +3505,7 @@ If omitted, the API server Deployment will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">
+<a href="#APIServerDeploymentPodTemplateSpec">
 APIServerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -3522,11 +3522,11 @@ Template describes the API server Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerSpec">APIServerSpec</h3>
+<h3 id="APIServerSpec">APIServerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -3545,7 +3545,7 @@ APIServerSpec defines the desired state of Tigera API server.
 
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -3563,11 +3563,11 @@ take precedence.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerStatus">APIServerStatus</h3>
+<h3 id="APIServerStatus">APIServerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -3621,11 +3621,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</h3>
+<h3 id="AWSEgressGateway">AWSEgressGateway</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -3644,7 +3644,7 @@ AWSEgressGateway defines the configurations for deploying EgressGateway in AWS
 
 <code>nativeIP</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NativeIP">
+<a href="#NativeIP">
 NativeIP
 </a>
 </em>
@@ -3681,11 +3681,11 @@ NativeIP must be Enabled if elastic IPs are set.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AdditionalLogSourceSpec">AdditionalLogSourceSpec</h3>
+<h3 id="AdditionalLogSourceSpec">AdditionalLogSourceSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <table>
@@ -3701,7 +3701,7 @@ NativeIP must be Enabled if elastic IPs are set.
 
 <code>eksCloudwatchLog</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EksCloudwatchLogsSpec">
+<a href="#EksCloudwatchLogsSpec">
 EksCloudwatchLogsSpec
 </a>
 </em>
@@ -3719,11 +3719,11 @@ audit logs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</h3>
+<h3 id="AdditionalLogStoreSpec">AdditionalLogStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <table>
@@ -3739,7 +3739,7 @@ audit logs.
 
 <code>s3</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.S3StoreSpec">
+<a href="#S3StoreSpec">
 S3StoreSpec
 </a>
 </em>
@@ -3759,7 +3759,7 @@ If specified, enables exporting of flow, audit, and DNS logs to Amazon S3 storag
 
 <code>syslog</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">
+<a href="#SyslogStoreSpec">
 SyslogStoreSpec
 </a>
 </em>
@@ -3779,7 +3779,7 @@ If specified, enables exporting of flow, audit, and DNS logs to syslog.
 
 <code>splunk</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SplunkStoreSpec">
+<a href="#SplunkStoreSpec">
 SplunkStoreSpec
 </a>
 </em>
@@ -3796,11 +3796,11 @@ If specified, enables exporting of flow, audit, and DNS logs to splunk.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AmazonCloudIntegrationSpec">AmazonCloudIntegrationSpec</h3>
+<h3 id="AmazonCloudIntegrationSpec">AmazonCloudIntegrationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AmazonCloudIntegration">AmazonCloudIntegration</a>)
+<a href="#AmazonCloudIntegration">AmazonCloudIntegration</a>)
 
 </p>
 <p>
@@ -3819,7 +3819,7 @@ AmazonCloudIntegrationSpec defines the desired state of AmazonCloudIntegration
 
 <code>defaultPodMetadataAccess</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MetadataAccessAllowedType">
+<a href="#MetadataAccessAllowedType">
 MetadataAccessAllowedType
 </a>
 </em>
@@ -3961,11 +3961,11 @@ to all ENIs in the VPC.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AmazonCloudIntegrationStatus">AmazonCloudIntegrationStatus</h3>
+<h3 id="AmazonCloudIntegrationStatus">AmazonCloudIntegrationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AmazonCloudIntegration">AmazonCloudIntegration</a>)
+<a href="#AmazonCloudIntegration">AmazonCloudIntegration</a>)
 
 </p>
 <p>
@@ -4019,11 +4019,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
+<h3 id="AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <table>
@@ -4060,19 +4060,19 @@ This field is not used for managed clusters in a Multi-cluster management setup.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
+<h3 id="ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</h3>
+<h3 id="ApplicationLayerSpec">ApplicationLayerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -4091,7 +4091,7 @@ ApplicationLayerSpec defines the desired state of ApplicationLayer
 
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -4111,7 +4111,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -4130,7 +4130,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -4150,7 +4150,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -4166,11 +4166,11 @@ User-configurable settings for the Envoy proxy.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerStatus">ApplicationLayerStatus</h3>
+<h3 id="ApplicationLayerStatus">ApplicationLayerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -4224,12 +4224,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Auth">Auth</h3>
+<h3 id="Auth">Auth</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerSpec">ManagerSpec</a>, 
-<a href="#operator.tigera.io/v1.ManagerStatus">ManagerStatus</a>)
+<a href="#ManagerSpec">ManagerSpec</a>, 
+<a href="#ManagerStatus">ManagerStatus</a>)
 
 </p>
 <p>
@@ -4248,7 +4248,7 @@ Auth defines authentication configuration.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthType">
+<a href="#AuthType">
 AuthType
 </a>
 </em>
@@ -4301,25 +4301,25 @@ ClientId configures the OAuth2/OIDC client ID to use for OAuth2 or OIDC login.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthMethod">AuthMethod
+<h3 id="AuthMethod">AuthMethod
 (<code>string</code> alias)</h3>
-<h3 id="operator.tigera.io/v1.AuthType">AuthType
+<h3 id="AuthType">AuthType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Auth">Auth</a>)
+<a href="#Auth">Auth</a>)
 
 </p>
 <p>
 AuthType represents the type of authentication to use. Valid
 options are: Token, Basic, OIDC, OAuth
 </p>
-<h3 id="operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</h3>
+<h3 id="AuthenticationLDAP">AuthenticationLDAP</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -4375,7 +4375,7 @@ the ldaps:// protocol.
 
 <code>userSearch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.UserSearch">
+<a href="#UserSearch">
 UserSearch
 </a>
 </em>
@@ -4394,7 +4394,7 @@ User entry search configuration to match the credentials with a user.
 
 <code>groupSearch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GroupSearch">
+<a href="#GroupSearch">
 GroupSearch
 </a>
 </em>
@@ -4411,11 +4411,11 @@ Group search configuration to find the groups that a user is in.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</h3>
+<h3 id="AuthenticationOIDC">AuthenticationOIDC</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -4541,7 +4541,7 @@ Deprecated. Please use Authentication.Spec.GroupsPrefix instead.
 
 <code>emailVerification</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EmailVerificationType">
+<a href="#EmailVerificationType">
 EmailVerificationType
 </a>
 </em>
@@ -4564,7 +4564,7 @@ Default: Verify
 
 <code>promptTypes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PromptType">
+<a href="#PromptType">
 []PromptType
 </a>
 </em>
@@ -4587,7 +4587,7 @@ Default: &ldquo;Consent&rdquo;
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.OIDCType">
+<a href="#OIDCType">
 OIDCType
 </a>
 </em>
@@ -4604,11 +4604,11 @@ Default: &ldquo;Dex&rdquo;
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationOpenshift">AuthenticationOpenshift</h3>
+<h3 id="AuthenticationOpenshift">AuthenticationOpenshift</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -4641,11 +4641,11 @@ IssuerURL is the URL to the Openshift OAuth provider. Ex.: <a href="https://api.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</h3>
+<h3 id="AuthenticationSpec">AuthenticationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>)
+<a href="#Authentication">Authentication</a>)
 
 </p>
 <p>
@@ -4721,7 +4721,7 @@ ClusterRoleBindings into Elastic.
 
 <code>oidc</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">
+<a href="#AuthenticationOIDC">
 AuthenticationOIDC
 </a>
 </em>
@@ -4741,7 +4741,7 @@ OIDC contains the configuration needed to setup OIDC authentication.
 
 <code>openshift</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOpenshift">
+<a href="#AuthenticationOpenshift">
 AuthenticationOpenshift
 </a>
 </em>
@@ -4761,7 +4761,7 @@ Openshift contains the configuration needed to setup Openshift OAuth authenticat
 
 <code>ldap</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">
+<a href="#AuthenticationLDAP">
 AuthenticationLDAP
 </a>
 </em>
@@ -4778,11 +4778,11 @@ LDAP contains the configuration needed to setup LDAP authentication.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationStatus">AuthenticationStatus</h3>
+<h3 id="AuthenticationStatus">AuthenticationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>)
+<a href="#Authentication">Authentication</a>)
 
 </p>
 <p>
@@ -4836,12 +4836,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.BGPOption">BGPOption
+<h3 id="BGPOption">BGPOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -4850,12 +4850,12 @@ BGPOption describes the mode of BGP to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.CAType">CAType
+<h3 id="CAType">CAType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">ManagementClusterTLS</a>)
+<a href="#ManagementClusterTLS">ManagementClusterTLS</a>)
 
 </p>
 <p>
@@ -4864,11 +4864,11 @@ CAType specifies which verification method the tunnel client should use to verif
 <p>
 One of: Tigera, Public
 </p>
-<h3 id="operator.tigera.io/v1.CNILogging">CNILogging</h3>
+<h3 id="CNILogging">CNILogging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Logging">Logging</a>)
+<a href="#Logging">Logging</a>)
 
 </p>
 <table>
@@ -4884,7 +4884,7 @@ One of: Tigera, Public
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -4955,12 +4955,12 @@ Default: 10
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CNIPluginType">CNIPluginType
+<h3 id="CNIPluginType">CNIPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -4969,11 +4969,11 @@ CNIPluginType describes the type of CNI plugin used.
 <p>
 One of: Calico, GKE, AmazonVPC, AzureVNET
 </p>
-<h3 id="operator.tigera.io/v1.CNISpec">CNISpec</h3>
+<h3 id="CNISpec">CNISpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -4992,7 +4992,7 @@ CNISpec contains configuration for the CNI plugin.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNIPluginType">
+<a href="#CNIPluginType">
 CNIPluginType
 </a>
 </em>
@@ -5024,7 +5024,7 @@ Default: Calico
 
 <code>ipam</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMSpec">
+<a href="#IPAMSpec">
 IPAMSpec
 </a>
 </em>
@@ -5042,11 +5042,11 @@ Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
+<h3 id="CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5065,7 +5065,7 @@ CSINodeDriverDaemonSet is the configuration for the csi-node-driver DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5085,7 +5085,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">
+<a href="#CSINodeDriverDaemonSetSpec">
 CSINodeDriverDaemonSetSpec
 </a>
 </em>
@@ -5106,11 +5106,11 @@ Spec is the specification of the csi-node-driver DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
+<h3 id="CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -5165,11 +5165,11 @@ If omitted, the csi-node-driver DaemonSet will use its default value for this co
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -5188,7 +5188,7 @@ CSINodeDriverDaemonSetPodSpec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">
+<a href="#CSINodeDriverDaemonSetContainer">
 []CSINodeDriverDaemonSetContainer
 </a>
 </em>
@@ -5275,11 +5275,11 @@ WARNING: Please note that this field will override the default csi-node-driver D
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
+<a href="#CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -5298,7 +5298,7 @@ CSINodeDriverDaemonSetPodTemplateSpec is the csi-node-driver DaemonSet&rsquo;s P
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5319,7 +5319,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">
+<a href="#CSINodeDriverDaemonSetPodSpec">
 CSINodeDriverDaemonSetPodSpec
 </a>
 </em>
@@ -5340,11 +5340,11 @@ Spec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
+<h3 id="CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
 
 </p>
 <p>
@@ -5384,7 +5384,7 @@ If omitted, the csi-node-driver DaemonSet will use its default value for minRead
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">
 CSINodeDriverDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -5401,11 +5401,11 @@ Template describes the csi-node-driver DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
+<h3 id="CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5424,7 +5424,7 @@ CalicoKubeControllersDeployment is the configuration for the calico-kube-control
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5444,7 +5444,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">
+<a href="#CalicoKubeControllersDeploymentSpec">
 CalicoKubeControllersDeploymentSpec
 </a>
 </em>
@@ -5465,11 +5465,11 @@ Spec is the specification of the calico-kube-controllers Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
+<h3 id="CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -5525,11 +5525,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -5548,7 +5548,7 @@ CalicoKubeControllersDeploymentPodSpec is the calico-kube-controller Deployment&
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">
+<a href="#CalicoKubeControllersDeploymentContainer">
 []CalicoKubeControllersDeploymentContainer
 </a>
 </em>
@@ -5637,11 +5637,11 @@ WARNING: Please note that this field will override the default calico-kube-contr
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
+<a href="#CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
 
 </p>
 <p>
@@ -5660,7 +5660,7 @@ CalicoKubeControllersDeploymentPodTemplateSpec is the calico-kube-controllers De
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5681,7 +5681,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">
+<a href="#CalicoKubeControllersDeploymentPodSpec">
 CalicoKubeControllersDeploymentPodSpec
 </a>
 </em>
@@ -5702,11 +5702,11 @@ Spec is the calico-kube-controllers Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
 
 </p>
 <p>
@@ -5746,7 +5746,7 @@ If omitted, the calico-kube-controllers Deployment will use its default value fo
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">
 CalicoKubeControllersDeploymentPodTemplateSpec
 </a>
 </em>
@@ -5763,11 +5763,11 @@ Template describes the calico-kube-controllers Deployment pod that will be creat
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</h3>
+<h3 id="CalicoNetworkSpec">CalicoNetworkSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5786,7 +5786,7 @@ CalicoNetworkSpec specifies configuration options for Calico provided pod networ
 
 <code>linuxDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinuxDataplaneOption">
+<a href="#LinuxDataplaneOption">
 LinuxDataplaneOption
 </a>
 </em>
@@ -5809,7 +5809,7 @@ Default: Iptables
 
 <code>bgp</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.BGPOption">
+<a href="#BGPOption">
 BGPOption
 </a>
 </em>
@@ -5829,7 +5829,7 @@ BGP configures whether or not to enable Calico&rsquo;s BGP capabilities.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPPool">
+<a href="#IPPool">
 []IPPool
 </a>
 </em>
@@ -5869,7 +5869,7 @@ If not specified, Calico will perform MTU auto-detection based on the cluster ne
 
 <code>nodeAddressAutodetectionV4</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -5890,7 +5890,7 @@ will use default auto-detection settings to acquire an IPv4 address for each nod
 
 <code>nodeAddressAutodetectionV6</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -5911,7 +5911,7 @@ IPv6 addresses will not be auto-detected.
 
 <code>hostPorts</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HostPortsType">
+<a href="#HostPortsType">
 HostPortsType
 </a>
 </em>
@@ -5932,7 +5932,7 @@ Default: Enabled
 
 <code>multiInterfaceMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MultiInterfaceMode">
+<a href="#MultiInterfaceMode">
 MultiInterfaceMode
 </a>
 </em>
@@ -5954,7 +5954,7 @@ Default: None
 
 <code>containerIPForwarding</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ContainerIPForwardingType">
+<a href="#ContainerIPForwardingType">
 ContainerIPForwardingType
 </a>
 </em>
@@ -5972,11 +5972,11 @@ Default: Disabled
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
+<h3 id="CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5995,7 +5995,7 @@ CalicoNodeDaemonSet is the configuration for the calico-node DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6015,7 +6015,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">
+<a href="#CalicoNodeDaemonSetSpec">
 CalicoNodeDaemonSetSpec
 </a>
 </em>
@@ -6036,11 +6036,11 @@ Spec is the specification of the calico-node DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
+<h3 id="CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6096,11 +6096,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6156,11 +6156,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6179,7 +6179,7 @@ CalicoNodeDaemonSetPodSpec is the calico-node DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">
+<a href="#CalicoNodeDaemonSetInitContainer">
 []CalicoNodeDaemonSetInitContainer
 </a>
 </em>
@@ -6201,7 +6201,7 @@ If omitted, the calico-node DaemonSet will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetContainer">
+<a href="#CalicoNodeDaemonSetContainer">
 []CalicoNodeDaemonSetContainer
 </a>
 </em>
@@ -6288,11 +6288,11 @@ WARNING: Please note that this field will override the default calico-node Daemo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
+<a href="#CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -6311,7 +6311,7 @@ CalicoNodeDaemonSetPodTemplateSpec is the calico-node DaemonSet&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6332,7 +6332,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">
+<a href="#CalicoNodeDaemonSetPodSpec">
 CalicoNodeDaemonSetPodSpec
 </a>
 </em>
@@ -6353,11 +6353,11 @@ Spec is the calico-node DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
+<h3 id="CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
 
 </p>
 <p>
@@ -6397,7 +6397,7 @@ If omitted, the calico-node DaemonSet will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">
 CalicoNodeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -6414,7 +6414,7 @@ Template describes the calico-node DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
+<h3 id="CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
 <p>
 CalicoNodeWindowsDaemonSet is the configuration for the calico-node-windows DaemonSet.
 </p>
@@ -6431,7 +6431,7 @@ CalicoNodeWindowsDaemonSet is the configuration for the calico-node-windows Daem
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6451,7 +6451,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">
+<a href="#CalicoNodeWindowsDaemonSetSpec">
 CalicoNodeWindowsDaemonSetSpec
 </a>
 </em>
@@ -6472,11 +6472,11 @@ Spec is the specification of the calico-node-windows DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6532,11 +6532,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6592,11 +6592,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6615,7 +6615,7 @@ CalicoNodeWindowsDaemonSetPodSpec is the calico-node-windows DaemonSet&rsquo;s P
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">
+<a href="#CalicoNodeWindowsDaemonSetInitContainer">
 []CalicoNodeWindowsDaemonSetInitContainer
 </a>
 </em>
@@ -6637,7 +6637,7 @@ If omitted, the calico-node-windows DaemonSet will use its default values for it
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">
+<a href="#CalicoNodeWindowsDaemonSetContainer">
 []CalicoNodeWindowsDaemonSetContainer
 </a>
 </em>
@@ -6724,11 +6724,11 @@ WARNING: Please note that this field will override the default calico-node-windo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -6747,7 +6747,7 @@ CalicoNodeWindowsDaemonSetPodTemplateSpec is the calico-node-windows DaemonSet&r
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6768,7 +6768,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">
 CalicoNodeWindowsDaemonSetPodSpec
 </a>
 </em>
@@ -6789,11 +6789,11 @@ Spec is the calico-node-windows DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
 
 </p>
 <p>
@@ -6833,7 +6833,7 @@ If omitted, the calico-node-windows DaemonSet will use its default value for min
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">
 CalicoNodeWindowsDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -6850,11 +6850,11 @@ Template describes the calico-node-windows DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -6873,7 +6873,7 @@ CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrad
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6893,7 +6893,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">
 CalicoWindowsUpgradeDaemonSetSpec
 </a>
 </em>
@@ -6914,11 +6914,11 @@ Spec is the specification of the calico-windows-upgrade DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6973,11 +6973,11 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6996,7 +6996,7 @@ CalicoWindowsUpgradeDaemonSetPodSpec is the calico-windows-upgrade DaemonSet&rsq
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">
+<a href="#CalicoWindowsUpgradeDaemonSetContainer">
 []CalicoWindowsUpgradeDaemonSetContainer
 </a>
 </em>
@@ -7083,11 +7083,11 @@ WARNING: Please note that this field will override the default calico-windows-up
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7106,7 +7106,7 @@ CalicoWindowsUpgradeDaemonSetPodTemplateSpec is the calico-windows-upgrade Daemo
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7127,7 +7127,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">
 CalicoWindowsUpgradeDaemonSetPodSpec
 </a>
 </em>
@@ -7148,11 +7148,11 @@ Spec is the calico-windows-upgrade DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
 
 </p>
 <p>
@@ -7192,7 +7192,7 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
 CalicoWindowsUpgradeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -7209,11 +7209,11 @@ Template describes the calico-windows-upgrade DaemonSet pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CertificateManagement">CertificateManagement</h3>
+<h3 id="CertificateManagement">CertificateManagement</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7305,29 +7305,29 @@ Default: SHA256WithRSA
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CollectProcessPathOption">CollectProcessPathOption
+<h3 id="CollectProcessPathOption">CollectProcessPathOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</h3>
+<h3 id="ComplianceSpec">ComplianceSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>)
+<a href="#Compliance">Compliance</a>)
 
 </p>
 <p>
 ComplianceSpec defines the desired state of Tigera compliance reporting capabilities.
 </p>
-<h3 id="operator.tigera.io/v1.ComplianceStatus">ComplianceStatus</h3>
+<h3 id="ComplianceStatus">ComplianceStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>)
+<a href="#Compliance">Compliance</a>)
 
 </p>
 <p>
@@ -7381,12 +7381,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComponentName">ComponentName
+<h3 id="ComponentName">ComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComponentResource">ComponentResource</a>)
+<a href="#ComponentResource">ComponentResource</a>)
 
 </p>
 <p>
@@ -7395,11 +7395,11 @@ ComponentName represents a single component.
 <p>
 One of: Node, Typha, KubeControllers
 </p>
-<h3 id="operator.tigera.io/v1.ComponentResource">ComponentResource</h3>
+<h3 id="ComponentResource">ComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7419,7 +7419,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentName">
+<a href="#ComponentName">
 ComponentName
 </a>
 </em>
@@ -7454,29 +7454,29 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ConditionStatus">ConditionStatus
+<h3 id="ConditionStatus">ConditionStatus
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 ConditionStatus represents the status of a particular condition. A condition may be one of: True, False, Unknown.
 </p>
-<h3 id="operator.tigera.io/v1.ContainerIPForwardingType">ContainerIPForwardingType
+<h3 id="ContainerIPForwardingType">ContainerIPForwardingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
 ContainerIPForwardingType specifies whether the CNI config for container ip forwarding is enabled.
 </p>
-<h3 id="operator.tigera.io/v1.DashboardsJob">DashboardsJob</h3>
+<h3 id="DashboardsJob">DashboardsJob</h3>
 <p>
 DashboardsJob is the configuration for the Dashboards job.
 </p>
@@ -7493,7 +7493,7 @@ DashboardsJob is the configuration for the Dashboards job.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobSpec">
+<a href="#DashboardsJobSpec">
 DashboardsJobSpec
 </a>
 </em>
@@ -7514,11 +7514,11 @@ Spec is the specification of the dashboards job.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobContainer">DashboardsJobContainer</h3>
+<h3 id="DashboardsJobContainer">DashboardsJobContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodSpec">DashboardsJobPodSpec</a>)
+<a href="#DashboardsJobPodSpec">DashboardsJobPodSpec</a>)
 
 </p>
 <p>
@@ -7573,11 +7573,11 @@ If omitted, the Dashboard Job will use its default value for this container&rsqu
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobPodSpec">DashboardsJobPodSpec</h3>
+<h3 id="DashboardsJobPodSpec">DashboardsJobPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</a>)
+<a href="#DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7596,7 +7596,7 @@ DashboardsJobPodSpec is the Dashboards job&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobContainer">
+<a href="#DashboardsJobContainer">
 []DashboardsJobContainer
 </a>
 </em>
@@ -7615,11 +7615,11 @@ If omitted, the Dashboard job will use its default values for its containers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</h3>
+<h3 id="DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobSpec">DashboardsJobSpec</a>)
+<a href="#DashboardsJobSpec">DashboardsJobSpec</a>)
 
 </p>
 <p>
@@ -7638,7 +7638,7 @@ DashboardsJobPodTemplateSpec is the Dashboards job&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodSpec">
+<a href="#DashboardsJobPodSpec">
 DashboardsJobPodSpec
 </a>
 </em>
@@ -7659,11 +7659,11 @@ Spec is the Dashboard job&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobSpec">DashboardsJobSpec</h3>
+<h3 id="DashboardsJobSpec">DashboardsJobSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJob">DashboardsJob</a>)
+<a href="#DashboardsJob">DashboardsJob</a>)
 
 </p>
 <p>
@@ -7682,7 +7682,7 @@ DashboardsJobSpec defines configuration for the Dashboards job.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodTemplateSpec">
+<a href="#DashboardsJobPodTemplateSpec">
 DashboardsJobPodTemplateSpec
 </a>
 </em>
@@ -7699,11 +7699,11 @@ Template describes the Dashboards job pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentContainer">EGWDeploymentContainer</h3>
+<h3 id="EGWDeploymentContainer">EGWDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -7759,11 +7759,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
+<h3 id="EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -7819,11 +7819,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
+<h3 id="EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7842,7 +7842,7 @@ EgressGatewayDeploymentPodSpec is the Egress Gateway Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentInitContainer">
+<a href="#EGWDeploymentInitContainer">
 []EGWDeploymentInitContainer
 </a>
 </em>
@@ -7864,7 +7864,7 @@ If omitted, the EGW Deployment will use its default values for its init containe
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentContainer">
+<a href="#EGWDeploymentContainer">
 []EGWDeploymentContainer
 </a>
 </em>
@@ -7999,11 +7999,11 @@ PriorityClassName allows to specify a PriorityClass resource to be used.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
+<h3 id="EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -8022,7 +8022,7 @@ EgressGatewayDeploymentPodTemplateSpec is the EGW Deployment&rsquo;s PodTemplate
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayMetadata">
+<a href="#EgressGatewayMetadata">
 EgressGatewayMetadata
 </a>
 </em>
@@ -8043,7 +8043,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">
+<a href="#EgressGatewayDeploymentPodSpec">
 EgressGatewayDeploymentPodSpec
 </a>
 </em>
@@ -8064,11 +8064,11 @@ Spec is the EGW Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
+<h3 id="EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -8109,7 +8109,7 @@ Default: 90
 
 <code>icmpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ICMPProbe">
+<a href="#ICMPProbe">
 ICMPProbe
 </a>
 </em>
@@ -8131,7 +8131,7 @@ fail. Timeout must be greater than interval.
 
 <code>httpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HTTPProbe">
+<a href="#HTTPProbe">
 HTTPProbe
 </a>
 </em>
@@ -8150,11 +8150,11 @@ fail. Timeout must be greater than interval.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayIPPool">EgressGatewayIPPool</h3>
+<h3 id="EgressGatewayIPPool">EgressGatewayIPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <table>
@@ -8203,11 +8203,11 @@ CIDR is the IPPool CIDR that the Egress Gateways can use.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayMetadata">EgressGatewayMetadata</h3>
+<h3 id="EgressGatewayMetadata">EgressGatewayMetadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8265,11 +8265,11 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</h3>
+<h3 id="EgressGatewaySpec">EgressGatewaySpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -8306,7 +8306,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -8347,7 +8347,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -8368,7 +8368,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -8388,7 +8388,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -8412,7 +8412,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -8429,11 +8429,11 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayStatus">EgressGatewayStatus</h3>
+<h3 id="EgressGatewayStatus">EgressGatewayStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -8487,11 +8487,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EksCloudwatchLogsSpec">EksCloudwatchLogsSpec</h3>
+<h3 id="EksCloudwatchLogsSpec">EksCloudwatchLogsSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">AdditionalLogSourceSpec</a>)
+<a href="#AdditionalLogSourceSpec">AdditionalLogSourceSpec</a>)
 
 </p>
 <p>
@@ -8579,20 +8579,20 @@ Default: 60
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EmailVerificationType">EmailVerificationType
+<h3 id="EmailVerificationType">EmailVerificationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.EncapsulationType">EncapsulationType
+<h3 id="EncapsulationType">EncapsulationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -8601,12 +8601,12 @@ EncapsulationType is the type of encapsulation to use on an IP pool.
 <p>
 One of: IPIP, VXLAN, IPIPCrossSubnet, VXLANCrossSubnet, None
 </p>
-<h3 id="operator.tigera.io/v1.EncryptionOption">EncryptionOption
+<h3 id="EncryptionOption">EncryptionOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</a>)
+<a href="#SyslogStoreSpec">SyslogStoreSpec</a>)
 
 </p>
 <p>
@@ -8615,11 +8615,11 @@ EncryptionOption specifies the traffic encryption mode when connecting to a Sysl
 <p>
 One of: None, TLS
 </p>
-<h3 id="operator.tigera.io/v1.EnvoySettings">EnvoySettings</h3>
+<h3 id="EnvoySettings">EnvoySettings</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -8672,19 +8672,19 @@ manipulating various headers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FIPSMode">FIPSMode
+<h3 id="FIPSMode">FIPSMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.GroupSearch">GroupSearch</h3>
+<h3 id="GroupSearch">GroupSearch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</a>)
+<a href="#AuthenticationLDAP">AuthenticationLDAP</a>)
 
 </p>
 <p>
@@ -8756,7 +8756,7 @@ The attribute of the group that represents its name. This attribute can be used 
 
 <code>userMatchers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.UserMatch">
+<a href="#UserMatch">
 []UserMatch
 </a>
 </em>
@@ -8774,11 +8774,11 @@ attribute value.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HTTPProbe">HTTPProbe</h3>
+<h3 id="HTTPProbe">HTTPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -8850,12 +8850,12 @@ Default: 30
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HostPortsType">HostPortsType
+<h3 id="HostPortsType">HostPortsType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -8864,11 +8864,11 @@ HostPortsType specifies host port support.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.ICMPProbe">ICMPProbe</h3>
+<h3 id="ICMPProbe">ICMPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -8940,19 +8940,19 @@ Default: 15
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPAMPluginType">IPAMPluginType
+<h3 id="IPAMPluginType">IPAMPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPAMSpec">IPAMSpec</a>)
+<a href="#IPAMSpec">IPAMSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IPAMSpec">IPAMSpec</h3>
+<h3 id="IPAMSpec">IPAMSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -8971,7 +8971,7 @@ IPAMSpec contains configuration for pod IP address management.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMPluginType">
+<a href="#IPAMPluginType">
 IPAMPluginType
 </a>
 </em>
@@ -8999,11 +8999,11 @@ Default: Calico
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPPool">IPPool</h3>
+<h3 id="IPPool">IPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -9036,7 +9036,7 @@ CIDR contains the address range for the IP Pool in classless inter-domain routin
 
 <code>encapsulation</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncapsulationType">
+<a href="#EncapsulationType">
 EncapsulationType
 </a>
 </em>
@@ -9058,7 +9058,7 @@ Default: IPIP
 
 <code>natOutgoing</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NATOutgoingType">
+<a href="#NATOutgoingType">
 NATOutgoingType
 </a>
 </em>
@@ -9134,11 +9134,11 @@ Default: false
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Image">Image</h3>
+<h3 id="Image">Image</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</a>)
+<a href="#ImageSetSpec">ImageSetSpec</a>)
 
 </p>
 <table>
@@ -9189,11 +9189,11 @@ The field should not include a leading <code>@</code> and must be prefixed with 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</h3>
+<h3 id="ImageSetSpec">ImageSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>)
+<a href="#ImageSet">ImageSet</a>)
 
 </p>
 <p>
@@ -9212,7 +9212,7 @@ ImageSetSpec defines the desired state of ImageSet.
 
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -9229,11 +9229,11 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Indices">Indices</h3>
+<h3 id="Indices">Indices</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -9267,12 +9267,12 @@ Replicas defines how many replicas each index will have. See <a href="https://ww
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationSpec">InstallationSpec</h3>
+<h3 id="InstallationSpec">InstallationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#Installation">Installation</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -9291,7 +9291,7 @@ InstallationSpec defines configuration for a Calico or Calico Enterprise install
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -9419,7 +9419,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -9442,7 +9442,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -9462,7 +9462,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -9482,7 +9482,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -9661,7 +9661,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -9683,7 +9683,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -9705,7 +9705,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -9725,7 +9725,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -9745,7 +9745,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -9764,7 +9764,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -9784,7 +9784,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -9804,7 +9804,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -9823,7 +9823,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -9844,7 +9844,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -9861,11 +9861,11 @@ Logging Configuration for Components
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationStatus">InstallationStatus</h3>
+<h3 id="InstallationStatus">InstallationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>)
+<a href="#Installation">Installation</a>)
 
 </p>
 <p>
@@ -9884,7 +9884,7 @@ InstallationStatus defines the observed state of the Calico or Calico Enterprise
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -9940,7 +9940,7 @@ that is being used. If an ImageSet is not being used then this will not be set.
 
 <code>computed</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -9997,19 +9997,19 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionComponentName">IntrusionDetectionComponentName
+<h3 id="IntrusionDetectionComponentName">IntrusionDetectionComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</a>)
+<a href="#IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</h3>
+<h3 id="IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <p>
@@ -10028,7 +10028,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentName">
+<a href="#IntrusionDetectionComponentName">
 IntrusionDetectionComponentName
 </a>
 </em>
@@ -10063,11 +10063,11 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</h3>
+<h3 id="IntrusionDetectionSpec">IntrusionDetectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>)
+<a href="#IntrusionDetection">IntrusionDetection</a>)
 
 </p>
 <p>
@@ -10086,7 +10086,7 @@ IntrusionDetectionSpec defines the desired state of Tigera intrusion detection c
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">
+<a href="#IntrusionDetectionComponentResource">
 []IntrusionDetectionComponentResource
 </a>
 </em>
@@ -10107,7 +10107,7 @@ Only DeepPacketInspection is supported for this spec.
 
 <code>anomalyDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+<a href="#AnomalyDetectionSpec">
 AnomalyDetectionSpec
 </a>
 </em>
@@ -10126,11 +10126,11 @@ management clusters.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionStatus">IntrusionDetectionStatus</h3>
+<h3 id="IntrusionDetectionStatus">IntrusionDetectionStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>)
+<a href="#IntrusionDetection">IntrusionDetection</a>)
 
 </p>
 <p>
@@ -10184,12 +10184,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
+<h3 id="KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</a>)
+<a href="#NodeAddressAutodetection">NodeAddressAutodetection</a>)
 
 </p>
 <p>
@@ -10198,7 +10198,7 @@ KubernetesAutodetectionMethod is a method of detecting an IP address based on th
 <p>
 One of: NodeInternalIP
 </p>
-<h3 id="operator.tigera.io/v1.LinseedDeployment">LinseedDeployment</h3>
+<h3 id="LinseedDeployment">LinseedDeployment</h3>
 <p>
 LinseedDeployment is the configuration for the linseed Deployment.
 </p>
@@ -10215,7 +10215,7 @@ LinseedDeployment is the configuration for the linseed Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentSpec">
+<a href="#LinseedDeploymentSpec">
 LinseedDeploymentSpec
 </a>
 </em>
@@ -10236,11 +10236,11 @@ Spec is the specification of the linseed Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentContainer">LinseedDeploymentContainer</h3>
+<h3 id="LinseedDeploymentContainer">LinseedDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
+<a href="#LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10295,11 +10295,11 @@ If omitted, the linseed Deployment will use its default value for this container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentInitContainer">LinseedDeploymentInitContainer</h3>
+<h3 id="LinseedDeploymentInitContainer">LinseedDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
+<a href="#LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10354,11 +10354,11 @@ If omitted, the linseed Deployment will use its default value for this init cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</h3>
+<h3 id="LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</a>)
+<a href="#LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -10377,7 +10377,7 @@ LinseedDeploymentPodSpec is the linseed Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentInitContainer">
+<a href="#LinseedDeploymentInitContainer">
 []LinseedDeploymentInitContainer
 </a>
 </em>
@@ -10399,7 +10399,7 @@ If omitted, the linseed Deployment will use its default values for its init cont
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentContainer">
+<a href="#LinseedDeploymentContainer">
 []LinseedDeploymentContainer
 </a>
 </em>
@@ -10418,11 +10418,11 @@ If omitted, the linseed Deployment will use its default values for its container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</h3>
+<h3 id="LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentSpec">LinseedDeploymentSpec</a>)
+<a href="#LinseedDeploymentSpec">LinseedDeploymentSpec</a>)
 
 </p>
 <p>
@@ -10441,7 +10441,7 @@ LinseedDeploymentPodTemplateSpec is the linseed Deployment&rsquo;s PodTemplateSp
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">
+<a href="#LinseedDeploymentPodSpec">
 LinseedDeploymentPodSpec
 </a>
 </em>
@@ -10462,11 +10462,11 @@ Spec is the linseed Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentSpec">LinseedDeploymentSpec</h3>
+<h3 id="LinseedDeploymentSpec">LinseedDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">LinseedDeployment</a>)
+<a href="#LinseedDeployment">LinseedDeployment</a>)
 
 </p>
 <p>
@@ -10485,7 +10485,7 @@ LinseedDeploymentSpec defines configuration for the linseed Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">
+<a href="#LinseedDeploymentPodTemplateSpec">
 LinseedDeploymentPodTemplateSpec
 </a>
 </em>
@@ -10502,12 +10502,12 @@ Template describes the linseed Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinuxDataplaneOption">LinuxDataplaneOption
+<h3 id="LinuxDataplaneOption">LinuxDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -10516,11 +10516,11 @@ LinuxDataplaneOption controls which dataplane is to be used on Linux nodes.
 <p>
 One of: Iptables, BPF
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</h3>
+<h3 id="LogCollectionSpec">LogCollectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -10536,7 +10536,7 @@ One of: Iptables, BPF
 
 <code>collectLogs</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionStatusType">
+<a href="#LogCollectionStatusType">
 LogCollectionStatusType
 </a>
 </em>
@@ -10594,19 +10594,19 @@ Default: -1
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectionStatusType">LogCollectionStatusType
+<h3 id="LogCollectionStatusType">LogCollectionStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</a>)
+<a href="#LogCollectionSpec">LogCollectionSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</h3>
+<h3 id="LogCollectorSpec">LogCollectorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>)
+<a href="#LogCollector">LogCollector</a>)
 
 </p>
 <p>
@@ -10625,7 +10625,7 @@ LogCollectorSpec defines the desired state of Tigera flow, audit, and DNS log co
 
 <code>additionalStores</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">
+<a href="#AdditionalLogStoreSpec">
 AdditionalLogStoreSpec
 </a>
 </em>
@@ -10645,7 +10645,7 @@ Configuration for exporting flow, audit, and DNS logs to external storage.
 
 <code>additionalSources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">
+<a href="#AdditionalLogSourceSpec">
 AdditionalLogSourceSpec
 </a>
 </em>
@@ -10665,7 +10665,7 @@ Configuration for importing audit logs from managed kubernetes cluster log sourc
 
 <code>collectProcessPath</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CollectProcessPathOption">
+<a href="#CollectProcessPathOption">
 CollectProcessPathOption
 </a>
 </em>
@@ -10684,11 +10684,11 @@ Default: Enabled
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectorStatus">LogCollectorStatus</h3>
+<h3 id="LogCollectorStatus">LogCollectorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>)
+<a href="#LogCollector">LogCollector</a>)
 
 </p>
 <p>
@@ -10742,31 +10742,31 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogLevel">LogLevel
+<h3 id="LogLevel">LogLevel
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNILogging">CNILogging</a>, 
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#CNILogging">CNILogging</a>, 
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogStorageComponentName">LogStorageComponentName
+<h3 id="LogStorageComponentName">LogStorageComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">LogStorageComponentResource</a>)
+<a href="#LogStorageComponentResource">LogStorageComponentResource</a>)
 
 </p>
 <p>
 LogStorageComponentName CRD enum
 </p>
-<h3 id="operator.tigera.io/v1.LogStorageComponentResource">LogStorageComponentResource</h3>
+<h3 id="LogStorageComponentResource">LogStorageComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -10785,7 +10785,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentName">
+<a href="#LogStorageComponentName">
 LogStorageComponentName
 </a>
 </em>
@@ -10820,11 +10820,11 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</h3>
+<h3 id="LogStorageSpec">LogStorageSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>)
+<a href="#LogStorage">LogStorage</a>)
 
 </p>
 <p>
@@ -10843,7 +10843,7 @@ LogStorageSpec defines the desired state of Tigera flow and DNS log storage.
 
 <code>nodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Nodes">
+<a href="#Nodes">
 Nodes
 </a>
 </em>
@@ -10862,7 +10862,7 @@ Nodes defines the configuration for a set of identical Elasticsearch cluster nod
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Indices">
+<a href="#Indices">
 Indices
 </a>
 </em>
@@ -10882,7 +10882,7 @@ Index defines the configuration for the indices in the Elasticsearch cluster.
 
 <code>retention</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Retention">
+<a href="#Retention">
 Retention
 </a>
 </em>
@@ -10944,7 +10944,7 @@ each of the indicated key-value pairs as labels as well as access to the specifi
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">
+<a href="#LogStorageComponentResource">
 []LogStorageComponentResource
 </a>
 </em>
@@ -10962,11 +10962,11 @@ Only ECKOperator is supported for this spec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorageStatus">LogStorageStatus</h3>
+<h3 id="LogStorageStatus">LogStorageStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>)
+<a href="#LogStorage">LogStorage</a>)
 
 </p>
 <p>
@@ -11056,11 +11056,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Logging">Logging</h3>
+<h3 id="Logging">Logging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>
@@ -11076,7 +11076,7 @@ Ready, Progressing, Degraded or other customer types.
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNILogging">
+<a href="#CNILogging">
 CNILogging
 </a>
 </em>
@@ -11093,11 +11093,11 @@ Customized logging specification for calico-cni plugin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</h3>
+<h3 id="ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>)
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>)
 
 </p>
 <p>
@@ -11135,7 +11135,7 @@ should be able to access this address. This field is used by managed clusters on
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">
+<a href="#ManagementClusterTLS">
 ManagementClusterTLS
 </a>
 </em>
@@ -11152,11 +11152,11 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnectionStatus">ManagementClusterConnectionStatus</h3>
+<h3 id="ManagementClusterConnectionStatus">ManagementClusterConnectionStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>)
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>)
 
 </p>
 <p>
@@ -11193,11 +11193,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterSpec">ManagementClusterSpec</h3>
+<h3 id="ManagementClusterSpec">ManagementClusterSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementCluster">ManagementCluster</a>)
+<a href="#ManagementCluster">ManagementCluster</a>)
 
 </p>
 <p>
@@ -11236,7 +11236,7 @@ Valid examples are: &ldquo;0.0.0.0:31000&rdquo;, &ldquo;example.com:32000&rdquo;
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLS">
+<a href="#TLS">
 TLS
 </a>
 </em>
@@ -11253,11 +11253,11 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterTLS">ManagementClusterTLS</h3>
+<h3 id="ManagementClusterTLS">ManagementClusterTLS</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
+<a href="#ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
 
 </p>
 <table>
@@ -11273,7 +11273,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>ca</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CAType">
+<a href="#CAType">
 CAType
 </a>
 </em>
@@ -11299,11 +11299,11 @@ Default: Tigera
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerSpec">ManagerSpec</h3>
+<h3 id="ManagerSpec">ManagerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>)
+<a href="#Manager">Manager</a>)
 
 </p>
 <p>
@@ -11322,7 +11322,7 @@ ManagerSpec defines configuration for the Calico Enterprise manager GUI.
 
 <code>auth</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Auth">
+<a href="#Auth">
 Auth
 </a>
 </em>
@@ -11339,11 +11339,11 @@ Deprecated. Please use the Authentication CR for configuring authentication.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerStatus">ManagerStatus</h3>
+<h3 id="ManagerStatus">ManagerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>)
+<a href="#Manager">Manager</a>)
 
 </p>
 <p>
@@ -11362,7 +11362,7 @@ ManagerStatus defines the observed state of the Calico Enterprise manager GUI.
 
 <code>auth</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Auth">
+<a href="#Auth">
 Auth
 </a>
 </em>
@@ -11417,24 +11417,24 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Metadata">Metadata</h3>
+<h3 id="Metadata">Metadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>, 
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>, 
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
+<a href="#TyphaDeployment">TyphaDeployment</a>, 
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11490,32 +11490,32 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MetadataAccessAllowedType">MetadataAccessAllowedType
+<h3 id="MetadataAccessAllowedType">MetadataAccessAllowedType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AmazonCloudIntegrationSpec">AmazonCloudIntegrationSpec</a>)
+<a href="#AmazonCloudIntegrationSpec">AmazonCloudIntegrationSpec</a>)
 
 </p>
 <p>
 MetadataAccessAllowedType
 </p>
-<h3 id="operator.tigera.io/v1.MonitorSpec">MonitorSpec</h3>
+<h3 id="MonitorSpec">MonitorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
 MonitorSpec defines the desired state of Tigera monitor.
 </p>
-<h3 id="operator.tigera.io/v1.MonitorStatus">MonitorStatus</h3>
+<h3 id="MonitorStatus">MonitorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -11569,12 +11569,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MultiInterfaceMode">MultiInterfaceMode
+<h3 id="MultiInterfaceMode">MultiInterfaceMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -11583,12 +11583,12 @@ MultiInterfaceMode describes the method of providing multiple pod interfaces.
 <p>
 One of: None, Multus
 </p>
-<h3 id="operator.tigera.io/v1.NATOutgoingType">NATOutgoingType
+<h3 id="NATOutgoingType">NATOutgoingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -11597,23 +11597,23 @@ NATOutgoingType describe the type of outgoing NAT to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.NativeIP">NativeIP
+<h3 id="NativeIP">NativeIP
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</a>)
+<a href="#AWSEgressGateway">AWSEgressGateway</a>)
 
 </p>
 <p>
 NativeIP defines if Egress Gateway pods should have AWS IPs.
 When NativeIP is enabled, the IPPools should be backed by AWS subnet.
 </p>
-<h3 id="operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</h3>
+<h3 id="NodeAddressAutodetection">NodeAddressAutodetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -11653,7 +11653,7 @@ filtering based on well-known interface names.
 
 <code>kubernetes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KubernetesAutodetectionMethod">
+<a href="#KubernetesAutodetectionMethod">
 KubernetesAutodetectionMethod
 </a>
 </em>
@@ -11744,11 +11744,11 @@ one of the provided CIDRs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeAffinity">NodeAffinity</h3>
+<h3 id="NodeAffinity">NodeAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</a>)
+<a href="#TyphaAffinity">TyphaAffinity</a>)
 
 </p>
 <p>
@@ -11817,11 +11817,11 @@ may or may not try to eventually evict the pod from its node.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeSet">NodeSet</h3>
+<h3 id="NodeSet">NodeSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Nodes">Nodes</a>)
+<a href="#Nodes">Nodes</a>)
 
 </p>
 <p>
@@ -11840,7 +11840,7 @@ NodeSets defines configuration specific to each Elasticsearch Node Set
 
 <code>selectionAttributes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeSetSelectionAttribute">
+<a href="#NodeSetSelectionAttribute">
 []NodeSetSelectionAttribute
 </a>
 </em>
@@ -11858,11 +11858,11 @@ to define Node Affinities and set the node awareness configuration in the runnin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeSetSelectionAttribute">NodeSetSelectionAttribute</h3>
+<h3 id="NodeSetSelectionAttribute">NodeSetSelectionAttribute</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeSet">NodeSet</a>)
+<a href="#NodeSet">NodeSet</a>)
 
 </p>
 <p>
@@ -11922,11 +11922,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Nodes">Nodes</h3>
+<h3 id="Nodes">Nodes</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -11962,7 +11962,7 @@ Count defines the number of nodes in the Elasticsearch cluster.
 
 <code>nodeSets</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeSet">
+<a href="#NodeSet">
 []NodeSet
 </a>
 </em>
@@ -11999,12 +11999,12 @@ ResourceRequirements defines the resource limits and requirements for the Elasti
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NonPrivilegedType">NonPrivilegedType
+<h3 id="NonPrivilegedType">NonPrivilegedType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -12013,12 +12013,12 @@ NonPrivilegedType specifies whether Calico runs as permissioned or not
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.OIDCType">OIDCType
+<h3 id="OIDCType">OIDCType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
 <p>
@@ -12026,22 +12026,22 @@ OIDCType defines how OIDC is configured for Tigera Enterprise. Dex should be the
 The Tigera option can help in specific use-cases, for instance, when you are unable to configure a client secret.
 One of: Dex, Tigera
 </p>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
+<h3 id="PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
 PolicyRecommendationSpec defines configuration for the Calico Enterprise Policy Recommendation
 service.
 </p>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
+<h3 id="PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
@@ -12074,13 +12074,13 @@ State provides user-readable status.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ProductVariant">ProductVariant
+<h3 id="ProductVariant">ProductVariant
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#InstallationSpec">InstallationSpec</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -12089,12 +12089,12 @@ ProductVariant represents the variant of the product.
 <p>
 One of: Calico, TigeraSecureEnterprise
 </p>
-<h3 id="operator.tigera.io/v1.PromptType">PromptType
+<h3 id="PromptType">PromptType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
 <p>
@@ -12102,23 +12102,23 @@ PromptType is a value that specifies whether the identity provider prompts the e
 consent.
 One of: None, Login, Consent, SelectAccount.
 </p>
-<h3 id="operator.tigera.io/v1.Provider">Provider
+<h3 id="Provider">Provider
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
 Provider represents a particular provider or flavor of Kubernetes. Valid options
 are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise.
 </p>
-<h3 id="operator.tigera.io/v1.Retention">Retention</h3>
+<h3 id="Retention">Retention</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -12260,11 +12260,11 @@ Default: 8
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.S3StoreSpec">S3StoreSpec</h3>
+<h3 id="S3StoreSpec">S3StoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -12331,11 +12331,11 @@ Path in the S3 bucket where to send logs
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SplunkStoreSpec">SplunkStoreSpec</h3>
+<h3 id="SplunkStoreSpec">SplunkStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -12368,23 +12368,23 @@ Location for splunk&rsquo;s http event collector end point. example <code>https:
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.StatusConditionType">StatusConditionType
+<h3 id="StatusConditionType">StatusConditionType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 StatusConditionType is a type of condition that may apply to a particular component.
 </p>
-<h3 id="operator.tigera.io/v1.SyslogLogType">SyslogLogType
+<h3 id="SyslogLogType">SyslogLogType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</a>)
+<a href="#SyslogStoreSpec">SyslogStoreSpec</a>)
 
 </p>
 <p>
@@ -12395,11 +12395,11 @@ Allowable values are Audit, DNS, Flows and IDSEvents.
 * Flows corresponds to flow logs generated by Calico node.
 * IDSEvents corresponds to event logs for the intrusion detection system (anomaly detection, suspicious IPs, suspicious domains and global alerts).
 </p>
-<h3 id="operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</h3>
+<h3 id="SyslogStoreSpec">SyslogStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -12455,7 +12455,7 @@ Default: 1024
 
 <code>logTypes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SyslogLogType">
+<a href="#SyslogLogType">
 []SyslogLogType
 </a>
 </em>
@@ -12475,7 +12475,7 @@ Default: Audit, DNS, Flows
 
 <code>encryption</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncryptionOption">
+<a href="#EncryptionOption">
 EncryptionOption
 </a>
 </em>
@@ -12493,11 +12493,11 @@ Default: None
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLS">TLS</h3>
+<h3 id="TLS">TLS</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterSpec">ManagementClusterSpec</a>)
+<a href="#ManagementClusterSpec">ManagementClusterSpec</a>)
 
 </p>
 <table>
@@ -12547,11 +12547,11 @@ Default: tigera-management-cluster-connection
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</h3>
+<h3 id="TigeraStatusCondition">TigeraStatusCondition</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</a>)
+<a href="#TigeraStatusStatus">TigeraStatusStatus</a>)
 
 </p>
 <p>
@@ -12570,7 +12570,7 @@ TigeraStatusCondition represents a condition attached to a particular component.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.StatusConditionType">
+<a href="#StatusConditionType">
 StatusConditionType
 </a>
 </em>
@@ -12589,7 +12589,7 @@ The type of condition. May be Available, Progressing, or Degraded.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ConditionStatus">
+<a href="#ConditionStatus">
 ConditionStatus
 </a>
 </em>
@@ -12678,26 +12678,26 @@ with respect to the current state of the instance.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatusReason">TigeraStatusReason
+<h3 id="TigeraStatusReason">TigeraStatusReason
 (<code>string</code> alias)</h3>
 <p>
 TigeraStatusReason represents the reason for a particular condition.
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusSpec">TigeraStatusSpec</h3>
+<h3 id="TigeraStatusSpec">TigeraStatusSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
 TigeraStatusSpec defines the desired state of TigeraStatus
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</h3>
+<h3 id="TigeraStatusStatus">TigeraStatusStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
@@ -12716,7 +12716,7 @@ TigeraStatusStatus defines the observed state of TigeraStatus
 
 <code>conditions</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">
+<a href="#TigeraStatusCondition">
 []TigeraStatusCondition
 </a>
 </em>
@@ -12733,11 +12733,11 @@ Available, Progressing, or Degraded.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</h3>
+<h3 id="TyphaAffinity">TyphaAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -12757,7 +12757,7 @@ TyphaAffinity allows configuration of node affinity characteristics for Typha po
 
 <code>nodeAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAffinity">
+<a href="#NodeAffinity">
 NodeAffinity
 </a>
 </em>
@@ -12774,11 +12774,11 @@ NodeAffinity describes node affinity scheduling rules for typha.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</h3>
+<h3 id="TyphaDeployment">TyphaDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -12797,7 +12797,7 @@ TyphaDeployment is the configuration for the typha Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -12817,7 +12817,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">
+<a href="#TyphaDeploymentSpec">
 TyphaDeploymentSpec
 </a>
 </em>
@@ -12838,11 +12838,11 @@ Spec is the specification of the typha Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
+<h3 id="TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -12898,11 +12898,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
+<h3 id="TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -12958,11 +12958,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
+<h3 id="TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -12981,7 +12981,7 @@ TyphaDeploymentPodSpec is the typha Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentInitContainer">
+<a href="#TyphaDeploymentInitContainer">
 []TyphaDeploymentInitContainer
 </a>
 </em>
@@ -13003,7 +13003,7 @@ If omitted, the typha Deployment will use its default values for its init contai
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentContainer">
+<a href="#TyphaDeploymentContainer">
 []TyphaDeploymentContainer
 </a>
 </em>
@@ -13137,11 +13137,11 @@ WARNING: Please note that this field will override the default calico-typha Depl
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
+<h3 id="TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -13160,7 +13160,7 @@ TyphaDeploymentPodTemplateSpec is the typha Deployment&rsquo;s PodTemplateSpec
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -13181,7 +13181,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">
+<a href="#TyphaDeploymentPodSpec">
 TyphaDeploymentPodSpec
 </a>
 </em>
@@ -13202,11 +13202,11 @@ Spec is the typha Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
+<h3 id="TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>)
+<a href="#TyphaDeployment">TyphaDeployment</a>)
 
 </p>
 <p>
@@ -13246,7 +13246,7 @@ If omitted, the typha Deployment will use its default value for minReadySeconds.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">
+<a href="#TyphaDeploymentPodTemplateSpec">
 TyphaDeploymentPodTemplateSpec
 </a>
 </em>
@@ -13266,7 +13266,7 @@ Template describes the typha Deployment pod that will be created.
 
 <code>strategy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentStrategy">
+<a href="#TyphaDeploymentStrategy">
 TyphaDeploymentStrategy
 </a>
 </em>
@@ -13283,11 +13283,11 @@ The deployment strategy to use to replace existing pods with new ones.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
+<h3 id="TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -13326,11 +13326,11 @@ to be.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.UserMatch">UserMatch</h3>
+<h3 id="UserMatch">UserMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GroupSearch">GroupSearch</a>)
+<a href="#GroupSearch">GroupSearch</a>)
 
 </p>
 <p>
@@ -13380,11 +13380,11 @@ The attribute of a group that links it to a user.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.UserSearch">UserSearch</h3>
+<h3 id="UserSearch">UserSearch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</a>)
+<a href="#AuthenticationLDAP">AuthenticationLDAP</a>)
 
 </p>
 <p>
@@ -13454,12 +13454,12 @@ Default: uid
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.WAFStatusType">WAFStatusType
+<h3 id="WAFStatusType">WAFStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <hr/>

--- a/calico-enterprise_versioned_docs/version-3.17/threat/anomaly-detection/storage.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/threat/anomaly-detection/storage.mdx
@@ -123,8 +123,8 @@ volumeBindingMode: WaitForFirstConsumer
 
 ### Configure anomaly detection to use the persistent storage
 
-For anomaly detection components to recognize the persistent storage you created, set the `StorageClassName` field in the [Intrusion Detection installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetection) to the name of the `StorageClass` you have provisioned.
-If you have configured persistent storage and would like to revert these changes, simply set the `StorageClassName` field in the [Intrusion Detection installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetection) to an empty string.
+For anomaly detection components to recognize the persistent storage you created, set the `StorageClassName` field in the [Intrusion Detection installation resource](../../reference/installation/api.mdx#IntrusionDetection to the name of the `StorageClass` you have provisioned.
+If you have configured persistent storage and would like to revert these changes, simply set the `StorageClassName` field in the [Intrusion Detection installation resource](../../reference/installation/api.mdx#IntrusionDetection to an empty string.
 :::note
 
 The examples used throughout this doc assume that the value for `StorageClassName` is `tigera-anomaly-detection`.

--- a/calico-enterprise_versioned_docs/version-3.17/threat/deeppacketinspection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/threat/deeppacketinspection.mdx
@@ -76,7 +76,7 @@ spec:
 
 ### Configure resource requirements
 
-Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionComponentResource).
+Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#IntrusionDetectionComponentResource.
 
 For a data transfer rate of 1GB/sec on workload endpoints being monitored, we recommend a minimum of 1 CPU and 1GB RAM.
 

--- a/calico-enterprise_versioned_docs/version-3.17/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/threat/web-application-firewall.mdx
@@ -295,9 +295,9 @@ kubectl delete applicationlayer tigera-secure
 
 #### Keep some ApplicationLayer features enabled
 
-To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) custom resource.
+To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#ApplicationLayer custom resource.
 
-Note that the [ApplicationLayer Specification](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerSpec) can specify configuration for [Application Logging](../reference/installation/api#operator.tigera.io/v1.LogCollectionSpec) and [Application Layer Policy](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerPolicyStatusType) also. 
+Note that the [ApplicationLayer Specification](../reference/installation/api#ApplicationLayerSpec can specify configuration for [Application Logging](../reference/installation/api#LogCollectionSpec and [Application Layer Policy](../reference/installation/api#ApplicationLayerPolicyStatusType also. 
 
 For the ApplicationLayer custom resource to be valid, at least one of these features have to be enabled, for example:
 

--- a/calico-enterprise_versioned_docs/version-3.17/visibility/elastic/archive-storage.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/visibility/elastic/archive-storage.mdx
@@ -48,8 +48,8 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
     -n tigera-operator
    ```
 
-3. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#operator.tigera.io/v1.S3StoreSpec)
+3. Update the [LogCollector](../../reference/installation/api.mdx#LogCollector
+   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#S3StoreSpec
    with your information noted from above.
    Example:
 
@@ -76,8 +76,8 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
 </TabItem>
 <TabItem label="Syslog" value="Syslog-1">
 
-1. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+1. Update the [LogCollector](../../reference/installation/api.mdx#LogCollector
+   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec
    with your syslog information.
    Example:
    ```yaml
@@ -104,7 +104,7 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    kubectl edit logcollector tigera-secure
    ```
 2. You can control which types of {variables.prodname} log data you would like to send to syslog.
-   The [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+   The [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec
    contains a field called `logTypes` which allows you to list which log types you would like to include.
    The allowable log types are:
 
@@ -113,11 +113,11 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    - Flows
    - IDSEvents
 
-   Refer to the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec) for more details on what data each log type represents.
+   Refer to the [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec for more details on what data each log type represents.
 
    :::note
 
-   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
+   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#LogStorage configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
 
    :::
 
@@ -125,7 +125,7 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
 
 **TLS configuration**
 
-3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec).
+3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec.
 
    ```yaml
    apiVersion: operator.tigera.io/v1
@@ -182,9 +182,9 @@ In this release, only [Splunk Enterprise](https://www.splunk.com/en_us/products/
    ```
 
 3. Update the
-   [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
+   [LogCollector](../../reference/installation/api.mdx#LogCollector
    resource named `tigera-secure` to include
-   a [Splunk section](../../reference/installation/api.mdx#operator.tigera.io/v1.SplunkStoreSpec)
+   a [Splunk section](../../reference/installation/api.mdx#SplunkStoreSpec
    with your Splunk information.
    Example:
 

--- a/calico-enterprise_versioned_docs/version-3.17/visibility/elastic/l7/configure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/visibility/elastic/l7/configure.mdx
@@ -73,7 +73,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
 
 **Configure the ApplicationLayer resource for L7 logs**
 
-1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) resource named, `tigera-secure` to include a logCollection section of the file, `_api.html` [here](../../../reference/installation/api.mdx).
+1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#ApplicationLayer resource named, `tigera-secure` to include a logCollection section of the file, `_api.html` [here](../../../reference/installation/api.mdx).
 
 1. Ensure that the `collectLogs` field is set to `Enabled`.
 

--- a/calico-enterprise_versioned_docs/version-3.17/visibility/elastic/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/visibility/elastic/overview.mdx
@@ -93,7 +93,7 @@ verbs: ['get']
 - Global network policies
 - Network sets
 
-{variables.prodname} also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec).
+{variables.prodname} also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#LogCollectorSpec.
 
 ## Additional resources
 
@@ -104,4 +104,4 @@ verbs: ['get']
 - [BGP logs](bgp.mdx)
 - [DNS logs](dns/dns-logs.mdx)
 - [Archive logs](archive-storage.mdx)
-- [Log collection options](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../reference/installation/api.mdx#LogCollectorSpec

--- a/calico-enterprise_versioned_docs/version-3.17/visibility/elastic/rbac-elasticsearch.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/visibility/elastic/rbac-elasticsearch.mdx
@@ -213,4 +213,4 @@ status:
 ## Additional resources
 
 - Configure [RBAC for tiered policies](../../network-policy/policy-tiers/rbac-tiered-policies.mdx).
-- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) resource.
+- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#ManagementCluster resource.

--- a/calico-enterprise_versioned_docs/version-3.17/visibility/elastic/retention.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/visibility/elastic/retention.mdx
@@ -12,7 +12,7 @@ Configure how long to retain logs and compliance reports.
 
 ## Before you begin...
 
-Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#operator.tigera.io/v1.Retention) and determine the appropriate values for your deployment.
+Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#Retention and determine the appropriate values for your deployment.
 
 :::note
 

--- a/calico-enterprise_versioned_docs/version-3.17/visibility/elastic/troubleshoot.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/visibility/elastic/troubleshoot.mdx
@@ -10,7 +10,7 @@ import variables from '@site/calico-enterprise_versioned_docs/version-3.17/varia
 
 The following user-configured resources are related to Elasticsearch:
 
-- [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage). It has settings for:
+- [LogStorage](../../reference/installation/api.mdx#LogStorage. It has settings for:
 
   - Elasticsearch (for example, nodeCount and replicas)
   - Kubernetes (for example, resourceRequirements, storage and nodeSelectors)
@@ -113,7 +113,7 @@ As a last resort, create a new [Elasticsearch cluster](#how-to-create-a-new-clus
 
 ### Elasticsearch is slow
 
-**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorageSpec).
+**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#LogStorageSpec.
 
 ### Elasticsearch crashes during booting
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -44,7 +44,7 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 
 If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), or you need to customize TLS certificates, you **must** customize this Helm chart by creating a `values.yaml` file. Otherwise, you can skip this step.
 
-1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider). For example:
+1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#Provider. For example:
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
@@ -46,4 +46,4 @@ key features like Flow Visualizer, metrics in the dashboard and Policy Board, po
 - [Configure flow log aggregation](../../../visibility/elastic/flow/aggregation.mdx)
 - [Log storage recommendations](../../../operations/logstorage/log-storage-recommendations.mdx)
 - [Archive logs](../../../visibility/elastic/archive-storage.mdx)
-- [Log collection options](../../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../../reference/installation/api.mdx#LogCollectorSpec

--- a/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/windows-calico/requirements.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/windows-calico/requirements.mdx
@@ -38,7 +38,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#BGPOption.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
@@ -103,7 +103,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
 
 1. <OpenShiftPrometheusOperator operation='upgrade' />
 
-1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster)
+1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#ManagementCluster
    CR to your cluster.
 
    ```bash
@@ -115,7 +115,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#operator.tigera.io/v1.Monitor)
+1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#Monitor
    CR to your cluster.
 
    ```bash
@@ -127,7 +127,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendation)
+1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#PolicyRecommendation
    CR to your cluster.
 
    ```bash

--- a/calico-enterprise_versioned_docs/version-3.18-2/multicluster/fine-tune-deployment.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/multicluster/fine-tune-deployment.mdx
@@ -153,4 +153,4 @@ To filter log data by a given managed cluster you can include the filter criteri
 
 # Additional resources
 
-- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection)
+- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#ManagementClusterConnection

--- a/calico-enterprise_versioned_docs/version-3.18-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -44,7 +44,7 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 
 If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), or you need to customize TLS certificates, you **must** customize this Helm chart by creating a `values.yaml` file. Otherwise, you can skip this step.
 
-1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider). For example:
+1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#Provider. For example:
 
   ```bash
   echo 'installation: { kubernetesProvider: EKS }' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.18-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -46,7 +46,7 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 
 If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), or you need to customize TLS certificates, you **must** customize this Helm chart by creating a `values.yaml` file. Otherwise, you can skip this step.
 
-1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider). For example:
+1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#Provider. For example:
 
   ```bash
   echo 'installation: { kubernetesProvider: EKS }' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.18-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
@@ -54,7 +54,7 @@ To control managed clusters from your central management plane, you must ensure 
     ```bash
     export MANAGEMENT_CLUSTER_ADDR=<your-management-cluster-addr>
     ```
-1.  Apply the [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) CR.
+1.  Apply the [ManagementCluster](../../../reference/installation/api.mdx#ManagementCluster CR.
 
     ```bash
     kubectl apply -f - <<EOF

--- a/calico-enterprise_versioned_docs/version-3.18-2/network-policy/policy-firewalls/aws-integration/metadata-access.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/network-policy/policy-firewalls/aws-integration/metadata-access.mdx
@@ -33,7 +33,7 @@ kubectl label pods <pod-name> aws.tigera.io/allow-metadata-access=true
 
 If the number of pods you need to allow exceeds the number that you need to block, it may be more convenient to change the default to _allow_ access and then deny access to individual pods that do not need it.
 
-- Edit the [AmazonCloudIntegration resource](../../../reference/installation/api.mdx#operator.tigera.io/v1.AmazonCloudIntegration).
+- Edit the [AmazonCloudIntegration resource](../../../reference/installation/api.mdx#AmazonCloudIntegration.
 
   ```
   kubectl edit amazoncloudintegration tigera-secure

--- a/calico-enterprise_versioned_docs/version-3.18-2/networking/configuring/dual-tor.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/networking/configuring/dual-tor.mdx
@@ -637,7 +637,7 @@ The only connections using interface-specific addresses should be BGP.
 If you plan to use [Egress Gateways](../egress/egress-gateway-on-prem.mdx) in your cluster, you must also adjust the {variables.nodecontainer} IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-{variables.prodname} [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+{variables.prodname} [Installation resource](../../reference/installation/api.mdx#NodeAddressAutodetection.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/networking/configuring/multiple-networks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/networking/configuring/multiple-networks.mdx
@@ -79,7 +79,7 @@ Although the following {variables.prodname} features are supported for your defa
 
 ### Configure cluster for multiple networks
 
-In the [Installation custom resource](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoNetworkSpec), set the `MultiInterfaceMode` to **Multus**.
+In the [Installation custom resource](../../reference/installation/api.mdx#CalicoNetworkSpec, set the `MultiInterfaceMode` to **Multus**.
 
 ### Create a new network
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/networking/egress/egress-gateway-on-prem.mdx
@@ -350,7 +350,7 @@ To modify the iptables backend for egress gateways, you must change the `iptable
 If you plan to use Egress Gateways in a [dual-ToR cluster](../configuring/dual-tor.mdx), you must also adjust the {variables.nodecontainer} IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-{variables.prodname} [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+{variables.prodname} [Installation resource](../../reference/installation/api.mdx#NodeAddressAutodetection.
 
 ### Configure namespaces and pods to use egress gateways
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/networking/ipam/initial-ippool.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/networking/ipam/initial-ippool.mdx
@@ -24,7 +24,7 @@ The **Kubernetes pod CIDR** is the expected IP address range for pod IPs. It is 
 
 [Calico IP pools](../../reference/resources/ippool.mdx) are ranges of IP addresses that Calico uses to assign to pods; the ranges must within the Kubernetes pod CIDR.
 
-The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#Installation
 resource and configures the default Calico IP pool. Note the following:
 
 - Default fields for any that are omitted:
@@ -44,7 +44,7 @@ resource and configures the default Calico IP pool. Note the following:
 ## How to
 
 1. Download the custom-resource.yaml file.
-1. Edit the [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation).  
+1. Edit the [Installation resource](../../reference/installation/api.mdx#Installation.  
    **Required values**: `cidr:`  
    **Empty values**: Defaulted
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/networking/ipam/ip-autodetection.mdx
@@ -51,7 +51,7 @@ By default, {variables.prodname} uses the **firstFound** method; the first valid
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#NodeAddressAutodetection in the operator Installation reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-enterprise_versioned_docs/version-3.18-2/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/operations/cnx/configure-identity-provider.mdx
@@ -17,7 +17,7 @@ Configure an external identity provider (IdP), create a user, and log in to {var
 
 ## Concepts
 
-The {variables.prodname} authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Authentication) named, `tigera-secure`.
+The {variables.prodname} authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#Authentication named, `tigera-secure`.
 
 When configuring your cluster, you may be asked for the following inputs:
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/operations/cnx/roles-and-permissions.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/operations/cnx/roles-and-permissions.mdx
@@ -18,7 +18,7 @@ Self-service is an important part of your Kubernetes platform networking and net
 
 ### Kubernetes RBAC authorization
 
-The [Calico Enterprise API server](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) is an extension to the standard [Kubernetes RBAC Authorization APIs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
+The [Calico Enterprise API server](../../reference/installation/api.mdx#APIServer is an extension to the standard [Kubernetes RBAC Authorization APIs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
 
 | Features                       | RBAC controls for...                                                                                                                                                                                                                            |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/calico-enterprise_versioned_docs/version-3.18-2/operations/comms/certificate-management.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/operations/comms/certificate-management.mdx
@@ -21,7 +21,7 @@ certificate issuance, {variables.prodname} provides a simple configuration optio
 **Limitations**
 
 If your cluster is already running {variables.prodname} and you would like to enable certificate management, you need to
-temporarily remove [the logstorage resource](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+temporarily remove [the logstorage resource](../../reference/installation/api.mdx#LogStorage
 before following the steps to enable certificate management and then re-apply afterwards. For detailed steps on
 re-creating logstorage, read more on [how to create a new Elasticsearch cluster](../../visibility/elastic/troubleshoot.mdx#how-to-create-a-new-cluster).
 
@@ -40,7 +40,7 @@ Currently, this feature is not supported in combination with [Multi-cluster mana
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../../reference/installation/api.mdx#Installation
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
    ```yaml

--- a/calico-enterprise_versioned_docs/version-3.18-2/operations/logstorage/log-storage-recommendations.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/operations/logstorage/log-storage-recommendations.mdx
@@ -82,4 +82,4 @@ is no tolerance for removing/restarting a node.
 
 - Read the [LogStorage overview page](../logstorage/index.mdx)
 - [Troubleshooting Elasticsearch](../../visibility/elastic/troubleshoot.mdx)
-- [LogStorage Specification](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+- [LogStorage Specification](../../reference/installation/api.mdx#LogStorage

--- a/calico-enterprise_versioned_docs/version-3.18-2/reference/architecture/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/reference/architecture/overview.mdx
@@ -124,7 +124,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### Manager
 
-**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#operator.tigera.io/v1.Manager).
+**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#Manager.
 
 ### Packet capture API
 
@@ -152,7 +152,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### API server
 
-**Main task**: Allows users to manage {variables.prodname} resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#operator.tigera.io/v1.APIServer).
+**Main task**: Allows users to manage {variables.prodname} resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#APIServer.
 
 ### BIRD
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/reference/component-resources/configuration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/reference/component-resources/configuration.mdx
@@ -245,7 +245,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-2">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#Installation API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico-enterprise_versioned_docs/version-3.18-2/reference/component-resources/typha/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/reference/component-resources/typha/prometheus.mdx
@@ -7,7 +7,7 @@ import variables from '@site/calico-enterprise_versioned_docs/version-3.18-2/var
 # Prometheus metrics
 
 Typha can be configured to report a number of metrics through Prometheus. The Prometheus port can be controlled
-via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#operator.tigera.io/v1.Installation).
+via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#Installation.
 
 ## Metric reference
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/reference/installation/_api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/reference/installation/_api.mdx
@@ -15,43 +15,43 @@ API Schema definitions for configuring the installation of Calico and Calico Ent
 </p>
 Resource Types:
 <ul><li>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>
+<a href="#APIServer">APIServer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.AmazonCloudIntegration">AmazonCloudIntegration</a>
+<a href="#AmazonCloudIntegration">AmazonCloudIntegration</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>
+<a href="#ApplicationLayer">ApplicationLayer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>
+<a href="#Authentication">Authentication</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>
+<a href="#Compliance">Compliance</a>
 </li><li>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>
+<a href="#EgressGateway">EgressGateway</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>
+<a href="#ImageSet">ImageSet</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>
+<a href="#Installation">Installation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>
+<a href="#IntrusionDetection">IntrusionDetection</a>
 </li><li>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>
+<a href="#LogCollector">LogCollector</a>
 </li><li>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>
+<a href="#LogStorage">LogStorage</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ManagementCluster">ManagementCluster</a>
+<a href="#ManagementCluster">ManagementCluster</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>
+<a href="#Manager">Manager</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>
+<a href="#Monitor">Monitor</a>
 </li><li>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>
+<a href="#PolicyRecommendation">PolicyRecommendation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>
+<a href="#Tenant">Tenant</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>
+<a href="#TigeraStatus">TigeraStatus</a>
 </li></ul>
-<h3 id="operator.tigera.io/v1.APIServer">APIServer</h3>
+<h3 id="APIServer">APIServer</h3>
 <p>
 APIServer installs the Tigera API server and related resources. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo; or &ldquo;tigera-secure&rdquo;.
@@ -112,7 +112,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerSpec">
+<a href="#APIServerSpec">
 APIServerSpec
 </a>
 </em>
@@ -130,7 +130,7 @@ Specification of the desired state for the Tigera API server.
 <td>
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -154,7 +154,7 @@ take precedence.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerStatus">
+<a href="#APIServerStatus">
 APIServerStatus
 </a>
 </em>
@@ -170,7 +170,7 @@ Most recently observed status for the Tigera API server.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AmazonCloudIntegration">AmazonCloudIntegration</h3>
+<h3 id="AmazonCloudIntegration">AmazonCloudIntegration</h3>
 <p>
 AmazonCloudIntegration is the Schema for the amazoncloudintegrations API
 </p>
@@ -230,7 +230,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AmazonCloudIntegrationSpec">
+<a href="#AmazonCloudIntegrationSpec">
 AmazonCloudIntegrationSpec
 </a>
 </em>
@@ -245,7 +245,7 @@ AmazonCloudIntegrationSpec
 <td>
 <code>defaultPodMetadataAccess</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MetadataAccessAllowedType">
+<a href="#MetadataAccessAllowedType">
 MetadataAccessAllowedType
 </a>
 </em>
@@ -393,7 +393,7 @@ to all ENIs in the VPC.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AmazonCloudIntegrationStatus">
+<a href="#AmazonCloudIntegrationStatus">
 AmazonCloudIntegrationStatus
 </a>
 </em>
@@ -406,7 +406,7 @@ AmazonCloudIntegrationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</h3>
+<h3 id="ApplicationLayer">ApplicationLayer</h3>
 <p>
 ApplicationLayer is the Schema for the applicationlayers API
 </p>
@@ -466,7 +466,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">
+<a href="#ApplicationLayerSpec">
 ApplicationLayerSpec
 </a>
 </em>
@@ -481,7 +481,7 @@ ApplicationLayerSpec
 <td>
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -501,7 +501,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -520,7 +520,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -540,7 +540,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -562,7 +562,7 @@ User-configurable settings for the Envoy proxy.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerStatus">
+<a href="#ApplicationLayerStatus">
 ApplicationLayerStatus
 </a>
 </em>
@@ -575,7 +575,7 @@ ApplicationLayerStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Authentication">Authentication</h3>
+<h3 id="Authentication">Authentication</h3>
 <p>
 Authentication is the Schema for the authentications API
 </p>
@@ -635,7 +635,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">
+<a href="#AuthenticationSpec">
 AuthenticationSpec
 </a>
 </em>
@@ -707,7 +707,7 @@ ClusterRoleBindings into Elastic.
 
 <code>oidc</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">
+<a href="#AuthenticationOIDC">
 AuthenticationOIDC
 </a>
 </em>
@@ -727,7 +727,7 @@ OIDC contains the configuration needed to setup OIDC authentication.
 
 <code>openshift</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOpenshift">
+<a href="#AuthenticationOpenshift">
 AuthenticationOpenshift
 </a>
 </em>
@@ -747,7 +747,7 @@ Openshift contains the configuration needed to setup Openshift OAuth authenticat
 
 <code>ldap</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">
+<a href="#AuthenticationLDAP">
 AuthenticationLDAP
 </a>
 </em>
@@ -770,7 +770,7 @@ LDAP contains the configuration needed to setup LDAP authentication.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationStatus">
+<a href="#AuthenticationStatus">
 AuthenticationStatus
 </a>
 </em>
@@ -783,7 +783,7 @@ AuthenticationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Compliance">Compliance</h3>
+<h3 id="Compliance">Compliance</h3>
 <p>
 Compliance installs the components required for Tigera compliance reporting. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -844,7 +844,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">
+<a href="#ComplianceSpec">
 ComplianceSpec
 </a>
 </em>
@@ -867,7 +867,7 @@ Specification of the desired state for Tigera compliance reporting.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceStatus">
+<a href="#ComplianceStatus">
 ComplianceStatus
 </a>
 </em>
@@ -883,7 +883,7 @@ Most recently observed state for Tigera compliance reporting.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGateway">EgressGateway</h3>
+<h3 id="EgressGateway">EgressGateway</h3>
 <p>
 EgressGateway is the Schema for the egressgateways API
 </p>
@@ -943,7 +943,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">
+<a href="#EgressGatewaySpec">
 EgressGatewaySpec
 </a>
 </em>
@@ -976,7 +976,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -1017,7 +1017,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -1038,7 +1038,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -1058,7 +1058,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -1082,7 +1082,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -1105,7 +1105,7 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayStatus">
+<a href="#EgressGatewayStatus">
 EgressGatewayStatus
 </a>
 </em>
@@ -1118,7 +1118,7 @@ EgressGatewayStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSet">ImageSet</h3>
+<h3 id="ImageSet">ImageSet</h3>
 <p>
 ImageSet is used to specify image digests for the images that the operator deploys.
 The name of the ImageSet is expected to be in the format <code>&lt;variant&gt;-&lt;release&gt;</code>.
@@ -1183,7 +1183,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">
+<a href="#ImageSetSpec">
 ImageSetSpec
 </a>
 </em>
@@ -1198,7 +1198,7 @@ ImageSetSpec
 <td>
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -1218,7 +1218,7 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Installation">Installation</h3>
+<h3 id="Installation">Installation</h3>
 <p>
 Installation configures an installation of Calico or Calico Enterprise. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo;. The Installation API installs core networking
@@ -1280,7 +1280,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -1298,7 +1298,7 @@ Specification of the desired state for the Calico or Calico Enterprise installat
 <td>
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -1426,7 +1426,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -1449,7 +1449,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -1469,7 +1469,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -1489,7 +1489,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -1668,7 +1668,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -1690,7 +1690,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -1712,7 +1712,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -1732,7 +1732,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -1752,7 +1752,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -1771,7 +1771,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -1791,7 +1791,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -1811,7 +1811,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -1831,7 +1831,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -1850,7 +1850,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -1871,7 +1871,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -1891,7 +1891,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -1932,7 +1932,7 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationStatus">
+<a href="#InstallationStatus">
 InstallationStatus
 </a>
 </em>
@@ -1948,7 +1948,7 @@ Most recently observed state for the Calico or Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</h3>
+<h3 id="IntrusionDetection">IntrusionDetection</h3>
 <p>
 IntrusionDetection installs the components required for Tigera intrusion detection. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2009,7 +2009,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">
+<a href="#IntrusionDetectionSpec">
 IntrusionDetectionSpec
 </a>
 </em>
@@ -2027,7 +2027,7 @@ Specification of the desired state for Tigera intrusion detection.
 <td>
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">
+<a href="#IntrusionDetectionComponentResource">
 []IntrusionDetectionComponentResource
 </a>
 </em>
@@ -2048,7 +2048,7 @@ Only DeepPacketInspection is supported for this spec.
 
 <code>anomalyDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+<a href="#AnomalyDetectionSpec">
 AnomalyDetectionSpec
 </a>
 </em>
@@ -2071,7 +2071,7 @@ AnomalyDetection is now deprecated, and configuring it has no effect.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionStatus">
+<a href="#IntrusionDetectionStatus">
 IntrusionDetectionStatus
 </a>
 </em>
@@ -2087,7 +2087,7 @@ Most recently observed state for Tigera intrusion detection.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollector">LogCollector</h3>
+<h3 id="LogCollector">LogCollector</h3>
 <p>
 LogCollector installs the components required for Tigera flow and DNS log collection. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;. When created, this installs fluentd on all nodes
@@ -2149,7 +2149,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">
+<a href="#LogCollectorSpec">
 LogCollectorSpec
 </a>
 </em>
@@ -2167,7 +2167,7 @@ Specification of the desired state for Tigera log collection.
 <td>
 <code>additionalStores</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">
+<a href="#AdditionalLogStoreSpec">
 AdditionalLogStoreSpec
 </a>
 </em>
@@ -2187,7 +2187,7 @@ Configuration for exporting flow, audit, and DNS logs to external storage.
 
 <code>additionalSources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">
+<a href="#AdditionalLogSourceSpec">
 AdditionalLogSourceSpec
 </a>
 </em>
@@ -2207,7 +2207,7 @@ Configuration for importing audit logs from managed kubernetes cluster log sourc
 
 <code>collectProcessPath</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CollectProcessPathOption">
+<a href="#CollectProcessPathOption">
 CollectProcessPathOption
 </a>
 </em>
@@ -2251,7 +2251,7 @@ the management cluster&rsquo;s tenant services are running.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectorStatus">
+<a href="#LogCollectorStatus">
 LogCollectorStatus
 </a>
 </em>
@@ -2267,7 +2267,7 @@ Most recently observed state for Tigera log collection.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorage">LogStorage</h3>
+<h3 id="LogStorage">LogStorage</h3>
 <p>
 LogStorage installs the components required for Tigera flow and DNS log storage. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;. When created, this installs an Elasticsearch cluster for use by
@@ -2329,7 +2329,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">
+<a href="#LogStorageSpec">
 LogStorageSpec
 </a>
 </em>
@@ -2347,7 +2347,7 @@ Specification of the desired state for Tigera log storage.
 <td>
 <code>nodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Nodes">
+<a href="#Nodes">
 Nodes
 </a>
 </em>
@@ -2366,7 +2366,7 @@ Nodes defines the configuration for a set of identical Elasticsearch cluster nod
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Indices">
+<a href="#Indices">
 Indices
 </a>
 </em>
@@ -2386,7 +2386,7 @@ Index defines the configuration for the indices in the Elasticsearch cluster.
 
 <code>retention</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Retention">
+<a href="#Retention">
 Retention
 </a>
 </em>
@@ -2448,7 +2448,7 @@ each of the indicated key-value pairs as labels as well as access to the specifi
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">
+<a href="#LogStorageComponentResource">
 []LogStorageComponentResource
 </a>
 </em>
@@ -2472,7 +2472,7 @@ Only ECKOperator is supported for this spec.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageStatus">
+<a href="#LogStorageStatus">
 LogStorageStatus
 </a>
 </em>
@@ -2488,7 +2488,7 @@ Most recently observed state for Tigera log storage.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementCluster">ManagementCluster</h3>
+<h3 id="ManagementCluster">ManagementCluster</h3>
 <p>
 The presence of ManagementCluster in your cluster, will configure it to be the management plane to which managed
 clusters can connect. At most one instance of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2549,7 +2549,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterSpec">
+<a href="#ManagementClusterSpec">
 ManagementClusterSpec
 </a>
 </em>
@@ -2584,7 +2584,7 @@ Valid examples are: &ldquo;0.0.0.0:31000&rdquo;, &ldquo;example.com:32000&rdquo;
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLS">
+<a href="#TLS">
 TLS
 </a>
 </em>
@@ -2604,7 +2604,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</h3>
+<h3 id="ManagementClusterConnection">ManagementClusterConnection</h3>
 <p>
 ManagementClusterConnection represents a link between a managed cluster and a management cluster. At most one
 instance of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2665,7 +2665,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">
+<a href="#ManagementClusterConnectionSpec">
 ManagementClusterConnectionSpec
 </a>
 </em>
@@ -2699,7 +2699,7 @@ should be able to access this address. This field is used by managed clusters on
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">
+<a href="#ManagementClusterTLS">
 ManagementClusterTLS
 </a>
 </em>
@@ -2722,7 +2722,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionStatus">
+<a href="#ManagementClusterConnectionStatus">
 ManagementClusterConnectionStatus
 </a>
 </em>
@@ -2735,7 +2735,7 @@ ManagementClusterConnectionStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Manager">Manager</h3>
+<h3 id="Manager">Manager</h3>
 <p>
 Manager installs the Calico Enterprise manager graphical user interface. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2796,7 +2796,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerSpec">
+<a href="#ManagerSpec">
 ManagerSpec
 </a>
 </em>
@@ -2814,7 +2814,7 @@ Specification of the desired state for the Calico Enterprise manager.
 <td>
 <code>auth</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Auth">
+<a href="#Auth">
 Auth
 </a>
 </em>
@@ -2837,7 +2837,7 @@ Deprecated. Please use the Authentication CR for configuring authentication.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerStatus">
+<a href="#ManagerStatus">
 ManagerStatus
 </a>
 </em>
@@ -2853,7 +2853,7 @@ Most recently observed state for the Calico Enterprise manager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Monitor">Monitor</h3>
+<h3 id="Monitor">Monitor</h3>
 <p>
 Monitor is the Schema for the monitor API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2914,7 +2914,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorSpec">
+<a href="#MonitorSpec">
 MonitorSpec
 </a>
 </em>
@@ -2934,7 +2934,7 @@ MonitorSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorStatus">
+<a href="#MonitorStatus">
 MonitorStatus
 </a>
 </em>
@@ -2947,7 +2947,7 @@ MonitorStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</h3>
+<h3 id="PolicyRecommendation">PolicyRecommendation</h3>
 <p>
 PolicyRecommendation is the Schema for the policy recommendation API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -3008,7 +3008,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationSpec">
+<a href="#PolicyRecommendationSpec">
 PolicyRecommendationSpec
 </a>
 </em>
@@ -3028,7 +3028,7 @@ PolicyRecommendationSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationStatus">
+<a href="#PolicyRecommendationStatus">
 PolicyRecommendationStatus
 </a>
 </em>
@@ -3041,7 +3041,7 @@ PolicyRecommendationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Tenant">Tenant</h3>
+<h3 id="Tenant">Tenant</h3>
 <p>
 Tenant is the Schema for the tenants API
 </p>
@@ -3101,7 +3101,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantSpec">
+<a href="#TenantSpec">
 TenantSpec
 </a>
 </em>
@@ -3133,7 +3133,7 @@ ID is the unique identifier for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -3155,7 +3155,7 @@ Indices defines the how to store a tenant&rsquo;s data
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantStatus">
+<a href="#TenantStatus">
 TenantStatus
 </a>
 </em>
@@ -3168,7 +3168,7 @@ TenantStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatus">TigeraStatus</h3>
+<h3 id="TigeraStatus">TigeraStatus</h3>
 <p>
 TigeraStatus represents the most recently observed status for Calico or a Calico Enterprise functional area.
 </p>
@@ -3228,7 +3228,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusSpec">
+<a href="#TigeraStatusSpec">
 TigeraStatusSpec
 </a>
 </em>
@@ -3248,7 +3248,7 @@ TigeraStatusSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">
+<a href="#TigeraStatusStatus">
 TigeraStatusStatus
 </a>
 </em>
@@ -3261,11 +3261,11 @@ TigeraStatusStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</h3>
+<h3 id="APIServerDeployment">APIServerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerSpec">APIServerSpec</a>)
+<a href="#APIServerSpec">APIServerSpec</a>)
 
 </p>
 <p>
@@ -3284,7 +3284,7 @@ APIServerDeployment is the configuration for the API server Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3304,7 +3304,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">
+<a href="#APIServerDeploymentSpec">
 APIServerDeploymentSpec
 </a>
 </em>
@@ -3325,11 +3325,11 @@ Spec is the specification of the API server Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
+<h3 id="APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -3385,11 +3385,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
+<h3 id="APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -3444,11 +3444,11 @@ If omitted, the API server Deployment will use its default value for this init c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
+<h3 id="APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -3467,7 +3467,7 @@ APIServerDeploymentDeploymentPodSpec is the API server Deployment&rsquo;s PodSpe
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentInitContainer">
+<a href="#APIServerDeploymentInitContainer">
 []APIServerDeploymentInitContainer
 </a>
 </em>
@@ -3489,7 +3489,7 @@ If omitted, the API server Deployment will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentContainer">
+<a href="#APIServerDeploymentContainer">
 []APIServerDeploymentContainer
 </a>
 </em>
@@ -3600,11 +3600,11 @@ WARNING: Please note that this field will override the default API server Deploy
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
+<h3 id="APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
+<a href="#APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -3623,7 +3623,7 @@ APIServerDeploymentPodTemplateSpec is the API server Deployment&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3644,7 +3644,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">
+<a href="#APIServerDeploymentPodSpec">
 APIServerDeploymentPodSpec
 </a>
 </em>
@@ -3665,11 +3665,11 @@ Spec is the API server Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
+<h3 id="APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>)
 
 </p>
 <p>
@@ -3709,7 +3709,7 @@ If omitted, the API server Deployment will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">
+<a href="#APIServerDeploymentPodTemplateSpec">
 APIServerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -3726,11 +3726,11 @@ Template describes the API server Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerSpec">APIServerSpec</h3>
+<h3 id="APIServerSpec">APIServerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -3749,7 +3749,7 @@ APIServerSpec defines the desired state of Tigera API server.
 
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -3767,11 +3767,11 @@ take precedence.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerStatus">APIServerStatus</h3>
+<h3 id="APIServerStatus">APIServerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -3825,11 +3825,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</h3>
+<h3 id="AWSEgressGateway">AWSEgressGateway</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -3848,7 +3848,7 @@ AWSEgressGateway defines the configurations for deploying EgressGateway in AWS
 
 <code>nativeIP</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NativeIP">
+<a href="#NativeIP">
 NativeIP
 </a>
 </em>
@@ -3885,11 +3885,11 @@ NativeIP must be Enabled if elastic IPs are set.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AdditionalLogSourceSpec">AdditionalLogSourceSpec</h3>
+<h3 id="AdditionalLogSourceSpec">AdditionalLogSourceSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <table>
@@ -3905,7 +3905,7 @@ NativeIP must be Enabled if elastic IPs are set.
 
 <code>eksCloudwatchLog</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EksCloudwatchLogsSpec">
+<a href="#EksCloudwatchLogsSpec">
 EksCloudwatchLogsSpec
 </a>
 </em>
@@ -3923,11 +3923,11 @@ audit logs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</h3>
+<h3 id="AdditionalLogStoreSpec">AdditionalLogStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <table>
@@ -3943,7 +3943,7 @@ audit logs.
 
 <code>s3</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.S3StoreSpec">
+<a href="#S3StoreSpec">
 S3StoreSpec
 </a>
 </em>
@@ -3963,7 +3963,7 @@ If specified, enables exporting of flow, audit, and DNS logs to Amazon S3 storag
 
 <code>syslog</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">
+<a href="#SyslogStoreSpec">
 SyslogStoreSpec
 </a>
 </em>
@@ -3983,7 +3983,7 @@ If specified, enables exporting of flow, audit, and DNS logs to syslog.
 
 <code>splunk</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SplunkStoreSpec">
+<a href="#SplunkStoreSpec">
 SplunkStoreSpec
 </a>
 </em>
@@ -4000,11 +4000,11 @@ If specified, enables exporting of flow, audit, and DNS logs to splunk.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AmazonCloudIntegrationSpec">AmazonCloudIntegrationSpec</h3>
+<h3 id="AmazonCloudIntegrationSpec">AmazonCloudIntegrationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AmazonCloudIntegration">AmazonCloudIntegration</a>)
+<a href="#AmazonCloudIntegration">AmazonCloudIntegration</a>)
 
 </p>
 <p>
@@ -4023,7 +4023,7 @@ AmazonCloudIntegrationSpec defines the desired state of AmazonCloudIntegration
 
 <code>defaultPodMetadataAccess</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MetadataAccessAllowedType">
+<a href="#MetadataAccessAllowedType">
 MetadataAccessAllowedType
 </a>
 </em>
@@ -4165,11 +4165,11 @@ to all ENIs in the VPC.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AmazonCloudIntegrationStatus">AmazonCloudIntegrationStatus</h3>
+<h3 id="AmazonCloudIntegrationStatus">AmazonCloudIntegrationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AmazonCloudIntegration">AmazonCloudIntegration</a>)
+<a href="#AmazonCloudIntegration">AmazonCloudIntegration</a>)
 
 </p>
 <p>
@@ -4223,11 +4223,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
+<h3 id="AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <table>
@@ -4258,19 +4258,19 @@ StorageClassName is now deprecated, and configuring it has no effect.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
+<h3 id="ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</h3>
+<h3 id="ApplicationLayerSpec">ApplicationLayerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -4289,7 +4289,7 @@ ApplicationLayerSpec defines the desired state of ApplicationLayer
 
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -4309,7 +4309,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -4328,7 +4328,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -4348,7 +4348,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -4364,11 +4364,11 @@ User-configurable settings for the Envoy proxy.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerStatus">ApplicationLayerStatus</h3>
+<h3 id="ApplicationLayerStatus">ApplicationLayerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -4422,12 +4422,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Auth">Auth</h3>
+<h3 id="Auth">Auth</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerSpec">ManagerSpec</a>, 
-<a href="#operator.tigera.io/v1.ManagerStatus">ManagerStatus</a>)
+<a href="#ManagerSpec">ManagerSpec</a>, 
+<a href="#ManagerStatus">ManagerStatus</a>)
 
 </p>
 <p>
@@ -4446,7 +4446,7 @@ Auth defines authentication configuration.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthType">
+<a href="#AuthType">
 AuthType
 </a>
 </em>
@@ -4499,25 +4499,25 @@ ClientId configures the OAuth2/OIDC client ID to use for OAuth2 or OIDC login.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthMethod">AuthMethod
+<h3 id="AuthMethod">AuthMethod
 (<code>string</code> alias)</h3>
-<h3 id="operator.tigera.io/v1.AuthType">AuthType
+<h3 id="AuthType">AuthType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Auth">Auth</a>)
+<a href="#Auth">Auth</a>)
 
 </p>
 <p>
 AuthType represents the type of authentication to use. Valid
 options are: Token, Basic, OIDC, OAuth
 </p>
-<h3 id="operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</h3>
+<h3 id="AuthenticationLDAP">AuthenticationLDAP</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -4573,7 +4573,7 @@ the ldaps:// protocol.
 
 <code>userSearch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.UserSearch">
+<a href="#UserSearch">
 UserSearch
 </a>
 </em>
@@ -4592,7 +4592,7 @@ User entry search configuration to match the credentials with a user.
 
 <code>groupSearch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GroupSearch">
+<a href="#GroupSearch">
 GroupSearch
 </a>
 </em>
@@ -4609,11 +4609,11 @@ Group search configuration to find the groups that a user is in.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</h3>
+<h3 id="AuthenticationOIDC">AuthenticationOIDC</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -4739,7 +4739,7 @@ Deprecated. Please use Authentication.Spec.GroupsPrefix instead.
 
 <code>emailVerification</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EmailVerificationType">
+<a href="#EmailVerificationType">
 EmailVerificationType
 </a>
 </em>
@@ -4762,7 +4762,7 @@ Default: Verify
 
 <code>promptTypes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PromptType">
+<a href="#PromptType">
 []PromptType
 </a>
 </em>
@@ -4785,7 +4785,7 @@ Default: &ldquo;Consent&rdquo;
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.OIDCType">
+<a href="#OIDCType">
 OIDCType
 </a>
 </em>
@@ -4802,11 +4802,11 @@ Default: &ldquo;Dex&rdquo;
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationOpenshift">AuthenticationOpenshift</h3>
+<h3 id="AuthenticationOpenshift">AuthenticationOpenshift</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -4839,11 +4839,11 @@ IssuerURL is the URL to the Openshift OAuth provider. Ex.: <a href="https://api.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</h3>
+<h3 id="AuthenticationSpec">AuthenticationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>)
+<a href="#Authentication">Authentication</a>)
 
 </p>
 <p>
@@ -4919,7 +4919,7 @@ ClusterRoleBindings into Elastic.
 
 <code>oidc</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">
+<a href="#AuthenticationOIDC">
 AuthenticationOIDC
 </a>
 </em>
@@ -4939,7 +4939,7 @@ OIDC contains the configuration needed to setup OIDC authentication.
 
 <code>openshift</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOpenshift">
+<a href="#AuthenticationOpenshift">
 AuthenticationOpenshift
 </a>
 </em>
@@ -4959,7 +4959,7 @@ Openshift contains the configuration needed to setup Openshift OAuth authenticat
 
 <code>ldap</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">
+<a href="#AuthenticationLDAP">
 AuthenticationLDAP
 </a>
 </em>
@@ -4976,11 +4976,11 @@ LDAP contains the configuration needed to setup LDAP authentication.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationStatus">AuthenticationStatus</h3>
+<h3 id="AuthenticationStatus">AuthenticationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>)
+<a href="#Authentication">Authentication</a>)
 
 </p>
 <p>
@@ -5034,12 +5034,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.BGPOption">BGPOption
+<h3 id="BGPOption">BGPOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -5048,12 +5048,12 @@ BGPOption describes the mode of BGP to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.CAType">CAType
+<h3 id="CAType">CAType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">ManagementClusterTLS</a>)
+<a href="#ManagementClusterTLS">ManagementClusterTLS</a>)
 
 </p>
 <p>
@@ -5062,11 +5062,11 @@ CAType specifies which verification method the tunnel client should use to verif
 <p>
 One of: Tigera, Public
 </p>
-<h3 id="operator.tigera.io/v1.CNILogging">CNILogging</h3>
+<h3 id="CNILogging">CNILogging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Logging">Logging</a>)
+<a href="#Logging">Logging</a>)
 
 </p>
 <table>
@@ -5082,7 +5082,7 @@ One of: Tigera, Public
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -5153,12 +5153,12 @@ Default: 10
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CNIPluginType">CNIPluginType
+<h3 id="CNIPluginType">CNIPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -5167,11 +5167,11 @@ CNIPluginType describes the type of CNI plugin used.
 <p>
 One of: Calico, GKE, AmazonVPC, AzureVNET
 </p>
-<h3 id="operator.tigera.io/v1.CNISpec">CNISpec</h3>
+<h3 id="CNISpec">CNISpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5190,7 +5190,7 @@ CNISpec contains configuration for the CNI plugin.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNIPluginType">
+<a href="#CNIPluginType">
 CNIPluginType
 </a>
 </em>
@@ -5222,7 +5222,7 @@ Default: Calico
 
 <code>ipam</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMSpec">
+<a href="#IPAMSpec">
 IPAMSpec
 </a>
 </em>
@@ -5240,11 +5240,11 @@ Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
+<h3 id="CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5263,7 +5263,7 @@ CSINodeDriverDaemonSet is the configuration for the csi-node-driver DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5283,7 +5283,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">
+<a href="#CSINodeDriverDaemonSetSpec">
 CSINodeDriverDaemonSetSpec
 </a>
 </em>
@@ -5304,11 +5304,11 @@ Spec is the specification of the csi-node-driver DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
+<h3 id="CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -5363,11 +5363,11 @@ If omitted, the csi-node-driver DaemonSet will use its default value for this co
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -5386,7 +5386,7 @@ CSINodeDriverDaemonSetPodSpec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">
+<a href="#CSINodeDriverDaemonSetContainer">
 []CSINodeDriverDaemonSetContainer
 </a>
 </em>
@@ -5473,11 +5473,11 @@ WARNING: Please note that this field will override the default csi-node-driver D
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
+<a href="#CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -5496,7 +5496,7 @@ CSINodeDriverDaemonSetPodTemplateSpec is the csi-node-driver DaemonSet&rsquo;s P
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5517,7 +5517,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">
+<a href="#CSINodeDriverDaemonSetPodSpec">
 CSINodeDriverDaemonSetPodSpec
 </a>
 </em>
@@ -5538,11 +5538,11 @@ Spec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
+<h3 id="CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
 
 </p>
 <p>
@@ -5582,7 +5582,7 @@ If omitted, the csi-node-driver DaemonSet will use its default value for minRead
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">
 CSINodeDriverDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -5599,11 +5599,11 @@ Template describes the csi-node-driver DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
+<h3 id="CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5622,7 +5622,7 @@ CalicoKubeControllersDeployment is the configuration for the calico-kube-control
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5642,7 +5642,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">
+<a href="#CalicoKubeControllersDeploymentSpec">
 CalicoKubeControllersDeploymentSpec
 </a>
 </em>
@@ -5663,11 +5663,11 @@ Spec is the specification of the calico-kube-controllers Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
+<h3 id="CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -5723,11 +5723,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -5746,7 +5746,7 @@ CalicoKubeControllersDeploymentPodSpec is the calico-kube-controller Deployment&
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">
+<a href="#CalicoKubeControllersDeploymentContainer">
 []CalicoKubeControllersDeploymentContainer
 </a>
 </em>
@@ -5835,11 +5835,11 @@ WARNING: Please note that this field will override the default calico-kube-contr
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
+<a href="#CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
 
 </p>
 <p>
@@ -5858,7 +5858,7 @@ CalicoKubeControllersDeploymentPodTemplateSpec is the calico-kube-controllers De
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5879,7 +5879,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">
+<a href="#CalicoKubeControllersDeploymentPodSpec">
 CalicoKubeControllersDeploymentPodSpec
 </a>
 </em>
@@ -5900,11 +5900,11 @@ Spec is the calico-kube-controllers Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
 
 </p>
 <p>
@@ -5944,7 +5944,7 @@ If omitted, the calico-kube-controllers Deployment will use its default value fo
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">
 CalicoKubeControllersDeploymentPodTemplateSpec
 </a>
 </em>
@@ -5961,11 +5961,11 @@ Template describes the calico-kube-controllers Deployment pod that will be creat
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</h3>
+<h3 id="CalicoNetworkSpec">CalicoNetworkSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5984,7 +5984,7 @@ CalicoNetworkSpec specifies configuration options for Calico provided pod networ
 
 <code>linuxDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinuxDataplaneOption">
+<a href="#LinuxDataplaneOption">
 LinuxDataplaneOption
 </a>
 </em>
@@ -6007,7 +6007,7 @@ Default: Iptables
 
 <code>windowsDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsDataplaneOption">
+<a href="#WindowsDataplaneOption">
 WindowsDataplaneOption
 </a>
 </em>
@@ -6030,7 +6030,7 @@ Default: Disabled
 
 <code>bgp</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.BGPOption">
+<a href="#BGPOption">
 BGPOption
 </a>
 </em>
@@ -6050,7 +6050,7 @@ BGP configures whether or not to enable Calico&rsquo;s BGP capabilities.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPPool">
+<a href="#IPPool">
 []IPPool
 </a>
 </em>
@@ -6090,7 +6090,7 @@ If not specified, Calico will perform MTU auto-detection based on the cluster ne
 
 <code>nodeAddressAutodetectionV4</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -6111,7 +6111,7 @@ will use default auto-detection settings to acquire an IPv4 address for each nod
 
 <code>nodeAddressAutodetectionV6</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -6132,7 +6132,7 @@ IPv6 addresses will not be auto-detected.
 
 <code>hostPorts</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HostPortsType">
+<a href="#HostPortsType">
 HostPortsType
 </a>
 </em>
@@ -6153,7 +6153,7 @@ Default: Enabled
 
 <code>multiInterfaceMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MultiInterfaceMode">
+<a href="#MultiInterfaceMode">
 MultiInterfaceMode
 </a>
 </em>
@@ -6175,7 +6175,7 @@ Default: None
 
 <code>containerIPForwarding</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ContainerIPForwardingType">
+<a href="#ContainerIPForwardingType">
 ContainerIPForwardingType
 </a>
 </em>
@@ -6193,11 +6193,11 @@ Default: Disabled
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
+<h3 id="CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -6216,7 +6216,7 @@ CalicoNodeDaemonSet is the configuration for the calico-node DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6236,7 +6236,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">
+<a href="#CalicoNodeDaemonSetSpec">
 CalicoNodeDaemonSetSpec
 </a>
 </em>
@@ -6257,11 +6257,11 @@ Spec is the specification of the calico-node DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
+<h3 id="CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6317,11 +6317,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6377,11 +6377,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6400,7 +6400,7 @@ CalicoNodeDaemonSetPodSpec is the calico-node DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">
+<a href="#CalicoNodeDaemonSetInitContainer">
 []CalicoNodeDaemonSetInitContainer
 </a>
 </em>
@@ -6422,7 +6422,7 @@ If omitted, the calico-node DaemonSet will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetContainer">
+<a href="#CalicoNodeDaemonSetContainer">
 []CalicoNodeDaemonSetContainer
 </a>
 </em>
@@ -6509,11 +6509,11 @@ WARNING: Please note that this field will override the default calico-node Daemo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
+<a href="#CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -6532,7 +6532,7 @@ CalicoNodeDaemonSetPodTemplateSpec is the calico-node DaemonSet&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6553,7 +6553,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">
+<a href="#CalicoNodeDaemonSetPodSpec">
 CalicoNodeDaemonSetPodSpec
 </a>
 </em>
@@ -6574,11 +6574,11 @@ Spec is the calico-node DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
+<h3 id="CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
 
 </p>
 <p>
@@ -6618,7 +6618,7 @@ If omitted, the calico-node DaemonSet will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">
 CalicoNodeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -6635,11 +6635,11 @@ Template describes the calico-node DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
+<h3 id="CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -6658,7 +6658,7 @@ CalicoNodeWindowsDaemonSet is the configuration for the calico-node-windows Daem
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6678,7 +6678,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">
+<a href="#CalicoNodeWindowsDaemonSetSpec">
 CalicoNodeWindowsDaemonSetSpec
 </a>
 </em>
@@ -6699,11 +6699,11 @@ Spec is the specification of the calico-node-windows DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6759,11 +6759,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6819,11 +6819,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6842,7 +6842,7 @@ CalicoNodeWindowsDaemonSetPodSpec is the calico-node-windows DaemonSet&rsquo;s P
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">
+<a href="#CalicoNodeWindowsDaemonSetInitContainer">
 []CalicoNodeWindowsDaemonSetInitContainer
 </a>
 </em>
@@ -6864,7 +6864,7 @@ If omitted, the calico-node-windows DaemonSet will use its default values for it
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">
+<a href="#CalicoNodeWindowsDaemonSetContainer">
 []CalicoNodeWindowsDaemonSetContainer
 </a>
 </em>
@@ -6951,11 +6951,11 @@ WARNING: Please note that this field will override the default calico-node-windo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -6974,7 +6974,7 @@ CalicoNodeWindowsDaemonSetPodTemplateSpec is the calico-node-windows DaemonSet&r
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6995,7 +6995,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">
 CalicoNodeWindowsDaemonSetPodSpec
 </a>
 </em>
@@ -7016,11 +7016,11 @@ Spec is the calico-node-windows DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
 
 </p>
 <p>
@@ -7060,7 +7060,7 @@ If omitted, the calico-node-windows DaemonSet will use its default value for min
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">
 CalicoNodeWindowsDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -7077,11 +7077,11 @@ Template describes the calico-node-windows DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7101,7 +7101,7 @@ CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrad
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7121,7 +7121,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">
 CalicoWindowsUpgradeDaemonSetSpec
 </a>
 </em>
@@ -7142,11 +7142,11 @@ Spec is the specification of the calico-windows-upgrade DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -7201,11 +7201,11 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7224,7 +7224,7 @@ CalicoWindowsUpgradeDaemonSetPodSpec is the calico-windows-upgrade DaemonSet&rsq
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">
+<a href="#CalicoWindowsUpgradeDaemonSetContainer">
 []CalicoWindowsUpgradeDaemonSetContainer
 </a>
 </em>
@@ -7311,11 +7311,11 @@ WARNING: Please note that this field will override the default calico-windows-up
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7334,7 +7334,7 @@ CalicoWindowsUpgradeDaemonSetPodTemplateSpec is the calico-windows-upgrade Daemo
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7355,7 +7355,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">
 CalicoWindowsUpgradeDaemonSetPodSpec
 </a>
 </em>
@@ -7376,11 +7376,11 @@ Spec is the calico-windows-upgrade DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
 
 </p>
 <p>
@@ -7420,7 +7420,7 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
 CalicoWindowsUpgradeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -7437,11 +7437,11 @@ Template describes the calico-windows-upgrade DaemonSet pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CertificateManagement">CertificateManagement</h3>
+<h3 id="CertificateManagement">CertificateManagement</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7533,29 +7533,29 @@ Default: SHA256WithRSA
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CollectProcessPathOption">CollectProcessPathOption
+<h3 id="CollectProcessPathOption">CollectProcessPathOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</h3>
+<h3 id="ComplianceSpec">ComplianceSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>)
+<a href="#Compliance">Compliance</a>)
 
 </p>
 <p>
 ComplianceSpec defines the desired state of Tigera compliance reporting capabilities.
 </p>
-<h3 id="operator.tigera.io/v1.ComplianceStatus">ComplianceStatus</h3>
+<h3 id="ComplianceStatus">ComplianceStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>)
+<a href="#Compliance">Compliance</a>)
 
 </p>
 <p>
@@ -7609,12 +7609,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComponentName">ComponentName
+<h3 id="ComponentName">ComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComponentResource">ComponentResource</a>)
+<a href="#ComponentResource">ComponentResource</a>)
 
 </p>
 <p>
@@ -7623,11 +7623,11 @@ ComponentName represents a single component.
 <p>
 One of: Node, Typha, KubeControllers
 </p>
-<h3 id="operator.tigera.io/v1.ComponentResource">ComponentResource</h3>
+<h3 id="ComponentResource">ComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7647,7 +7647,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentName">
+<a href="#ComponentName">
 ComponentName
 </a>
 </em>
@@ -7682,44 +7682,44 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ConditionStatus">ConditionStatus
+<h3 id="ConditionStatus">ConditionStatus
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 ConditionStatus represents the status of a particular condition. A condition may be one of: True, False, Unknown.
 </p>
-<h3 id="operator.tigera.io/v1.ContainerIPForwardingType">ContainerIPForwardingType
+<h3 id="ContainerIPForwardingType">ContainerIPForwardingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
 ContainerIPForwardingType specifies whether the CNI config for container ip forwarding is enabled.
 </p>
-<h3 id="operator.tigera.io/v1.DataType">DataType
+<h3 id="DataType">DataType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Index">Index</a>)
+<a href="#Index">Index</a>)
 
 </p>
 <p>
 DataType represent the type of data stored
 </p>
-<h3 id="operator.tigera.io/v1.EGWDeploymentContainer">EGWDeploymentContainer</h3>
+<h3 id="EGWDeploymentContainer">EGWDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -7775,11 +7775,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
+<h3 id="EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -7835,11 +7835,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
+<h3 id="EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7858,7 +7858,7 @@ EgressGatewayDeploymentPodSpec is the Egress Gateway Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentInitContainer">
+<a href="#EGWDeploymentInitContainer">
 []EGWDeploymentInitContainer
 </a>
 </em>
@@ -7880,7 +7880,7 @@ If omitted, the EGW Deployment will use its default values for its init containe
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentContainer">
+<a href="#EGWDeploymentContainer">
 []EGWDeploymentContainer
 </a>
 </em>
@@ -8015,11 +8015,11 @@ PriorityClassName allows to specify a PriorityClass resource to be used.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
+<h3 id="EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -8038,7 +8038,7 @@ EgressGatewayDeploymentPodTemplateSpec is the EGW Deployment&rsquo;s PodTemplate
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayMetadata">
+<a href="#EgressGatewayMetadata">
 EgressGatewayMetadata
 </a>
 </em>
@@ -8059,7 +8059,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">
+<a href="#EgressGatewayDeploymentPodSpec">
 EgressGatewayDeploymentPodSpec
 </a>
 </em>
@@ -8080,11 +8080,11 @@ Spec is the EGW Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
+<h3 id="EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -8125,7 +8125,7 @@ Default: 90
 
 <code>icmpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ICMPProbe">
+<a href="#ICMPProbe">
 ICMPProbe
 </a>
 </em>
@@ -8147,7 +8147,7 @@ fail. Timeout must be greater than interval.
 
 <code>httpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HTTPProbe">
+<a href="#HTTPProbe">
 HTTPProbe
 </a>
 </em>
@@ -8166,11 +8166,11 @@ fail. Timeout must be greater than interval.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayIPPool">EgressGatewayIPPool</h3>
+<h3 id="EgressGatewayIPPool">EgressGatewayIPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <table>
@@ -8219,11 +8219,11 @@ CIDR is the IPPool CIDR that the Egress Gateways can use.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayMetadata">EgressGatewayMetadata</h3>
+<h3 id="EgressGatewayMetadata">EgressGatewayMetadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8281,11 +8281,11 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</h3>
+<h3 id="EgressGatewaySpec">EgressGatewaySpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -8322,7 +8322,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -8363,7 +8363,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -8384,7 +8384,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -8404,7 +8404,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -8428,7 +8428,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -8445,11 +8445,11 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayStatus">EgressGatewayStatus</h3>
+<h3 id="EgressGatewayStatus">EgressGatewayStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -8503,11 +8503,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EksCloudwatchLogsSpec">EksCloudwatchLogsSpec</h3>
+<h3 id="EksCloudwatchLogsSpec">EksCloudwatchLogsSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">AdditionalLogSourceSpec</a>)
+<a href="#AdditionalLogSourceSpec">AdditionalLogSourceSpec</a>)
 
 </p>
 <p>
@@ -8595,20 +8595,20 @@ Default: 60
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EmailVerificationType">EmailVerificationType
+<h3 id="EmailVerificationType">EmailVerificationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.EncapsulationType">EncapsulationType
+<h3 id="EncapsulationType">EncapsulationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -8617,12 +8617,12 @@ EncapsulationType is the type of encapsulation to use on an IP pool.
 <p>
 One of: IPIP, VXLAN, IPIPCrossSubnet, VXLANCrossSubnet, None
 </p>
-<h3 id="operator.tigera.io/v1.EncryptionOption">EncryptionOption
+<h3 id="EncryptionOption">EncryptionOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</a>)
+<a href="#SyslogStoreSpec">SyslogStoreSpec</a>)
 
 </p>
 <p>
@@ -8631,11 +8631,11 @@ EncryptionOption specifies the traffic encryption mode when connecting to a Sysl
 <p>
 One of: None, TLS
 </p>
-<h3 id="operator.tigera.io/v1.EnvoySettings">EnvoySettings</h3>
+<h3 id="EnvoySettings">EnvoySettings</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -8688,19 +8688,19 @@ manipulating various headers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FIPSMode">FIPSMode
+<h3 id="FIPSMode">FIPSMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.GroupSearch">GroupSearch</h3>
+<h3 id="GroupSearch">GroupSearch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</a>)
+<a href="#AuthenticationLDAP">AuthenticationLDAP</a>)
 
 </p>
 <p>
@@ -8772,7 +8772,7 @@ The attribute of the group that represents its name. This attribute can be used 
 
 <code>userMatchers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.UserMatch">
+<a href="#UserMatch">
 []UserMatch
 </a>
 </em>
@@ -8790,11 +8790,11 @@ attribute value.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HTTPProbe">HTTPProbe</h3>
+<h3 id="HTTPProbe">HTTPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -8866,12 +8866,12 @@ Default: 30
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HostPortsType">HostPortsType
+<h3 id="HostPortsType">HostPortsType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -8880,11 +8880,11 @@ HostPortsType specifies host port support.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.ICMPProbe">ICMPProbe</h3>
+<h3 id="ICMPProbe">ICMPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -8956,19 +8956,19 @@ Default: 15
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPAMPluginType">IPAMPluginType
+<h3 id="IPAMPluginType">IPAMPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPAMSpec">IPAMSpec</a>)
+<a href="#IPAMSpec">IPAMSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IPAMSpec">IPAMSpec</h3>
+<h3 id="IPAMSpec">IPAMSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -8987,7 +8987,7 @@ IPAMSpec contains configuration for pod IP address management.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMPluginType">
+<a href="#IPAMPluginType">
 IPAMPluginType
 </a>
 </em>
@@ -9015,11 +9015,11 @@ Default: Calico
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPPool">IPPool</h3>
+<h3 id="IPPool">IPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -9052,7 +9052,7 @@ CIDR contains the address range for the IP Pool in classless inter-domain routin
 
 <code>encapsulation</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncapsulationType">
+<a href="#EncapsulationType">
 EncapsulationType
 </a>
 </em>
@@ -9074,7 +9074,7 @@ Default: IPIP
 
 <code>natOutgoing</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NATOutgoingType">
+<a href="#NATOutgoingType">
 NATOutgoingType
 </a>
 </em>
@@ -9150,11 +9150,11 @@ Default: false
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Image">Image</h3>
+<h3 id="Image">Image</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</a>)
+<a href="#ImageSetSpec">ImageSetSpec</a>)
 
 </p>
 <table>
@@ -9205,11 +9205,11 @@ The field should not include a leading <code>@</code> and must be prefixed with 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</h3>
+<h3 id="ImageSetSpec">ImageSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>)
+<a href="#ImageSet">ImageSet</a>)
 
 </p>
 <p>
@@ -9228,7 +9228,7 @@ ImageSetSpec defines the desired state of ImageSet.
 
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -9245,11 +9245,11 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Index">Index</h3>
+<h3 id="Index">Index</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -9287,7 +9287,7 @@ excludes the numerical identifier suffix)
 
 <code>dataType</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DataType">
+<a href="#DataType">
 DataType
 </a>
 </em>
@@ -9303,11 +9303,11 @@ DataType represents the type of data stored in the defined index
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Indices">Indices</h3>
+<h3 id="Indices">Indices</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -9341,12 +9341,12 @@ Replicas defines how many replicas each index will have. See <a href="https://ww
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationSpec">InstallationSpec</h3>
+<h3 id="InstallationSpec">InstallationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#Installation">Installation</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -9365,7 +9365,7 @@ InstallationSpec defines configuration for a Calico or Calico Enterprise install
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -9493,7 +9493,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -9516,7 +9516,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -9536,7 +9536,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -9556,7 +9556,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -9735,7 +9735,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -9757,7 +9757,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -9779,7 +9779,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -9799,7 +9799,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -9819,7 +9819,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -9838,7 +9838,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -9858,7 +9858,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -9878,7 +9878,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -9898,7 +9898,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -9917,7 +9917,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -9938,7 +9938,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -9958,7 +9958,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -9993,11 +9993,11 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationStatus">InstallationStatus</h3>
+<h3 id="InstallationStatus">InstallationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>)
+<a href="#Installation">Installation</a>)
 
 </p>
 <p>
@@ -10016,7 +10016,7 @@ InstallationStatus defines the observed state of the Calico or Calico Enterprise
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -10072,7 +10072,7 @@ that is being used. If an ImageSet is not being used then this will not be set.
 
 <code>computed</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -10129,19 +10129,19 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionComponentName">IntrusionDetectionComponentName
+<h3 id="IntrusionDetectionComponentName">IntrusionDetectionComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</a>)
+<a href="#IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</h3>
+<h3 id="IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <p>
@@ -10160,7 +10160,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentName">
+<a href="#IntrusionDetectionComponentName">
 IntrusionDetectionComponentName
 </a>
 </em>
@@ -10195,11 +10195,11 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</h3>
+<h3 id="IntrusionDetectionSpec">IntrusionDetectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>)
+<a href="#IntrusionDetection">IntrusionDetection</a>)
 
 </p>
 <p>
@@ -10218,7 +10218,7 @@ IntrusionDetectionSpec defines the desired state of Tigera intrusion detection c
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">
+<a href="#IntrusionDetectionComponentResource">
 []IntrusionDetectionComponentResource
 </a>
 </em>
@@ -10239,7 +10239,7 @@ Only DeepPacketInspection is supported for this spec.
 
 <code>anomalyDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+<a href="#AnomalyDetectionSpec">
 AnomalyDetectionSpec
 </a>
 </em>
@@ -10256,11 +10256,11 @@ AnomalyDetection is now deprecated, and configuring it has no effect.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionStatus">IntrusionDetectionStatus</h3>
+<h3 id="IntrusionDetectionStatus">IntrusionDetectionStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>)
+<a href="#IntrusionDetection">IntrusionDetection</a>)
 
 </p>
 <p>
@@ -10314,12 +10314,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
+<h3 id="KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</a>)
+<a href="#NodeAddressAutodetection">NodeAddressAutodetection</a>)
 
 </p>
 <p>
@@ -10328,12 +10328,12 @@ KubernetesAutodetectionMethod is a method of detecting an IP address based on th
 <p>
 One of: NodeInternalIP
 </p>
-<h3 id="operator.tigera.io/v1.LinuxDataplaneOption">LinuxDataplaneOption
+<h3 id="LinuxDataplaneOption">LinuxDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -10342,11 +10342,11 @@ LinuxDataplaneOption controls which dataplane is to be used on Linux nodes.
 <p>
 One of: Iptables, BPF
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</h3>
+<h3 id="LogCollectionSpec">LogCollectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -10362,7 +10362,7 @@ One of: Iptables, BPF
 
 <code>collectLogs</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionStatusType">
+<a href="#LogCollectionStatusType">
 LogCollectionStatusType
 </a>
 </em>
@@ -10420,19 +10420,19 @@ Default: -1
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectionStatusType">LogCollectionStatusType
+<h3 id="LogCollectionStatusType">LogCollectionStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</a>)
+<a href="#LogCollectionSpec">LogCollectionSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</h3>
+<h3 id="LogCollectorSpec">LogCollectorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>)
+<a href="#LogCollector">LogCollector</a>)
 
 </p>
 <p>
@@ -10451,7 +10451,7 @@ LogCollectorSpec defines the desired state of Tigera flow, audit, and DNS log co
 
 <code>additionalStores</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">
+<a href="#AdditionalLogStoreSpec">
 AdditionalLogStoreSpec
 </a>
 </em>
@@ -10471,7 +10471,7 @@ Configuration for exporting flow, audit, and DNS logs to external storage.
 
 <code>additionalSources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">
+<a href="#AdditionalLogSourceSpec">
 AdditionalLogSourceSpec
 </a>
 </em>
@@ -10491,7 +10491,7 @@ Configuration for importing audit logs from managed kubernetes cluster log sourc
 
 <code>collectProcessPath</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CollectProcessPathOption">
+<a href="#CollectProcessPathOption">
 CollectProcessPathOption
 </a>
 </em>
@@ -10529,11 +10529,11 @@ the management cluster&rsquo;s tenant services are running.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectorStatus">LogCollectorStatus</h3>
+<h3 id="LogCollectorStatus">LogCollectorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>)
+<a href="#LogCollector">LogCollector</a>)
 
 </p>
 <p>
@@ -10587,31 +10587,31 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogLevel">LogLevel
+<h3 id="LogLevel">LogLevel
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNILogging">CNILogging</a>, 
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#CNILogging">CNILogging</a>, 
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogStorageComponentName">LogStorageComponentName
+<h3 id="LogStorageComponentName">LogStorageComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">LogStorageComponentResource</a>)
+<a href="#LogStorageComponentResource">LogStorageComponentResource</a>)
 
 </p>
 <p>
 LogStorageComponentName CRD enum
 </p>
-<h3 id="operator.tigera.io/v1.LogStorageComponentResource">LogStorageComponentResource</h3>
+<h3 id="LogStorageComponentResource">LogStorageComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -10630,7 +10630,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentName">
+<a href="#LogStorageComponentName">
 LogStorageComponentName
 </a>
 </em>
@@ -10665,11 +10665,11 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</h3>
+<h3 id="LogStorageSpec">LogStorageSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>)
+<a href="#LogStorage">LogStorage</a>)
 
 </p>
 <p>
@@ -10688,7 +10688,7 @@ LogStorageSpec defines the desired state of Tigera flow and DNS log storage.
 
 <code>nodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Nodes">
+<a href="#Nodes">
 Nodes
 </a>
 </em>
@@ -10707,7 +10707,7 @@ Nodes defines the configuration for a set of identical Elasticsearch cluster nod
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Indices">
+<a href="#Indices">
 Indices
 </a>
 </em>
@@ -10727,7 +10727,7 @@ Index defines the configuration for the indices in the Elasticsearch cluster.
 
 <code>retention</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Retention">
+<a href="#Retention">
 Retention
 </a>
 </em>
@@ -10789,7 +10789,7 @@ each of the indicated key-value pairs as labels as well as access to the specifi
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">
+<a href="#LogStorageComponentResource">
 []LogStorageComponentResource
 </a>
 </em>
@@ -10807,11 +10807,11 @@ Only ECKOperator is supported for this spec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorageStatus">LogStorageStatus</h3>
+<h3 id="LogStorageStatus">LogStorageStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>)
+<a href="#LogStorage">LogStorage</a>)
 
 </p>
 <p>
@@ -10901,11 +10901,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Logging">Logging</h3>
+<h3 id="Logging">Logging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>
@@ -10921,7 +10921,7 @@ Ready, Progressing, Degraded or other customer types.
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNILogging">
+<a href="#CNILogging">
 CNILogging
 </a>
 </em>
@@ -10938,11 +10938,11 @@ Customized logging specification for calico-cni plugin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</h3>
+<h3 id="ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>)
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>)
 
 </p>
 <p>
@@ -10980,7 +10980,7 @@ should be able to access this address. This field is used by managed clusters on
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">
+<a href="#ManagementClusterTLS">
 ManagementClusterTLS
 </a>
 </em>
@@ -10997,11 +10997,11 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnectionStatus">ManagementClusterConnectionStatus</h3>
+<h3 id="ManagementClusterConnectionStatus">ManagementClusterConnectionStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>)
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>)
 
 </p>
 <p>
@@ -11038,11 +11038,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterSpec">ManagementClusterSpec</h3>
+<h3 id="ManagementClusterSpec">ManagementClusterSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementCluster">ManagementCluster</a>)
+<a href="#ManagementCluster">ManagementCluster</a>)
 
 </p>
 <p>
@@ -11081,7 +11081,7 @@ Valid examples are: &ldquo;0.0.0.0:31000&rdquo;, &ldquo;example.com:32000&rdquo;
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLS">
+<a href="#TLS">
 TLS
 </a>
 </em>
@@ -11098,11 +11098,11 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterTLS">ManagementClusterTLS</h3>
+<h3 id="ManagementClusterTLS">ManagementClusterTLS</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
+<a href="#ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
 
 </p>
 <table>
@@ -11118,7 +11118,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>ca</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CAType">
+<a href="#CAType">
 CAType
 </a>
 </em>
@@ -11144,11 +11144,11 @@ Default: Tigera
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerSpec">ManagerSpec</h3>
+<h3 id="ManagerSpec">ManagerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>)
+<a href="#Manager">Manager</a>)
 
 </p>
 <p>
@@ -11167,7 +11167,7 @@ ManagerSpec defines configuration for the Calico Enterprise manager GUI.
 
 <code>auth</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Auth">
+<a href="#Auth">
 Auth
 </a>
 </em>
@@ -11184,11 +11184,11 @@ Deprecated. Please use the Authentication CR for configuring authentication.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerStatus">ManagerStatus</h3>
+<h3 id="ManagerStatus">ManagerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>)
+<a href="#Manager">Manager</a>)
 
 </p>
 <p>
@@ -11207,7 +11207,7 @@ ManagerStatus defines the observed state of the Calico Enterprise manager GUI.
 
 <code>auth</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Auth">
+<a href="#Auth">
 Auth
 </a>
 </em>
@@ -11262,24 +11262,24 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Metadata">Metadata</h3>
+<h3 id="Metadata">Metadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>, 
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>, 
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
+<a href="#TyphaDeployment">TyphaDeployment</a>, 
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11335,32 +11335,32 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MetadataAccessAllowedType">MetadataAccessAllowedType
+<h3 id="MetadataAccessAllowedType">MetadataAccessAllowedType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AmazonCloudIntegrationSpec">AmazonCloudIntegrationSpec</a>)
+<a href="#AmazonCloudIntegrationSpec">AmazonCloudIntegrationSpec</a>)
 
 </p>
 <p>
 MetadataAccessAllowedType
 </p>
-<h3 id="operator.tigera.io/v1.MonitorSpec">MonitorSpec</h3>
+<h3 id="MonitorSpec">MonitorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
 MonitorSpec defines the desired state of Tigera monitor.
 </p>
-<h3 id="operator.tigera.io/v1.MonitorStatus">MonitorStatus</h3>
+<h3 id="MonitorStatus">MonitorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -11414,12 +11414,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MultiInterfaceMode">MultiInterfaceMode
+<h3 id="MultiInterfaceMode">MultiInterfaceMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -11428,12 +11428,12 @@ MultiInterfaceMode describes the method of providing multiple pod interfaces.
 <p>
 One of: None, Multus
 </p>
-<h3 id="operator.tigera.io/v1.NATOutgoingType">NATOutgoingType
+<h3 id="NATOutgoingType">NATOutgoingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -11442,23 +11442,23 @@ NATOutgoingType describe the type of outgoing NAT to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.NativeIP">NativeIP
+<h3 id="NativeIP">NativeIP
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</a>)
+<a href="#AWSEgressGateway">AWSEgressGateway</a>)
 
 </p>
 <p>
 NativeIP defines if Egress Gateway pods should have AWS IPs.
 When NativeIP is enabled, the IPPools should be backed by AWS subnet.
 </p>
-<h3 id="operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</h3>
+<h3 id="NodeAddressAutodetection">NodeAddressAutodetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -11498,7 +11498,7 @@ filtering based on well-known interface names.
 
 <code>kubernetes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KubernetesAutodetectionMethod">
+<a href="#KubernetesAutodetectionMethod">
 KubernetesAutodetectionMethod
 </a>
 </em>
@@ -11589,11 +11589,11 @@ one of the provided CIDRs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeAffinity">NodeAffinity</h3>
+<h3 id="NodeAffinity">NodeAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</a>)
+<a href="#TyphaAffinity">TyphaAffinity</a>)
 
 </p>
 <p>
@@ -11662,11 +11662,11 @@ may or may not try to eventually evict the pod from its node.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeSet">NodeSet</h3>
+<h3 id="NodeSet">NodeSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Nodes">Nodes</a>)
+<a href="#Nodes">Nodes</a>)
 
 </p>
 <p>
@@ -11685,7 +11685,7 @@ NodeSets defines configuration specific to each Elasticsearch Node Set
 
 <code>selectionAttributes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeSetSelectionAttribute">
+<a href="#NodeSetSelectionAttribute">
 []NodeSetSelectionAttribute
 </a>
 </em>
@@ -11703,11 +11703,11 @@ to define Node Affinities and set the node awareness configuration in the runnin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeSetSelectionAttribute">NodeSetSelectionAttribute</h3>
+<h3 id="NodeSetSelectionAttribute">NodeSetSelectionAttribute</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeSet">NodeSet</a>)
+<a href="#NodeSet">NodeSet</a>)
 
 </p>
 <p>
@@ -11767,11 +11767,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Nodes">Nodes</h3>
+<h3 id="Nodes">Nodes</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -11807,7 +11807,7 @@ Count defines the number of nodes in the Elasticsearch cluster.
 
 <code>nodeSets</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeSet">
+<a href="#NodeSet">
 []NodeSet
 </a>
 </em>
@@ -11844,12 +11844,12 @@ ResourceRequirements defines the resource limits and requirements for the Elasti
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NonPrivilegedType">NonPrivilegedType
+<h3 id="NonPrivilegedType">NonPrivilegedType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -11858,12 +11858,12 @@ NonPrivilegedType specifies whether Calico runs as permissioned or not
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.OIDCType">OIDCType
+<h3 id="OIDCType">OIDCType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
 <p>
@@ -11871,22 +11871,22 @@ OIDCType defines how OIDC is configured for Tigera Enterprise. Dex should be the
 The Tigera option can help in specific use-cases, for instance, when you are unable to configure a client secret.
 One of: Dex, Tigera
 </p>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
+<h3 id="PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
 PolicyRecommendationSpec defines configuration for the Calico Enterprise Policy Recommendation
 service.
 </p>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
+<h3 id="PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
@@ -11919,13 +11919,13 @@ State provides user-readable status.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ProductVariant">ProductVariant
+<h3 id="ProductVariant">ProductVariant
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#InstallationSpec">InstallationSpec</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -11934,12 +11934,12 @@ ProductVariant represents the variant of the product.
 <p>
 One of: Calico, TigeraSecureEnterprise
 </p>
-<h3 id="operator.tigera.io/v1.PromptType">PromptType
+<h3 id="PromptType">PromptType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
 <p>
@@ -11947,23 +11947,23 @@ PromptType is a value that specifies whether the identity provider prompts the e
 consent.
 One of: None, Login, Consent, SelectAccount.
 </p>
-<h3 id="operator.tigera.io/v1.Provider">Provider
+<h3 id="Provider">Provider
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
 Provider represents a particular provider or flavor of Kubernetes. Valid options
 are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG.
 </p>
-<h3 id="operator.tigera.io/v1.Retention">Retention</h3>
+<h3 id="Retention">Retention</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -12105,11 +12105,11 @@ Default: 8
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.S3StoreSpec">S3StoreSpec</h3>
+<h3 id="S3StoreSpec">S3StoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -12176,11 +12176,11 @@ Path in the S3 bucket where to send logs
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SplunkStoreSpec">SplunkStoreSpec</h3>
+<h3 id="SplunkStoreSpec">SplunkStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -12213,23 +12213,23 @@ Location for splunk&rsquo;s http event collector end point. example <code>https:
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.StatusConditionType">StatusConditionType
+<h3 id="StatusConditionType">StatusConditionType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 StatusConditionType is a type of condition that may apply to a particular component.
 </p>
-<h3 id="operator.tigera.io/v1.SyslogLogType">SyslogLogType
+<h3 id="SyslogLogType">SyslogLogType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</a>)
+<a href="#SyslogStoreSpec">SyslogStoreSpec</a>)
 
 </p>
 <p>
@@ -12240,11 +12240,11 @@ Allowable values are Audit, DNS, Flows and IDSEvents.
 * Flows corresponds to flow logs generated by Calico node.
 * IDSEvents corresponds to event logs for the intrusion detection system (anomaly detection, suspicious IPs, suspicious domains and global alerts).
 </p>
-<h3 id="operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</h3>
+<h3 id="SyslogStoreSpec">SyslogStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -12300,7 +12300,7 @@ Default: 1024
 
 <code>logTypes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SyslogLogType">
+<a href="#SyslogLogType">
 []SyslogLogType
 </a>
 </em>
@@ -12320,7 +12320,7 @@ Default: Audit, DNS, Flows
 
 <code>encryption</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncryptionOption">
+<a href="#EncryptionOption">
 EncryptionOption
 </a>
 </em>
@@ -12338,11 +12338,11 @@ Default: None
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLS">TLS</h3>
+<h3 id="TLS">TLS</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterSpec">ManagementClusterSpec</a>)
+<a href="#ManagementClusterSpec">ManagementClusterSpec</a>)
 
 </p>
 <table>
@@ -12392,11 +12392,11 @@ Default: tigera-management-cluster-connection
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantSpec">TenantSpec</h3>
+<h3 id="TenantSpec">TenantSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
 <table>
@@ -12429,7 +12429,7 @@ ID is the unique identifier for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -12445,18 +12445,18 @@ Indices defines the how to store a tenant&rsquo;s data
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantStatus">TenantStatus</h3>
+<h3 id="TenantStatus">TenantStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</h3>
+<h3 id="TigeraStatusCondition">TigeraStatusCondition</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</a>)
+<a href="#TigeraStatusStatus">TigeraStatusStatus</a>)
 
 </p>
 <p>
@@ -12475,7 +12475,7 @@ TigeraStatusCondition represents a condition attached to a particular component.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.StatusConditionType">
+<a href="#StatusConditionType">
 StatusConditionType
 </a>
 </em>
@@ -12494,7 +12494,7 @@ The type of condition. May be Available, Progressing, or Degraded.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ConditionStatus">
+<a href="#ConditionStatus">
 ConditionStatus
 </a>
 </em>
@@ -12583,26 +12583,26 @@ with respect to the current state of the instance.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatusReason">TigeraStatusReason
+<h3 id="TigeraStatusReason">TigeraStatusReason
 (<code>string</code> alias)</h3>
 <p>
 TigeraStatusReason represents the reason for a particular condition.
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusSpec">TigeraStatusSpec</h3>
+<h3 id="TigeraStatusSpec">TigeraStatusSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
 TigeraStatusSpec defines the desired state of TigeraStatus
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</h3>
+<h3 id="TigeraStatusStatus">TigeraStatusStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
@@ -12621,7 +12621,7 @@ TigeraStatusStatus defines the observed state of TigeraStatus
 
 <code>conditions</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">
+<a href="#TigeraStatusCondition">
 []TigeraStatusCondition
 </a>
 </em>
@@ -12638,11 +12638,11 @@ Available, Progressing, or Degraded.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</h3>
+<h3 id="TyphaAffinity">TyphaAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -12662,7 +12662,7 @@ TyphaAffinity allows configuration of node affinity characteristics for Typha po
 
 <code>nodeAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAffinity">
+<a href="#NodeAffinity">
 NodeAffinity
 </a>
 </em>
@@ -12679,11 +12679,11 @@ NodeAffinity describes node affinity scheduling rules for typha.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</h3>
+<h3 id="TyphaDeployment">TyphaDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -12702,7 +12702,7 @@ TyphaDeployment is the configuration for the typha Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -12722,7 +12722,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">
+<a href="#TyphaDeploymentSpec">
 TyphaDeploymentSpec
 </a>
 </em>
@@ -12743,11 +12743,11 @@ Spec is the specification of the typha Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
+<h3 id="TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -12803,11 +12803,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
+<h3 id="TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -12863,11 +12863,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
+<h3 id="TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -12886,7 +12886,7 @@ TyphaDeploymentPodSpec is the typha Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentInitContainer">
+<a href="#TyphaDeploymentInitContainer">
 []TyphaDeploymentInitContainer
 </a>
 </em>
@@ -12908,7 +12908,7 @@ If omitted, the typha Deployment will use its default values for its init contai
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentContainer">
+<a href="#TyphaDeploymentContainer">
 []TyphaDeploymentContainer
 </a>
 </em>
@@ -13042,11 +13042,11 @@ WARNING: Please note that this field will override the default calico-typha Depl
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
+<h3 id="TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -13065,7 +13065,7 @@ TyphaDeploymentPodTemplateSpec is the typha Deployment&rsquo;s PodTemplateSpec
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -13086,7 +13086,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">
+<a href="#TyphaDeploymentPodSpec">
 TyphaDeploymentPodSpec
 </a>
 </em>
@@ -13107,11 +13107,11 @@ Spec is the typha Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
+<h3 id="TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>)
+<a href="#TyphaDeployment">TyphaDeployment</a>)
 
 </p>
 <p>
@@ -13151,7 +13151,7 @@ If omitted, the typha Deployment will use its default value for minReadySeconds.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">
+<a href="#TyphaDeploymentPodTemplateSpec">
 TyphaDeploymentPodTemplateSpec
 </a>
 </em>
@@ -13171,7 +13171,7 @@ Template describes the typha Deployment pod that will be created.
 
 <code>strategy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentStrategy">
+<a href="#TyphaDeploymentStrategy">
 TyphaDeploymentStrategy
 </a>
 </em>
@@ -13188,11 +13188,11 @@ The deployment strategy to use to replace existing pods with new ones.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
+<h3 id="TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -13231,11 +13231,11 @@ to be.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.UserMatch">UserMatch</h3>
+<h3 id="UserMatch">UserMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GroupSearch">GroupSearch</a>)
+<a href="#GroupSearch">GroupSearch</a>)
 
 </p>
 <p>
@@ -13285,11 +13285,11 @@ The attribute of a group that links it to a user.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.UserSearch">UserSearch</h3>
+<h3 id="UserSearch">UserSearch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</a>)
+<a href="#AuthenticationLDAP">AuthenticationLDAP</a>)
 
 </p>
 <p>
@@ -13359,27 +13359,27 @@ Default: uid
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.WAFStatusType">WAFStatusType
+<h3 id="WAFStatusType">WAFStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsDataplaneOption">WindowsDataplaneOption
+<h3 id="WindowsDataplaneOption">WindowsDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsNodeSpec">WindowsNodeSpec</h3>
+<h3 id="WindowsNodeSpec">WindowsNodeSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>

--- a/calico-enterprise_versioned_docs/version-3.18-2/reference/installation/helm_customization.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/reference/installation/helm_customization.mdx
@@ -8,18 +8,18 @@ import variables from '@site/calico-enterprise_versioned_docs/version-3.18-2/var
 
 You can customize the following resources and settings during {variables.prodname} Helm-based installation using the file, `values.yaml`.
 
-- [Installation](api.mdx#operator.tigera.io/v1.InstallationSpec)
-- [Api server](api.mdx#operator.tigera.io/v1.APIServerSpec)
-- [Compliance](api.mdx#operator.tigera.io/v1.ComplianceSpec)
-- [Intrusion detection](api.mdx#operator.tigera.io/v1.IntrusionDetectionSpec)
-- [Log collector](api.mdx#operator.tigera.io/v1.LogCollectorSpec)
-- [Log storage](api.mdx#operator.tigera.io/v1.LogStorageSpec)
-- [Manager](api.mdx#operator.tigera.io/v1.ManagerSpec)
-- [Monitor](api.mdx#operator.tigera.io/v1.MonitorSpec)
-- [Policy recommendation](api.mdx#operator.tigera.io/v1.PolicyRecommendationSpec)
-- [Authentication](api.mdx#operator.tigera.io/v1.AuthenticationSpec)
-- [Application layer](api.mdx#operator.tigera.io/v1.ApplicationLayerSpec)
-- [Amazon cloud integration](api.mdx#operator.tigera.io/v1.AmazonCloudIntegrationSpec)
+- [Installation](api.mdx#InstallationSpec
+- [Api server](api.mdx#APIServerSpec
+- [Compliance](api.mdx#ComplianceSpec
+- [Intrusion detection](api.mdx#IntrusionDetectionSpec
+- [Log collector](api.mdx#LogCollectorSpec
+- [Log storage](api.mdx#LogStorageSpec
+- [Manager](api.mdx#ManagerSpec
+- [Monitor](api.mdx#MonitorSpec
+- [Policy recommendation](api.mdx#PolicyRecommendationSpec
+- [Authentication](api.mdx#AuthenticationSpec
+- [Application layer](api.mdx#ApplicationLayerSpec
+- [Amazon cloud integration](api.mdx#AmazonCloudIntegrationSpec
 - [Default felix configuration](../resources/felixconfig.mdx#spec)
 
 :::note
@@ -94,7 +94,7 @@ Common customizations that you might want to configure are number of replicas, p
 
 ### Number of replicas
 This setting defines the number of replicas for {variables.prodname} components that can run simultaneously in multiple instances.
-To configure this setting, see [controlPlaneReplicas](api.mdx#operator.tigera.io/v1.InstallationSpec).
+To configure this setting, see [controlPlaneReplicas](api.mdx#InstallationSpec.
 The components for the replicas are:
 
 - tigera-manager

--- a/calico-enterprise_versioned_docs/version-3.18-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/release-notes/index.mdx
@@ -68,7 +68,7 @@ For more information, see [Optimize egress networking for workloads with long-li
 
 We've added support for XFF to propagate the original IP address when proxying application layer traffic with Envoy within a Kubernetes cluster.
 
-For more information, see [Installation reference](../reference/installation/api#operator.tigera.io/v1.EnvoySettings).
+For more information, see [Installation reference](../reference/installation/api#EnvoySettings.
 
 ### Alert-only mode for Workload-based Web Application Firewall (WAF)
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/threat/deeppacketinspection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/threat/deeppacketinspection.mdx
@@ -76,7 +76,7 @@ spec:
 
 ### Configure resource requirements
 
-Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionComponentResource).
+Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#IntrusionDetectionComponentResource.
 
 For a data transfer rate of 1GB/sec on workload endpoints being monitored, we recommend a minimum of 1 CPU and 1GB RAM.
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/threat/web-application-firewall.mdx
@@ -322,9 +322,9 @@ kubectl delete applicationlayer tigera-secure
 
 #### Keep some ApplicationLayer features enabled
 
-To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) custom resource.
+To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#ApplicationLayer custom resource.
 
-Note that the [ApplicationLayer Specification](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerSpec) can specify configuration for [Application Logging](../reference/installation/api#operator.tigera.io/v1.LogCollectionSpec) and [Application Layer Policy](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerPolicyStatusType) also. 
+Note that the [ApplicationLayer Specification](../reference/installation/api#ApplicationLayerSpec can specify configuration for [Application Logging](../reference/installation/api#LogCollectionSpec and [Application Layer Policy](../reference/installation/api#ApplicationLayerPolicyStatusType also. 
 
 For the ApplicationLayer custom resource to be valid, at least one of these features have to be enabled, for example:
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/visibility/elastic/archive-storage.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/visibility/elastic/archive-storage.mdx
@@ -48,8 +48,8 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
     -n tigera-operator
    ```
 
-3. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#operator.tigera.io/v1.S3StoreSpec)
+3. Update the [LogCollector](../../reference/installation/api.mdx#LogCollector
+   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#S3StoreSpec
    with your information noted from above.
    Example:
 
@@ -76,8 +76,8 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
 </TabItem>
 <TabItem label="Syslog" value="Syslog-1">
 
-1. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+1. Update the [LogCollector](../../reference/installation/api.mdx#LogCollector
+   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec
    with your syslog information.
    Example:
    ```yaml
@@ -104,7 +104,7 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    kubectl edit logcollector tigera-secure
    ```
 2. You can control which types of {variables.prodname} log data you would like to send to syslog.
-   The [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+   The [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec
    contains a field called `logTypes` which allows you to list which log types you would like to include.
    The allowable log types are:
 
@@ -113,11 +113,11 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    - Flows
    - IDSEvents
 
-   Refer to the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec) for more details on what data each log type represents.
+   Refer to the [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec for more details on what data each log type represents.
 
    :::note
 
-   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
+   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#LogStorage configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
 
    :::
 
@@ -125,7 +125,7 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
 
 **TLS configuration**
 
-3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec).
+3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec.
 
    ```yaml
    apiVersion: operator.tigera.io/v1
@@ -180,9 +180,9 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    ```
 
 3. Update the
-   [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
+   [LogCollector](../../reference/installation/api.mdx#LogCollector
    resource named `tigera-secure` to include
-   a [Splunk section](../../reference/installation/api.mdx#operator.tigera.io/v1.SplunkStoreSpec)
+   a [Splunk section](../../reference/installation/api.mdx#SplunkStoreSpec
    with your Splunk information.
    Example:
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/visibility/elastic/l7/configure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/visibility/elastic/l7/configure.mdx
@@ -73,7 +73,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
 
 **Configure the ApplicationLayer resource for L7 logs**
 
-1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) resource named, `tigera-secure` to include a logCollection section of the file, `_api.html` [here](../../../reference/installation/api.mdx).
+1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#ApplicationLayer resource named, `tigera-secure` to include a logCollection section of the file, `_api.html` [here](../../../reference/installation/api.mdx).
 
 1. Ensure that the `collectLogs` field is set to `Enabled`.
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/visibility/elastic/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/visibility/elastic/overview.mdx
@@ -93,7 +93,7 @@ verbs: ['get']
 - Global network policies
 - Network sets
 
-{variables.prodname} also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec).
+{variables.prodname} also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#LogCollectorSpec.
 
 ## Additional resources
 
@@ -104,4 +104,4 @@ verbs: ['get']
 - [BGP logs](bgp.mdx)
 - [DNS logs](dns/dns-logs.mdx)
 - [Archive logs](archive-storage.mdx)
-- [Log collection options](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../reference/installation/api.mdx#LogCollectorSpec

--- a/calico-enterprise_versioned_docs/version-3.18-2/visibility/elastic/rbac-elasticsearch.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/visibility/elastic/rbac-elasticsearch.mdx
@@ -213,4 +213,4 @@ status:
 ## Additional resources
 
 - Configure [RBAC for tiered policies](../../network-policy/policy-tiers/rbac-tiered-policies.mdx).
-- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) resource.
+- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#ManagementCluster resource.

--- a/calico-enterprise_versioned_docs/version-3.18-2/visibility/elastic/retention.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/visibility/elastic/retention.mdx
@@ -12,7 +12,7 @@ Configure how long to retain logs and compliance reports.
 
 ## Before you begin...
 
-Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#operator.tigera.io/v1.Retention) and determine the appropriate values for your deployment.
+Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#Retention and determine the appropriate values for your deployment.
 
 :::note
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/visibility/elastic/troubleshoot.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/visibility/elastic/troubleshoot.mdx
@@ -10,7 +10,7 @@ import variables from '@site/calico-enterprise_versioned_docs/version-3.18-2/var
 
 The following user-configured resources are related to Elasticsearch:
 
-- [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage). It has settings for:
+- [LogStorage](../../reference/installation/api.mdx#LogStorage. It has settings for:
 
   - Elasticsearch (for example, nodeCount and replicas)
   - Kubernetes (for example, resourceRequirements, storage and nodeSelectors)
@@ -113,7 +113,7 @@ As a last resort, create a new [Elasticsearch cluster](#how-to-create-a-new-clus
 
 ### Elasticsearch is slow
 
-**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorageSpec).
+**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#LogStorageSpec.
 
 ### Elasticsearch crashes during booting
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -49,7 +49,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#Provider
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
@@ -46,4 +46,4 @@ key features like Flow Visualizer, metrics in the dashboard and Policy Board, po
 - [Configure flow log aggregation](../../../visibility/elastic/flow/aggregation.mdx)
 - [Log storage recommendations](../../../operations/logstorage/log-storage-recommendations.mdx)
 - [Archive logs](../../../visibility/elastic/archive-storage.mdx)
-- [Log collection options](../../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../../reference/installation/api.mdx#LogCollectorSpec

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/windows-calico/requirements.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/windows-calico/requirements.mdx
@@ -38,7 +38,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#BGPOption.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
@@ -115,7 +115,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
 
 1. <OpenShiftPrometheusOperator operation='upgrade' />
 
-1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster)
+1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#ManagementCluster
    CR to your cluster.
 
    ```bash
@@ -127,7 +127,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#operator.tigera.io/v1.Monitor)
+1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#Monitor
    CR to your cluster.
 
    ```bash
@@ -139,7 +139,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendation)
+1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#PolicyRecommendation
    CR to your cluster.
 
    ```bash
@@ -151,7 +151,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. Remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#operator.tigera.io/v1.Manager).
+1. Remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#Manager.
 
    ```bash
    oc apply -f - <<EOF

--- a/calico-enterprise_versioned_docs/version-3.19-2/multicluster/fine-tune-deployment.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/multicluster/fine-tune-deployment.mdx
@@ -153,4 +153,4 @@ To filter log data by a given managed cluster you can include the filter criteri
 
 # Additional resources
 
-- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection)
+- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#ManagementClusterConnection

--- a/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -49,7 +49,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#Provider
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -51,7 +51,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#Provider
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
@@ -54,7 +54,7 @@ To control managed clusters from your central management plane, you must ensure 
     ```bash
     export MANAGEMENT_CLUSTER_ADDR=<your-management-cluster-addr>
     ```
-1.  Apply the [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) CR.
+1.  Apply the [ManagementCluster](../../../reference/installation/api.mdx#ManagementCluster CR.
 
     ```bash
     kubectl apply -f - <<EOF

--- a/calico-enterprise_versioned_docs/version-3.19-2/networking/configuring/dual-tor.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/networking/configuring/dual-tor.mdx
@@ -637,7 +637,7 @@ The only connections using interface-specific addresses should be BGP.
 If you plan to use [Egress Gateways](../egress/egress-gateway-on-prem.mdx) in your cluster, you must also adjust the {variables.nodecontainer} IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-{variables.prodname} [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+{variables.prodname} [Installation resource](../../reference/installation/api.mdx#NodeAddressAutodetection.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/networking/configuring/multiple-networks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/networking/configuring/multiple-networks.mdx
@@ -79,7 +79,7 @@ Although the following {variables.prodname} features are supported for your defa
 
 ### Configure cluster for multiple networks
 
-In the [Installation custom resource](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoNetworkSpec), set the `MultiInterfaceMode` to **Multus**.
+In the [Installation custom resource](../../reference/installation/api.mdx#CalicoNetworkSpec, set the `MultiInterfaceMode` to **Multus**.
 
 ### Create a new network
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/networking/egress/egress-gateway-on-prem.mdx
@@ -350,7 +350,7 @@ To modify the iptables backend for egress gateways, you must change the `iptable
 If you plan to use Egress Gateways in a [dual-ToR cluster](../configuring/dual-tor.mdx), you must also adjust the {variables.nodecontainer} IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-{variables.prodname} [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+{variables.prodname} [Installation resource](../../reference/installation/api.mdx#NodeAddressAutodetection.
 
 ### Configure namespaces and pods to use egress gateways
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/networking/ipam/initial-ippool.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/networking/ipam/initial-ippool.mdx
@@ -24,7 +24,7 @@ The **Kubernetes pod CIDR** is the expected IP address range for pod IPs. It is 
 
 [Calico IP pools](../../reference/resources/ippool.mdx) are ranges of IP addresses that Calico uses to assign to pods; the ranges must within the Kubernetes pod CIDR.
 
-The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#Installation
 resource and configures the default Calico IP pool. Note the following:
 
 - Default fields for any that are omitted:
@@ -44,7 +44,7 @@ resource and configures the default Calico IP pool. Note the following:
 ## How to
 
 1. Download the custom-resource.yaml file.
-1. Edit the [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation).
+1. Edit the [Installation resource](../../reference/installation/api.mdx#Installation.
    **Required values**: `cidr:`
    **Empty values**: Defaulted
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/networking/ipam/ip-autodetection.mdx
@@ -51,7 +51,7 @@ By default, {variables.prodname} uses the **firstFound** method; the first valid
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#NodeAddressAutodetection in the operator Installation reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-enterprise_versioned_docs/version-3.19-2/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/operations/cnx/configure-identity-provider.mdx
@@ -17,7 +17,7 @@ Configure an external identity provider (IdP), create a user, and log in to {var
 
 ## Concepts
 
-The {variables.prodname} authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Authentication) named, `tigera-secure`.
+The {variables.prodname} authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#Authentication named, `tigera-secure`.
 
 When configuring your cluster, you may be asked for the following inputs:
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/operations/cnx/roles-and-permissions.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/operations/cnx/roles-and-permissions.mdx
@@ -18,7 +18,7 @@ Self-service is an important part of your Kubernetes platform networking and net
 
 ### Kubernetes RBAC authorization
 
-The [Calico Enterprise API server](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) is an extension to the standard [Kubernetes RBAC Authorization APIs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
+The [Calico Enterprise API server](../../reference/installation/api.mdx#APIServer is an extension to the standard [Kubernetes RBAC Authorization APIs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
 
 | Features                       | RBAC controls for...                                                                                                                                                                                                                            |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/calico-enterprise_versioned_docs/version-3.19-2/operations/comms/certificate-management.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/operations/comms/certificate-management.mdx
@@ -21,7 +21,7 @@ certificate issuance, {variables.prodname} provides a simple configuration optio
 **Limitations**
 
 If your cluster is already running {variables.prodname} and you would like to enable certificate management, you need to
-temporarily remove [the logstorage resource](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+temporarily remove [the logstorage resource](../../reference/installation/api.mdx#LogStorage
 before following the steps to enable certificate management and then re-apply afterwards. For detailed steps on
 re-creating logstorage, read more on [how to create a new Elasticsearch cluster](../../visibility/elastic/troubleshoot.mdx#how-to-create-a-new-cluster).
 
@@ -40,7 +40,7 @@ Currently, this feature is not supported in combination with [Multi-cluster mana
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../../reference/installation/api.mdx#Installation
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
    ```yaml

--- a/calico-enterprise_versioned_docs/version-3.19-2/operations/logstorage/log-storage-recommendations.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/operations/logstorage/log-storage-recommendations.mdx
@@ -82,4 +82,4 @@ is no tolerance for removing/restarting a node.
 
 - Read the [LogStorage overview page](../logstorage/index.mdx)
 - [Troubleshooting Elasticsearch](../../visibility/elastic/troubleshoot.mdx)
-- [LogStorage Specification](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+- [LogStorage Specification](../../reference/installation/api.mdx#LogStorage

--- a/calico-enterprise_versioned_docs/version-3.19-2/reference/architecture/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/reference/architecture/overview.mdx
@@ -124,7 +124,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### Manager
 
-**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#operator.tigera.io/v1.Manager).
+**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#Manager.
 
 ### Packet capture API
 
@@ -152,7 +152,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### API server
 
-**Main task**: Allows users to manage {variables.prodname} resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#operator.tigera.io/v1.APIServer).
+**Main task**: Allows users to manage {variables.prodname} resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#APIServer.
 
 ### BIRD
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/reference/component-resources/configuration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/reference/component-resources/configuration.mdx
@@ -243,7 +243,7 @@ By enabling this feature, you can avoid errors that can occur when a pod tries t
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](../installation/api#operator.tigera.io/v1.CalicoNetworkSpec) of the default `operator.tigera.io/v1/installation` resource.
+The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](../installation/api#CalicoNetworkSpec of the default `operator.tigera.io/v1/installation` resource.
 
 The following example configures the CNI to delay a pod from starting its containers for up to 10 seconds, or until the pod's dataplane has been programmed:
 
@@ -313,7 +313,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-2">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#Installation API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico-enterprise_versioned_docs/version-3.19-2/reference/component-resources/configure-resources.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/reference/component-resources/configure-resources.mdx
@@ -16,11 +16,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../../reference/installation/api.mdx#APIServer CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the APIServer CR using the below command:
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#APIServerDeployment, patch the APIServer CR using the below command:
 
 ```bash
 kubectl patch apiserver tigera-secure  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -68,11 +68,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## ApplicationLayer custom resource
 
-The [ApplicationLayer](../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
+The [ApplicationLayer](../../reference/installation/api.mdx#ApplicationLayer CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
 
 ### L7LogCollectorDaemonSet
 
-To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.L7LogCollectorDaemonSet), patch the ApplicationLayer CR using the below command:
+To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#L7LogCollectorDaemonSet, patch the ApplicationLayer CR using the below command:
 
 ```bash
 kubectl patch applicationlayer tigera-secure  --type=merge --patch='{"spec": {"l7LogCollectorDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"l7-collector","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"envoy-proxy","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -120,11 +120,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Authentication custom resource
 
-The [Authentication](../../reference/installation/api.mdx#operator.tigera.io/v1.Authentication) CR provides a way to configure resources for DexDeployment. The following sections provide example configurations for this CR.
+The [Authentication](../../reference/installation/api.mdx#Authentication CR provides a way to configure resources for DexDeployment. The following sections provide example configurations for this CR.
 
 ### DexDeployment
 
-To configure resource specification for the [DexDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.DexDeployment), patch the Authentication CR using the below command:
+To configure resource specification for the [DexDeployment](../../reference/installation/api.mdx#DexDeployment, patch the Authentication CR using the below command:
 
 ```bash
 kubectl patch authentication tigera-secure  --type=merge --patch='{"spec": {"dexDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-dex","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -159,13 +159,13 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Compliance custom resource
 
-The [Compliance](../../reference/installation/api.mdx#operator.tigera.io/v1.Compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
+The [Compliance](../../reference/installation/api.mdx#Compliance CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
 
 Example Configurations:
 
 ### ComplianceControllerDeployment
 
-To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceControllerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#ComplianceControllerDeployment, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -200,7 +200,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceSnapshotterDeployment
 
-To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceSnapshotterDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#ComplianceSnapshotterDeployment, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceSnapshotterDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-snapshotter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -235,7 +235,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceBenchmarkerDaemonSet
 
-To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#ComplianceBenchmarkerDaemonSet, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceBenchmarkerDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-benchmarker","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -270,7 +270,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceServerDeployment
 
-To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceServerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#ComplianceServerDeployment, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -305,7 +305,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceReporterPodTemplate.
 
-To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceReporterPodTemplate), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#ComplianceReporterPodTemplate, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceReporterPodTemplate": {"template": {"spec": {"containers":[{"name":"reporter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}'
@@ -344,7 +344,7 @@ The [Installation CR](../../reference/installation/api.mdx) provides a way to co
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#TyphaDeployment, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -379,7 +379,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#calicoNodeDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -414,7 +414,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#calicoNodeWindowsDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -449,7 +449,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#CalicoKubeControllersDeployment component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -485,7 +485,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#CSINodeDriverDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -533,11 +533,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## IntrusionDetection custom resource
 
-The [IntrusionDetection](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
+The [IntrusionDetection](../../reference/installation/api.mdx#IntrusionDetection CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
 
 ### IntrusionDetectionControllerDeployment.
 
-To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionControllerDeployment), patch the IntrusionDetection CR using the below command:
+To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#IntrusionDetectionControllerDeployment, patch the IntrusionDetection CR using the below command:
 
 ```bash
 kubectl patch intrusiondetection tigera-secure  --type=merge --patch='{"spec": {"intrusionDetectionControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"webhooks-processor","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}},{"name":"controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -585,11 +585,11 @@ This command will output the configured resource requests and limits for the Int
 
 ## LogCollector custom resource
 
-The [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
+The [LogCollector](../../reference/installation/api.mdx#LogCollector CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
 
 ### FluentdDaemonSet.
 
-To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.FluentdDaemonSet), patch the LogCollector CR using the below command:
+To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#FluentdDaemonSet, patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"fluentdDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"fluentd","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -624,7 +624,7 @@ This command will output the configured resource requests and limits for the Flu
 
 ### EKSLogForwarderDeployment.
 
-To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.EKSLogForwarderDeployment), patch the LogCollector CR using the below command:
+To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#EKSLogForwarderDeployment, patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"eksLogForwarderDeployment": {"spec": {"template": {"spec": {"containers":[{"name":"eks-log-forwarder","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -659,11 +659,11 @@ This command will output the configured resource requests and limits for the EKS
 
 ## LogStorage custom resource
 
-The [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) CR provides a way to configure resources for ECKOperatorStatefulSet, Kibana, LinseedDeployment, ElasticsearchMetricsDeployment. The following sections provide example configurations for this CR.
+The [LogStorage](../../reference/installation/api.mdx#LogStorage CR provides a way to configure resources for ECKOperatorStatefulSet, Kibana, LinseedDeployment, ElasticsearchMetricsDeployment. The following sections provide example configurations for this CR.
 
 ### ECKOperatorStatefulSet.
 
-To configure resource specification for the [ECKOperatorStatefulSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ECKOperatorStatefulSet), patch the LogStorage CR using the below command:
+To configure resource specification for the [ECKOperatorStatefulSet](../../reference/installation/api.mdx#ECKOperatorStatefulSet, patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"eckOperatorStatefulSet":{"spec": {"template": {"spec": {"containers":[{"name":"manager","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -698,7 +698,7 @@ This command will output the configured resource requests and limits for the ECK
 
 ### Kibana
 
-To configure resource specification for the [Kibana](../../reference/installation/api.mdx#operator.tigera.io/v1.Kibana), patch the LogStorage CR using the below command:
+To configure resource specification for the [Kibana](../../reference/installation/api.mdx#Kibana, patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"kibana":{"spec": {"template": {"spec": {"containers":[{"name":"kibana","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -733,7 +733,7 @@ This command will output the configured resource requests and limits for the Kib
 
 ### LinseedDeployment
 
-To configure resource specification for the [LinseedDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.LinseedDeployment), patch the LogStorage CR using the below command:
+To configure resource specification for the [LinseedDeployment](../../reference/installation/api.mdx#LinseedDeployment, patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"linseedDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-linseed","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -768,7 +768,7 @@ This command will output the configured resource requests and limits for the Lin
 
 ### ElasticsearchMetricsDeployment
 
-To configure resource specification for the [ElasticsearchMetricsDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ElasticsearchMetricsDeployment), patch the LogStorage CR using the below command:
+To configure resource specification for the [ElasticsearchMetricsDeployment](../../reference/installation/api.mdx#ElasticsearchMetricsDeployment, patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"elasticsearchMetricsDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-elasticsearch-metrics","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -803,11 +803,11 @@ This command will output the configured resource requests and limits for the Ela
 
 ## ManagementClusterConnection custom resource
 
-The [ManagementClusterConnection](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
+The [ManagementClusterConnection](../../reference/installation/api.mdx#ManagementClusterConnection CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
 
 ### GuardianDeployment
 
-To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.GuardianDeployment), patch the ManagementClusterConnection CR using the below command:
+To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#GuardianDeployment, patch the ManagementClusterConnection CR using the below command:
 
 ```bash
 kubectl patch managementclusterconnection tigera-secure  --type=merge --patch='{"spec": {"guardianDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-guardian","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -842,11 +842,11 @@ This command will output the configured resource requests and limits for the Gua
 
 ## Manager custom resource
 
-The [Manager](../../reference/installation/api.mdx#operator.tigera.io/v1.Manager) CR provides a way to configure resources for ManagerDeployment. The following sections provide example configurations for this CR.
+The [Manager](../../reference/installation/api.mdx#Manager CR provides a way to configure resources for ManagerDeployment. The following sections provide example configurations for this CR.
 
 ### ManagerDeployment
 
-To configure resource specification for the [ManagerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagerDeployment), patch the Manager CR using the below command:
+To configure resource specification for the [ManagerDeployment](../../reference/installation/api.mdx#ManagerDeployment, patch the Manager CR using the below command:
 
 ```bash
 kubectl patch manager tigera-secure  --type=merge --patch='{"spec": {"managerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-voltron","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-es-proxy","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-manager","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -908,11 +908,11 @@ This command will output the configured resource requests and limits for the Man
 
 ## Monitor custom resource
 
-The [Monitor](../../reference/installation/api.mdx#operator.tigera.io/v1.Monitor) CR provides a way to configure resources for Prometheus, AlertManager. The following sections provide example configurations for this CR.
+The [Monitor](../../reference/installation/api.mdx#Monitor CR provides a way to configure resources for Prometheus, AlertManager. The following sections provide example configurations for this CR.
 
 ### Prometheus
 
-To configure resource specification for the [Prometheus](../../reference/installation/api.mdx#operator.tigera.io/v1.Prometheus), Resources for the default container "prometheus" can be configured using the "resources" field under "commonPrometheusFields". For all other injected containers, such as "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
+To configure resource specification for the [Prometheus](../../reference/installation/api.mdx#Prometheus, Resources for the default container "prometheus" can be configured using the "resources" field under "commonPrometheusFields". For all other injected containers, such as "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
 
 ```bash
 kubectl patch monitor tigera-secure --type=merge --patch='{"spec": {"prometheus": {"spec":{ "commonPrometheusFields": {"resources": {"limits": {"cpu":"500m","memory":"500Mi"}, "requests": {"cpu":"50m", "memory":"50Mi"}}, "containers":[{"name":"authn-proxy","resources":{"limits": {"cpu":"250m","memory":"500Mi"},"requests": {"cpu":"25m","memory":"50Mi"}}}]}}}}}'
@@ -977,7 +977,7 @@ The "config-reloader" container has default resource values set based by the Pro
 
 ### AlertManager
 
-To configure resource specification for the [AlertManager](../../reference/installation/api.mdx#operator.tigera.io/v1.AlertManager),  you can set resources for the default container "prometheus" using the "resources" field under "commonPrometheusFields". For all other injected containers, like "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
+To configure resource specification for the [AlertManager](../../reference/installation/api.mdx#AlertManager,  you can set resources for the default container "prometheus" using the "resources" field under "commonPrometheusFields". For all other injected containers, like "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
 
 ```bash
 kubectl patch monitor tigera-secure  --type=merge --patch='{"spec": {"alertManager": {"spec": {"resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}}}}'
@@ -1029,11 +1029,11 @@ The "config-reloader" container has default resource values set by the AlertMana
 
 ## PacketCapture custom resource
 
-The [PacketCapture](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCapture) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
+The [PacketCapture](../../reference/installation/api.mdx#PacketCapture CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
 
 ### PacketCaptureDeployment
 
-To configure resource specification for the [PacketCapture](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCapture), patch the PacketCapture CR using the below command:
+To configure resource specification for the [PacketCapture](../../reference/installation/api.mdx#PacketCapture, patch the PacketCapture CR using the below command:
 
 ```bash
 kubectl patch packetcaptures.operator.tigera.io tigera-secure  --type=merge --patch='{"spec": {"packetCaptureDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-packetcapture-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -1068,11 +1068,11 @@ This command will output the configured resource requests and limits for the Pac
 
 ## PolicyRecommendation custom resource
 
-The [PolicyRecommendation](../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendation) CR provides a way to configure resources for PolicyRecommendation. The following sections provide example configurations for this CR.
+The [PolicyRecommendation](../../reference/installation/api.mdx#PolicyRecommendation CR provides a way to configure resources for PolicyRecommendation. The following sections provide example configurations for this CR.
 
 ### PolicyRecommendationDeployment
 
-To configure resource specification for the [PolicyRecommendationDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendationDeployment), patch the PolicyRecommendation CR using the below command:
+To configure resource specification for the [PolicyRecommendationDeployment](../../reference/installation/api.mdx#PolicyRecommendationDeployment, patch the PolicyRecommendation CR using the below command:
 
 ```bash
 kubectl patch policyrecommendation tigera-secure  --type=merge --patch='{"spec": {"policyRecommendationDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"policy-recommendation-controller","resources":{"requests":{"cpu":"100m", "memory":"100Mi"},"limits":{"cpu":"1", "memory":"512Mi"}}}]}}}}}}'
@@ -1116,11 +1116,11 @@ The provided example illustrates configuring the apiserver component. Follow a s
 
 ### APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
+The [APIServer](../../reference/installation/api.mdx#APIServer CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
 
 #### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), update values.yaml with the appropriate resource values.
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#APIServerDeployment, update values.yaml with the appropriate resource values.
 
 ```bash
 apiServer:

--- a/calico-enterprise_versioned_docs/version-3.19-2/reference/component-resources/typha/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/reference/component-resources/typha/prometheus.mdx
@@ -7,7 +7,7 @@ import variables from '@site/calico-enterprise_versioned_docs/version-3.19-2/var
 # Prometheus metrics
 
 Typha can be configured to report a number of metrics through Prometheus. The Prometheus port can be controlled
-via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#operator.tigera.io/v1.Installation).
+via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#Installation.
 
 ## Metric reference
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/reference/installation/_api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/reference/installation/_api.mdx
@@ -15,47 +15,47 @@ API Schema definitions for configuring the installation of Calico and Calico Ent
 </p>
 Resource Types:
 <ul><li>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>
+<a href="#APIServer">APIServer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>
+<a href="#ApplicationLayer">ApplicationLayer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>
+<a href="#Authentication">Authentication</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>
+<a href="#Compliance">Compliance</a>
 </li><li>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>
+<a href="#EgressGateway">EgressGateway</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>
+<a href="#ImageSet">ImageSet</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>
+<a href="#Installation">Installation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>
+<a href="#IntrusionDetection">IntrusionDetection</a>
 </li><li>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>
+<a href="#LogCollector">LogCollector</a>
 </li><li>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>
+<a href="#LogStorage">LogStorage</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ManagementCluster">ManagementCluster</a>
+<a href="#ManagementCluster">ManagementCluster</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>
+<a href="#Manager">Manager</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>
+<a href="#Monitor">Monitor</a>
 </li><li>
-<a href="#operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</a>
+<a href="#PacketCaptureAPI">PacketCaptureAPI</a>
 </li><li>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>
+<a href="#PolicyRecommendation">PolicyRecommendation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TLSPassThroughRoute">TLSPassThroughRoute</a>
+<a href="#TLSPassThroughRoute">TLSPassThroughRoute</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TLSTerminatedRoute">TLSTerminatedRoute</a>
+<a href="#TLSTerminatedRoute">TLSTerminatedRoute</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>
+<a href="#Tenant">Tenant</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>
+<a href="#TigeraStatus">TigeraStatus</a>
 </li></ul>
-<h3 id="operator.tigera.io/v1.APIServer">APIServer</h3>
+<h3 id="APIServer">APIServer</h3>
 <p>
 APIServer installs the Tigera API server and related resources. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo; or &ldquo;tigera-secure&rdquo;.
@@ -116,7 +116,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerSpec">
+<a href="#APIServerSpec">
 APIServerSpec
 </a>
 </em>
@@ -134,7 +134,7 @@ Specification of the desired state for the Tigera API server.
 <td>
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -158,7 +158,7 @@ take precedence.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerStatus">
+<a href="#APIServerStatus">
 APIServerStatus
 </a>
 </em>
@@ -174,7 +174,7 @@ Most recently observed status for the Tigera API server.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</h3>
+<h3 id="ApplicationLayer">ApplicationLayer</h3>
 <p>
 ApplicationLayer is the Schema for the applicationlayers API
 </p>
@@ -234,7 +234,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">
+<a href="#ApplicationLayerSpec">
 ApplicationLayerSpec
 </a>
 </em>
@@ -249,7 +249,7 @@ ApplicationLayerSpec
 <td>
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -269,7 +269,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -288,7 +288,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -308,7 +308,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -327,7 +327,7 @@ User-configurable settings for the Envoy proxy.
 
 <code>l7LogCollectorDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSet">
+<a href="#L7LogCollectorDaemonSet">
 L7LogCollectorDaemonSet
 </a>
 </em>
@@ -350,7 +350,7 @@ L7LogCollectorDaemonSet configures the L7LogCollector DaemonSet.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerStatus">
+<a href="#ApplicationLayerStatus">
 ApplicationLayerStatus
 </a>
 </em>
@@ -363,7 +363,7 @@ ApplicationLayerStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Authentication">Authentication</h3>
+<h3 id="Authentication">Authentication</h3>
 <p>
 Authentication is the Schema for the authentications API
 </p>
@@ -423,7 +423,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">
+<a href="#AuthenticationSpec">
 AuthenticationSpec
 </a>
 </em>
@@ -495,7 +495,7 @@ ClusterRoleBindings into Elastic.
 
 <code>oidc</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">
+<a href="#AuthenticationOIDC">
 AuthenticationOIDC
 </a>
 </em>
@@ -515,7 +515,7 @@ OIDC contains the configuration needed to setup OIDC authentication.
 
 <code>openshift</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOpenshift">
+<a href="#AuthenticationOpenshift">
 AuthenticationOpenshift
 </a>
 </em>
@@ -535,7 +535,7 @@ Openshift contains the configuration needed to setup Openshift OAuth authenticat
 
 <code>ldap</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">
+<a href="#AuthenticationLDAP">
 AuthenticationLDAP
 </a>
 </em>
@@ -555,7 +555,7 @@ LDAP contains the configuration needed to setup LDAP authentication.
 
 <code>dexDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeployment">
+<a href="#DexDeployment">
 DexDeployment
 </a>
 </em>
@@ -578,7 +578,7 @@ DexDeployment configures the Dex Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationStatus">
+<a href="#AuthenticationStatus">
 AuthenticationStatus
 </a>
 </em>
@@ -591,7 +591,7 @@ AuthenticationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Compliance">Compliance</h3>
+<h3 id="Compliance">Compliance</h3>
 <p>
 Compliance installs the components required for Tigera compliance reporting. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -652,7 +652,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">
+<a href="#ComplianceSpec">
 ComplianceSpec
 </a>
 </em>
@@ -670,7 +670,7 @@ Specification of the desired state for Tigera compliance reporting.
 <td>
 <code>complianceControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeployment">
+<a href="#ComplianceControllerDeployment">
 ComplianceControllerDeployment
 </a>
 </em>
@@ -690,7 +690,7 @@ ComplianceControllerDeployment configures the Compliance Controller Deployment.
 
 <code>complianceSnapshotterDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeployment">
+<a href="#ComplianceSnapshotterDeployment">
 ComplianceSnapshotterDeployment
 </a>
 </em>
@@ -710,7 +710,7 @@ ComplianceSnapshotterDeployment configures the Compliance Snapshotter Deployment
 
 <code>complianceBenchmarkerDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">
+<a href="#ComplianceBenchmarkerDaemonSet">
 ComplianceBenchmarkerDaemonSet
 </a>
 </em>
@@ -730,7 +730,7 @@ ComplianceBenchmarkerDaemonSet configures the Compliance Benchmarker DaemonSet.
 
 <code>complianceServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeployment">
+<a href="#ComplianceServerDeployment">
 ComplianceServerDeployment
 </a>
 </em>
@@ -750,7 +750,7 @@ ComplianceServerDeployment configures the Compliance Server Deployment.
 
 <code>complianceReporterPodTemplate</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplate">
+<a href="#ComplianceReporterPodTemplate">
 ComplianceReporterPodTemplate
 </a>
 </em>
@@ -773,7 +773,7 @@ ComplianceReporterPodTemplate configures the Compliance Reporter PodTemplate.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceStatus">
+<a href="#ComplianceStatus">
 ComplianceStatus
 </a>
 </em>
@@ -789,7 +789,7 @@ Most recently observed state for Tigera compliance reporting.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGateway">EgressGateway</h3>
+<h3 id="EgressGateway">EgressGateway</h3>
 <p>
 EgressGateway is the Schema for the egressgateways API
 </p>
@@ -849,7 +849,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">
+<a href="#EgressGatewaySpec">
 EgressGatewaySpec
 </a>
 </em>
@@ -882,7 +882,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -923,7 +923,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -944,7 +944,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -964,7 +964,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -988,7 +988,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -1011,7 +1011,7 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayStatus">
+<a href="#EgressGatewayStatus">
 EgressGatewayStatus
 </a>
 </em>
@@ -1024,7 +1024,7 @@ EgressGatewayStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSet">ImageSet</h3>
+<h3 id="ImageSet">ImageSet</h3>
 <p>
 ImageSet is used to specify image digests for the images that the operator deploys.
 The name of the ImageSet is expected to be in the format <code>&lt;variant&gt;-&lt;release&gt;</code>.
@@ -1089,7 +1089,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">
+<a href="#ImageSetSpec">
 ImageSetSpec
 </a>
 </em>
@@ -1104,7 +1104,7 @@ ImageSetSpec
 <td>
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -1124,7 +1124,7 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Installation">Installation</h3>
+<h3 id="Installation">Installation</h3>
 <p>
 Installation configures an installation of Calico or Calico Enterprise. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo;. The Installation API installs core networking
@@ -1186,7 +1186,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -1204,7 +1204,7 @@ Specification of the desired state for the Calico or Calico Enterprise installat
 <td>
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -1332,7 +1332,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -1355,7 +1355,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -1375,7 +1375,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -1395,7 +1395,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -1574,7 +1574,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -1596,7 +1596,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -1618,7 +1618,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -1638,7 +1638,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -1658,7 +1658,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -1677,7 +1677,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -1697,7 +1697,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -1717,7 +1717,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -1737,7 +1737,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -1756,7 +1756,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -1777,7 +1777,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -1797,7 +1797,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -1838,7 +1838,7 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationStatus">
+<a href="#InstallationStatus">
 InstallationStatus
 </a>
 </em>
@@ -1854,7 +1854,7 @@ Most recently observed state for the Calico or Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</h3>
+<h3 id="IntrusionDetection">IntrusionDetection</h3>
 <p>
 IntrusionDetection installs the components required for Tigera intrusion detection. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -1915,7 +1915,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">
+<a href="#IntrusionDetectionSpec">
 IntrusionDetectionSpec
 </a>
 </em>
@@ -1933,7 +1933,7 @@ Specification of the desired state for Tigera intrusion detection.
 <td>
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">
+<a href="#IntrusionDetectionComponentResource">
 []IntrusionDetectionComponentResource
 </a>
 </em>
@@ -1954,7 +1954,7 @@ Only DeepPacketInspection is supported for this spec.
 
 <code>anomalyDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+<a href="#AnomalyDetectionSpec">
 AnomalyDetectionSpec
 </a>
 </em>
@@ -1974,7 +1974,7 @@ AnomalyDetection is now deprecated, and configuring it has no effect.
 
 <code>intrusionDetectionControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeployment">
+<a href="#IntrusionDetectionControllerDeployment">
 IntrusionDetectionControllerDeployment
 </a>
 </em>
@@ -1997,7 +1997,7 @@ IntrusionDetectionControllerDeployment configures the IntrusionDetection Control
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionStatus">
+<a href="#IntrusionDetectionStatus">
 IntrusionDetectionStatus
 </a>
 </em>
@@ -2013,7 +2013,7 @@ Most recently observed state for Tigera intrusion detection.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollector">LogCollector</h3>
+<h3 id="LogCollector">LogCollector</h3>
 <p>
 LogCollector installs the components required for Tigera flow and DNS log collection. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;. When created, this installs fluentd on all nodes
@@ -2075,7 +2075,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">
+<a href="#LogCollectorSpec">
 LogCollectorSpec
 </a>
 </em>
@@ -2093,7 +2093,7 @@ Specification of the desired state for Tigera log collection.
 <td>
 <code>additionalStores</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">
+<a href="#AdditionalLogStoreSpec">
 AdditionalLogStoreSpec
 </a>
 </em>
@@ -2113,7 +2113,7 @@ Configuration for exporting flow, audit, and DNS logs to external storage.
 
 <code>additionalSources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">
+<a href="#AdditionalLogSourceSpec">
 AdditionalLogSourceSpec
 </a>
 </em>
@@ -2133,7 +2133,7 @@ Configuration for importing audit logs from managed kubernetes cluster log sourc
 
 <code>collectProcessPath</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CollectProcessPathOption">
+<a href="#CollectProcessPathOption">
 CollectProcessPathOption
 </a>
 </em>
@@ -2174,7 +2174,7 @@ the management cluster&rsquo;s tenant services are running.
 
 <code>fluentdDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSet">
+<a href="#FluentdDaemonSet">
 FluentdDaemonSet
 </a>
 </em>
@@ -2193,7 +2193,7 @@ FluentdDaemonSet configures the Fluentd DaemonSet.
 
 <code>eksLogForwarderDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeployment">
+<a href="#EKSLogForwarderDeployment">
 EKSLogForwarderDeployment
 </a>
 </em>
@@ -2216,7 +2216,7 @@ EKSLogForwarderDeployment configures the EKSLogForwarderDeployment Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectorStatus">
+<a href="#LogCollectorStatus">
 LogCollectorStatus
 </a>
 </em>
@@ -2232,7 +2232,7 @@ Most recently observed state for Tigera log collection.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorage">LogStorage</h3>
+<h3 id="LogStorage">LogStorage</h3>
 <p>
 LogStorage installs the components required for Tigera flow and DNS log storage. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;. When created, this installs an Elasticsearch cluster for use by
@@ -2294,7 +2294,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">
+<a href="#LogStorageSpec">
 LogStorageSpec
 </a>
 </em>
@@ -2312,7 +2312,7 @@ Specification of the desired state for Tigera log storage.
 <td>
 <code>nodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Nodes">
+<a href="#Nodes">
 Nodes
 </a>
 </em>
@@ -2331,7 +2331,7 @@ Nodes defines the configuration for a set of identical Elasticsearch cluster nod
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Indices">
+<a href="#Indices">
 Indices
 </a>
 </em>
@@ -2351,7 +2351,7 @@ Index defines the configuration for the indices in the Elasticsearch cluster.
 
 <code>retention</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Retention">
+<a href="#Retention">
 Retention
 </a>
 </em>
@@ -2413,7 +2413,7 @@ each of the indicated key-value pairs as labels as well as access to the specifi
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">
+<a href="#LogStorageComponentResource">
 []LogStorageComponentResource
 </a>
 </em>
@@ -2434,7 +2434,7 @@ Only ECKOperator is supported for this spec.
 
 <code>eckOperatorStatefulSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSet">
+<a href="#ECKOperatorStatefulSet">
 ECKOperatorStatefulSet
 </a>
 </em>
@@ -2455,7 +2455,7 @@ ComponentResources, then these overrides take precedence.
 
 <code>kibana</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Kibana">
+<a href="#Kibana">
 Kibana
 </a>
 </em>
@@ -2475,7 +2475,7 @@ Kibana configures the Kibana Spec.
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -2494,7 +2494,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>elasticsearchMetricsDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeployment">
+<a href="#ElasticsearchMetricsDeployment">
 ElasticsearchMetricsDeployment
 </a>
 </em>
@@ -2516,7 +2516,7 @@ ElasticsearchMetricsDeployment configures the tigera-elasticsearch-metric Deploy
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageStatus">
+<a href="#LogStorageStatus">
 LogStorageStatus
 </a>
 </em>
@@ -2532,7 +2532,7 @@ Most recently observed state for Tigera log storage.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementCluster">ManagementCluster</h3>
+<h3 id="ManagementCluster">ManagementCluster</h3>
 <p>
 The presence of ManagementCluster in your cluster, will configure it to be the management plane to which managed
 clusters can connect. At most one instance of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2593,7 +2593,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterSpec">
+<a href="#ManagementClusterSpec">
 ManagementClusterSpec
 </a>
 </em>
@@ -2628,7 +2628,7 @@ Valid examples are: &ldquo;0.0.0.0:31000&rdquo;, &ldquo;example.com:32000&rdquo;
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLS">
+<a href="#TLS">
 TLS
 </a>
 </em>
@@ -2648,7 +2648,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</h3>
+<h3 id="ManagementClusterConnection">ManagementClusterConnection</h3>
 <p>
 ManagementClusterConnection represents a link between a managed cluster and a management cluster. At most one
 instance of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2709,7 +2709,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">
+<a href="#ManagementClusterConnectionSpec">
 ManagementClusterConnectionSpec
 </a>
 </em>
@@ -2743,7 +2743,7 @@ should be able to access this address. This field is used by managed clusters on
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">
+<a href="#ManagementClusterTLS">
 ManagementClusterTLS
 </a>
 </em>
@@ -2763,7 +2763,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>guardianDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeployment">
+<a href="#GuardianDeployment">
 GuardianDeployment
 </a>
 </em>
@@ -2785,7 +2785,7 @@ GuardianDeployment configures the guardian Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionStatus">
+<a href="#ManagementClusterConnectionStatus">
 ManagementClusterConnectionStatus
 </a>
 </em>
@@ -2798,7 +2798,7 @@ ManagementClusterConnectionStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Manager">Manager</h3>
+<h3 id="Manager">Manager</h3>
 <p>
 Manager installs the Calico Enterprise manager graphical user interface. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2859,7 +2859,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerSpec">
+<a href="#ManagerSpec">
 ManagerSpec
 </a>
 </em>
@@ -2877,7 +2877,7 @@ Specification of the desired state for the Calico Enterprise manager.
 <td>
 <code>managerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeployment">
+<a href="#ManagerDeployment">
 ManagerDeployment
 </a>
 </em>
@@ -2900,7 +2900,7 @@ ManagerDeployment configures the Manager Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerStatus">
+<a href="#ManagerStatus">
 ManagerStatus
 </a>
 </em>
@@ -2916,7 +2916,7 @@ Most recently observed state for the Calico Enterprise manager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Monitor">Monitor</h3>
+<h3 id="Monitor">Monitor</h3>
 <p>
 Monitor is the Schema for the monitor API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2977,7 +2977,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorSpec">
+<a href="#MonitorSpec">
 MonitorSpec
 </a>
 </em>
@@ -2992,7 +2992,7 @@ MonitorSpec
 <td>
 <code>externalPrometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">
+<a href="#ExternalPrometheus">
 ExternalPrometheus
 </a>
 </em>
@@ -3013,7 +3013,7 @@ scraping from git-ops tools without the need of post-installation steps.
 
 <code>prometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Prometheus">
+<a href="#Prometheus">
 Prometheus
 </a>
 </em>
@@ -3033,7 +3033,7 @@ Prometheus is the configuration for the Prometheus.
 
 <code>alertManager</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AlertManager">
+<a href="#AlertManager">
 AlertManager
 </a>
 </em>
@@ -3056,7 +3056,7 @@ AlertManager is the configuration for the AlertManager.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorStatus">
+<a href="#MonitorStatus">
 MonitorStatus
 </a>
 </em>
@@ -3069,7 +3069,7 @@ MonitorStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</h3>
+<h3 id="PacketCaptureAPI">PacketCaptureAPI</h3>
 <p>
 PacketCaptureAPI is used to configure the resource requirement for PacketCaptureAPI deployment. It must be named &ldquo;tigera-secure&rdquo;.
 </p>
@@ -3129,7 +3129,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPISpec">
+<a href="#PacketCaptureAPISpec">
 PacketCaptureAPISpec
 </a>
 </em>
@@ -3147,7 +3147,7 @@ Specification of the desired state for the PacketCaptureAPI.
 <td>
 <code>packetCaptureAPIDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeployment">
+<a href="#PacketCaptureAPIDeployment">
 PacketCaptureAPIDeployment
 </a>
 </em>
@@ -3170,7 +3170,7 @@ PacketCaptureAPIDeployment configures the PacketCaptureAPI Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIStatus">
+<a href="#PacketCaptureAPIStatus">
 PacketCaptureAPIStatus
 </a>
 </em>
@@ -3186,7 +3186,7 @@ Most recently observed state for the PacketCaptureAPI.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</h3>
+<h3 id="PolicyRecommendation">PolicyRecommendation</h3>
 <p>
 PolicyRecommendation is the Schema for the policy recommendation API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -3247,7 +3247,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationSpec">
+<a href="#PolicyRecommendationSpec">
 PolicyRecommendationSpec
 </a>
 </em>
@@ -3262,7 +3262,7 @@ PolicyRecommendationSpec
 <td>
 <code>policyRecommendationDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeployment">
+<a href="#PolicyRecommendationDeployment">
 PolicyRecommendationDeployment
 </a>
 </em>
@@ -3285,7 +3285,7 @@ PolicyRecommendation configures the PolicyRecommendation Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationStatus">
+<a href="#PolicyRecommendationStatus">
 PolicyRecommendationStatus
 </a>
 </em>
@@ -3298,7 +3298,7 @@ PolicyRecommendationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSPassThroughRoute">TLSPassThroughRoute</h3>
+<h3 id="TLSPassThroughRoute">TLSPassThroughRoute</h3>
 <table>
 <thead>
 <tr>
@@ -3355,7 +3355,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRouteSpec">
+<a href="#TLSPassThroughRouteSpec">
 TLSPassThroughRouteSpec
 </a>
 </em>
@@ -3373,7 +3373,7 @@ Dest is the destination URL
 <td>
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -3389,7 +3389,7 @@ TargetType
 
 <code>sniMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SNIMatch">
+<a href="#SNIMatch">
 SNIMatch
 </a>
 </em>
@@ -3426,7 +3426,7 @@ Destination is the destination url to proxy the request to.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSTerminatedRoute">TLSTerminatedRoute</h3>
+<h3 id="TLSTerminatedRoute">TLSTerminatedRoute</h3>
 <table>
 <thead>
 <tr>
@@ -3483,7 +3483,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLSTerminatedRouteSpec">
+<a href="#TLSTerminatedRouteSpec">
 TLSTerminatedRouteSpec
 </a>
 </em>
@@ -3498,7 +3498,7 @@ TLSTerminatedRouteSpec
 <td>
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -3514,7 +3514,7 @@ TargetType
 
 <code>pathMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PathMatch">
+<a href="#PathMatch">
 PathMatch
 </a>
 </em>
@@ -3632,7 +3632,7 @@ is UI.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Tenant">Tenant</h3>
+<h3 id="Tenant">Tenant</h3>
 <p>
 Tenant is the Schema for the tenants API
 </p>
@@ -3692,7 +3692,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantSpec">
+<a href="#TenantSpec">
 TenantSpec
 </a>
 </em>
@@ -3741,7 +3741,7 @@ Name is a human readable name for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -3760,7 +3760,7 @@ Indices defines the how to store a tenant&rsquo;s data
 
 <code>elastic</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantElasticSpec">
+<a href="#TenantElasticSpec">
 TenantElasticSpec
 </a>
 </em>
@@ -3799,7 +3799,7 @@ in the Tenant&rsquo;s namespace. Defaults to the controlPlaneReplicas in Install
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -3818,7 +3818,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>dashboardsJob</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJob">
+<a href="#DashboardsJob">
 DashboardsJob
 </a>
 </em>
@@ -3840,7 +3840,7 @@ DashboardsJob configures the Dashboards job
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantStatus">
+<a href="#TenantStatus">
 TenantStatus
 </a>
 </em>
@@ -3853,7 +3853,7 @@ TenantStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatus">TigeraStatus</h3>
+<h3 id="TigeraStatus">TigeraStatus</h3>
 <p>
 TigeraStatus represents the most recently observed status for Calico or a Calico Enterprise functional area.
 </p>
@@ -3913,7 +3913,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusSpec">
+<a href="#TigeraStatusSpec">
 TigeraStatusSpec
 </a>
 </em>
@@ -3933,7 +3933,7 @@ TigeraStatusSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">
+<a href="#TigeraStatusStatus">
 TigeraStatusStatus
 </a>
 </em>
@@ -3946,11 +3946,11 @@ TigeraStatusStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</h3>
+<h3 id="APIServerDeployment">APIServerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerSpec">APIServerSpec</a>)
+<a href="#APIServerSpec">APIServerSpec</a>)
 
 </p>
 <p>
@@ -3969,7 +3969,7 @@ APIServerDeployment is the configuration for the API server Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3989,7 +3989,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">
+<a href="#APIServerDeploymentSpec">
 APIServerDeploymentSpec
 </a>
 </em>
@@ -4010,11 +4010,11 @@ Spec is the specification of the API server Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
+<h3 id="APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -4071,11 +4071,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
+<h3 id="APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -4131,11 +4131,11 @@ If omitted, the API server Deployment will use its default value for this init c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
+<h3 id="APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -4154,7 +4154,7 @@ APIServerDeploymentDeploymentPodSpec is the API server Deployment&rsquo;s PodSpe
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentInitContainer">
+<a href="#APIServerDeploymentInitContainer">
 []APIServerDeploymentInitContainer
 </a>
 </em>
@@ -4176,7 +4176,7 @@ If omitted, the API server Deployment will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentContainer">
+<a href="#APIServerDeploymentContainer">
 []APIServerDeploymentContainer
 </a>
 </em>
@@ -4287,11 +4287,11 @@ WARNING: Please note that this field will override the default API server Deploy
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
+<h3 id="APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
+<a href="#APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -4310,7 +4310,7 @@ APIServerDeploymentPodTemplateSpec is the API server Deployment&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4331,7 +4331,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">
+<a href="#APIServerDeploymentPodSpec">
 APIServerDeploymentPodSpec
 </a>
 </em>
@@ -4352,11 +4352,11 @@ Spec is the API server Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
+<h3 id="APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>)
 
 </p>
 <p>
@@ -4396,7 +4396,7 @@ If omitted, the API server Deployment will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">
+<a href="#APIServerDeploymentPodTemplateSpec">
 APIServerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -4413,11 +4413,11 @@ Template describes the API server Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerSpec">APIServerSpec</h3>
+<h3 id="APIServerSpec">APIServerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -4436,7 +4436,7 @@ APIServerSpec defines the desired state of Tigera API server.
 
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -4454,11 +4454,11 @@ take precedence.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerStatus">APIServerStatus</h3>
+<h3 id="APIServerStatus">APIServerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -4512,11 +4512,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</h3>
+<h3 id="AWSEgressGateway">AWSEgressGateway</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -4535,7 +4535,7 @@ AWSEgressGateway defines the configurations for deploying EgressGateway in AWS
 
 <code>nativeIP</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NativeIP">
+<a href="#NativeIP">
 NativeIP
 </a>
 </em>
@@ -4572,11 +4572,11 @@ NativeIP must be Enabled if elastic IPs are set.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AdditionalLogSourceSpec">AdditionalLogSourceSpec</h3>
+<h3 id="AdditionalLogSourceSpec">AdditionalLogSourceSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <table>
@@ -4592,7 +4592,7 @@ NativeIP must be Enabled if elastic IPs are set.
 
 <code>eksCloudwatchLog</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EksCloudwatchLogsSpec">
+<a href="#EksCloudwatchLogsSpec">
 EksCloudwatchLogsSpec
 </a>
 </em>
@@ -4610,11 +4610,11 @@ audit logs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</h3>
+<h3 id="AdditionalLogStoreSpec">AdditionalLogStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <table>
@@ -4630,7 +4630,7 @@ audit logs.
 
 <code>s3</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.S3StoreSpec">
+<a href="#S3StoreSpec">
 S3StoreSpec
 </a>
 </em>
@@ -4650,7 +4650,7 @@ If specified, enables exporting of flow, audit, and DNS logs to Amazon S3 storag
 
 <code>syslog</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">
+<a href="#SyslogStoreSpec">
 SyslogStoreSpec
 </a>
 </em>
@@ -4670,7 +4670,7 @@ If specified, enables exporting of flow, audit, and DNS logs to syslog.
 
 <code>splunk</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SplunkStoreSpec">
+<a href="#SplunkStoreSpec">
 SplunkStoreSpec
 </a>
 </em>
@@ -4687,11 +4687,11 @@ If specified, enables exporting of flow, audit, and DNS logs to splunk.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AlertManager">AlertManager</h3>
+<h3 id="AlertManager">AlertManager</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.MonitorSpec">MonitorSpec</a>)
+<a href="#MonitorSpec">MonitorSpec</a>)
 
 </p>
 <table>
@@ -4707,7 +4707,7 @@ If specified, enables exporting of flow, audit, and DNS logs to splunk.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AlertManagerSpec">
+<a href="#AlertManagerSpec">
 AlertManagerSpec
 </a>
 </em>
@@ -4728,11 +4728,11 @@ Spec is the specification of the Alertmanager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AlertManagerSpec">AlertManagerSpec</h3>
+<h3 id="AlertManagerSpec">AlertManagerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AlertManager">AlertManager</a>)
+<a href="#AlertManager">AlertManager</a>)
 
 </p>
 <table>
@@ -4764,11 +4764,11 @@ Define resources requests and limits for single Pods.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
+<h3 id="AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <table>
@@ -4799,19 +4799,19 @@ StorageClassName is now deprecated, and configuring it has no effect.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
+<h3 id="ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</h3>
+<h3 id="ApplicationLayerSpec">ApplicationLayerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -4830,7 +4830,7 @@ ApplicationLayerSpec defines the desired state of ApplicationLayer
 
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -4850,7 +4850,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -4869,7 +4869,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -4889,7 +4889,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -4908,7 +4908,7 @@ User-configurable settings for the Envoy proxy.
 
 <code>l7LogCollectorDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSet">
+<a href="#L7LogCollectorDaemonSet">
 L7LogCollectorDaemonSet
 </a>
 </em>
@@ -4925,11 +4925,11 @@ L7LogCollectorDaemonSet configures the L7LogCollector DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerStatus">ApplicationLayerStatus</h3>
+<h3 id="ApplicationLayerStatus">ApplicationLayerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -4983,13 +4983,13 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthMethod">AuthMethod
+<h3 id="AuthMethod">AuthMethod
 (<code>string</code> alias)</h3>
-<h3 id="operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</h3>
+<h3 id="AuthenticationLDAP">AuthenticationLDAP</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -5045,7 +5045,7 @@ the ldaps:// protocol.
 
 <code>userSearch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.UserSearch">
+<a href="#UserSearch">
 UserSearch
 </a>
 </em>
@@ -5064,7 +5064,7 @@ User entry search configuration to match the credentials with a user.
 
 <code>groupSearch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GroupSearch">
+<a href="#GroupSearch">
 GroupSearch
 </a>
 </em>
@@ -5081,11 +5081,11 @@ Group search configuration to find the groups that a user is in.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</h3>
+<h3 id="AuthenticationOIDC">AuthenticationOIDC</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -5211,7 +5211,7 @@ Deprecated. Please use Authentication.Spec.GroupsPrefix instead.
 
 <code>emailVerification</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EmailVerificationType">
+<a href="#EmailVerificationType">
 EmailVerificationType
 </a>
 </em>
@@ -5234,7 +5234,7 @@ Default: Verify
 
 <code>promptTypes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PromptType">
+<a href="#PromptType">
 []PromptType
 </a>
 </em>
@@ -5257,7 +5257,7 @@ Default: &ldquo;Consent&rdquo;
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.OIDCType">
+<a href="#OIDCType">
 OIDCType
 </a>
 </em>
@@ -5274,11 +5274,11 @@ Default: &ldquo;Dex&rdquo;
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationOpenshift">AuthenticationOpenshift</h3>
+<h3 id="AuthenticationOpenshift">AuthenticationOpenshift</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -5311,11 +5311,11 @@ IssuerURL is the URL to the Openshift OAuth provider. Ex.: <a href="https://api.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</h3>
+<h3 id="AuthenticationSpec">AuthenticationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>)
+<a href="#Authentication">Authentication</a>)
 
 </p>
 <p>
@@ -5391,7 +5391,7 @@ ClusterRoleBindings into Elastic.
 
 <code>oidc</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">
+<a href="#AuthenticationOIDC">
 AuthenticationOIDC
 </a>
 </em>
@@ -5411,7 +5411,7 @@ OIDC contains the configuration needed to setup OIDC authentication.
 
 <code>openshift</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOpenshift">
+<a href="#AuthenticationOpenshift">
 AuthenticationOpenshift
 </a>
 </em>
@@ -5431,7 +5431,7 @@ Openshift contains the configuration needed to setup Openshift OAuth authenticat
 
 <code>ldap</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">
+<a href="#AuthenticationLDAP">
 AuthenticationLDAP
 </a>
 </em>
@@ -5451,7 +5451,7 @@ LDAP contains the configuration needed to setup LDAP authentication.
 
 <code>dexDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeployment">
+<a href="#DexDeployment">
 DexDeployment
 </a>
 </em>
@@ -5468,11 +5468,11 @@ DexDeployment configures the Dex Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationStatus">AuthenticationStatus</h3>
+<h3 id="AuthenticationStatus">AuthenticationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>)
+<a href="#Authentication">Authentication</a>)
 
 </p>
 <p>
@@ -5526,12 +5526,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.BGPOption">BGPOption
+<h3 id="BGPOption">BGPOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -5540,12 +5540,12 @@ BGPOption describes the mode of BGP to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.CAType">CAType
+<h3 id="CAType">CAType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">ManagementClusterTLS</a>)
+<a href="#ManagementClusterTLS">ManagementClusterTLS</a>)
 
 </p>
 <p>
@@ -5554,11 +5554,11 @@ CAType specifies which verification method the tunnel client should use to verif
 <p>
 One of: Tigera, Public
 </p>
-<h3 id="operator.tigera.io/v1.CNILogging">CNILogging</h3>
+<h3 id="CNILogging">CNILogging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Logging">Logging</a>)
+<a href="#Logging">Logging</a>)
 
 </p>
 <table>
@@ -5574,7 +5574,7 @@ One of: Tigera, Public
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -5645,12 +5645,12 @@ Default: 10
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CNIPluginType">CNIPluginType
+<h3 id="CNIPluginType">CNIPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -5659,11 +5659,11 @@ CNIPluginType describes the type of CNI plugin used.
 <p>
 One of: Calico, GKE, AmazonVPC, AzureVNET
 </p>
-<h3 id="operator.tigera.io/v1.CNISpec">CNISpec</h3>
+<h3 id="CNISpec">CNISpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5682,7 +5682,7 @@ CNISpec contains configuration for the CNI plugin.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNIPluginType">
+<a href="#CNIPluginType">
 CNIPluginType
 </a>
 </em>
@@ -5714,7 +5714,7 @@ Default: Calico
 
 <code>ipam</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMSpec">
+<a href="#IPAMSpec">
 IPAMSpec
 </a>
 </em>
@@ -5732,11 +5732,11 @@ Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
+<h3 id="CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5755,7 +5755,7 @@ CSINodeDriverDaemonSet is the configuration for the csi-node-driver DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5775,7 +5775,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">
+<a href="#CSINodeDriverDaemonSetSpec">
 CSINodeDriverDaemonSetSpec
 </a>
 </em>
@@ -5796,11 +5796,11 @@ Spec is the specification of the csi-node-driver DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
+<h3 id="CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -5856,11 +5856,11 @@ If omitted, the csi-node-driver DaemonSet will use its default value for this co
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -5879,7 +5879,7 @@ CSINodeDriverDaemonSetPodSpec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">
+<a href="#CSINodeDriverDaemonSetContainer">
 []CSINodeDriverDaemonSetContainer
 </a>
 </em>
@@ -5966,11 +5966,11 @@ WARNING: Please note that this field will override the default csi-node-driver D
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
+<a href="#CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -5989,7 +5989,7 @@ CSINodeDriverDaemonSetPodTemplateSpec is the csi-node-driver DaemonSet&rsquo;s P
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6010,7 +6010,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">
+<a href="#CSINodeDriverDaemonSetPodSpec">
 CSINodeDriverDaemonSetPodSpec
 </a>
 </em>
@@ -6031,11 +6031,11 @@ Spec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
+<h3 id="CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
 
 </p>
 <p>
@@ -6075,7 +6075,7 @@ If omitted, the csi-node-driver DaemonSet will use its default value for minRead
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">
 CSINodeDriverDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -6092,11 +6092,11 @@ Template describes the csi-node-driver DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
+<h3 id="CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -6115,7 +6115,7 @@ CalicoKubeControllersDeployment is the configuration for the calico-kube-control
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6135,7 +6135,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">
+<a href="#CalicoKubeControllersDeploymentSpec">
 CalicoKubeControllersDeploymentSpec
 </a>
 </em>
@@ -6156,11 +6156,11 @@ Spec is the specification of the calico-kube-controllers Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
+<h3 id="CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -6217,11 +6217,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6240,7 +6240,7 @@ CalicoKubeControllersDeploymentPodSpec is the calico-kube-controller Deployment&
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">
+<a href="#CalicoKubeControllersDeploymentContainer">
 []CalicoKubeControllersDeploymentContainer
 </a>
 </em>
@@ -6329,11 +6329,11 @@ WARNING: Please note that this field will override the default calico-kube-contr
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
+<a href="#CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
 
 </p>
 <p>
@@ -6352,7 +6352,7 @@ CalicoKubeControllersDeploymentPodTemplateSpec is the calico-kube-controllers De
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6373,7 +6373,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">
+<a href="#CalicoKubeControllersDeploymentPodSpec">
 CalicoKubeControllersDeploymentPodSpec
 </a>
 </em>
@@ -6394,11 +6394,11 @@ Spec is the calico-kube-controllers Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
 
 </p>
 <p>
@@ -6438,7 +6438,7 @@ If omitted, the calico-kube-controllers Deployment will use its default value fo
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">
 CalicoKubeControllersDeploymentPodTemplateSpec
 </a>
 </em>
@@ -6455,11 +6455,11 @@ Template describes the calico-kube-controllers Deployment pod that will be creat
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</h3>
+<h3 id="CalicoNetworkSpec">CalicoNetworkSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -6478,7 +6478,7 @@ CalicoNetworkSpec specifies configuration options for Calico provided pod networ
 
 <code>linuxDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinuxDataplaneOption">
+<a href="#LinuxDataplaneOption">
 LinuxDataplaneOption
 </a>
 </em>
@@ -6501,7 +6501,7 @@ Default: Iptables
 
 <code>windowsDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsDataplaneOption">
+<a href="#WindowsDataplaneOption">
 WindowsDataplaneOption
 </a>
 </em>
@@ -6524,7 +6524,7 @@ Default: Disabled
 
 <code>bgp</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.BGPOption">
+<a href="#BGPOption">
 BGPOption
 </a>
 </em>
@@ -6544,7 +6544,7 @@ BGP configures whether or not to enable Calico&rsquo;s BGP capabilities.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPPool">
+<a href="#IPPool">
 []IPPool
 </a>
 </em>
@@ -6584,7 +6584,7 @@ If not specified, Calico will perform MTU auto-detection based on the cluster ne
 
 <code>nodeAddressAutodetectionV4</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -6605,7 +6605,7 @@ will use default auto-detection settings to acquire an IPv4 address for each nod
 
 <code>nodeAddressAutodetectionV6</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -6626,7 +6626,7 @@ IPv6 addresses will not be auto-detected.
 
 <code>hostPorts</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HostPortsType">
+<a href="#HostPortsType">
 HostPortsType
 </a>
 </em>
@@ -6647,7 +6647,7 @@ Default: Enabled
 
 <code>multiInterfaceMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MultiInterfaceMode">
+<a href="#MultiInterfaceMode">
 MultiInterfaceMode
 </a>
 </em>
@@ -6669,7 +6669,7 @@ Default: None
 
 <code>containerIPForwarding</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ContainerIPForwardingType">
+<a href="#ContainerIPForwardingType">
 ContainerIPForwardingType
 </a>
 </em>
@@ -6690,7 +6690,7 @@ Default: Disabled
 
 <code>sysctl</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Sysctl">
+<a href="#Sysctl">
 []Sysctl
 </a>
 </em>
@@ -6737,11 +6737,11 @@ Default: 0
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
+<h3 id="CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -6760,7 +6760,7 @@ CalicoNodeDaemonSet is the configuration for the calico-node DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6780,7 +6780,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">
+<a href="#CalicoNodeDaemonSetSpec">
 CalicoNodeDaemonSetSpec
 </a>
 </em>
@@ -6801,11 +6801,11 @@ Spec is the specification of the calico-node DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
+<h3 id="CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6862,11 +6862,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6923,11 +6923,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6946,7 +6946,7 @@ CalicoNodeDaemonSetPodSpec is the calico-node DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">
+<a href="#CalicoNodeDaemonSetInitContainer">
 []CalicoNodeDaemonSetInitContainer
 </a>
 </em>
@@ -6968,7 +6968,7 @@ If omitted, the calico-node DaemonSet will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetContainer">
+<a href="#CalicoNodeDaemonSetContainer">
 []CalicoNodeDaemonSetContainer
 </a>
 </em>
@@ -7055,11 +7055,11 @@ WARNING: Please note that this field will override the default calico-node Daemo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
+<a href="#CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7078,7 +7078,7 @@ CalicoNodeDaemonSetPodTemplateSpec is the calico-node DaemonSet&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7099,7 +7099,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">
+<a href="#CalicoNodeDaemonSetPodSpec">
 CalicoNodeDaemonSetPodSpec
 </a>
 </em>
@@ -7120,11 +7120,11 @@ Spec is the calico-node DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
+<h3 id="CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
 
 </p>
 <p>
@@ -7164,7 +7164,7 @@ If omitted, the calico-node DaemonSet will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">
 CalicoNodeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -7181,11 +7181,11 @@ Template describes the calico-node DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
+<h3 id="CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7204,7 +7204,7 @@ CalicoNodeWindowsDaemonSet is the configuration for the calico-node-windows Daem
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7224,7 +7224,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">
+<a href="#CalicoNodeWindowsDaemonSetSpec">
 CalicoNodeWindowsDaemonSetSpec
 </a>
 </em>
@@ -7245,11 +7245,11 @@ Spec is the specification of the calico-node-windows DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -7306,11 +7306,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -7367,11 +7367,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7390,7 +7390,7 @@ CalicoNodeWindowsDaemonSetPodSpec is the calico-node-windows DaemonSet&rsquo;s P
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">
+<a href="#CalicoNodeWindowsDaemonSetInitContainer">
 []CalicoNodeWindowsDaemonSetInitContainer
 </a>
 </em>
@@ -7412,7 +7412,7 @@ If omitted, the calico-node-windows DaemonSet will use its default values for it
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">
+<a href="#CalicoNodeWindowsDaemonSetContainer">
 []CalicoNodeWindowsDaemonSetContainer
 </a>
 </em>
@@ -7499,11 +7499,11 @@ WARNING: Please note that this field will override the default calico-node-windo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7522,7 +7522,7 @@ CalicoNodeWindowsDaemonSetPodTemplateSpec is the calico-node-windows DaemonSet&r
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7543,7 +7543,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">
 CalicoNodeWindowsDaemonSetPodSpec
 </a>
 </em>
@@ -7564,11 +7564,11 @@ Spec is the calico-node-windows DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
 
 </p>
 <p>
@@ -7608,7 +7608,7 @@ If omitted, the calico-node-windows DaemonSet will use its default value for min
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">
 CalicoNodeWindowsDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -7625,11 +7625,11 @@ Template describes the calico-node-windows DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7649,7 +7649,7 @@ CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrad
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7669,7 +7669,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">
 CalicoWindowsUpgradeDaemonSetSpec
 </a>
 </em>
@@ -7690,11 +7690,11 @@ Spec is the specification of the calico-windows-upgrade DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -7749,11 +7749,11 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7772,7 +7772,7 @@ CalicoWindowsUpgradeDaemonSetPodSpec is the calico-windows-upgrade DaemonSet&rsq
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">
+<a href="#CalicoWindowsUpgradeDaemonSetContainer">
 []CalicoWindowsUpgradeDaemonSetContainer
 </a>
 </em>
@@ -7859,11 +7859,11 @@ WARNING: Please note that this field will override the default calico-windows-up
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7882,7 +7882,7 @@ CalicoWindowsUpgradeDaemonSetPodTemplateSpec is the calico-windows-upgrade Daemo
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7903,7 +7903,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">
 CalicoWindowsUpgradeDaemonSetPodSpec
 </a>
 </em>
@@ -7924,11 +7924,11 @@ Spec is the calico-windows-upgrade DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
 
 </p>
 <p>
@@ -7968,7 +7968,7 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
 CalicoWindowsUpgradeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -7985,11 +7985,11 @@ Template describes the calico-windows-upgrade DaemonSet pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CertificateManagement">CertificateManagement</h3>
+<h3 id="CertificateManagement">CertificateManagement</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -8081,19 +8081,19 @@ Default: SHA256WithRSA
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CollectProcessPathOption">CollectProcessPathOption
+<h3 id="CollectProcessPathOption">CollectProcessPathOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.CommonPrometheusFields">CommonPrometheusFields</h3>
+<h3 id="CommonPrometheusFields">CommonPrometheusFields</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PrometheusSpec">PrometheusSpec</a>)
+<a href="#PrometheusSpec">PrometheusSpec</a>)
 
 </p>
 <table>
@@ -8109,7 +8109,7 @@ Default: SHA256WithRSA
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PrometheusContainer">
+<a href="#PrometheusContainer">
 []PrometheusContainer
 </a>
 </em>
@@ -8147,11 +8147,11 @@ Define resources requests and limits for single Pods.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</h3>
+<h3 id="ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -8170,7 +8170,7 @@ ComplianceBenchmarkerDaemonSet is the configuration for the Compliance Benchmark
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetSpec">
+<a href="#ComplianceBenchmarkerDaemonSetSpec">
 ComplianceBenchmarkerDaemonSetSpec
 </a>
 </em>
@@ -8191,11 +8191,11 @@ Spec is the specification of the Compliance Benchmarker DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetContainer">ComplianceBenchmarkerDaemonSetContainer</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetContainer">ComplianceBenchmarkerDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -8251,11 +8251,11 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetInitContainer">ComplianceBenchmarkerDaemonSetInitContainer</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetInitContainer">ComplianceBenchmarkerDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -8311,11 +8311,11 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8334,7 +8334,7 @@ ComplianceBenchmarkerDaemonSetPodSpec is the Compliance Benchmarker DaemonSet&rs
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetInitContainer">
+<a href="#ComplianceBenchmarkerDaemonSetInitContainer">
 []ComplianceBenchmarkerDaemonSetInitContainer
 </a>
 </em>
@@ -8356,7 +8356,7 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default values for
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetContainer">
+<a href="#ComplianceBenchmarkerDaemonSetContainer">
 []ComplianceBenchmarkerDaemonSetContainer
 </a>
 </em>
@@ -8375,11 +8375,11 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default values for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -8398,7 +8398,7 @@ ComplianceBenchmarkerDaemonSetPodTemplateSpec is the Compliance Benchmarker Daem
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">
+<a href="#ComplianceBenchmarkerDaemonSetPodSpec">
 ComplianceBenchmarkerDaemonSetPodSpec
 </a>
 </em>
@@ -8419,11 +8419,11 @@ Spec is the Compliance Benchmarker DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</a>)
+<a href="#ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</a>)
 
 </p>
 <p>
@@ -8442,7 +8442,7 @@ ComplianceBenchmarkerDaemonSetSpec defines configuration for the Compliance Benc
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodTemplateSpec">
+<a href="#ComplianceBenchmarkerDaemonSetPodTemplateSpec">
 ComplianceBenchmarkerDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -8459,11 +8459,11 @@ Template describes the Compliance Benchmarker DaemonSet pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeployment">ComplianceControllerDeployment</h3>
+<h3 id="ComplianceControllerDeployment">ComplianceControllerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -8482,7 +8482,7 @@ ComplianceControllerDeployment is the configuration for the compliance controlle
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentSpec">
+<a href="#ComplianceControllerDeploymentSpec">
 ComplianceControllerDeploymentSpec
 </a>
 </em>
@@ -8503,11 +8503,11 @@ Spec is the specification of the compliance controller Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentContainer">ComplianceControllerDeploymentContainer</h3>
+<h3 id="ComplianceControllerDeploymentContainer">ComplianceControllerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
+<a href="#ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -8563,11 +8563,11 @@ If omitted, the compliance controller Deployment will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentInitContainer">ComplianceControllerDeploymentInitContainer</h3>
+<h3 id="ComplianceControllerDeploymentInitContainer">ComplianceControllerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
+<a href="#ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -8623,11 +8623,11 @@ If omitted, the compliance controller Deployment will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</h3>
+<h3 id="ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</a>)
+<a href="#ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8646,7 +8646,7 @@ ComplianceControllerDeploymentPodSpec is the compliance controller Deployment&rs
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentInitContainer">
+<a href="#ComplianceControllerDeploymentInitContainer">
 []ComplianceControllerDeploymentInitContainer
 </a>
 </em>
@@ -8668,7 +8668,7 @@ If omitted, the compliance controller Deployment will use its default values for
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentContainer">
+<a href="#ComplianceControllerDeploymentContainer">
 []ComplianceControllerDeploymentContainer
 </a>
 </em>
@@ -8687,11 +8687,11 @@ If omitted, the compliance controller Deployment will use its default values for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</h3>
+<h3 id="ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</a>)
+<a href="#ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -8710,7 +8710,7 @@ ComplianceControllerDeploymentPodTemplateSpec is the compliance controller Deplo
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">
+<a href="#ComplianceControllerDeploymentPodSpec">
 ComplianceControllerDeploymentPodSpec
 </a>
 </em>
@@ -8731,11 +8731,11 @@ Spec is the compliance controller Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</h3>
+<h3 id="ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeployment">ComplianceControllerDeployment</a>)
+<a href="#ComplianceControllerDeployment">ComplianceControllerDeployment</a>)
 
 </p>
 <p>
@@ -8754,7 +8754,7 @@ ComplianceControllerDeploymentSpec defines configuration for the compliance cont
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodTemplateSpec">
+<a href="#ComplianceControllerDeploymentPodTemplateSpec">
 ComplianceControllerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -8771,11 +8771,11 @@ Template describes the compliance controller Deployment pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodSpec">ComplianceReporterPodSpec</h3>
+<h3 id="ComplianceReporterPodSpec">ComplianceReporterPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</a>)
+<a href="#ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8794,7 +8794,7 @@ ComplianceReporterPodSpec is the ComplianceReporter PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateInitContainer">
+<a href="#ComplianceReporterPodTemplateInitContainer">
 []ComplianceReporterPodTemplateInitContainer
 </a>
 </em>
@@ -8816,7 +8816,7 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateContainer">
+<a href="#ComplianceReporterPodTemplateContainer">
 []ComplianceReporterPodTemplateContainer
 </a>
 </em>
@@ -8835,11 +8835,11 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</h3>
+<h3 id="ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -8858,7 +8858,7 @@ ComplianceReporterPodTemplate is the configuration for the ComplianceReporter Po
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateSpec">
+<a href="#ComplianceReporterPodTemplateSpec">
 ComplianceReporterPodTemplateSpec
 </a>
 </em>
@@ -8875,11 +8875,11 @@ Spec is the specification of the ComplianceReporter PodTemplateSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplateContainer">ComplianceReporterPodTemplateContainer</h3>
+<h3 id="ComplianceReporterPodTemplateContainer">ComplianceReporterPodTemplateContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
+<a href="#ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
 
 </p>
 <p>
@@ -8935,11 +8935,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplateInitContainer">ComplianceReporterPodTemplateInitContainer</h3>
+<h3 id="ComplianceReporterPodTemplateInitContainer">ComplianceReporterPodTemplateInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
+<a href="#ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
 
 </p>
 <p>
@@ -8995,11 +8995,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</h3>
+<h3 id="ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</a>)
+<a href="#ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</a>)
 
 </p>
 <p>
@@ -9018,7 +9018,7 @@ ComplianceReporterPodTemplateSpec is the ComplianceReporter PodTemplateSpec.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodSpec">
+<a href="#ComplianceReporterPodSpec">
 ComplianceReporterPodSpec
 </a>
 </em>
@@ -9039,11 +9039,11 @@ Spec is the ComplianceReporter PodTemplate&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeployment">ComplianceServerDeployment</h3>
+<h3 id="ComplianceServerDeployment">ComplianceServerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -9062,7 +9062,7 @@ ComplianceServerDeployment is the configuration for the ComplianceServer Deploym
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentSpec">
+<a href="#ComplianceServerDeploymentSpec">
 ComplianceServerDeploymentSpec
 </a>
 </em>
@@ -9083,11 +9083,11 @@ Spec is the specification of the ComplianceServer Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentContainer">ComplianceServerDeploymentContainer</h3>
+<h3 id="ComplianceServerDeploymentContainer">ComplianceServerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
+<a href="#ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9143,11 +9143,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentInitContainer">ComplianceServerDeploymentInitContainer</h3>
+<h3 id="ComplianceServerDeploymentInitContainer">ComplianceServerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
+<a href="#ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9203,11 +9203,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</h3>
+<h3 id="ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</a>)
+<a href="#ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -9226,7 +9226,7 @@ ComplianceServerDeploymentPodSpec is the ComplianceServer Deployment&rsquo;s Pod
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentInitContainer">
+<a href="#ComplianceServerDeploymentInitContainer">
 []ComplianceServerDeploymentInitContainer
 </a>
 </em>
@@ -9248,7 +9248,7 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentContainer">
+<a href="#ComplianceServerDeploymentContainer">
 []ComplianceServerDeploymentContainer
 </a>
 </em>
@@ -9267,11 +9267,11 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</h3>
+<h3 id="ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</a>)
+<a href="#ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -9290,7 +9290,7 @@ ComplianceServerDeploymentPodTemplateSpec is the ComplianceServer Deployment&rsq
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">
+<a href="#ComplianceServerDeploymentPodSpec">
 ComplianceServerDeploymentPodSpec
 </a>
 </em>
@@ -9311,11 +9311,11 @@ Spec is the ComplianceServer Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</h3>
+<h3 id="ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeployment">ComplianceServerDeployment</a>)
+<a href="#ComplianceServerDeployment">ComplianceServerDeployment</a>)
 
 </p>
 <p>
@@ -9334,7 +9334,7 @@ ComplianceServerDeploymentSpec defines configuration for the ComplianceServer De
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodTemplateSpec">
+<a href="#ComplianceServerDeploymentPodTemplateSpec">
 ComplianceServerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -9351,11 +9351,11 @@ Template describes the ComplianceServer Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</h3>
+<h3 id="ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -9374,7 +9374,7 @@ ComplianceSnapshotterDeployment is the configuration for the compliance snapshot
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentSpec">
+<a href="#ComplianceSnapshotterDeploymentSpec">
 ComplianceSnapshotterDeploymentSpec
 </a>
 </em>
@@ -9395,11 +9395,11 @@ Spec is the specification of the compliance snapshotter Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentContainer">ComplianceSnapshotterDeploymentContainer</h3>
+<h3 id="ComplianceSnapshotterDeploymentContainer">ComplianceSnapshotterDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9455,11 +9455,11 @@ If omitted, the compliance snapshotter Deployment will use its default value for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentInitContainer">ComplianceSnapshotterDeploymentInitContainer</h3>
+<h3 id="ComplianceSnapshotterDeploymentInitContainer">ComplianceSnapshotterDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9515,11 +9515,11 @@ If omitted, the compliance snapshotter Deployment will use its default value for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</h3>
+<h3 id="ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -9538,7 +9538,7 @@ ComplianceSnapshotterDeploymentPodSpec is the compliance snapshotter Deployment&
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentInitContainer">
+<a href="#ComplianceSnapshotterDeploymentInitContainer">
 []ComplianceSnapshotterDeploymentInitContainer
 </a>
 </em>
@@ -9560,7 +9560,7 @@ If omitted, the compliance snapshotter Deployment will use its default values fo
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentContainer">
+<a href="#ComplianceSnapshotterDeploymentContainer">
 []ComplianceSnapshotterDeploymentContainer
 </a>
 </em>
@@ -9579,11 +9579,11 @@ If omitted, the compliance snapshotter Deployment will use its default values fo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</h3>
+<h3 id="ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</a>)
 
 </p>
 <p>
@@ -9602,7 +9602,7 @@ ComplianceSnapshotterDeploymentPodTemplateSpec is the compliance snapshotter Dep
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">
+<a href="#ComplianceSnapshotterDeploymentPodSpec">
 ComplianceSnapshotterDeploymentPodSpec
 </a>
 </em>
@@ -9623,11 +9623,11 @@ Spec is the compliance snapshotter Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</h3>
+<h3 id="ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</a>)
+<a href="#ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</a>)
 
 </p>
 <p>
@@ -9646,7 +9646,7 @@ ComplianceSnapshotterDeploymentSpec defines configuration for the compliance sna
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodTemplateSpec">
+<a href="#ComplianceSnapshotterDeploymentPodTemplateSpec">
 ComplianceSnapshotterDeploymentPodTemplateSpec
 </a>
 </em>
@@ -9663,11 +9663,11 @@ Template describes the compliance snapshotter Deployment pod that will be create
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</h3>
+<h3 id="ComplianceSpec">ComplianceSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>)
+<a href="#Compliance">Compliance</a>)
 
 </p>
 <p>
@@ -9686,7 +9686,7 @@ ComplianceSpec defines the desired state of Tigera compliance reporting capabili
 
 <code>complianceControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeployment">
+<a href="#ComplianceControllerDeployment">
 ComplianceControllerDeployment
 </a>
 </em>
@@ -9706,7 +9706,7 @@ ComplianceControllerDeployment configures the Compliance Controller Deployment.
 
 <code>complianceSnapshotterDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeployment">
+<a href="#ComplianceSnapshotterDeployment">
 ComplianceSnapshotterDeployment
 </a>
 </em>
@@ -9726,7 +9726,7 @@ ComplianceSnapshotterDeployment configures the Compliance Snapshotter Deployment
 
 <code>complianceBenchmarkerDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">
+<a href="#ComplianceBenchmarkerDaemonSet">
 ComplianceBenchmarkerDaemonSet
 </a>
 </em>
@@ -9746,7 +9746,7 @@ ComplianceBenchmarkerDaemonSet configures the Compliance Benchmarker DaemonSet.
 
 <code>complianceServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeployment">
+<a href="#ComplianceServerDeployment">
 ComplianceServerDeployment
 </a>
 </em>
@@ -9766,7 +9766,7 @@ ComplianceServerDeployment configures the Compliance Server Deployment.
 
 <code>complianceReporterPodTemplate</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplate">
+<a href="#ComplianceReporterPodTemplate">
 ComplianceReporterPodTemplate
 </a>
 </em>
@@ -9783,11 +9783,11 @@ ComplianceReporterPodTemplate configures the Compliance Reporter PodTemplate.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceStatus">ComplianceStatus</h3>
+<h3 id="ComplianceStatus">ComplianceStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>)
+<a href="#Compliance">Compliance</a>)
 
 </p>
 <p>
@@ -9841,12 +9841,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComponentName">ComponentName
+<h3 id="ComponentName">ComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComponentResource">ComponentResource</a>)
+<a href="#ComponentResource">ComponentResource</a>)
 
 </p>
 <p>
@@ -9855,11 +9855,11 @@ ComponentName represents a single component.
 <p>
 One of: Node, Typha, KubeControllers
 </p>
-<h3 id="operator.tigera.io/v1.ComponentResource">ComponentResource</h3>
+<h3 id="ComponentResource">ComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -9879,7 +9879,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentName">
+<a href="#ComponentName">
 ComponentName
 </a>
 </em>
@@ -9914,33 +9914,33 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ConditionStatus">ConditionStatus
+<h3 id="ConditionStatus">ConditionStatus
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 ConditionStatus represents the status of a particular condition. A condition may be one of: True, False, Unknown.
 </p>
-<h3 id="operator.tigera.io/v1.ContainerIPForwardingType">ContainerIPForwardingType
+<h3 id="ContainerIPForwardingType">ContainerIPForwardingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
 ContainerIPForwardingType specifies whether the CNI config for container ip forwarding is enabled.
 </p>
-<h3 id="operator.tigera.io/v1.DashboardsJob">DashboardsJob</h3>
+<h3 id="DashboardsJob">DashboardsJob</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -9959,7 +9959,7 @@ DashboardsJob is the configuration for the Dashboards job.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobSpec">
+<a href="#DashboardsJobSpec">
 DashboardsJobSpec
 </a>
 </em>
@@ -9980,11 +9980,11 @@ Spec is the specification of the dashboards job.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobContainer">DashboardsJobContainer</h3>
+<h3 id="DashboardsJobContainer">DashboardsJobContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodSpec">DashboardsJobPodSpec</a>)
+<a href="#DashboardsJobPodSpec">DashboardsJobPodSpec</a>)
 
 </p>
 <p>
@@ -10040,11 +10040,11 @@ If omitted, the Dashboard Job will use its default value for this container&rsqu
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobPodSpec">DashboardsJobPodSpec</h3>
+<h3 id="DashboardsJobPodSpec">DashboardsJobPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</a>)
+<a href="#DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -10063,7 +10063,7 @@ DashboardsJobPodSpec is the Dashboards job&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobContainer">
+<a href="#DashboardsJobContainer">
 []DashboardsJobContainer
 </a>
 </em>
@@ -10082,11 +10082,11 @@ If omitted, the Dashboard job will use its default values for its containers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</h3>
+<h3 id="DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobSpec">DashboardsJobSpec</a>)
+<a href="#DashboardsJobSpec">DashboardsJobSpec</a>)
 
 </p>
 <p>
@@ -10105,7 +10105,7 @@ DashboardsJobPodTemplateSpec is the Dashboards job&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodSpec">
+<a href="#DashboardsJobPodSpec">
 DashboardsJobPodSpec
 </a>
 </em>
@@ -10126,11 +10126,11 @@ Spec is the Dashboard job&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobSpec">DashboardsJobSpec</h3>
+<h3 id="DashboardsJobSpec">DashboardsJobSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJob">DashboardsJob</a>)
+<a href="#DashboardsJob">DashboardsJob</a>)
 
 </p>
 <p>
@@ -10149,7 +10149,7 @@ DashboardsJobSpec defines configuration for the Dashboards job.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodTemplateSpec">
+<a href="#DashboardsJobPodTemplateSpec">
 DashboardsJobPodTemplateSpec
 </a>
 </em>
@@ -10166,22 +10166,22 @@ Template describes the Dashboards job pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DataType">DataType
+<h3 id="DataType">DataType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Index">Index</a>)
+<a href="#Index">Index</a>)
 
 </p>
 <p>
 DataType represent the type of data stored
 </p>
-<h3 id="operator.tigera.io/v1.DexDeployment">DexDeployment</h3>
+<h3 id="DexDeployment">DexDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -10200,7 +10200,7 @@ DexDeployment is the configuration for the Dex Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentSpec">
+<a href="#DexDeploymentSpec">
 DexDeploymentSpec
 </a>
 </em>
@@ -10221,11 +10221,11 @@ Spec is the specification of the Dex Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentContainer">DexDeploymentContainer</h3>
+<h3 id="DexDeploymentContainer">DexDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
+<a href="#DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10281,11 +10281,11 @@ If omitted, the Dex Deployment will use its default value for this container&rsq
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentInitContainer">DexDeploymentInitContainer</h3>
+<h3 id="DexDeploymentInitContainer">DexDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
+<a href="#DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10341,11 +10341,11 @@ If omitted, the Dex Deployment will use its default value for this init containe
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentPodSpec">DexDeploymentPodSpec</h3>
+<h3 id="DexDeploymentPodSpec">DexDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</a>)
+<a href="#DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -10364,7 +10364,7 @@ DexDeploymentPodSpec is the Dex Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentInitContainer">
+<a href="#DexDeploymentInitContainer">
 []DexDeploymentInitContainer
 </a>
 </em>
@@ -10386,7 +10386,7 @@ If omitted, the Dex Deployment will use its default values for its init containe
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentContainer">
+<a href="#DexDeploymentContainer">
 []DexDeploymentContainer
 </a>
 </em>
@@ -10405,11 +10405,11 @@ If omitted, the Dex Deployment will use its default values for its containers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</h3>
+<h3 id="DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentSpec">DexDeploymentSpec</a>)
+<a href="#DexDeploymentSpec">DexDeploymentSpec</a>)
 
 </p>
 <p>
@@ -10428,7 +10428,7 @@ DexDeploymentPodTemplateSpec is the Dex Deployment&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodSpec">
+<a href="#DexDeploymentPodSpec">
 DexDeploymentPodSpec
 </a>
 </em>
@@ -10449,11 +10449,11 @@ Spec is the Dex Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentSpec">DexDeploymentSpec</h3>
+<h3 id="DexDeploymentSpec">DexDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeployment">DexDeployment</a>)
+<a href="#DexDeployment">DexDeployment</a>)
 
 </p>
 <p>
@@ -10472,7 +10472,7 @@ DexDeploymentSpec defines configuration for the Dex Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodTemplateSpec">
+<a href="#DexDeploymentPodTemplateSpec">
 DexDeploymentPodTemplateSpec
 </a>
 </em>
@@ -10489,11 +10489,11 @@ Template describes the Dex Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSet">ECKOperatorStatefulSet</h3>
+<h3 id="ECKOperatorStatefulSet">ECKOperatorStatefulSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -10512,7 +10512,7 @@ ECKOperatorStatefulSet is the configuration for the ECKOperator StatefulSet.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetSpec">
+<a href="#ECKOperatorStatefulSetSpec">
 ECKOperatorStatefulSetSpec
 </a>
 </em>
@@ -10533,11 +10533,11 @@ Spec is the specification of the ECKOperator StatefulSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetContainer">ECKOperatorStatefulSetContainer</h3>
+<h3 id="ECKOperatorStatefulSetContainer">ECKOperatorStatefulSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
+<a href="#ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
 
 </p>
 <p>
@@ -10593,11 +10593,11 @@ If omitted, the ECKOperator StatefulSet will use its default value for this cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetInitContainer">ECKOperatorStatefulSetInitContainer</h3>
+<h3 id="ECKOperatorStatefulSetInitContainer">ECKOperatorStatefulSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
+<a href="#ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
 
 </p>
 <p>
@@ -10652,11 +10652,11 @@ If omitted, the ECKOperator StatefulSet will use its default value for this init
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</h3>
+<h3 id="ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</a>)
+<a href="#ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -10675,7 +10675,7 @@ ECKOperatorStatefulSetPodSpec is the ECKOperator StatefulSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetInitContainer">
+<a href="#ECKOperatorStatefulSetInitContainer">
 []ECKOperatorStatefulSetInitContainer
 </a>
 </em>
@@ -10697,7 +10697,7 @@ If omitted, the ECKOperator StatefulSet will use its default values for its init
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetContainer">
+<a href="#ECKOperatorStatefulSetContainer">
 []ECKOperatorStatefulSetContainer
 </a>
 </em>
@@ -10716,11 +10716,11 @@ If omitted, the ECKOperator StatefulSet will use its default values for its cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</h3>
+<h3 id="ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</a>)
+<a href="#ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</a>)
 
 </p>
 <p>
@@ -10739,7 +10739,7 @@ ECKOperatorStatefulSetPodTemplateSpec is the ECKOperator StatefulSet&rsquo;s Pod
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">
+<a href="#ECKOperatorStatefulSetPodSpec">
 ECKOperatorStatefulSetPodSpec
 </a>
 </em>
@@ -10760,11 +10760,11 @@ Spec is the ECKOperator StatefulSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</h3>
+<h3 id="ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSet">ECKOperatorStatefulSet</a>)
+<a href="#ECKOperatorStatefulSet">ECKOperatorStatefulSet</a>)
 
 </p>
 <p>
@@ -10783,7 +10783,7 @@ ECKOperatorStatefulSetSpec defines configuration for the ECKOperator StatefulSet
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodTemplateSpec">
+<a href="#ECKOperatorStatefulSetPodTemplateSpec">
 ECKOperatorStatefulSetPodTemplateSpec
 </a>
 </em>
@@ -10800,11 +10800,11 @@ Template describes the ECKOperator StatefulSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentContainer">EGWDeploymentContainer</h3>
+<h3 id="EGWDeploymentContainer">EGWDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10861,11 +10861,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
+<h3 id="EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10922,11 +10922,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeployment">EKSLogForwarderDeployment</h3>
+<h3 id="EKSLogForwarderDeployment">EKSLogForwarderDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <p>
@@ -10945,7 +10945,7 @@ EKSLogForwarderDeployment is the configuration for the EKSLogForwarder Deploymen
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentSpec">
+<a href="#EKSLogForwarderDeploymentSpec">
 EKSLogForwarderDeploymentSpec
 </a>
 </em>
@@ -10966,11 +10966,11 @@ Spec is the specification of the EKSLogForwarder Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentContainer">EKSLogForwarderDeploymentContainer</h3>
+<h3 id="EKSLogForwarderDeploymentContainer">EKSLogForwarderDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
+<a href="#EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -11026,11 +11026,11 @@ If omitted, the EKSLogForwarder Deployment will use its default value for this c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentInitContainer">EKSLogForwarderDeploymentInitContainer</h3>
+<h3 id="EKSLogForwarderDeploymentInitContainer">EKSLogForwarderDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
+<a href="#EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -11086,11 +11086,11 @@ If omitted, the EKSLogForwarder Deployment will use its default value for this i
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</h3>
+<h3 id="EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</a>)
+<a href="#EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11109,7 +11109,7 @@ EKSLogForwarderDeploymentPodSpec is the EKSLogForwarder Deployment&rsquo;s PodSp
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentInitContainer">
+<a href="#EKSLogForwarderDeploymentInitContainer">
 []EKSLogForwarderDeploymentInitContainer
 </a>
 </em>
@@ -11131,7 +11131,7 @@ If omitted, the EKSLogForwarder Deployment will use its default values for its i
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentContainer">
+<a href="#EKSLogForwarderDeploymentContainer">
 []EKSLogForwarderDeploymentContainer
 </a>
 </em>
@@ -11150,11 +11150,11 @@ If omitted, the EKSLogForwarder Deployment will use its default values for its c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</h3>
+<h3 id="EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</a>)
+<a href="#EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</a>)
 
 </p>
 <p>
@@ -11173,7 +11173,7 @@ EKSLogForwarderDeploymentPodTemplateSpec is the EKSLogForwarder Deployment&rsquo
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">
+<a href="#EKSLogForwarderDeploymentPodSpec">
 EKSLogForwarderDeploymentPodSpec
 </a>
 </em>
@@ -11194,11 +11194,11 @@ Spec is the EKSLogForwarder Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</h3>
+<h3 id="EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeployment">EKSLogForwarderDeployment</a>)
+<a href="#EKSLogForwarderDeployment">EKSLogForwarderDeployment</a>)
 
 </p>
 <p>
@@ -11217,7 +11217,7 @@ EKSLogForwarderDeploymentSpec defines configuration for the EKSLogForwarder Depl
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodTemplateSpec">
+<a href="#EKSLogForwarderDeploymentPodTemplateSpec">
 EKSLogForwarderDeploymentPodTemplateSpec
 </a>
 </em>
@@ -11234,11 +11234,11 @@ Template describes the EKSLogForwarder Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
+<h3 id="EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11257,7 +11257,7 @@ EgressGatewayDeploymentPodSpec is the Egress Gateway Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentInitContainer">
+<a href="#EGWDeploymentInitContainer">
 []EGWDeploymentInitContainer
 </a>
 </em>
@@ -11279,7 +11279,7 @@ If omitted, the EGW Deployment will use its default values for its init containe
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentContainer">
+<a href="#EGWDeploymentContainer">
 []EGWDeploymentContainer
 </a>
 </em>
@@ -11414,11 +11414,11 @@ PriorityClassName allows to specify a PriorityClass resource to be used.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
+<h3 id="EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -11437,7 +11437,7 @@ EgressGatewayDeploymentPodTemplateSpec is the EGW Deployment&rsquo;s PodTemplate
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayMetadata">
+<a href="#EgressGatewayMetadata">
 EgressGatewayMetadata
 </a>
 </em>
@@ -11458,7 +11458,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">
+<a href="#EgressGatewayDeploymentPodSpec">
 EgressGatewayDeploymentPodSpec
 </a>
 </em>
@@ -11479,11 +11479,11 @@ Spec is the EGW Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
+<h3 id="EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -11524,7 +11524,7 @@ Default: 90
 
 <code>icmpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ICMPProbe">
+<a href="#ICMPProbe">
 ICMPProbe
 </a>
 </em>
@@ -11546,7 +11546,7 @@ fail. Timeout must be greater than interval.
 
 <code>httpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HTTPProbe">
+<a href="#HTTPProbe">
 HTTPProbe
 </a>
 </em>
@@ -11565,11 +11565,11 @@ fail. Timeout must be greater than interval.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayIPPool">EgressGatewayIPPool</h3>
+<h3 id="EgressGatewayIPPool">EgressGatewayIPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <table>
@@ -11618,11 +11618,11 @@ CIDR is the IPPool CIDR that the Egress Gateways can use.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayMetadata">EgressGatewayMetadata</h3>
+<h3 id="EgressGatewayMetadata">EgressGatewayMetadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11680,11 +11680,11 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</h3>
+<h3 id="EgressGatewaySpec">EgressGatewaySpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -11721,7 +11721,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -11762,7 +11762,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -11783,7 +11783,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -11803,7 +11803,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -11827,7 +11827,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -11844,11 +11844,11 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayStatus">EgressGatewayStatus</h3>
+<h3 id="EgressGatewayStatus">EgressGatewayStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -11902,11 +11902,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EksCloudwatchLogsSpec">EksCloudwatchLogsSpec</h3>
+<h3 id="EksCloudwatchLogsSpec">EksCloudwatchLogsSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">AdditionalLogSourceSpec</a>)
+<a href="#AdditionalLogSourceSpec">AdditionalLogSourceSpec</a>)
 
 </p>
 <p>
@@ -11994,11 +11994,11 @@ Default: 60
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</h3>
+<h3 id="ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -12017,7 +12017,7 @@ ElasticsearchMetricsDeployment is the configuration for the tigera-elasticsearch
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentSpec">
+<a href="#ElasticsearchMetricsDeploymentSpec">
 ElasticsearchMetricsDeploymentSpec
 </a>
 </em>
@@ -12038,11 +12038,11 @@ Spec is the specification of the ElasticsearchMetrics Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentContainer">ElasticsearchMetricsDeploymentContainer</h3>
+<h3 id="ElasticsearchMetricsDeploymentContainer">ElasticsearchMetricsDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -12098,11 +12098,11 @@ If omitted, the ElasticsearchMetrics Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentInitContainer">ElasticsearchMetricsDeploymentInitContainer</h3>
+<h3 id="ElasticsearchMetricsDeploymentInitContainer">ElasticsearchMetricsDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -12158,11 +12158,11 @@ If omitted, the ElasticsearchMetrics Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</h3>
+<h3 id="ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -12181,7 +12181,7 @@ ElasticsearchMetricsDeploymentPodSpec is the tElasticsearchMetricsDeployment&rsq
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentInitContainer">
+<a href="#ElasticsearchMetricsDeploymentInitContainer">
 []ElasticsearchMetricsDeploymentInitContainer
 </a>
 </em>
@@ -12203,7 +12203,7 @@ If omitted, the ElasticsearchMetrics Deployment will use its default values for 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentContainer">
+<a href="#ElasticsearchMetricsDeploymentContainer">
 []ElasticsearchMetricsDeploymentContainer
 </a>
 </em>
@@ -12222,11 +12222,11 @@ If omitted, the ElasticsearchMetrics Deployment will use its default values for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</h3>
+<h3 id="ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</a>)
 
 </p>
 <p>
@@ -12245,7 +12245,7 @@ ElasticsearchMetricsDeploymentPodTemplateSpec is the ElasticsearchMetricsDeploym
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">
+<a href="#ElasticsearchMetricsDeploymentPodSpec">
 ElasticsearchMetricsDeploymentPodSpec
 </a>
 </em>
@@ -12266,11 +12266,11 @@ Spec is the ElasticsearchMetrics Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</h3>
+<h3 id="ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</a>)
+<a href="#ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</a>)
 
 </p>
 <p>
@@ -12289,7 +12289,7 @@ ElasticsearchMetricsDeploymentSpec defines configuration for the ElasticsearchMe
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodTemplateSpec">
+<a href="#ElasticsearchMetricsDeploymentPodTemplateSpec">
 ElasticsearchMetricsDeploymentPodTemplateSpec
 </a>
 </em>
@@ -12306,20 +12306,20 @@ Template describes the ElasticsearchMetrics Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EmailVerificationType">EmailVerificationType
+<h3 id="EmailVerificationType">EmailVerificationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.EncapsulationType">EncapsulationType
+<h3 id="EncapsulationType">EncapsulationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -12328,12 +12328,12 @@ EncapsulationType is the type of encapsulation to use on an IP pool.
 <p>
 One of: IPIP, VXLAN, IPIPCrossSubnet, VXLANCrossSubnet, None
 </p>
-<h3 id="operator.tigera.io/v1.EncryptionOption">EncryptionOption
+<h3 id="EncryptionOption">EncryptionOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</a>)
+<a href="#SyslogStoreSpec">SyslogStoreSpec</a>)
 
 </p>
 <p>
@@ -12342,11 +12342,11 @@ EncryptionOption specifies the traffic encryption mode when connecting to a Sysl
 <p>
 One of: None, TLS
 </p>
-<h3 id="operator.tigera.io/v1.Endpoint">Endpoint</h3>
+<h3 id="Endpoint">Endpoint</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ServiceMonitor">ServiceMonitor</a>)
+<a href="#ServiceMonitor">ServiceMonitor</a>)
 
 </p>
 <p>
@@ -12507,11 +12507,11 @@ More info: <a href="https://prometheus.io/docs/prometheus/latest/configuration/c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EnvoySettings">EnvoySettings</h3>
+<h3 id="EnvoySettings">EnvoySettings</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -12564,11 +12564,11 @@ manipulating various headers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ExternalPrometheus">ExternalPrometheus</h3>
+<h3 id="ExternalPrometheus">ExternalPrometheus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.MonitorSpec">MonitorSpec</a>)
+<a href="#MonitorSpec">MonitorSpec</a>)
 
 </p>
 <table>
@@ -12584,7 +12584,7 @@ manipulating various headers.
 
 <code>serviceMonitor</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ServiceMonitor">
+<a href="#ServiceMonitor">
 ServiceMonitor
 </a>
 </em>
@@ -12624,19 +12624,19 @@ must be created before the operator will create Prometheus resources.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FIPSMode">FIPSMode
+<h3 id="FIPSMode">FIPSMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSet">FluentdDaemonSet</h3>
+<h3 id="FluentdDaemonSet">FluentdDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <p>
@@ -12655,7 +12655,7 @@ FluentdDaemonSet is the configuration for the Fluentd DaemonSet.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetSpec">
+<a href="#FluentdDaemonSetSpec">
 FluentdDaemonSetSpec
 </a>
 </em>
@@ -12676,11 +12676,11 @@ Spec is the specification of the Fluentd DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetContainer">FluentdDaemonSetContainer</h3>
+<h3 id="FluentdDaemonSetContainer">FluentdDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
+<a href="#FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -12736,11 +12736,11 @@ If omitted, the Fluentd DaemonSet will use its default value for this container&
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetInitContainer">FluentdDaemonSetInitContainer</h3>
+<h3 id="FluentdDaemonSetInitContainer">FluentdDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
+<a href="#FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -12796,11 +12796,11 @@ If omitted, the Fluentd DaemonSet will use its default value for this init conta
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</h3>
+<h3 id="FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</a>)
+<a href="#FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -12819,7 +12819,7 @@ FluentdDaemonSetPodSpec is the Fluentd DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetInitContainer">
+<a href="#FluentdDaemonSetInitContainer">
 []FluentdDaemonSetInitContainer
 </a>
 </em>
@@ -12841,7 +12841,7 @@ If omitted, the Fluentd DaemonSet will use its default values for its init conta
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetContainer">
+<a href="#FluentdDaemonSetContainer">
 []FluentdDaemonSetContainer
 </a>
 </em>
@@ -12860,11 +12860,11 @@ If omitted, the Fluentd DaemonSet will use its default values for its containers
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</h3>
+<h3 id="FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetSpec">FluentdDaemonSetSpec</a>)
+<a href="#FluentdDaemonSetSpec">FluentdDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -12883,7 +12883,7 @@ FluentdDaemonSetPodTemplateSpec is the Fluentd DaemonSet&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodSpec">
+<a href="#FluentdDaemonSetPodSpec">
 FluentdDaemonSetPodSpec
 </a>
 </em>
@@ -12904,11 +12904,11 @@ Spec is the Fluentd DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetSpec">FluentdDaemonSetSpec</h3>
+<h3 id="FluentdDaemonSetSpec">FluentdDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSet">FluentdDaemonSet</a>)
+<a href="#FluentdDaemonSet">FluentdDaemonSet</a>)
 
 </p>
 <p>
@@ -12927,7 +12927,7 @@ FluentdDaemonSetSpec defines configuration for the Fluentd DaemonSet.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodTemplateSpec">
+<a href="#FluentdDaemonSetPodTemplateSpec">
 FluentdDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -12944,11 +12944,11 @@ Template describes the Fluentd DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GroupSearch">GroupSearch</h3>
+<h3 id="GroupSearch">GroupSearch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</a>)
+<a href="#AuthenticationLDAP">AuthenticationLDAP</a>)
 
 </p>
 <p>
@@ -13020,7 +13020,7 @@ The attribute of the group that represents its name. This attribute can be used 
 
 <code>userMatchers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.UserMatch">
+<a href="#UserMatch">
 []UserMatch
 </a>
 </em>
@@ -13038,11 +13038,11 @@ attribute value.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeployment">GuardianDeployment</h3>
+<h3 id="GuardianDeployment">GuardianDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
+<a href="#ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
 
 </p>
 <p>
@@ -13061,7 +13061,7 @@ GuardianDeployment is the configuration for the guardian Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentSpec">
+<a href="#GuardianDeploymentSpec">
 GuardianDeploymentSpec
 </a>
 </em>
@@ -13082,11 +13082,11 @@ Spec is the specification of the guardian Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentContainer">GuardianDeploymentContainer</h3>
+<h3 id="GuardianDeploymentContainer">GuardianDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
+<a href="#GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -13142,11 +13142,11 @@ If omitted, the guardian Deployment will use its default value for this containe
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentInitContainer">GuardianDeploymentInitContainer</h3>
+<h3 id="GuardianDeploymentInitContainer">GuardianDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
+<a href="#GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -13201,11 +13201,11 @@ If omitted, the guardian Deployment will use its default value for this init con
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</h3>
+<h3 id="GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</a>)
+<a href="#GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -13224,7 +13224,7 @@ GuardianDeploymentPodSpec is the guardian Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentInitContainer">
+<a href="#GuardianDeploymentInitContainer">
 []GuardianDeploymentInitContainer
 </a>
 </em>
@@ -13246,7 +13246,7 @@ If omitted, the guardian Deployment will use its default values for its init con
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentContainer">
+<a href="#GuardianDeploymentContainer">
 []GuardianDeploymentContainer
 </a>
 </em>
@@ -13265,11 +13265,11 @@ If omitted, the guardian Deployment will use its default values for its containe
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</h3>
+<h3 id="GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentSpec">GuardianDeploymentSpec</a>)
+<a href="#GuardianDeploymentSpec">GuardianDeploymentSpec</a>)
 
 </p>
 <p>
@@ -13288,7 +13288,7 @@ GuardianDeploymentPodTemplateSpec is the guardian Deployment&rsquo;s PodTemplate
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodSpec">
+<a href="#GuardianDeploymentPodSpec">
 GuardianDeploymentPodSpec
 </a>
 </em>
@@ -13309,11 +13309,11 @@ Spec is the guardian Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentSpec">GuardianDeploymentSpec</h3>
+<h3 id="GuardianDeploymentSpec">GuardianDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeployment">GuardianDeployment</a>)
+<a href="#GuardianDeployment">GuardianDeployment</a>)
 
 </p>
 <p>
@@ -13332,7 +13332,7 @@ GuardianDeploymentSpec defines configuration for the guardian Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodTemplateSpec">
+<a href="#GuardianDeploymentPodTemplateSpec">
 GuardianDeploymentPodTemplateSpec
 </a>
 </em>
@@ -13349,11 +13349,11 @@ Template describes the guardian Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HTTPProbe">HTTPProbe</h3>
+<h3 id="HTTPProbe">HTTPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -13425,12 +13425,12 @@ Default: 30
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HostPortsType">HostPortsType
+<h3 id="HostPortsType">HostPortsType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -13439,11 +13439,11 @@ HostPortsType specifies host port support.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.ICMPProbe">ICMPProbe</h3>
+<h3 id="ICMPProbe">ICMPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -13515,19 +13515,19 @@ Default: 15
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPAMPluginType">IPAMPluginType
+<h3 id="IPAMPluginType">IPAMPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPAMSpec">IPAMSpec</a>)
+<a href="#IPAMSpec">IPAMSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IPAMSpec">IPAMSpec</h3>
+<h3 id="IPAMSpec">IPAMSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -13546,7 +13546,7 @@ IPAMSpec contains configuration for pod IP address management.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMPluginType">
+<a href="#IPAMPluginType">
 IPAMPluginType
 </a>
 </em>
@@ -13574,11 +13574,11 @@ Default: Calico
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPPool">IPPool</h3>
+<h3 id="IPPool">IPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -13628,7 +13628,7 @@ CIDR contains the address range for the IP Pool in classless inter-domain routin
 
 <code>encapsulation</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncapsulationType">
+<a href="#EncapsulationType">
 EncapsulationType
 </a>
 </em>
@@ -13650,7 +13650,7 @@ Default: IPIP
 
 <code>natOutgoing</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NATOutgoingType">
+<a href="#NATOutgoingType">
 NATOutgoingType
 </a>
 </em>
@@ -13729,7 +13729,7 @@ Default: false
 
 <code>allowedUses</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPPoolAllowedUse">
+<a href="#IPPoolAllowedUse">
 []IPPoolAllowedUse
 </a>
 </em>
@@ -13746,19 +13746,19 @@ AllowedUse controls what the IP pool will be used for.  If not specified or empt
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPPoolAllowedUse">IPPoolAllowedUse
+<h3 id="IPPoolAllowedUse">IPPoolAllowedUse
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.Image">Image</h3>
+<h3 id="Image">Image</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</a>)
+<a href="#ImageSetSpec">ImageSetSpec</a>)
 
 </p>
 <table>
@@ -13809,11 +13809,11 @@ The field should not include a leading <code>@</code> and must be prefixed with 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</h3>
+<h3 id="ImageSetSpec">ImageSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>)
+<a href="#ImageSet">ImageSet</a>)
 
 </p>
 <p>
@@ -13832,7 +13832,7 @@ ImageSetSpec defines the desired state of ImageSet.
 
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -13849,11 +13849,11 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Index">Index</h3>
+<h3 id="Index">Index</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -13891,7 +13891,7 @@ excludes the numerical identifier suffix)
 
 <code>dataType</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DataType">
+<a href="#DataType">
 DataType
 </a>
 </em>
@@ -13907,11 +13907,11 @@ DataType represents the type of data stored in the defined index
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Indices">Indices</h3>
+<h3 id="Indices">Indices</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -13945,12 +13945,12 @@ Replicas defines how many replicas each index will have. See <a href="https://ww
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationSpec">InstallationSpec</h3>
+<h3 id="InstallationSpec">InstallationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#Installation">Installation</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -13969,7 +13969,7 @@ InstallationSpec defines configuration for a Calico or Calico Enterprise install
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -14097,7 +14097,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -14120,7 +14120,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -14140,7 +14140,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -14160,7 +14160,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -14339,7 +14339,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -14361,7 +14361,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -14383,7 +14383,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -14403,7 +14403,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -14423,7 +14423,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -14442,7 +14442,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -14462,7 +14462,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -14482,7 +14482,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -14502,7 +14502,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -14521,7 +14521,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -14542,7 +14542,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -14562,7 +14562,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -14597,11 +14597,11 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationStatus">InstallationStatus</h3>
+<h3 id="InstallationStatus">InstallationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>)
+<a href="#Installation">Installation</a>)
 
 </p>
 <p>
@@ -14620,7 +14620,7 @@ InstallationStatus defines the observed state of the Calico or Calico Enterprise
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -14676,7 +14676,7 @@ that is being used. If an ImageSet is not being used then this will not be set.
 
 <code>computed</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -14733,19 +14733,19 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionComponentName">IntrusionDetectionComponentName
+<h3 id="IntrusionDetectionComponentName">IntrusionDetectionComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</a>)
+<a href="#IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</h3>
+<h3 id="IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <p>
@@ -14764,7 +14764,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentName">
+<a href="#IntrusionDetectionComponentName">
 IntrusionDetectionComponentName
 </a>
 </em>
@@ -14799,11 +14799,11 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</h3>
+<h3 id="IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <p>
@@ -14822,7 +14822,7 @@ IntrusionDetectionControllerDeployment is the configuration for the IntrusionDet
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentSpec">
+<a href="#IntrusionDetectionControllerDeploymentSpec">
 IntrusionDetectionControllerDeploymentSpec
 </a>
 </em>
@@ -14843,11 +14843,11 @@ Spec is the specification of the IntrusionDetectionController Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentContainer">IntrusionDetectionControllerDeploymentContainer</h3>
+<h3 id="IntrusionDetectionControllerDeploymentContainer">IntrusionDetectionControllerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -14903,11 +14903,11 @@ If omitted, the IntrusionDetection Deployment will use its default value for thi
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentInitContainer">IntrusionDetectionControllerDeploymentInitContainer</h3>
+<h3 id="IntrusionDetectionControllerDeploymentInitContainer">IntrusionDetectionControllerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -14963,11 +14963,11 @@ If omitted, the IntrusionDetectionController Deployment will use its default val
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</h3>
+<h3 id="IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -14986,7 +14986,7 @@ IntrusionDetectionControllerDeploymentPodSpec is the IntrusionDetectionControlle
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentInitContainer">
+<a href="#IntrusionDetectionControllerDeploymentInitContainer">
 []IntrusionDetectionControllerDeploymentInitContainer
 </a>
 </em>
@@ -15008,7 +15008,7 @@ If omitted, the IntrusionDetectionController Deployment will use its default val
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentContainer">
+<a href="#IntrusionDetectionControllerDeploymentContainer">
 []IntrusionDetectionControllerDeploymentContainer
 </a>
 </em>
@@ -15027,11 +15027,11 @@ If omitted, the IntrusionDetectionController Deployment will use its default val
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</h3>
+<h3 id="IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -15050,7 +15050,7 @@ IntrusionDetectionControllerDeploymentPodTemplateSpec is the IntrusionDetectionC
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">
+<a href="#IntrusionDetectionControllerDeploymentPodSpec">
 IntrusionDetectionControllerDeploymentPodSpec
 </a>
 </em>
@@ -15071,11 +15071,11 @@ Spec is the IntrusionDetectionController Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</h3>
+<h3 id="IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</a>)
+<a href="#IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</a>)
 
 </p>
 <p>
@@ -15094,7 +15094,7 @@ IntrusionDetectionControllerDeploymentSpec defines configuration for the Intrusi
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodTemplateSpec">
+<a href="#IntrusionDetectionControllerDeploymentPodTemplateSpec">
 IntrusionDetectionControllerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -15111,11 +15111,11 @@ Template describes the IntrusionDetectionController Deployment pod that will be 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</h3>
+<h3 id="IntrusionDetectionSpec">IntrusionDetectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>)
+<a href="#IntrusionDetection">IntrusionDetection</a>)
 
 </p>
 <p>
@@ -15134,7 +15134,7 @@ IntrusionDetectionSpec defines the desired state of Tigera intrusion detection c
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">
+<a href="#IntrusionDetectionComponentResource">
 []IntrusionDetectionComponentResource
 </a>
 </em>
@@ -15155,7 +15155,7 @@ Only DeepPacketInspection is supported for this spec.
 
 <code>anomalyDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+<a href="#AnomalyDetectionSpec">
 AnomalyDetectionSpec
 </a>
 </em>
@@ -15175,7 +15175,7 @@ AnomalyDetection is now deprecated, and configuring it has no effect.
 
 <code>intrusionDetectionControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeployment">
+<a href="#IntrusionDetectionControllerDeployment">
 IntrusionDetectionControllerDeployment
 </a>
 </em>
@@ -15192,11 +15192,11 @@ IntrusionDetectionControllerDeployment configures the IntrusionDetection Control
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionStatus">IntrusionDetectionStatus</h3>
+<h3 id="IntrusionDetectionStatus">IntrusionDetectionStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>)
+<a href="#IntrusionDetection">IntrusionDetection</a>)
 
 </p>
 <p>
@@ -15250,11 +15250,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Kibana">Kibana</h3>
+<h3 id="Kibana">Kibana</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -15273,7 +15273,7 @@ Kibana is the configuration for the Kibana.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaSpec">
+<a href="#KibanaSpec">
 KibanaSpec
 </a>
 </em>
@@ -15294,11 +15294,11 @@ Spec is the specification of the Kibana.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaContainer">KibanaContainer</h3>
+<h3 id="KibanaContainer">KibanaContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaPodSpec">KibanaPodSpec</a>)
+<a href="#KibanaPodSpec">KibanaPodSpec</a>)
 
 </p>
 <p>
@@ -15354,11 +15354,11 @@ If omitted, the Kibana will use its default value for this container&rsquo;s res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaInitContainer">KibanaInitContainer</h3>
+<h3 id="KibanaInitContainer">KibanaInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaPodSpec">KibanaPodSpec</a>)
+<a href="#KibanaPodSpec">KibanaPodSpec</a>)
 
 </p>
 <p>
@@ -15415,11 +15415,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaPodSpec">KibanaPodSpec</h3>
+<h3 id="KibanaPodSpec">KibanaPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaPodTemplateSpec">KibanaPodTemplateSpec</a>)
+<a href="#KibanaPodTemplateSpec">KibanaPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -15438,7 +15438,7 @@ KibanaPodSpec is the Kibana Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaInitContainer">
+<a href="#KibanaInitContainer">
 []KibanaInitContainer
 </a>
 </em>
@@ -15460,7 +15460,7 @@ If omitted, the Kibana Deployment will use its default values for its init conta
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaContainer">
+<a href="#KibanaContainer">
 []KibanaContainer
 </a>
 </em>
@@ -15479,11 +15479,11 @@ If omitted, the Kibana Deployment will use its default values for its containers
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaPodTemplateSpec">KibanaPodTemplateSpec</h3>
+<h3 id="KibanaPodTemplateSpec">KibanaPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaSpec">KibanaSpec</a>)
+<a href="#KibanaSpec">KibanaSpec</a>)
 
 </p>
 <p>
@@ -15502,7 +15502,7 @@ KibanaPodTemplateSpec is the Kibana&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaPodSpec">
+<a href="#KibanaPodSpec">
 KibanaPodSpec
 </a>
 </em>
@@ -15523,11 +15523,11 @@ Spec is the Kibana&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaSpec">KibanaSpec</h3>
+<h3 id="KibanaSpec">KibanaSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Kibana">Kibana</a>)
+<a href="#Kibana">Kibana</a>)
 
 </p>
 <table>
@@ -15543,7 +15543,7 @@ Spec is the Kibana&rsquo;s PodSpec.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaPodTemplateSpec">
+<a href="#KibanaPodTemplateSpec">
 KibanaPodTemplateSpec
 </a>
 </em>
@@ -15560,12 +15560,12 @@ Template describes the Kibana pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
+<h3 id="KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</a>)
+<a href="#NodeAddressAutodetection">NodeAddressAutodetection</a>)
 
 </p>
 <p>
@@ -15574,11 +15574,11 @@ KubernetesAutodetectionMethod is a method of detecting an IP address based on th
 <p>
 One of: NodeInternalIP
 </p>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</h3>
+<h3 id="L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <p>
@@ -15597,7 +15597,7 @@ L7LogCollectorDaemonSet is the configuration for the L7LogCollector DaemonSet.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetSpec">
+<a href="#L7LogCollectorDaemonSetSpec">
 L7LogCollectorDaemonSetSpec
 </a>
 </em>
@@ -15618,11 +15618,11 @@ Spec is the specification of the L7LogCollector DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetContainer">L7LogCollectorDaemonSetContainer</h3>
+<h3 id="L7LogCollectorDaemonSetContainer">L7LogCollectorDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
+<a href="#L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -15678,11 +15678,11 @@ If omitted, the L7LogCollector DaemonSet will use its default value for this con
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetInitContainer">L7LogCollectorDaemonSetInitContainer</h3>
+<h3 id="L7LogCollectorDaemonSetInitContainer">L7LogCollectorDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
+<a href="#L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -15737,11 +15737,11 @@ If omitted, the L7LogCollector DaemonSet will use its default value for this ini
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</h3>
+<h3 id="L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</a>)
+<a href="#L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -15760,7 +15760,7 @@ L7LogCollectorDaemonSetPodSpec is the L7LogCollector DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetInitContainer">
+<a href="#L7LogCollectorDaemonSetInitContainer">
 []L7LogCollectorDaemonSetInitContainer
 </a>
 </em>
@@ -15782,7 +15782,7 @@ If omitted, the L7LogCollector DaemonSet will use its default values for its ini
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetContainer">
+<a href="#L7LogCollectorDaemonSetContainer">
 []L7LogCollectorDaemonSetContainer
 </a>
 </em>
@@ -15801,11 +15801,11 @@ If omitted, the L7LogCollector DaemonSet will use its default values for its con
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</h3>
+<h3 id="L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</a>)
+<a href="#L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -15824,7 +15824,7 @@ L7LogCollectorDaemonSetPodTemplateSpec is the L7LogCollector DaemonSet&rsquo;s P
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">
+<a href="#L7LogCollectorDaemonSetPodSpec">
 L7LogCollectorDaemonSetPodSpec
 </a>
 </em>
@@ -15845,11 +15845,11 @@ Spec is the L7LogCollector DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</h3>
+<h3 id="L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</a>)
+<a href="#L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</a>)
 
 </p>
 <p>
@@ -15868,7 +15868,7 @@ L7LogCollectorDaemonSetSpec defines configuration for the L7LogCollector DaemonS
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodTemplateSpec">
+<a href="#L7LogCollectorDaemonSetPodTemplateSpec">
 L7LogCollectorDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -15885,12 +15885,12 @@ Template describes the L7LogCollector DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeployment">LinseedDeployment</h3>
+<h3 id="LinseedDeployment">LinseedDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>, 
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>, 
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -15909,7 +15909,7 @@ LinseedDeployment is the configuration for the linseed Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentSpec">
+<a href="#LinseedDeploymentSpec">
 LinseedDeploymentSpec
 </a>
 </em>
@@ -15930,11 +15930,11 @@ Spec is the specification of the linseed Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentContainer">LinseedDeploymentContainer</h3>
+<h3 id="LinseedDeploymentContainer">LinseedDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
+<a href="#LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -15990,11 +15990,11 @@ If omitted, the linseed Deployment will use its default value for this container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentInitContainer">LinseedDeploymentInitContainer</h3>
+<h3 id="LinseedDeploymentInitContainer">LinseedDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
+<a href="#LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -16050,11 +16050,11 @@ If omitted, the linseed Deployment will use its default value for this init cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</h3>
+<h3 id="LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</a>)
+<a href="#LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -16073,7 +16073,7 @@ LinseedDeploymentPodSpec is the linseed Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentInitContainer">
+<a href="#LinseedDeploymentInitContainer">
 []LinseedDeploymentInitContainer
 </a>
 </em>
@@ -16095,7 +16095,7 @@ If omitted, the linseed Deployment will use its default values for its init cont
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentContainer">
+<a href="#LinseedDeploymentContainer">
 []LinseedDeploymentContainer
 </a>
 </em>
@@ -16114,11 +16114,11 @@ If omitted, the linseed Deployment will use its default values for its container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</h3>
+<h3 id="LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentSpec">LinseedDeploymentSpec</a>)
+<a href="#LinseedDeploymentSpec">LinseedDeploymentSpec</a>)
 
 </p>
 <p>
@@ -16137,7 +16137,7 @@ LinseedDeploymentPodTemplateSpec is the linseed Deployment&rsquo;s PodTemplateSp
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">
+<a href="#LinseedDeploymentPodSpec">
 LinseedDeploymentPodSpec
 </a>
 </em>
@@ -16158,11 +16158,11 @@ Spec is the linseed Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentSpec">LinseedDeploymentSpec</h3>
+<h3 id="LinseedDeploymentSpec">LinseedDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">LinseedDeployment</a>)
+<a href="#LinseedDeployment">LinseedDeployment</a>)
 
 </p>
 <p>
@@ -16181,7 +16181,7 @@ LinseedDeploymentSpec defines configuration for the linseed Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">
+<a href="#LinseedDeploymentPodTemplateSpec">
 LinseedDeploymentPodTemplateSpec
 </a>
 </em>
@@ -16198,12 +16198,12 @@ Template describes the linseed Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinuxDataplaneOption">LinuxDataplaneOption
+<h3 id="LinuxDataplaneOption">LinuxDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -16212,11 +16212,11 @@ LinuxDataplaneOption controls which dataplane is to be used on Linux nodes.
 <p>
 One of: Iptables, BPF
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</h3>
+<h3 id="LogCollectionSpec">LogCollectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -16232,7 +16232,7 @@ One of: Iptables, BPF
 
 <code>collectLogs</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionStatusType">
+<a href="#LogCollectionStatusType">
 LogCollectionStatusType
 </a>
 </em>
@@ -16290,19 +16290,19 @@ Default: -1
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectionStatusType">LogCollectionStatusType
+<h3 id="LogCollectionStatusType">LogCollectionStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</a>)
+<a href="#LogCollectionSpec">LogCollectionSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</h3>
+<h3 id="LogCollectorSpec">LogCollectorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>)
+<a href="#LogCollector">LogCollector</a>)
 
 </p>
 <p>
@@ -16321,7 +16321,7 @@ LogCollectorSpec defines the desired state of Tigera flow, audit, and DNS log co
 
 <code>additionalStores</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">
+<a href="#AdditionalLogStoreSpec">
 AdditionalLogStoreSpec
 </a>
 </em>
@@ -16341,7 +16341,7 @@ Configuration for exporting flow, audit, and DNS logs to external storage.
 
 <code>additionalSources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">
+<a href="#AdditionalLogSourceSpec">
 AdditionalLogSourceSpec
 </a>
 </em>
@@ -16361,7 +16361,7 @@ Configuration for importing audit logs from managed kubernetes cluster log sourc
 
 <code>collectProcessPath</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CollectProcessPathOption">
+<a href="#CollectProcessPathOption">
 CollectProcessPathOption
 </a>
 </em>
@@ -16402,7 +16402,7 @@ the management cluster&rsquo;s tenant services are running.
 
 <code>fluentdDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSet">
+<a href="#FluentdDaemonSet">
 FluentdDaemonSet
 </a>
 </em>
@@ -16421,7 +16421,7 @@ FluentdDaemonSet configures the Fluentd DaemonSet.
 
 <code>eksLogForwarderDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeployment">
+<a href="#EKSLogForwarderDeployment">
 EKSLogForwarderDeployment
 </a>
 </em>
@@ -16438,11 +16438,11 @@ EKSLogForwarderDeployment configures the EKSLogForwarderDeployment Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectorStatus">LogCollectorStatus</h3>
+<h3 id="LogCollectorStatus">LogCollectorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>)
+<a href="#LogCollector">LogCollector</a>)
 
 </p>
 <p>
@@ -16496,31 +16496,31 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogLevel">LogLevel
+<h3 id="LogLevel">LogLevel
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNILogging">CNILogging</a>, 
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#CNILogging">CNILogging</a>, 
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogStorageComponentName">LogStorageComponentName
+<h3 id="LogStorageComponentName">LogStorageComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">LogStorageComponentResource</a>)
+<a href="#LogStorageComponentResource">LogStorageComponentResource</a>)
 
 </p>
 <p>
 LogStorageComponentName CRD enum
 </p>
-<h3 id="operator.tigera.io/v1.LogStorageComponentResource">LogStorageComponentResource</h3>
+<h3 id="LogStorageComponentResource">LogStorageComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -16539,7 +16539,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentName">
+<a href="#LogStorageComponentName">
 LogStorageComponentName
 </a>
 </em>
@@ -16575,11 +16575,11 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</h3>
+<h3 id="LogStorageSpec">LogStorageSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>)
+<a href="#LogStorage">LogStorage</a>)
 
 </p>
 <p>
@@ -16598,7 +16598,7 @@ LogStorageSpec defines the desired state of Tigera flow and DNS log storage.
 
 <code>nodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Nodes">
+<a href="#Nodes">
 Nodes
 </a>
 </em>
@@ -16617,7 +16617,7 @@ Nodes defines the configuration for a set of identical Elasticsearch cluster nod
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Indices">
+<a href="#Indices">
 Indices
 </a>
 </em>
@@ -16637,7 +16637,7 @@ Index defines the configuration for the indices in the Elasticsearch cluster.
 
 <code>retention</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Retention">
+<a href="#Retention">
 Retention
 </a>
 </em>
@@ -16699,7 +16699,7 @@ each of the indicated key-value pairs as labels as well as access to the specifi
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">
+<a href="#LogStorageComponentResource">
 []LogStorageComponentResource
 </a>
 </em>
@@ -16720,7 +16720,7 @@ Only ECKOperator is supported for this spec.
 
 <code>eckOperatorStatefulSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSet">
+<a href="#ECKOperatorStatefulSet">
 ECKOperatorStatefulSet
 </a>
 </em>
@@ -16741,7 +16741,7 @@ ComponentResources, then these overrides take precedence.
 
 <code>kibana</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Kibana">
+<a href="#Kibana">
 Kibana
 </a>
 </em>
@@ -16761,7 +16761,7 @@ Kibana configures the Kibana Spec.
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -16780,7 +16780,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>elasticsearchMetricsDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeployment">
+<a href="#ElasticsearchMetricsDeployment">
 ElasticsearchMetricsDeployment
 </a>
 </em>
@@ -16796,11 +16796,11 @@ ElasticsearchMetricsDeployment configures the tigera-elasticsearch-metric Deploy
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorageStatus">LogStorageStatus</h3>
+<h3 id="LogStorageStatus">LogStorageStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>)
+<a href="#LogStorage">LogStorage</a>)
 
 </p>
 <p>
@@ -16890,11 +16890,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Logging">Logging</h3>
+<h3 id="Logging">Logging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>
@@ -16910,7 +16910,7 @@ Ready, Progressing, Degraded or other customer types.
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNILogging">
+<a href="#CNILogging">
 CNILogging
 </a>
 </em>
@@ -16927,11 +16927,11 @@ Customized logging specification for calico-cni plugin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</h3>
+<h3 id="ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>)
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>)
 
 </p>
 <p>
@@ -16969,7 +16969,7 @@ should be able to access this address. This field is used by managed clusters on
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">
+<a href="#ManagementClusterTLS">
 ManagementClusterTLS
 </a>
 </em>
@@ -16989,7 +16989,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>guardianDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeployment">
+<a href="#GuardianDeployment">
 GuardianDeployment
 </a>
 </em>
@@ -17005,11 +17005,11 @@ GuardianDeployment configures the guardian Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnectionStatus">ManagementClusterConnectionStatus</h3>
+<h3 id="ManagementClusterConnectionStatus">ManagementClusterConnectionStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>)
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>)
 
 </p>
 <p>
@@ -17046,11 +17046,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterSpec">ManagementClusterSpec</h3>
+<h3 id="ManagementClusterSpec">ManagementClusterSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementCluster">ManagementCluster</a>)
+<a href="#ManagementCluster">ManagementCluster</a>)
 
 </p>
 <p>
@@ -17089,7 +17089,7 @@ Valid examples are: &ldquo;0.0.0.0:31000&rdquo;, &ldquo;example.com:32000&rdquo;
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLS">
+<a href="#TLS">
 TLS
 </a>
 </em>
@@ -17106,11 +17106,11 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterTLS">ManagementClusterTLS</h3>
+<h3 id="ManagementClusterTLS">ManagementClusterTLS</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
+<a href="#ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
 
 </p>
 <table>
@@ -17126,7 +17126,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>ca</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CAType">
+<a href="#CAType">
 CAType
 </a>
 </em>
@@ -17152,11 +17152,11 @@ Default: Tigera
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeployment">ManagerDeployment</h3>
+<h3 id="ManagerDeployment">ManagerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerSpec">ManagerSpec</a>)
+<a href="#ManagerSpec">ManagerSpec</a>)
 
 </p>
 <p>
@@ -17175,7 +17175,7 @@ ManagerDeployment is the configuration for the Manager Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentSpec">
+<a href="#ManagerDeploymentSpec">
 ManagerDeploymentSpec
 </a>
 </em>
@@ -17196,11 +17196,11 @@ Spec is the specification of the Manager Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentContainer">ManagerDeploymentContainer</h3>
+<h3 id="ManagerDeploymentContainer">ManagerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
+<a href="#ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -17256,11 +17256,11 @@ If omitted, the Manager Deployment will use its default value for this container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentInitContainer">ManagerDeploymentInitContainer</h3>
+<h3 id="ManagerDeploymentInitContainer">ManagerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
+<a href="#ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -17317,11 +17317,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</h3>
+<h3 id="ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</a>)
+<a href="#ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -17340,7 +17340,7 @@ ManagerDeploymentPodSpec is the Manager Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentInitContainer">
+<a href="#ManagerDeploymentInitContainer">
 []ManagerDeploymentInitContainer
 </a>
 </em>
@@ -17362,7 +17362,7 @@ If omitted, the Manager Deployment will use its default values for its init cont
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentContainer">
+<a href="#ManagerDeploymentContainer">
 []ManagerDeploymentContainer
 </a>
 </em>
@@ -17381,11 +17381,11 @@ If omitted, the Manager Deployment will use its default values for its container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</h3>
+<h3 id="ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentSpec">ManagerDeploymentSpec</a>)
+<a href="#ManagerDeploymentSpec">ManagerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -17404,7 +17404,7 @@ ManagerDeploymentPodTemplateSpec is the Manager Deployment&rsquo;s PodTemplateSp
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodSpec">
+<a href="#ManagerDeploymentPodSpec">
 ManagerDeploymentPodSpec
 </a>
 </em>
@@ -17425,11 +17425,11 @@ Spec is the Manager Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentSpec">ManagerDeploymentSpec</h3>
+<h3 id="ManagerDeploymentSpec">ManagerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeployment">ManagerDeployment</a>)
+<a href="#ManagerDeployment">ManagerDeployment</a>)
 
 </p>
 <p>
@@ -17448,7 +17448,7 @@ ManagerDeploymentSpec defines configuration for the Manager Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodTemplateSpec">
+<a href="#ManagerDeploymentPodTemplateSpec">
 ManagerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -17465,11 +17465,11 @@ Template describes the Manager Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerSpec">ManagerSpec</h3>
+<h3 id="ManagerSpec">ManagerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>)
+<a href="#Manager">Manager</a>)
 
 </p>
 <p>
@@ -17488,7 +17488,7 @@ ManagerSpec defines configuration for the Calico Enterprise manager GUI.
 
 <code>managerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeployment">
+<a href="#ManagerDeployment">
 ManagerDeployment
 </a>
 </em>
@@ -17505,11 +17505,11 @@ ManagerDeployment configures the Manager Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerStatus">ManagerStatus</h3>
+<h3 id="ManagerStatus">ManagerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>)
+<a href="#Manager">Manager</a>)
 
 </p>
 <p>
@@ -17563,24 +17563,24 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Metadata">Metadata</h3>
+<h3 id="Metadata">Metadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>, 
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>, 
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
+<a href="#TyphaDeployment">TyphaDeployment</a>, 
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -17636,11 +17636,11 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MonitorSpec">MonitorSpec</h3>
+<h3 id="MonitorSpec">MonitorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -17659,7 +17659,7 @@ MonitorSpec defines the desired state of Tigera monitor.
 
 <code>externalPrometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">
+<a href="#ExternalPrometheus">
 ExternalPrometheus
 </a>
 </em>
@@ -17680,7 +17680,7 @@ scraping from git-ops tools without the need of post-installation steps.
 
 <code>prometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Prometheus">
+<a href="#Prometheus">
 Prometheus
 </a>
 </em>
@@ -17700,7 +17700,7 @@ Prometheus is the configuration for the Prometheus.
 
 <code>alertManager</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AlertManager">
+<a href="#AlertManager">
 AlertManager
 </a>
 </em>
@@ -17717,11 +17717,11 @@ AlertManager is the configuration for the AlertManager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MonitorStatus">MonitorStatus</h3>
+<h3 id="MonitorStatus">MonitorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -17775,12 +17775,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MultiInterfaceMode">MultiInterfaceMode
+<h3 id="MultiInterfaceMode">MultiInterfaceMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -17789,12 +17789,12 @@ MultiInterfaceMode describes the method of providing multiple pod interfaces.
 <p>
 One of: None, Multus
 </p>
-<h3 id="operator.tigera.io/v1.NATOutgoingType">NATOutgoingType
+<h3 id="NATOutgoingType">NATOutgoingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -17803,23 +17803,23 @@ NATOutgoingType describe the type of outgoing NAT to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.NativeIP">NativeIP
+<h3 id="NativeIP">NativeIP
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</a>)
+<a href="#AWSEgressGateway">AWSEgressGateway</a>)
 
 </p>
 <p>
 NativeIP defines if Egress Gateway pods should have AWS IPs.
 When NativeIP is enabled, the IPPools should be backed by AWS subnet.
 </p>
-<h3 id="operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</h3>
+<h3 id="NodeAddressAutodetection">NodeAddressAutodetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -17859,7 +17859,7 @@ filtering based on well-known interface names.
 
 <code>kubernetes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KubernetesAutodetectionMethod">
+<a href="#KubernetesAutodetectionMethod">
 KubernetesAutodetectionMethod
 </a>
 </em>
@@ -17950,11 +17950,11 @@ one of the provided CIDRs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeAffinity">NodeAffinity</h3>
+<h3 id="NodeAffinity">NodeAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</a>)
+<a href="#TyphaAffinity">TyphaAffinity</a>)
 
 </p>
 <p>
@@ -18023,11 +18023,11 @@ may or may not try to eventually evict the pod from its node.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeSet">NodeSet</h3>
+<h3 id="NodeSet">NodeSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Nodes">Nodes</a>)
+<a href="#Nodes">Nodes</a>)
 
 </p>
 <p>
@@ -18046,7 +18046,7 @@ NodeSets defines configuration specific to each Elasticsearch Node Set
 
 <code>selectionAttributes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeSetSelectionAttribute">
+<a href="#NodeSetSelectionAttribute">
 []NodeSetSelectionAttribute
 </a>
 </em>
@@ -18064,11 +18064,11 @@ to define Node Affinities and set the node awareness configuration in the runnin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeSetSelectionAttribute">NodeSetSelectionAttribute</h3>
+<h3 id="NodeSetSelectionAttribute">NodeSetSelectionAttribute</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeSet">NodeSet</a>)
+<a href="#NodeSet">NodeSet</a>)
 
 </p>
 <p>
@@ -18128,11 +18128,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Nodes">Nodes</h3>
+<h3 id="Nodes">Nodes</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -18168,7 +18168,7 @@ Count defines the number of nodes in the Elasticsearch cluster.
 
 <code>nodeSets</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeSet">
+<a href="#NodeSet">
 []NodeSet
 </a>
 </em>
@@ -18205,12 +18205,12 @@ ResourceRequirements defines the resource limits and requirements for the Elasti
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NonPrivilegedType">NonPrivilegedType
+<h3 id="NonPrivilegedType">NonPrivilegedType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -18219,12 +18219,12 @@ NonPrivilegedType specifies whether Calico runs as permissioned or not
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.OIDCType">OIDCType
+<h3 id="OIDCType">OIDCType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
 <p>
@@ -18232,11 +18232,11 @@ OIDCType defines how OIDC is configured for Tigera Enterprise. Dex should be the
 The Tigera option can help in specific use-cases, for instance, when you are unable to configure a client secret.
 One of: Dex, Tigera
 </p>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</h3>
+<h3 id="PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPISpec">PacketCaptureAPISpec</a>)
+<a href="#PacketCaptureAPISpec">PacketCaptureAPISpec</a>)
 
 </p>
 <p>
@@ -18255,7 +18255,7 @@ PacketCaptureAPIDeployment is the configuration for the PacketCaptureAPI Deploym
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentSpec">
+<a href="#PacketCaptureAPIDeploymentSpec">
 PacketCaptureAPIDeploymentSpec
 </a>
 </em>
@@ -18276,11 +18276,11 @@ Spec is the specification of the PacketCaptureAPI Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentContainer">PacketCaptureAPIDeploymentContainer</h3>
+<h3 id="PacketCaptureAPIDeploymentContainer">PacketCaptureAPIDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
+<a href="#PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18336,11 +18336,11 @@ If omitted, the PacketCaptureAPI Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentInitContainer">PacketCaptureAPIDeploymentInitContainer</h3>
+<h3 id="PacketCaptureAPIDeploymentInitContainer">PacketCaptureAPIDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
+<a href="#PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18396,11 +18396,11 @@ If omitted, the PacketCaptureAPI Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</h3>
+<h3 id="PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</a>)
+<a href="#PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -18419,7 +18419,7 @@ PacketCaptureAPIDeploymentPodSpec is the PacketCaptureAPI Deployment&rsquo;s Pod
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentInitContainer">
+<a href="#PacketCaptureAPIDeploymentInitContainer">
 []PacketCaptureAPIDeploymentInitContainer
 </a>
 </em>
@@ -18441,7 +18441,7 @@ If omitted, the PacketCaptureAPI Deployment will use its default values for its 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentContainer">
+<a href="#PacketCaptureAPIDeploymentContainer">
 []PacketCaptureAPIDeploymentContainer
 </a>
 </em>
@@ -18460,11 +18460,11 @@ If omitted, the PacketCaptureAPI Deployment will use its default values for its 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</h3>
+<h3 id="PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</a>)
+<a href="#PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</a>)
 
 </p>
 <p>
@@ -18483,7 +18483,7 @@ PacketCaptureAPIDeploymentPodTemplateSpec is the PacketCaptureAPI Deployment&rsq
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">
+<a href="#PacketCaptureAPIDeploymentPodSpec">
 PacketCaptureAPIDeploymentPodSpec
 </a>
 </em>
@@ -18504,11 +18504,11 @@ Spec is the PacketCaptureAPI Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</h3>
+<h3 id="PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</a>)
+<a href="#PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</a>)
 
 </p>
 <p>
@@ -18527,7 +18527,7 @@ PacketCaptureAPIDeploymentSpec defines configuration for the PacketCaptureAPI De
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodTemplateSpec">
+<a href="#PacketCaptureAPIDeploymentPodTemplateSpec">
 PacketCaptureAPIDeploymentPodTemplateSpec
 </a>
 </em>
@@ -18544,11 +18544,11 @@ Template describes the PacketCaptureAPI Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPISpec">PacketCaptureAPISpec</h3>
+<h3 id="PacketCaptureAPISpec">PacketCaptureAPISpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</a>)
+<a href="#PacketCaptureAPI">PacketCaptureAPI</a>)
 
 </p>
 <p>
@@ -18567,7 +18567,7 @@ PacketCaptureAPISpec defines configuration for the Packet Capture API.
 
 <code>packetCaptureAPIDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeployment">
+<a href="#PacketCaptureAPIDeployment">
 PacketCaptureAPIDeployment
 </a>
 </em>
@@ -18584,11 +18584,11 @@ PacketCaptureAPIDeployment configures the PacketCaptureAPI Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIStatus">PacketCaptureAPIStatus</h3>
+<h3 id="PacketCaptureAPIStatus">PacketCaptureAPIStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</a>)
+<a href="#PacketCaptureAPI">PacketCaptureAPI</a>)
 
 </p>
 <p>
@@ -18642,11 +18642,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PathMatch">PathMatch</h3>
+<h3 id="PathMatch">PathMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
+<a href="#TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
 
 </p>
 <table>
@@ -18712,11 +18712,11 @@ PathReplace if not nil will be used to replace PathRegexp matches.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeployment">PolicyRecommendationDeployment</h3>
+<h3 id="PolicyRecommendationDeployment">PolicyRecommendationDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationSpec">PolicyRecommendationSpec</a>)
+<a href="#PolicyRecommendationSpec">PolicyRecommendationSpec</a>)
 
 </p>
 <p>
@@ -18735,7 +18735,7 @@ PolicyRecommendationDeployment is the configuration for the PolicyRecommendation
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentSpec">
+<a href="#PolicyRecommendationDeploymentSpec">
 PolicyRecommendationDeploymentSpec
 </a>
 </em>
@@ -18756,11 +18756,11 @@ Spec is the specification of the PolicyRecommendation Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentContainer">PolicyRecommendationDeploymentContainer</h3>
+<h3 id="PolicyRecommendationDeploymentContainer">PolicyRecommendationDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
+<a href="#PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18816,11 +18816,11 @@ If omitted, the PolicyRecommendation Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentInitContainer">PolicyRecommendationDeploymentInitContainer</h3>
+<h3 id="PolicyRecommendationDeploymentInitContainer">PolicyRecommendationDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
+<a href="#PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18875,11 +18875,11 @@ If omitted, the PolicyRecommendation Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</h3>
+<h3 id="PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</a>)
+<a href="#PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -18898,7 +18898,7 @@ PolicyRecommendationDeploymentPodSpec is the PolicyRecommendation Deployment&rsq
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentInitContainer">
+<a href="#PolicyRecommendationDeploymentInitContainer">
 []PolicyRecommendationDeploymentInitContainer
 </a>
 </em>
@@ -18920,7 +18920,7 @@ If omitted, the PolicyRecommendation Deployment will use its default values for 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentContainer">
+<a href="#PolicyRecommendationDeploymentContainer">
 []PolicyRecommendationDeploymentContainer
 </a>
 </em>
@@ -18939,11 +18939,11 @@ If omitted, the PolicyRecommendation Deployment will use its default values for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</h3>
+<h3 id="PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</a>)
+<a href="#PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</a>)
 
 </p>
 <p>
@@ -18962,7 +18962,7 @@ PolicyRecommendationDeploymentPodTemplateSpec is the PolicyRecommendation Deploy
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">
+<a href="#PolicyRecommendationDeploymentPodSpec">
 PolicyRecommendationDeploymentPodSpec
 </a>
 </em>
@@ -18983,11 +18983,11 @@ Spec is the PolicyRecommendation Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</h3>
+<h3 id="PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeployment">PolicyRecommendationDeployment</a>)
+<a href="#PolicyRecommendationDeployment">PolicyRecommendationDeployment</a>)
 
 </p>
 <p>
@@ -19006,7 +19006,7 @@ PolicyRecommendationDeploymentSpec defines configuration for the PolicyRecommend
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodTemplateSpec">
+<a href="#PolicyRecommendationDeploymentPodTemplateSpec">
 PolicyRecommendationDeploymentPodTemplateSpec
 </a>
 </em>
@@ -19023,11 +19023,11 @@ Template describes the PolicyRecommendation Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
+<h3 id="PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
@@ -19047,7 +19047,7 @@ service.
 
 <code>policyRecommendationDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeployment">
+<a href="#PolicyRecommendationDeployment">
 PolicyRecommendationDeployment
 </a>
 </em>
@@ -19064,11 +19064,11 @@ PolicyRecommendation configures the PolicyRecommendation Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
+<h3 id="PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
@@ -19101,13 +19101,13 @@ State provides user-readable status.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ProductVariant">ProductVariant
+<h3 id="ProductVariant">ProductVariant
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#InstallationSpec">InstallationSpec</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -19116,11 +19116,11 @@ ProductVariant represents the variant of the product.
 <p>
 One of: Calico, TigeraSecureEnterprise
 </p>
-<h3 id="operator.tigera.io/v1.Prometheus">Prometheus</h3>
+<h3 id="Prometheus">Prometheus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.MonitorSpec">MonitorSpec</a>)
+<a href="#MonitorSpec">MonitorSpec</a>)
 
 </p>
 <table>
@@ -19136,7 +19136,7 @@ One of: Calico, TigeraSecureEnterprise
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PrometheusSpec">
+<a href="#PrometheusSpec">
 PrometheusSpec
 </a>
 </em>
@@ -19157,11 +19157,11 @@ Spec is the specification of the Prometheus.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PrometheusContainer">PrometheusContainer</h3>
+<h3 id="PrometheusContainer">PrometheusContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CommonPrometheusFields">CommonPrometheusFields</a>)
+<a href="#CommonPrometheusFields">CommonPrometheusFields</a>)
 
 </p>
 <p>
@@ -19217,11 +19217,11 @@ If omitted, the Prometheus will use its default value for this container&rsquo;s
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PrometheusSpec">PrometheusSpec</h3>
+<h3 id="PrometheusSpec">PrometheusSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Prometheus">Prometheus</a>)
+<a href="#Prometheus">Prometheus</a>)
 
 </p>
 <table>
@@ -19237,7 +19237,7 @@ If omitted, the Prometheus will use its default value for this container&rsquo;s
 
 <code>commonPrometheusFields</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CommonPrometheusFields">
+<a href="#CommonPrometheusFields">
 CommonPrometheusFields
 </a>
 </em>
@@ -19253,12 +19253,12 @@ CommonPrometheusFields are the options available to both the Prometheus server a
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PromptType">PromptType
+<h3 id="PromptType">PromptType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
 <p>
@@ -19266,23 +19266,23 @@ PromptType is a value that specifies whether the identity provider prompts the e
 consent.
 One of: None, Login, Consent, SelectAccount.
 </p>
-<h3 id="operator.tigera.io/v1.Provider">Provider
+<h3 id="Provider">Provider
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
 Provider represents a particular provider or flavor of Kubernetes. Valid options
 are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG.
 </p>
-<h3 id="operator.tigera.io/v1.Retention">Retention</h3>
+<h3 id="Retention">Retention</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -19424,11 +19424,11 @@ Default: 8
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.S3StoreSpec">S3StoreSpec</h3>
+<h3 id="S3StoreSpec">S3StoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -19495,11 +19495,11 @@ Path in the S3 bucket where to send logs
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SNIMatch">SNIMatch</h3>
+<h3 id="SNIMatch">SNIMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>)
+<a href="#TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>)
 
 </p>
 <table>
@@ -19529,11 +19529,11 @@ ServerName is used to match the server name for the request.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ServiceMonitor">ServiceMonitor</h3>
+<h3 id="ServiceMonitor">ServiceMonitor</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">ExternalPrometheus</a>)
+<a href="#ExternalPrometheus">ExternalPrometheus</a>)
 
 </p>
 <table>
@@ -19568,7 +19568,7 @@ Default: k8s-app=tigera-prometheus
 
 <code>endpoints</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Endpoint">
+<a href="#Endpoint">
 []Endpoint
 </a>
 </em>
@@ -19585,11 +19585,11 @@ related to connecting to our Prometheus server are automatically set by the oper
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SplunkStoreSpec">SplunkStoreSpec</h3>
+<h3 id="SplunkStoreSpec">SplunkStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -19622,22 +19622,22 @@ Location for splunk&rsquo;s http event collector end point. example <code>https:
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.StatusConditionType">StatusConditionType
+<h3 id="StatusConditionType">StatusConditionType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 StatusConditionType is a type of condition that may apply to a particular component.
 </p>
-<h3 id="operator.tigera.io/v1.Sysctl">Sysctl</h3>
+<h3 id="Sysctl">Sysctl</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -19678,12 +19678,12 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SyslogLogType">SyslogLogType
+<h3 id="SyslogLogType">SyslogLogType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</a>)
+<a href="#SyslogStoreSpec">SyslogStoreSpec</a>)
 
 </p>
 <p>
@@ -19694,11 +19694,11 @@ Allowable values are Audit, DNS, Flows and IDSEvents.
 * Flows corresponds to flow logs generated by Calico node.
 * IDSEvents corresponds to event logs for the intrusion detection system (anomaly detection, suspicious IPs, suspicious domains and global alerts).
 </p>
-<h3 id="operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</h3>
+<h3 id="SyslogStoreSpec">SyslogStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -19754,7 +19754,7 @@ Default: 1024
 
 <code>logTypes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SyslogLogType">
+<a href="#SyslogLogType">
 []SyslogLogType
 </a>
 </em>
@@ -19774,7 +19774,7 @@ Default: Audit, DNS, Flows
 
 <code>encryption</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncryptionOption">
+<a href="#EncryptionOption">
 EncryptionOption
 </a>
 </em>
@@ -19792,11 +19792,11 @@ Default: None
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLS">TLS</h3>
+<h3 id="TLS">TLS</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterSpec">ManagementClusterSpec</a>)
+<a href="#ManagementClusterSpec">ManagementClusterSpec</a>)
 
 </p>
 <table>
@@ -19846,11 +19846,11 @@ Default: tigera-management-cluster-connection
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</h3>
+<h3 id="TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRoute">TLSPassThroughRoute</a>)
+<a href="#TLSPassThroughRoute">TLSPassThroughRoute</a>)
 
 </p>
 <table>
@@ -19866,7 +19866,7 @@ Default: tigera-management-cluster-connection
 
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -19882,7 +19882,7 @@ TargetType
 
 <code>sniMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SNIMatch">
+<a href="#SNIMatch">
 SNIMatch
 </a>
 </em>
@@ -19916,11 +19916,11 @@ Destination is the destination url to proxy the request to.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</h3>
+<h3 id="TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSTerminatedRoute">TLSTerminatedRoute</a>)
+<a href="#TLSTerminatedRoute">TLSTerminatedRoute</a>)
 
 </p>
 <table>
@@ -19936,7 +19936,7 @@ Destination is the destination url to proxy the request to.
 
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -19952,7 +19952,7 @@ TargetType
 
 <code>pathMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PathMatch">
+<a href="#PathMatch">
 PathMatch
 </a>
 </em>
@@ -20067,20 +20067,20 @@ is UI.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TargetType">TargetType
+<h3 id="TargetType">TargetType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>, 
-<a href="#operator.tigera.io/v1.TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
+<a href="#TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>, 
+<a href="#TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.TenantElasticSpec">TenantElasticSpec</h3>
+<h3 id="TenantElasticSpec">TenantElasticSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <table>
@@ -20135,11 +20135,11 @@ bool
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantSpec">TenantSpec</h3>
+<h3 id="TenantSpec">TenantSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
 <table>
@@ -20189,7 +20189,7 @@ Name is a human readable name for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -20208,7 +20208,7 @@ Indices defines the how to store a tenant&rsquo;s data
 
 <code>elastic</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantElasticSpec">
+<a href="#TenantElasticSpec">
 TenantElasticSpec
 </a>
 </em>
@@ -20247,7 +20247,7 @@ in the Tenant&rsquo;s namespace. Defaults to the controlPlaneReplicas in Install
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -20266,7 +20266,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>dashboardsJob</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJob">
+<a href="#DashboardsJob">
 DashboardsJob
 </a>
 </em>
@@ -20282,18 +20282,18 @@ DashboardsJob configures the Dashboards job
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantStatus">TenantStatus</h3>
+<h3 id="TenantStatus">TenantStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</h3>
+<h3 id="TigeraStatusCondition">TigeraStatusCondition</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</a>)
+<a href="#TigeraStatusStatus">TigeraStatusStatus</a>)
 
 </p>
 <p>
@@ -20312,7 +20312,7 @@ TigeraStatusCondition represents a condition attached to a particular component.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.StatusConditionType">
+<a href="#StatusConditionType">
 StatusConditionType
 </a>
 </em>
@@ -20331,7 +20331,7 @@ The type of condition. May be Available, Progressing, or Degraded.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ConditionStatus">
+<a href="#ConditionStatus">
 ConditionStatus
 </a>
 </em>
@@ -20420,26 +20420,26 @@ with respect to the current state of the instance.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatusReason">TigeraStatusReason
+<h3 id="TigeraStatusReason">TigeraStatusReason
 (<code>string</code> alias)</h3>
 <p>
 TigeraStatusReason represents the reason for a particular condition.
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusSpec">TigeraStatusSpec</h3>
+<h3 id="TigeraStatusSpec">TigeraStatusSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
 TigeraStatusSpec defines the desired state of TigeraStatus
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</h3>
+<h3 id="TigeraStatusStatus">TigeraStatusStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
@@ -20458,7 +20458,7 @@ TigeraStatusStatus defines the observed state of TigeraStatus
 
 <code>conditions</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">
+<a href="#TigeraStatusCondition">
 []TigeraStatusCondition
 </a>
 </em>
@@ -20475,11 +20475,11 @@ Available, Progressing, or Degraded.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</h3>
+<h3 id="TyphaAffinity">TyphaAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -20499,7 +20499,7 @@ TyphaAffinity allows configuration of node affinity characteristics for Typha po
 
 <code>nodeAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAffinity">
+<a href="#NodeAffinity">
 NodeAffinity
 </a>
 </em>
@@ -20516,11 +20516,11 @@ NodeAffinity describes node affinity scheduling rules for typha.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</h3>
+<h3 id="TyphaDeployment">TyphaDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -20539,7 +20539,7 @@ TyphaDeployment is the configuration for the typha Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -20559,7 +20559,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">
+<a href="#TyphaDeploymentSpec">
 TyphaDeploymentSpec
 </a>
 </em>
@@ -20580,11 +20580,11 @@ Spec is the specification of the typha Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
+<h3 id="TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -20641,11 +20641,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
+<h3 id="TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -20702,11 +20702,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
+<h3 id="TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -20725,7 +20725,7 @@ TyphaDeploymentPodSpec is the typha Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentInitContainer">
+<a href="#TyphaDeploymentInitContainer">
 []TyphaDeploymentInitContainer
 </a>
 </em>
@@ -20747,7 +20747,7 @@ If omitted, the typha Deployment will use its default values for its init contai
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentContainer">
+<a href="#TyphaDeploymentContainer">
 []TyphaDeploymentContainer
 </a>
 </em>
@@ -20881,11 +20881,11 @@ WARNING: Please note that this field will override the default calico-typha Depl
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
+<h3 id="TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -20904,7 +20904,7 @@ TyphaDeploymentPodTemplateSpec is the typha Deployment&rsquo;s PodTemplateSpec
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -20925,7 +20925,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">
+<a href="#TyphaDeploymentPodSpec">
 TyphaDeploymentPodSpec
 </a>
 </em>
@@ -20946,11 +20946,11 @@ Spec is the typha Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
+<h3 id="TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>)
+<a href="#TyphaDeployment">TyphaDeployment</a>)
 
 </p>
 <p>
@@ -20990,7 +20990,7 @@ If omitted, the typha Deployment will use its default value for minReadySeconds.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">
+<a href="#TyphaDeploymentPodTemplateSpec">
 TyphaDeploymentPodTemplateSpec
 </a>
 </em>
@@ -21010,7 +21010,7 @@ Template describes the typha Deployment pod that will be created.
 
 <code>strategy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentStrategy">
+<a href="#TyphaDeploymentStrategy">
 TyphaDeploymentStrategy
 </a>
 </em>
@@ -21027,11 +21027,11 @@ The deployment strategy to use to replace existing pods with new ones.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
+<h3 id="TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -21070,11 +21070,11 @@ to be.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.UserMatch">UserMatch</h3>
+<h3 id="UserMatch">UserMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GroupSearch">GroupSearch</a>)
+<a href="#GroupSearch">GroupSearch</a>)
 
 </p>
 <p>
@@ -21124,11 +21124,11 @@ The attribute of a group that links it to a user.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.UserSearch">UserSearch</h3>
+<h3 id="UserSearch">UserSearch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</a>)
+<a href="#AuthenticationLDAP">AuthenticationLDAP</a>)
 
 </p>
 <p>
@@ -21198,27 +21198,27 @@ Default: uid
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.WAFStatusType">WAFStatusType
+<h3 id="WAFStatusType">WAFStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsDataplaneOption">WindowsDataplaneOption
+<h3 id="WindowsDataplaneOption">WindowsDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsNodeSpec">WindowsNodeSpec</h3>
+<h3 id="WindowsNodeSpec">WindowsNodeSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>

--- a/calico-enterprise_versioned_docs/version-3.19-2/reference/installation/helm_customization.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/reference/installation/helm_customization.mdx
@@ -8,18 +8,18 @@ import variables from '@site/calico-enterprise_versioned_docs/version-3.19-2/var
 
 You can customize the following resources and settings during {variables.prodname} Helm-based installation using the file, `values.yaml`.
 
-- [Installation](api.mdx#operator.tigera.io/v1.InstallationSpec)
-- [Api server](api.mdx#operator.tigera.io/v1.APIServerSpec)
-- [Compliance](api.mdx#operator.tigera.io/v1.ComplianceSpec)
-- [Intrusion detection](api.mdx#operator.tigera.io/v1.IntrusionDetectionSpec)
-- [Log collector](api.mdx#operator.tigera.io/v1.LogCollectorSpec)
-- [Log storage](api.mdx#operator.tigera.io/v1.LogStorageSpec)
-- [Manager](api.mdx#operator.tigera.io/v1.ManagerSpec)
-- [Monitor](api.mdx#operator.tigera.io/v1.MonitorSpec)
-- [Policy recommendation](api.mdx#operator.tigera.io/v1.PolicyRecommendationSpec)
-- [Authentication](api.mdx#operator.tigera.io/v1.AuthenticationSpec)
-- [Application layer](api.mdx#operator.tigera.io/v1.ApplicationLayerSpec)
-- [Amazon cloud integration](api.mdx#operator.tigera.io/v1.AmazonCloudIntegrationSpec)
+- [Installation](api.mdx#InstallationSpec
+- [Api server](api.mdx#APIServerSpec
+- [Compliance](api.mdx#ComplianceSpec
+- [Intrusion detection](api.mdx#IntrusionDetectionSpec
+- [Log collector](api.mdx#LogCollectorSpec
+- [Log storage](api.mdx#LogStorageSpec
+- [Manager](api.mdx#ManagerSpec
+- [Monitor](api.mdx#MonitorSpec
+- [Policy recommendation](api.mdx#PolicyRecommendationSpec
+- [Authentication](api.mdx#AuthenticationSpec
+- [Application layer](api.mdx#ApplicationLayerSpec
+- [Amazon cloud integration](api.mdx#AmazonCloudIntegrationSpec
 - [Default felix configuration](../resources/felixconfig.mdx#spec)
 
 :::note
@@ -94,7 +94,7 @@ Common customizations that you might want to configure are number of replicas, p
 
 ### Number of replicas
 This setting defines the number of replicas for {variables.prodname} components that can run simultaneously in multiple instances.
-To configure this setting, see [controlPlaneReplicas](api.mdx#operator.tigera.io/v1.InstallationSpec).
+To configure this setting, see [controlPlaneReplicas](api.mdx#InstallationSpec.
 The components for the replicas are:
 
 - tigera-manager

--- a/calico-enterprise_versioned_docs/version-3.19-2/threat/deeppacketinspection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/threat/deeppacketinspection.mdx
@@ -76,7 +76,7 @@ spec:
 
 ### Configure resource requirements
 
-Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionComponentResource).
+Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#IntrusionDetectionComponentResource.
 
 For a data transfer rate of 1GB/sec on workload endpoints being monitored, we recommend a minimum of 1 CPU and 1GB RAM.
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/threat/web-application-firewall.mdx
@@ -359,9 +359,9 @@ kubectl delete applicationlayer tigera-secure
 
 #### Keep some ApplicationLayer features enabled
 
-To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) custom resource.
+To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#ApplicationLayer custom resource.
 
-Note that the [ApplicationLayer Specification](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerSpec) can specify configuration for [Application Logging](../reference/installation/api#operator.tigera.io/v1.LogCollectionSpec) and [Application Layer Policy](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerPolicyStatusType) also. 
+Note that the [ApplicationLayer Specification](../reference/installation/api#ApplicationLayerSpec can specify configuration for [Application Logging](../reference/installation/api#LogCollectionSpec and [Application Layer Policy](../reference/installation/api#ApplicationLayerPolicyStatusType also. 
 
 For the ApplicationLayer custom resource to be valid, at least one of these features have to be enabled, for example:
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/visibility/elastic/archive-storage.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/visibility/elastic/archive-storage.mdx
@@ -48,8 +48,8 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
     -n tigera-operator
    ```
 
-3. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#operator.tigera.io/v1.S3StoreSpec)
+3. Update the [LogCollector](../../reference/installation/api.mdx#LogCollector
+   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#S3StoreSpec
    with your information noted from above.
    Example:
 
@@ -76,8 +76,8 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
 </TabItem>
 <TabItem label="Syslog" value="Syslog-1">
 
-1. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+1. Update the [LogCollector](../../reference/installation/api.mdx#LogCollector
+   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec
    with your syslog information.
    Example:
    ```yaml
@@ -104,7 +104,7 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    kubectl edit logcollector tigera-secure
    ```
 2. You can control which types of {variables.prodname} log data you would like to send to syslog.
-   The [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+   The [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec
    contains a field called `logTypes` which allows you to list which log types you would like to include.
    The allowable log types are:
 
@@ -113,11 +113,11 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    - Flows
    - IDSEvents
 
-   Refer to the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec) for more details on what data each log type represents.
+   Refer to the [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec for more details on what data each log type represents.
 
    :::note
 
-   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
+   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#LogStorage configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
 
    :::
 
@@ -125,7 +125,7 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
 
 **TLS configuration**
 
-3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec).
+3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec.
 
    ```yaml
    apiVersion: operator.tigera.io/v1
@@ -180,9 +180,9 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    ```
 
 3. Update the
-   [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
+   [LogCollector](../../reference/installation/api.mdx#LogCollector
    resource named `tigera-secure` to include
-   a [Splunk section](../../reference/installation/api.mdx#operator.tigera.io/v1.SplunkStoreSpec)
+   a [Splunk section](../../reference/installation/api.mdx#SplunkStoreSpec
    with your Splunk information.
    Example:
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/visibility/elastic/l7/configure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/visibility/elastic/l7/configure.mdx
@@ -73,7 +73,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
 
 **Configure the ApplicationLayer resource for L7 logs**
 
-1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) resource named, `tigera-secure` to include a logCollection section of the file, `_api.html` [here](../../../reference/installation/api.mdx).
+1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#ApplicationLayer resource named, `tigera-secure` to include a logCollection section of the file, `_api.html` [here](../../../reference/installation/api.mdx).
 
 1. Ensure that the `collectLogs` field is set to `Enabled`.
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/visibility/elastic/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/visibility/elastic/overview.mdx
@@ -93,7 +93,7 @@ verbs: ['get']
 - Global network policies
 - Network sets
 
-{variables.prodname} also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec).
+{variables.prodname} also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#LogCollectorSpec.
 
 ## Additional resources
 
@@ -104,4 +104,4 @@ verbs: ['get']
 - [BGP logs](bgp.mdx)
 - [DNS logs](dns/dns-logs.mdx)
 - [Archive logs](archive-storage.mdx)
-- [Log collection options](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../reference/installation/api.mdx#LogCollectorSpec

--- a/calico-enterprise_versioned_docs/version-3.19-2/visibility/elastic/rbac-elasticsearch.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/visibility/elastic/rbac-elasticsearch.mdx
@@ -213,4 +213,4 @@ status:
 ## Additional resources
 
 - Configure [RBAC for tiered policies](../../network-policy/policy-tiers/rbac-tiered-policies.mdx).
-- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) resource.
+- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#ManagementCluster resource.

--- a/calico-enterprise_versioned_docs/version-3.19-2/visibility/elastic/retention.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/visibility/elastic/retention.mdx
@@ -12,7 +12,7 @@ Configure how long to retain logs and compliance reports.
 
 ## Before you begin...
 
-Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#operator.tigera.io/v1.Retention) and determine the appropriate values for your deployment.
+Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#Retention and determine the appropriate values for your deployment.
 
 :::note
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/visibility/elastic/troubleshoot.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/visibility/elastic/troubleshoot.mdx
@@ -10,7 +10,7 @@ import variables from '@site/calico-enterprise_versioned_docs/version-3.19-2/var
 
 The following user-configured resources are related to Elasticsearch:
 
-- [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage). It has settings for:
+- [LogStorage](../../reference/installation/api.mdx#LogStorage. It has settings for:
 
   - Elasticsearch (for example, nodeCount and replicas)
   - Kubernetes (for example, resourceRequirements, storage and nodeSelectors)
@@ -113,7 +113,7 @@ As a last resort, create a new [Elasticsearch cluster](#how-to-create-a-new-clus
 
 ### Elasticsearch is slow
 
-**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorageSpec).
+**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#LogStorageSpec.
 
 ### Elasticsearch crashes during booting
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -49,7 +49,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#Provider
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.20-1/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
@@ -46,4 +46,4 @@ key features like Flow Visualizer, metrics in the dashboard and Policy Board, po
 - [Configure flow log aggregation](../../../visibility/elastic/flow/aggregation.mdx)
 - [Log storage recommendations](../../../operations/logstorage/log-storage-recommendations.mdx)
 - [Archive logs](../../../visibility/elastic/archive-storage.mdx)
-- [Log collection options](../../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../../reference/installation/api.mdx#LogCollectorSpec

--- a/calico-enterprise_versioned_docs/version-3.20-1/getting-started/install-on-clusters/windows-calico/requirements.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/getting-started/install-on-clusters/windows-calico/requirements.mdx
@@ -38,7 +38,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#BGPOption.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
@@ -101,7 +101,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
 
 1. <OpenShiftPrometheusOperator operation='upgrade' />
 
-1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster)
+1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#ManagementCluster
    CR to your cluster.
 
    ```bash
@@ -113,7 +113,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#operator.tigera.io/v1.Monitor)
+1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#Monitor
    CR to your cluster.
 
    ```bash
@@ -125,7 +125,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendation)
+1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#PolicyRecommendation
    CR to your cluster.
 
    ```bash
@@ -137,7 +137,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster was at one time v3.18 or older, remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#operator.tigera.io/v1.Manager).
+1. If your cluster was at one time v3.18 or older, remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#Manager.
 
    ```bash
    oc apply -f - <<EOF
@@ -148,7 +148,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.19 or older, apply a new [PacketCaptureAPI](../../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI)
+1. If your cluster is v3.19 or older, apply a new [PacketCaptureAPI](../../../reference/installation/api.mdx#PacketCaptureAPI
     CR to your cluster.
 
    ```bash

--- a/calico-enterprise_versioned_docs/version-3.20-1/multicluster/fine-tune-deployment.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/multicluster/fine-tune-deployment.mdx
@@ -153,4 +153,4 @@ To filter log data by a given managed cluster you can include the filter criteri
 
 # Additional resources
 
-- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection)
+- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#ManagementClusterConnection

--- a/calico-enterprise_versioned_docs/version-3.20-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -49,7 +49,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#Provider
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.20-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -51,7 +51,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#Provider
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.20-1/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
@@ -54,7 +54,7 @@ To control managed clusters from your central management plane, you must ensure 
     ```bash
     export MANAGEMENT_CLUSTER_ADDR=<your-management-cluster-addr>
     ```
-1.  Apply the [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) CR.
+1.  Apply the [ManagementCluster](../../../reference/installation/api.mdx#ManagementCluster CR.
 
     ```bash
     kubectl apply -f - <<EOF

--- a/calico-enterprise_versioned_docs/version-3.20-1/networking/configuring/dual-tor.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/networking/configuring/dual-tor.mdx
@@ -637,7 +637,7 @@ The only connections using interface-specific addresses should be BGP.
 If you plan to use [Egress Gateways](../egress/egress-gateway-on-prem.mdx) in your cluster, you must also adjust the {variables.nodecontainer} IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-{variables.prodname} [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+{variables.prodname} [Installation resource](../../reference/installation/api.mdx#NodeAddressAutodetection.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/networking/configuring/multiple-networks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/networking/configuring/multiple-networks.mdx
@@ -79,7 +79,7 @@ Although the following {variables.prodname} features are supported for your defa
 
 ### Configure cluster for multiple networks
 
-In the [Installation custom resource](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoNetworkSpec), set the `MultiInterfaceMode` to **Multus**.
+In the [Installation custom resource](../../reference/installation/api.mdx#CalicoNetworkSpec, set the `MultiInterfaceMode` to **Multus**.
 
 ### Create a new network
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/networking/egress/egress-gateway-on-prem.mdx
@@ -350,7 +350,7 @@ To modify the iptables backend for egress gateways, you must change the `iptable
 If you plan to use Egress Gateways in a [dual-ToR cluster](../configuring/dual-tor.mdx), you must also adjust the {variables.nodecontainer} IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-{variables.prodname} [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+{variables.prodname} [Installation resource](../../reference/installation/api.mdx#NodeAddressAutodetection.
 
 ### Configure namespaces and pods to use egress gateways
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/networking/ipam/initial-ippool.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/networking/ipam/initial-ippool.mdx
@@ -24,7 +24,7 @@ The **Kubernetes pod CIDR** is the expected IP address range for pod IPs. It is 
 
 [Calico IP pools](../../reference/resources/ippool.mdx) are ranges of IP addresses that Calico uses to assign to pods; the ranges must within the Kubernetes pod CIDR.
 
-The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#Installation
 resource and configures the default Calico IP pool. Note the following:
 
 - Default fields for any that are omitted:
@@ -44,7 +44,7 @@ resource and configures the default Calico IP pool. Note the following:
 ## How to
 
 1. Download the custom-resource.yaml file.
-1. Edit the [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation).
+1. Edit the [Installation resource](../../reference/installation/api.mdx#Installation.
    **Required values**: `cidr:`
    **Empty values**: Defaulted
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/networking/ipam/ip-autodetection.mdx
@@ -51,7 +51,7 @@ By default, {variables.prodname} uses the **firstFound** method; the first valid
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#NodeAddressAutodetection in the operator Installation reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-enterprise_versioned_docs/version-3.20-1/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/operations/cnx/configure-identity-provider.mdx
@@ -17,7 +17,7 @@ Configure an external identity provider (IdP), create a user, and log in to {var
 
 ## Concepts
 
-The {variables.prodname} authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Authentication) named, `tigera-secure`.
+The {variables.prodname} authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#Authentication named, `tigera-secure`.
 
 When configuring your cluster, you may be asked for the following inputs:
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/operations/cnx/roles-and-permissions.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/operations/cnx/roles-and-permissions.mdx
@@ -18,7 +18,7 @@ Self-service is an important part of your Kubernetes platform networking and net
 
 ### Kubernetes RBAC authorization
 
-The [Calico Enterprise API server](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) is an extension to the standard [Kubernetes RBAC Authorization APIs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
+The [Calico Enterprise API server](../../reference/installation/api.mdx#APIServer is an extension to the standard [Kubernetes RBAC Authorization APIs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
 
 | Features                       | RBAC controls for...                                                                                                                                                                                                                            |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/calico-enterprise_versioned_docs/version-3.20-1/operations/comms/certificate-management.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/operations/comms/certificate-management.mdx
@@ -21,7 +21,7 @@ certificate issuance, {variables.prodname} provides a simple configuration optio
 **Limitations**
 
 If your cluster is already running {variables.prodname} and you would like to enable certificate management, you need to
-temporarily remove [the logstorage resource](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+temporarily remove [the logstorage resource](../../reference/installation/api.mdx#LogStorage
 before following the steps to enable certificate management and then re-apply afterwards. For detailed steps on
 re-creating logstorage, read more on [how to create a new Elasticsearch cluster](../../visibility/elastic/troubleshoot.mdx#how-to-create-a-new-cluster).
 
@@ -40,7 +40,7 @@ Currently, this feature is not supported in combination with [Multi-cluster mana
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../../reference/installation/api.mdx#Installation
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
    ```yaml

--- a/calico-enterprise_versioned_docs/version-3.20-1/operations/logstorage/log-storage-recommendations.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/operations/logstorage/log-storage-recommendations.mdx
@@ -82,4 +82,4 @@ is no tolerance for removing/restarting a node.
 
 - Read the [LogStorage overview page](../logstorage/index.mdx)
 - [Troubleshooting Elasticsearch](../../visibility/elastic/troubleshoot.mdx)
-- [LogStorage Specification](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+- [LogStorage Specification](../../reference/installation/api.mdx#LogStorage

--- a/calico-enterprise_versioned_docs/version-3.20-1/reference/architecture/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/reference/architecture/overview.mdx
@@ -124,7 +124,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### Manager
 
-**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#operator.tigera.io/v1.Manager).
+**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#Manager.
 
 ### Packet capture API
 
@@ -152,7 +152,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### API server
 
-**Main task**: Allows users to manage {variables.prodname} resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#operator.tigera.io/v1.APIServer).
+**Main task**: Allows users to manage {variables.prodname} resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#APIServer.
 
 ### BIRD
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/reference/component-resources/configuration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/reference/component-resources/configuration.mdx
@@ -241,7 +241,7 @@ By enabling this feature, you can avoid errors that can occur when a pod tries t
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](../installation/api#operator.tigera.io/v1.CalicoNetworkSpec) of the default `operator.tigera.io/v1/installation` resource.
+The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](../installation/api#CalicoNetworkSpec of the default `operator.tigera.io/v1/installation` resource.
 
 The following example configures the CNI to delay a pod from starting its containers for up to 10 seconds, or until the pod's dataplane has been programmed:
 
@@ -311,7 +311,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-2">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#Installation API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico-enterprise_versioned_docs/version-3.20-1/reference/component-resources/configure-resources.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/reference/component-resources/configure-resources.mdx
@@ -16,11 +16,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../../reference/installation/api.mdx#APIServer CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the APIServer CR using the below command:
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#APIServerDeployment, patch the APIServer CR using the below command:
 
 ```bash
 kubectl patch apiserver tigera-secure  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -68,11 +68,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## ApplicationLayer custom resource
 
-The [ApplicationLayer](../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
+The [ApplicationLayer](../../reference/installation/api.mdx#ApplicationLayer CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
 
 ### L7LogCollectorDaemonSet
 
-To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.L7LogCollectorDaemonSet), patch the ApplicationLayer CR using the below command:
+To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#L7LogCollectorDaemonSet, patch the ApplicationLayer CR using the below command:
 
 ```bash
 kubectl patch applicationlayer tigera-secure  --type=merge --patch='{"spec": {"l7LogCollectorDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"l7-collector","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"envoy-proxy","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -120,11 +120,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Authentication custom resource
 
-The [Authentication](../../reference/installation/api.mdx#operator.tigera.io/v1.Authentication) CR provides a way to configure resources for DexDeployment. The following sections provide example configurations for this CR.
+The [Authentication](../../reference/installation/api.mdx#Authentication CR provides a way to configure resources for DexDeployment. The following sections provide example configurations for this CR.
 
 ### DexDeployment
 
-To configure resource specification for the [DexDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.DexDeployment), patch the Authentication CR using the below command:
+To configure resource specification for the [DexDeployment](../../reference/installation/api.mdx#DexDeployment, patch the Authentication CR using the below command:
 
 ```bash
 kubectl patch authentication tigera-secure  --type=merge --patch='{"spec": {"dexDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-dex","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -159,13 +159,13 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Compliance custom resource
 
-The [Compliance](../../reference/installation/api.mdx#operator.tigera.io/v1.Compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
+The [Compliance](../../reference/installation/api.mdx#Compliance CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
 
 Example Configurations:
 
 ### ComplianceControllerDeployment
 
-To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceControllerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#ComplianceControllerDeployment, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -200,7 +200,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceSnapshotterDeployment
 
-To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceSnapshotterDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#ComplianceSnapshotterDeployment, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceSnapshotterDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-snapshotter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -235,7 +235,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceBenchmarkerDaemonSet
 
-To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#ComplianceBenchmarkerDaemonSet, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceBenchmarkerDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-benchmarker","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -270,7 +270,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceServerDeployment
 
-To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceServerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#ComplianceServerDeployment, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -305,7 +305,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceReporterPodTemplate.
 
-To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceReporterPodTemplate), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#ComplianceReporterPodTemplate, patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceReporterPodTemplate": {"template": {"spec": {"containers":[{"name":"reporter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}'
@@ -344,7 +344,7 @@ The [Installation CR](../../reference/installation/api.mdx) provides a way to co
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#TyphaDeployment, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -379,7 +379,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#calicoNodeDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -414,7 +414,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#calicoNodeWindowsDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -449,7 +449,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#CalicoKubeControllersDeployment component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -485,7 +485,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#CSINodeDriverDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -533,11 +533,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## IntrusionDetection custom resource
 
-The [IntrusionDetection](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
+The [IntrusionDetection](../../reference/installation/api.mdx#IntrusionDetection CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
 
 ### IntrusionDetectionControllerDeployment.
 
-To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionControllerDeployment), patch the IntrusionDetection CR using the below command:
+To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#IntrusionDetectionControllerDeployment, patch the IntrusionDetection CR using the below command:
 
 ```bash
 kubectl patch intrusiondetection tigera-secure  --type=merge --patch='{"spec": {"intrusionDetectionControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"webhooks-processor","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}},{"name":"controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -585,11 +585,11 @@ This command will output the configured resource requests and limits for the Int
 
 ## LogCollector custom resource
 
-The [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
+The [LogCollector](../../reference/installation/api.mdx#LogCollector CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
 
 ### FluentdDaemonSet.
 
-To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.FluentdDaemonSet), patch the LogCollector CR using the below command:
+To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#FluentdDaemonSet, patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"fluentdDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"fluentd","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -624,7 +624,7 @@ This command will output the configured resource requests and limits for the Flu
 
 ### EKSLogForwarderDeployment.
 
-To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.EKSLogForwarderDeployment), patch the LogCollector CR using the below command:
+To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#EKSLogForwarderDeployment, patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"eksLogForwarderDeployment": {"spec": {"template": {"spec": {"containers":[{"name":"eks-log-forwarder","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -659,11 +659,11 @@ This command will output the configured resource requests and limits for the EKS
 
 ## LogStorage custom resource
 
-The [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) CR provides a way to configure resources for ECKOperatorStatefulSet, Kibana, LinseedDeployment, ElasticsearchMetricsDeployment. The following sections provide example configurations for this CR.
+The [LogStorage](../../reference/installation/api.mdx#LogStorage CR provides a way to configure resources for ECKOperatorStatefulSet, Kibana, LinseedDeployment, ElasticsearchMetricsDeployment. The following sections provide example configurations for this CR.
 
 ### ECKOperatorStatefulSet.
 
-To configure resource specification for the [ECKOperatorStatefulSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ECKOperatorStatefulSet), patch the LogStorage CR using the below command:
+To configure resource specification for the [ECKOperatorStatefulSet](../../reference/installation/api.mdx#ECKOperatorStatefulSet, patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"eckOperatorStatefulSet":{"spec": {"template": {"spec": {"containers":[{"name":"manager","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -698,7 +698,7 @@ This command will output the configured resource requests and limits for the ECK
 
 ### Kibana
 
-To configure resource specification for the [Kibana](../../reference/installation/api.mdx#operator.tigera.io/v1.Kibana), patch the LogStorage CR using the below command:
+To configure resource specification for the [Kibana](../../reference/installation/api.mdx#Kibana, patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"kibana":{"spec": {"template": {"spec": {"containers":[{"name":"kibana","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -733,7 +733,7 @@ This command will output the configured resource requests and limits for the Kib
 
 ### LinseedDeployment
 
-To configure resource specification for the [LinseedDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.LinseedDeployment), patch the LogStorage CR using the below command:
+To configure resource specification for the [LinseedDeployment](../../reference/installation/api.mdx#LinseedDeployment, patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"linseedDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-linseed","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -768,7 +768,7 @@ This command will output the configured resource requests and limits for the Lin
 
 ### ElasticsearchMetricsDeployment
 
-To configure resource specification for the [ElasticsearchMetricsDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ElasticsearchMetricsDeployment), patch the LogStorage CR using the below command:
+To configure resource specification for the [ElasticsearchMetricsDeployment](../../reference/installation/api.mdx#ElasticsearchMetricsDeployment, patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"elasticsearchMetricsDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-elasticsearch-metrics","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -803,11 +803,11 @@ This command will output the configured resource requests and limits for the Ela
 
 ## ManagementClusterConnection custom resource
 
-The [ManagementClusterConnection](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
+The [ManagementClusterConnection](../../reference/installation/api.mdx#ManagementClusterConnection CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
 
 ### GuardianDeployment
 
-To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.GuardianDeployment), patch the ManagementClusterConnection CR using the below command:
+To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#GuardianDeployment, patch the ManagementClusterConnection CR using the below command:
 
 ```bash
 kubectl patch managementclusterconnection tigera-secure  --type=merge --patch='{"spec": {"guardianDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-guardian","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -842,11 +842,11 @@ This command will output the configured resource requests and limits for the Gua
 
 ## Manager custom resource
 
-The [Manager](../../reference/installation/api.mdx#operator.tigera.io/v1.Manager) CR provides a way to configure resources for ManagerDeployment. The following sections provide example configurations for this CR.
+The [Manager](../../reference/installation/api.mdx#Manager CR provides a way to configure resources for ManagerDeployment. The following sections provide example configurations for this CR.
 
 ### ManagerDeployment
 
-To configure resource specification for the [ManagerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagerDeployment), patch the Manager CR using the below command:
+To configure resource specification for the [ManagerDeployment](../../reference/installation/api.mdx#ManagerDeployment, patch the Manager CR using the below command:
 
 ```bash
 kubectl patch manager tigera-secure  --type=merge --patch='{"spec": {"managerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-voltron","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-es-proxy","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-manager","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -908,11 +908,11 @@ This command will output the configured resource requests and limits for the Man
 
 ## Monitor custom resource
 
-The [Monitor](../../reference/installation/api.mdx#operator.tigera.io/v1.Monitor) CR provides a way to configure resources for Prometheus, AlertManager. The following sections provide example configurations for this CR.
+The [Monitor](../../reference/installation/api.mdx#Monitor CR provides a way to configure resources for Prometheus, AlertManager. The following sections provide example configurations for this CR.
 
 ### Prometheus
 
-To configure resource specification for the [Prometheus](../../reference/installation/api.mdx#operator.tigera.io/v1.Prometheus), Resources for the default container "prometheus" can be configured using the "resources" field under "commonPrometheusFields". For all other injected containers, such as "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
+To configure resource specification for the [Prometheus](../../reference/installation/api.mdx#Prometheus, Resources for the default container "prometheus" can be configured using the "resources" field under "commonPrometheusFields". For all other injected containers, such as "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
 
 ```bash
 kubectl patch monitor tigera-secure --type=merge --patch='{"spec": {"prometheus": {"spec":{ "commonPrometheusFields": {"resources": {"limits": {"cpu":"500m","memory":"500Mi"}, "requests": {"cpu":"50m", "memory":"50Mi"}}, "containers":[{"name":"authn-proxy","resources":{"limits": {"cpu":"250m","memory":"500Mi"},"requests": {"cpu":"25m","memory":"50Mi"}}}]}}}}}'
@@ -977,7 +977,7 @@ The "config-reloader" container has default resource values set based by the Pro
 
 ### AlertManager
 
-To configure resource specification for the [AlertManager](../../reference/installation/api.mdx#operator.tigera.io/v1.AlertManager),  you can set resources for the default container "prometheus" using the "resources" field under "commonPrometheusFields". For all other injected containers, like "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
+To configure resource specification for the [AlertManager](../../reference/installation/api.mdx#AlertManager,  you can set resources for the default container "prometheus" using the "resources" field under "commonPrometheusFields". For all other injected containers, like "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
 
 ```bash
 kubectl patch monitor tigera-secure  --type=merge --patch='{"spec": {"alertManager": {"spec": {"resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}}}}'
@@ -1029,11 +1029,11 @@ The "config-reloader" container has default resource values set by the AlertMana
 
 ## PacketCaptureAPI custom resource
 
-The [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
+The [PacketCaptureAPI](../../reference/installation/api.mdx#PacketCaptureAPI CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
 
 ### PacketCaptureAPIDeployment
 
-To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI), patch the PacketCapture CR using the below command:
+To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#PacketCaptureAPI, patch the PacketCapture CR using the below command:
 
 ```bash
 kubectl patch packetcaptureapis tigera-secure  --type=merge --patch='{"spec": {"packetCaptureAPIDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-packetcapture-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -1068,11 +1068,11 @@ This command will output the configured resource requests and limits for the Pac
 
 ## PolicyRecommendation custom resource
 
-The [PolicyRecommendation](../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendation) CR provides a way to configure resources for PolicyRecommendation. The following sections provide example configurations for this CR.
+The [PolicyRecommendation](../../reference/installation/api.mdx#PolicyRecommendation CR provides a way to configure resources for PolicyRecommendation. The following sections provide example configurations for this CR.
 
 ### PolicyRecommendationDeployment
 
-To configure resource specification for the [PolicyRecommendationDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendationDeployment), patch the PolicyRecommendation CR using the below command:
+To configure resource specification for the [PolicyRecommendationDeployment](../../reference/installation/api.mdx#PolicyRecommendationDeployment, patch the PolicyRecommendation CR using the below command:
 
 ```bash
 kubectl patch policyrecommendation tigera-secure  --type=merge --patch='{"spec": {"policyRecommendationDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"policy-recommendation-controller","resources":{"requests":{"cpu":"100m", "memory":"100Mi"},"limits":{"cpu":"1", "memory":"512Mi"}}}]}}}}}}'
@@ -1116,11 +1116,11 @@ The provided example illustrates configuring the apiserver component. Follow a s
 
 ### APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
+The [APIServer](../../reference/installation/api.mdx#APIServer CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
 
 #### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), update values.yaml with the appropriate resource values.
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#APIServerDeployment, update values.yaml with the appropriate resource values.
 
 ```bash
 apiServer:

--- a/calico-enterprise_versioned_docs/version-3.20-1/reference/component-resources/typha/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/reference/component-resources/typha/prometheus.mdx
@@ -7,7 +7,7 @@ import variables from '@site/calico-enterprise_versioned_docs/version-3.20-1/var
 # Prometheus metrics
 
 Typha can be configured to report a number of metrics through Prometheus. The Prometheus port can be controlled
-via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#operator.tigera.io/v1.Installation).
+via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#Installation.
 
 ## Metric reference
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/reference/installation/_api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/reference/installation/_api.mdx
@@ -15,47 +15,47 @@ API Schema definitions for configuring the installation of Calico and Calico Ent
 </p>
 Resource Types:
 <ul><li>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>
+<a href="#APIServer">APIServer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>
+<a href="#ApplicationLayer">ApplicationLayer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>
+<a href="#Authentication">Authentication</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>
+<a href="#Compliance">Compliance</a>
 </li><li>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>
+<a href="#EgressGateway">EgressGateway</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>
+<a href="#ImageSet">ImageSet</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>
+<a href="#Installation">Installation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>
+<a href="#IntrusionDetection">IntrusionDetection</a>
 </li><li>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>
+<a href="#LogCollector">LogCollector</a>
 </li><li>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>
+<a href="#LogStorage">LogStorage</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ManagementCluster">ManagementCluster</a>
+<a href="#ManagementCluster">ManagementCluster</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>
+<a href="#Manager">Manager</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>
+<a href="#Monitor">Monitor</a>
 </li><li>
-<a href="#operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</a>
+<a href="#PacketCaptureAPI">PacketCaptureAPI</a>
 </li><li>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>
+<a href="#PolicyRecommendation">PolicyRecommendation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TLSPassThroughRoute">TLSPassThroughRoute</a>
+<a href="#TLSPassThroughRoute">TLSPassThroughRoute</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TLSTerminatedRoute">TLSTerminatedRoute</a>
+<a href="#TLSTerminatedRoute">TLSTerminatedRoute</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>
+<a href="#Tenant">Tenant</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>
+<a href="#TigeraStatus">TigeraStatus</a>
 </li></ul>
-<h3 id="operator.tigera.io/v1.APIServer">APIServer</h3>
+<h3 id="APIServer">APIServer</h3>
 <p>
 APIServer installs the Tigera API server and related resources. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo; or &ldquo;tigera-secure&rdquo;.
@@ -116,7 +116,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerSpec">
+<a href="#APIServerSpec">
 APIServerSpec
 </a>
 </em>
@@ -134,7 +134,7 @@ Specification of the desired state for the Tigera API server.
 <td>
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -158,7 +158,7 @@ take precedence.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerStatus">
+<a href="#APIServerStatus">
 APIServerStatus
 </a>
 </em>
@@ -174,7 +174,7 @@ Most recently observed status for the Tigera API server.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</h3>
+<h3 id="ApplicationLayer">ApplicationLayer</h3>
 <p>
 ApplicationLayer is the Schema for the applicationlayers API
 </p>
@@ -234,7 +234,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">
+<a href="#ApplicationLayerSpec">
 ApplicationLayerSpec
 </a>
 </em>
@@ -249,7 +249,7 @@ ApplicationLayerSpec
 <td>
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -269,7 +269,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -288,7 +288,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -308,7 +308,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -327,7 +327,7 @@ User-configurable settings for the Envoy proxy.
 
 <code>l7LogCollectorDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSet">
+<a href="#L7LogCollectorDaemonSet">
 L7LogCollectorDaemonSet
 </a>
 </em>
@@ -350,7 +350,7 @@ L7LogCollectorDaemonSet configures the L7LogCollector DaemonSet.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerStatus">
+<a href="#ApplicationLayerStatus">
 ApplicationLayerStatus
 </a>
 </em>
@@ -363,7 +363,7 @@ ApplicationLayerStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Authentication">Authentication</h3>
+<h3 id="Authentication">Authentication</h3>
 <p>
 Authentication is the Schema for the authentications API
 </p>
@@ -423,7 +423,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">
+<a href="#AuthenticationSpec">
 AuthenticationSpec
 </a>
 </em>
@@ -495,7 +495,7 @@ ClusterRoleBindings into Elastic.
 
 <code>oidc</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">
+<a href="#AuthenticationOIDC">
 AuthenticationOIDC
 </a>
 </em>
@@ -515,7 +515,7 @@ OIDC contains the configuration needed to setup OIDC authentication.
 
 <code>openshift</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOpenshift">
+<a href="#AuthenticationOpenshift">
 AuthenticationOpenshift
 </a>
 </em>
@@ -535,7 +535,7 @@ Openshift contains the configuration needed to setup Openshift OAuth authenticat
 
 <code>ldap</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">
+<a href="#AuthenticationLDAP">
 AuthenticationLDAP
 </a>
 </em>
@@ -555,7 +555,7 @@ LDAP contains the configuration needed to setup LDAP authentication.
 
 <code>dexDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeployment">
+<a href="#DexDeployment">
 DexDeployment
 </a>
 </em>
@@ -578,7 +578,7 @@ DexDeployment configures the Dex Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationStatus">
+<a href="#AuthenticationStatus">
 AuthenticationStatus
 </a>
 </em>
@@ -591,7 +591,7 @@ AuthenticationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Compliance">Compliance</h3>
+<h3 id="Compliance">Compliance</h3>
 <p>
 Compliance installs the components required for Tigera compliance reporting. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -652,7 +652,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">
+<a href="#ComplianceSpec">
 ComplianceSpec
 </a>
 </em>
@@ -670,7 +670,7 @@ Specification of the desired state for Tigera compliance reporting.
 <td>
 <code>complianceControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeployment">
+<a href="#ComplianceControllerDeployment">
 ComplianceControllerDeployment
 </a>
 </em>
@@ -690,7 +690,7 @@ ComplianceControllerDeployment configures the Compliance Controller Deployment.
 
 <code>complianceSnapshotterDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeployment">
+<a href="#ComplianceSnapshotterDeployment">
 ComplianceSnapshotterDeployment
 </a>
 </em>
@@ -710,7 +710,7 @@ ComplianceSnapshotterDeployment configures the Compliance Snapshotter Deployment
 
 <code>complianceBenchmarkerDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">
+<a href="#ComplianceBenchmarkerDaemonSet">
 ComplianceBenchmarkerDaemonSet
 </a>
 </em>
@@ -730,7 +730,7 @@ ComplianceBenchmarkerDaemonSet configures the Compliance Benchmarker DaemonSet.
 
 <code>complianceServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeployment">
+<a href="#ComplianceServerDeployment">
 ComplianceServerDeployment
 </a>
 </em>
@@ -750,7 +750,7 @@ ComplianceServerDeployment configures the Compliance Server Deployment.
 
 <code>complianceReporterPodTemplate</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplate">
+<a href="#ComplianceReporterPodTemplate">
 ComplianceReporterPodTemplate
 </a>
 </em>
@@ -773,7 +773,7 @@ ComplianceReporterPodTemplate configures the Compliance Reporter PodTemplate.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceStatus">
+<a href="#ComplianceStatus">
 ComplianceStatus
 </a>
 </em>
@@ -789,7 +789,7 @@ Most recently observed state for Tigera compliance reporting.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGateway">EgressGateway</h3>
+<h3 id="EgressGateway">EgressGateway</h3>
 <p>
 EgressGateway is the Schema for the egressgateways API
 </p>
@@ -849,7 +849,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">
+<a href="#EgressGatewaySpec">
 EgressGatewaySpec
 </a>
 </em>
@@ -882,7 +882,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -923,7 +923,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -944,7 +944,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -964,7 +964,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -988,7 +988,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -1011,7 +1011,7 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayStatus">
+<a href="#EgressGatewayStatus">
 EgressGatewayStatus
 </a>
 </em>
@@ -1024,7 +1024,7 @@ EgressGatewayStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSet">ImageSet</h3>
+<h3 id="ImageSet">ImageSet</h3>
 <p>
 ImageSet is used to specify image digests for the images that the operator deploys.
 The name of the ImageSet is expected to be in the format <code>&lt;variant&gt;-&lt;release&gt;</code>.
@@ -1089,7 +1089,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">
+<a href="#ImageSetSpec">
 ImageSetSpec
 </a>
 </em>
@@ -1104,7 +1104,7 @@ ImageSetSpec
 <td>
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -1124,7 +1124,7 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Installation">Installation</h3>
+<h3 id="Installation">Installation</h3>
 <p>
 Installation configures an installation of Calico or Calico Enterprise. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo;. The Installation API installs core networking
@@ -1186,7 +1186,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -1204,7 +1204,7 @@ Specification of the desired state for the Calico or Calico Enterprise installat
 <td>
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -1332,7 +1332,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -1355,7 +1355,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -1375,7 +1375,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -1395,7 +1395,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -1574,7 +1574,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -1596,7 +1596,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -1618,7 +1618,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -1638,7 +1638,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -1658,7 +1658,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -1677,7 +1677,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -1697,7 +1697,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -1717,7 +1717,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -1737,7 +1737,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -1756,7 +1756,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -1777,7 +1777,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -1797,7 +1797,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -1838,7 +1838,7 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationStatus">
+<a href="#InstallationStatus">
 InstallationStatus
 </a>
 </em>
@@ -1854,7 +1854,7 @@ Most recently observed state for the Calico or Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</h3>
+<h3 id="IntrusionDetection">IntrusionDetection</h3>
 <p>
 IntrusionDetection installs the components required for Tigera intrusion detection. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -1915,7 +1915,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">
+<a href="#IntrusionDetectionSpec">
 IntrusionDetectionSpec
 </a>
 </em>
@@ -1933,7 +1933,7 @@ Specification of the desired state for Tigera intrusion detection.
 <td>
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">
+<a href="#IntrusionDetectionComponentResource">
 []IntrusionDetectionComponentResource
 </a>
 </em>
@@ -1954,7 +1954,7 @@ Only DeepPacketInspection is supported for this spec.
 
 <code>anomalyDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+<a href="#AnomalyDetectionSpec">
 AnomalyDetectionSpec
 </a>
 </em>
@@ -1974,7 +1974,7 @@ AnomalyDetection is now deprecated, and configuring it has no effect.
 
 <code>intrusionDetectionControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeployment">
+<a href="#IntrusionDetectionControllerDeployment">
 IntrusionDetectionControllerDeployment
 </a>
 </em>
@@ -1997,7 +1997,7 @@ IntrusionDetectionControllerDeployment configures the IntrusionDetection Control
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionStatus">
+<a href="#IntrusionDetectionStatus">
 IntrusionDetectionStatus
 </a>
 </em>
@@ -2013,7 +2013,7 @@ Most recently observed state for Tigera intrusion detection.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollector">LogCollector</h3>
+<h3 id="LogCollector">LogCollector</h3>
 <p>
 LogCollector installs the components required for Tigera flow and DNS log collection. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;. When created, this installs fluentd on all nodes
@@ -2075,7 +2075,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">
+<a href="#LogCollectorSpec">
 LogCollectorSpec
 </a>
 </em>
@@ -2093,7 +2093,7 @@ Specification of the desired state for Tigera log collection.
 <td>
 <code>additionalStores</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">
+<a href="#AdditionalLogStoreSpec">
 AdditionalLogStoreSpec
 </a>
 </em>
@@ -2113,7 +2113,7 @@ Configuration for exporting flow, audit, and DNS logs to external storage.
 
 <code>additionalSources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">
+<a href="#AdditionalLogSourceSpec">
 AdditionalLogSourceSpec
 </a>
 </em>
@@ -2133,7 +2133,7 @@ Configuration for importing audit logs from managed kubernetes cluster log sourc
 
 <code>collectProcessPath</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CollectProcessPathOption">
+<a href="#CollectProcessPathOption">
 CollectProcessPathOption
 </a>
 </em>
@@ -2174,7 +2174,7 @@ the management cluster&rsquo;s tenant services are running.
 
 <code>fluentdDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSet">
+<a href="#FluentdDaemonSet">
 FluentdDaemonSet
 </a>
 </em>
@@ -2193,7 +2193,7 @@ FluentdDaemonSet configures the Fluentd DaemonSet.
 
 <code>eksLogForwarderDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeployment">
+<a href="#EKSLogForwarderDeployment">
 EKSLogForwarderDeployment
 </a>
 </em>
@@ -2216,7 +2216,7 @@ EKSLogForwarderDeployment configures the EKSLogForwarderDeployment Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectorStatus">
+<a href="#LogCollectorStatus">
 LogCollectorStatus
 </a>
 </em>
@@ -2232,7 +2232,7 @@ Most recently observed state for Tigera log collection.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorage">LogStorage</h3>
+<h3 id="LogStorage">LogStorage</h3>
 <p>
 LogStorage installs the components required for Tigera flow and DNS log storage. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;. When created, this installs an Elasticsearch cluster for use by
@@ -2294,7 +2294,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">
+<a href="#LogStorageSpec">
 LogStorageSpec
 </a>
 </em>
@@ -2312,7 +2312,7 @@ Specification of the desired state for Tigera log storage.
 <td>
 <code>nodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Nodes">
+<a href="#Nodes">
 Nodes
 </a>
 </em>
@@ -2331,7 +2331,7 @@ Nodes defines the configuration for a set of identical Elasticsearch cluster nod
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Indices">
+<a href="#Indices">
 Indices
 </a>
 </em>
@@ -2351,7 +2351,7 @@ Index defines the configuration for the indices in the Elasticsearch cluster.
 
 <code>retention</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Retention">
+<a href="#Retention">
 Retention
 </a>
 </em>
@@ -2413,7 +2413,7 @@ each of the indicated key-value pairs as labels as well as access to the specifi
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">
+<a href="#LogStorageComponentResource">
 []LogStorageComponentResource
 </a>
 </em>
@@ -2434,7 +2434,7 @@ Only ECKOperator is supported for this spec.
 
 <code>eckOperatorStatefulSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSet">
+<a href="#ECKOperatorStatefulSet">
 ECKOperatorStatefulSet
 </a>
 </em>
@@ -2455,7 +2455,7 @@ ComponentResources, then these overrides take precedence.
 
 <code>kibana</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Kibana">
+<a href="#Kibana">
 Kibana
 </a>
 </em>
@@ -2475,7 +2475,7 @@ Kibana configures the Kibana Spec.
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -2494,7 +2494,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>elasticsearchMetricsDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeployment">
+<a href="#ElasticsearchMetricsDeployment">
 ElasticsearchMetricsDeployment
 </a>
 </em>
@@ -2516,7 +2516,7 @@ ElasticsearchMetricsDeployment configures the tigera-elasticsearch-metric Deploy
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageStatus">
+<a href="#LogStorageStatus">
 LogStorageStatus
 </a>
 </em>
@@ -2532,7 +2532,7 @@ Most recently observed state for Tigera log storage.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementCluster">ManagementCluster</h3>
+<h3 id="ManagementCluster">ManagementCluster</h3>
 <p>
 The presence of ManagementCluster in your cluster, will configure it to be the management plane to which managed
 clusters can connect. At most one instance of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2593,7 +2593,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterSpec">
+<a href="#ManagementClusterSpec">
 ManagementClusterSpec
 </a>
 </em>
@@ -2628,7 +2628,7 @@ Valid examples are: &ldquo;0.0.0.0:31000&rdquo;, &ldquo;example.com:32000&rdquo;
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLS">
+<a href="#TLS">
 TLS
 </a>
 </em>
@@ -2648,7 +2648,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</h3>
+<h3 id="ManagementClusterConnection">ManagementClusterConnection</h3>
 <p>
 ManagementClusterConnection represents a link between a managed cluster and a management cluster. At most one
 instance of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2709,7 +2709,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">
+<a href="#ManagementClusterConnectionSpec">
 ManagementClusterConnectionSpec
 </a>
 </em>
@@ -2743,7 +2743,7 @@ should be able to access this address. This field is used by managed clusters on
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">
+<a href="#ManagementClusterTLS">
 ManagementClusterTLS
 </a>
 </em>
@@ -2763,7 +2763,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>guardianDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeployment">
+<a href="#GuardianDeployment">
 GuardianDeployment
 </a>
 </em>
@@ -2785,7 +2785,7 @@ GuardianDeployment configures the guardian Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionStatus">
+<a href="#ManagementClusterConnectionStatus">
 ManagementClusterConnectionStatus
 </a>
 </em>
@@ -2798,7 +2798,7 @@ ManagementClusterConnectionStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Manager">Manager</h3>
+<h3 id="Manager">Manager</h3>
 <p>
 Manager installs the Calico Enterprise manager graphical user interface. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2859,7 +2859,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerSpec">
+<a href="#ManagerSpec">
 ManagerSpec
 </a>
 </em>
@@ -2877,7 +2877,7 @@ Specification of the desired state for the Calico Enterprise manager.
 <td>
 <code>managerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeployment">
+<a href="#ManagerDeployment">
 ManagerDeployment
 </a>
 </em>
@@ -2900,7 +2900,7 @@ ManagerDeployment configures the Manager Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerStatus">
+<a href="#ManagerStatus">
 ManagerStatus
 </a>
 </em>
@@ -2916,7 +2916,7 @@ Most recently observed state for the Calico Enterprise manager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Monitor">Monitor</h3>
+<h3 id="Monitor">Monitor</h3>
 <p>
 Monitor is the Schema for the monitor API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -2977,7 +2977,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorSpec">
+<a href="#MonitorSpec">
 MonitorSpec
 </a>
 </em>
@@ -2992,7 +2992,7 @@ MonitorSpec
 <td>
 <code>externalPrometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">
+<a href="#ExternalPrometheus">
 ExternalPrometheus
 </a>
 </em>
@@ -3013,7 +3013,7 @@ scraping from git-ops tools without the need of post-installation steps.
 
 <code>prometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Prometheus">
+<a href="#Prometheus">
 Prometheus
 </a>
 </em>
@@ -3033,7 +3033,7 @@ Prometheus is the configuration for the Prometheus.
 
 <code>alertManager</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AlertManager">
+<a href="#AlertManager">
 AlertManager
 </a>
 </em>
@@ -3056,7 +3056,7 @@ AlertManager is the configuration for the AlertManager.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorStatus">
+<a href="#MonitorStatus">
 MonitorStatus
 </a>
 </em>
@@ -3069,7 +3069,7 @@ MonitorStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</h3>
+<h3 id="PacketCaptureAPI">PacketCaptureAPI</h3>
 <p>
 PacketCaptureAPI is used to configure the resource requirement for PacketCaptureAPI deployment. It must be named &ldquo;tigera-secure&rdquo;.
 </p>
@@ -3129,7 +3129,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPISpec">
+<a href="#PacketCaptureAPISpec">
 PacketCaptureAPISpec
 </a>
 </em>
@@ -3147,7 +3147,7 @@ Specification of the desired state for the PacketCaptureAPI.
 <td>
 <code>packetCaptureAPIDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeployment">
+<a href="#PacketCaptureAPIDeployment">
 PacketCaptureAPIDeployment
 </a>
 </em>
@@ -3170,7 +3170,7 @@ PacketCaptureAPIDeployment configures the PacketCaptureAPI Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIStatus">
+<a href="#PacketCaptureAPIStatus">
 PacketCaptureAPIStatus
 </a>
 </em>
@@ -3186,7 +3186,7 @@ Most recently observed state for the PacketCaptureAPI.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</h3>
+<h3 id="PolicyRecommendation">PolicyRecommendation</h3>
 <p>
 PolicyRecommendation is the Schema for the policy recommendation API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -3247,7 +3247,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationSpec">
+<a href="#PolicyRecommendationSpec">
 PolicyRecommendationSpec
 </a>
 </em>
@@ -3262,7 +3262,7 @@ PolicyRecommendationSpec
 <td>
 <code>policyRecommendationDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeployment">
+<a href="#PolicyRecommendationDeployment">
 PolicyRecommendationDeployment
 </a>
 </em>
@@ -3285,7 +3285,7 @@ PolicyRecommendation configures the PolicyRecommendation Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationStatus">
+<a href="#PolicyRecommendationStatus">
 PolicyRecommendationStatus
 </a>
 </em>
@@ -3298,7 +3298,7 @@ PolicyRecommendationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSPassThroughRoute">TLSPassThroughRoute</h3>
+<h3 id="TLSPassThroughRoute">TLSPassThroughRoute</h3>
 <table>
 <thead>
 <tr>
@@ -3355,7 +3355,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRouteSpec">
+<a href="#TLSPassThroughRouteSpec">
 TLSPassThroughRouteSpec
 </a>
 </em>
@@ -3373,7 +3373,7 @@ Dest is the destination URL
 <td>
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -3389,7 +3389,7 @@ TargetType
 
 <code>sniMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SNIMatch">
+<a href="#SNIMatch">
 SNIMatch
 </a>
 </em>
@@ -3426,7 +3426,7 @@ Destination is the destination url to proxy the request to.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSTerminatedRoute">TLSTerminatedRoute</h3>
+<h3 id="TLSTerminatedRoute">TLSTerminatedRoute</h3>
 <table>
 <thead>
 <tr>
@@ -3483,7 +3483,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLSTerminatedRouteSpec">
+<a href="#TLSTerminatedRouteSpec">
 TLSTerminatedRouteSpec
 </a>
 </em>
@@ -3498,7 +3498,7 @@ TLSTerminatedRouteSpec
 <td>
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -3514,7 +3514,7 @@ TargetType
 
 <code>pathMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PathMatch">
+<a href="#PathMatch">
 PathMatch
 </a>
 </em>
@@ -3632,7 +3632,7 @@ is UI.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Tenant">Tenant</h3>
+<h3 id="Tenant">Tenant</h3>
 <p>
 Tenant is the Schema for the tenants API
 </p>
@@ -3692,7 +3692,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantSpec">
+<a href="#TenantSpec">
 TenantSpec
 </a>
 </em>
@@ -3741,7 +3741,7 @@ Name is a human readable name for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -3760,7 +3760,7 @@ Indices defines the how to store a tenant&rsquo;s data
 
 <code>elastic</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantElasticSpec">
+<a href="#TenantElasticSpec">
 TenantElasticSpec
 </a>
 </em>
@@ -3799,7 +3799,7 @@ in the Tenant&rsquo;s namespace. Defaults to the controlPlaneReplicas in Install
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -3818,7 +3818,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>esKubeControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -3837,7 +3837,7 @@ ESKubeControllerDeployment configures the ESKubeController Deployment.
 
 <code>dashboardsJob</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJob">
+<a href="#DashboardsJob">
 DashboardsJob
 </a>
 </em>
@@ -3859,7 +3859,7 @@ DashboardsJob configures the Dashboards job
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantStatus">
+<a href="#TenantStatus">
 TenantStatus
 </a>
 </em>
@@ -3872,7 +3872,7 @@ TenantStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatus">TigeraStatus</h3>
+<h3 id="TigeraStatus">TigeraStatus</h3>
 <p>
 TigeraStatus represents the most recently observed status for Calico or a Calico Enterprise functional area.
 </p>
@@ -3932,7 +3932,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusSpec">
+<a href="#TigeraStatusSpec">
 TigeraStatusSpec
 </a>
 </em>
@@ -3952,7 +3952,7 @@ TigeraStatusSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">
+<a href="#TigeraStatusStatus">
 TigeraStatusStatus
 </a>
 </em>
@@ -3965,11 +3965,11 @@ TigeraStatusStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</h3>
+<h3 id="APIServerDeployment">APIServerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerSpec">APIServerSpec</a>)
+<a href="#APIServerSpec">APIServerSpec</a>)
 
 </p>
 <p>
@@ -3988,7 +3988,7 @@ APIServerDeployment is the configuration for the API server Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4008,7 +4008,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">
+<a href="#APIServerDeploymentSpec">
 APIServerDeploymentSpec
 </a>
 </em>
@@ -4029,11 +4029,11 @@ Spec is the specification of the API server Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
+<h3 id="APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -4090,11 +4090,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
+<h3 id="APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -4150,11 +4150,11 @@ If omitted, the API server Deployment will use its default value for this init c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
+<h3 id="APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -4173,7 +4173,7 @@ APIServerDeploymentDeploymentPodSpec is the API server Deployment&rsquo;s PodSpe
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentInitContainer">
+<a href="#APIServerDeploymentInitContainer">
 []APIServerDeploymentInitContainer
 </a>
 </em>
@@ -4195,7 +4195,7 @@ If omitted, the API server Deployment will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentContainer">
+<a href="#APIServerDeploymentContainer">
 []APIServerDeploymentContainer
 </a>
 </em>
@@ -4306,11 +4306,11 @@ WARNING: Please note that this field will override the default API server Deploy
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
+<h3 id="APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
+<a href="#APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -4329,7 +4329,7 @@ APIServerDeploymentPodTemplateSpec is the API server Deployment&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4350,7 +4350,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">
+<a href="#APIServerDeploymentPodSpec">
 APIServerDeploymentPodSpec
 </a>
 </em>
@@ -4371,11 +4371,11 @@ Spec is the API server Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
+<h3 id="APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>)
 
 </p>
 <p>
@@ -4415,7 +4415,7 @@ If omitted, the API server Deployment will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">
+<a href="#APIServerDeploymentPodTemplateSpec">
 APIServerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -4432,11 +4432,11 @@ Template describes the API server Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerSpec">APIServerSpec</h3>
+<h3 id="APIServerSpec">APIServerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -4455,7 +4455,7 @@ APIServerSpec defines the desired state of Tigera API server.
 
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -4473,11 +4473,11 @@ take precedence.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerStatus">APIServerStatus</h3>
+<h3 id="APIServerStatus">APIServerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -4531,11 +4531,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</h3>
+<h3 id="AWSEgressGateway">AWSEgressGateway</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -4554,7 +4554,7 @@ AWSEgressGateway defines the configurations for deploying EgressGateway in AWS
 
 <code>nativeIP</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NativeIP">
+<a href="#NativeIP">
 NativeIP
 </a>
 </em>
@@ -4591,11 +4591,11 @@ NativeIP must be Enabled if elastic IPs are set.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AdditionalLogSourceSpec">AdditionalLogSourceSpec</h3>
+<h3 id="AdditionalLogSourceSpec">AdditionalLogSourceSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <table>
@@ -4611,7 +4611,7 @@ NativeIP must be Enabled if elastic IPs are set.
 
 <code>eksCloudwatchLog</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EksCloudwatchLogsSpec">
+<a href="#EksCloudwatchLogsSpec">
 EksCloudwatchLogsSpec
 </a>
 </em>
@@ -4629,11 +4629,11 @@ audit logs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</h3>
+<h3 id="AdditionalLogStoreSpec">AdditionalLogStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <table>
@@ -4649,7 +4649,7 @@ audit logs.
 
 <code>s3</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.S3StoreSpec">
+<a href="#S3StoreSpec">
 S3StoreSpec
 </a>
 </em>
@@ -4669,7 +4669,7 @@ If specified, enables exporting of flow, audit, and DNS logs to Amazon S3 storag
 
 <code>syslog</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">
+<a href="#SyslogStoreSpec">
 SyslogStoreSpec
 </a>
 </em>
@@ -4689,7 +4689,7 @@ If specified, enables exporting of flow, audit, and DNS logs to syslog.
 
 <code>splunk</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SplunkStoreSpec">
+<a href="#SplunkStoreSpec">
 SplunkStoreSpec
 </a>
 </em>
@@ -4706,11 +4706,11 @@ If specified, enables exporting of flow, audit, and DNS logs to splunk.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AlertManager">AlertManager</h3>
+<h3 id="AlertManager">AlertManager</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.MonitorSpec">MonitorSpec</a>)
+<a href="#MonitorSpec">MonitorSpec</a>)
 
 </p>
 <table>
@@ -4726,7 +4726,7 @@ If specified, enables exporting of flow, audit, and DNS logs to splunk.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AlertManagerSpec">
+<a href="#AlertManagerSpec">
 AlertManagerSpec
 </a>
 </em>
@@ -4747,11 +4747,11 @@ Spec is the specification of the Alertmanager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AlertManagerSpec">AlertManagerSpec</h3>
+<h3 id="AlertManagerSpec">AlertManagerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AlertManager">AlertManager</a>)
+<a href="#AlertManager">AlertManager</a>)
 
 </p>
 <table>
@@ -4783,11 +4783,11 @@ Define resources requests and limits for single Pods.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
+<h3 id="AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <table>
@@ -4818,19 +4818,19 @@ StorageClassName is now deprecated, and configuring it has no effect.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
+<h3 id="ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</h3>
+<h3 id="ApplicationLayerSpec">ApplicationLayerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -4849,7 +4849,7 @@ ApplicationLayerSpec defines the desired state of ApplicationLayer
 
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -4869,7 +4869,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -4888,7 +4888,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -4908,7 +4908,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -4927,7 +4927,7 @@ User-configurable settings for the Envoy proxy.
 
 <code>l7LogCollectorDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSet">
+<a href="#L7LogCollectorDaemonSet">
 L7LogCollectorDaemonSet
 </a>
 </em>
@@ -4944,11 +4944,11 @@ L7LogCollectorDaemonSet configures the L7LogCollector DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerStatus">ApplicationLayerStatus</h3>
+<h3 id="ApplicationLayerStatus">ApplicationLayerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -5002,13 +5002,13 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthMethod">AuthMethod
+<h3 id="AuthMethod">AuthMethod
 (<code>string</code> alias)</h3>
-<h3 id="operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</h3>
+<h3 id="AuthenticationLDAP">AuthenticationLDAP</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -5064,7 +5064,7 @@ the ldaps:// protocol.
 
 <code>userSearch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.UserSearch">
+<a href="#UserSearch">
 UserSearch
 </a>
 </em>
@@ -5083,7 +5083,7 @@ User entry search configuration to match the credentials with a user.
 
 <code>groupSearch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GroupSearch">
+<a href="#GroupSearch">
 GroupSearch
 </a>
 </em>
@@ -5100,11 +5100,11 @@ Group search configuration to find the groups that a user is in.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</h3>
+<h3 id="AuthenticationOIDC">AuthenticationOIDC</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -5230,7 +5230,7 @@ Deprecated. Please use Authentication.Spec.GroupsPrefix instead.
 
 <code>emailVerification</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EmailVerificationType">
+<a href="#EmailVerificationType">
 EmailVerificationType
 </a>
 </em>
@@ -5253,7 +5253,7 @@ Default: Verify
 
 <code>promptTypes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PromptType">
+<a href="#PromptType">
 []PromptType
 </a>
 </em>
@@ -5276,7 +5276,7 @@ Default: &ldquo;Consent&rdquo;
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.OIDCType">
+<a href="#OIDCType">
 OIDCType
 </a>
 </em>
@@ -5293,11 +5293,11 @@ Default: &ldquo;Dex&rdquo;
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationOpenshift">AuthenticationOpenshift</h3>
+<h3 id="AuthenticationOpenshift">AuthenticationOpenshift</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -5330,11 +5330,11 @@ IssuerURL is the URL to the Openshift OAuth provider. Ex.: <a href="https://api.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</h3>
+<h3 id="AuthenticationSpec">AuthenticationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>)
+<a href="#Authentication">Authentication</a>)
 
 </p>
 <p>
@@ -5410,7 +5410,7 @@ ClusterRoleBindings into Elastic.
 
 <code>oidc</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">
+<a href="#AuthenticationOIDC">
 AuthenticationOIDC
 </a>
 </em>
@@ -5430,7 +5430,7 @@ OIDC contains the configuration needed to setup OIDC authentication.
 
 <code>openshift</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationOpenshift">
+<a href="#AuthenticationOpenshift">
 AuthenticationOpenshift
 </a>
 </em>
@@ -5450,7 +5450,7 @@ Openshift contains the configuration needed to setup Openshift OAuth authenticat
 
 <code>ldap</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">
+<a href="#AuthenticationLDAP">
 AuthenticationLDAP
 </a>
 </em>
@@ -5470,7 +5470,7 @@ LDAP contains the configuration needed to setup LDAP authentication.
 
 <code>dexDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeployment">
+<a href="#DexDeployment">
 DexDeployment
 </a>
 </em>
@@ -5487,11 +5487,11 @@ DexDeployment configures the Dex Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AuthenticationStatus">AuthenticationStatus</h3>
+<h3 id="AuthenticationStatus">AuthenticationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Authentication">Authentication</a>)
+<a href="#Authentication">Authentication</a>)
 
 </p>
 <p>
@@ -5545,12 +5545,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.BGPOption">BGPOption
+<h3 id="BGPOption">BGPOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -5559,12 +5559,12 @@ BGPOption describes the mode of BGP to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.CAType">CAType
+<h3 id="CAType">CAType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">ManagementClusterTLS</a>)
+<a href="#ManagementClusterTLS">ManagementClusterTLS</a>)
 
 </p>
 <p>
@@ -5573,11 +5573,11 @@ CAType specifies which verification method the tunnel client should use to verif
 <p>
 One of: Tigera, Public
 </p>
-<h3 id="operator.tigera.io/v1.CNILogging">CNILogging</h3>
+<h3 id="CNILogging">CNILogging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Logging">Logging</a>)
+<a href="#Logging">Logging</a>)
 
 </p>
 <table>
@@ -5593,7 +5593,7 @@ One of: Tigera, Public
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -5664,12 +5664,12 @@ Default: 10
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CNIPluginType">CNIPluginType
+<h3 id="CNIPluginType">CNIPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -5678,11 +5678,11 @@ CNIPluginType describes the type of CNI plugin used.
 <p>
 One of: Calico, GKE, AmazonVPC, AzureVNET
 </p>
-<h3 id="operator.tigera.io/v1.CNISpec">CNISpec</h3>
+<h3 id="CNISpec">CNISpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5701,7 +5701,7 @@ CNISpec contains configuration for the CNI plugin.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNIPluginType">
+<a href="#CNIPluginType">
 CNIPluginType
 </a>
 </em>
@@ -5733,7 +5733,7 @@ Default: Calico
 
 <code>ipam</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMSpec">
+<a href="#IPAMSpec">
 IPAMSpec
 </a>
 </em>
@@ -5751,11 +5751,11 @@ Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
+<h3 id="CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5774,7 +5774,7 @@ CSINodeDriverDaemonSet is the configuration for the csi-node-driver DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5794,7 +5794,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">
+<a href="#CSINodeDriverDaemonSetSpec">
 CSINodeDriverDaemonSetSpec
 </a>
 </em>
@@ -5815,11 +5815,11 @@ Spec is the specification of the csi-node-driver DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
+<h3 id="CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -5875,11 +5875,11 @@ If omitted, the csi-node-driver DaemonSet will use its default value for this co
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -5898,7 +5898,7 @@ CSINodeDriverDaemonSetPodSpec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">
+<a href="#CSINodeDriverDaemonSetContainer">
 []CSINodeDriverDaemonSetContainer
 </a>
 </em>
@@ -5985,11 +5985,11 @@ WARNING: Please note that this field will override the default csi-node-driver D
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
+<a href="#CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -6008,7 +6008,7 @@ CSINodeDriverDaemonSetPodTemplateSpec is the csi-node-driver DaemonSet&rsquo;s P
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6029,7 +6029,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">
+<a href="#CSINodeDriverDaemonSetPodSpec">
 CSINodeDriverDaemonSetPodSpec
 </a>
 </em>
@@ -6050,11 +6050,11 @@ Spec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
+<h3 id="CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
 
 </p>
 <p>
@@ -6094,7 +6094,7 @@ If omitted, the csi-node-driver DaemonSet will use its default value for minRead
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">
 CSINodeDriverDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -6111,12 +6111,12 @@ Template describes the csi-node-driver DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
+<h3 id="CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>, 
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -6135,7 +6135,7 @@ CalicoKubeControllersDeployment is the configuration for the calico-kube-control
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6155,7 +6155,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">
+<a href="#CalicoKubeControllersDeploymentSpec">
 CalicoKubeControllersDeploymentSpec
 </a>
 </em>
@@ -6176,11 +6176,11 @@ Spec is the specification of the calico-kube-controllers Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
+<h3 id="CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -6237,11 +6237,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6260,7 +6260,7 @@ CalicoKubeControllersDeploymentPodSpec is the calico-kube-controller Deployment&
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">
+<a href="#CalicoKubeControllersDeploymentContainer">
 []CalicoKubeControllersDeploymentContainer
 </a>
 </em>
@@ -6349,11 +6349,11 @@ WARNING: Please note that this field will override the default calico-kube-contr
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
+<a href="#CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
 
 </p>
 <p>
@@ -6372,7 +6372,7 @@ CalicoKubeControllersDeploymentPodTemplateSpec is the calico-kube-controllers De
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6393,7 +6393,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">
+<a href="#CalicoKubeControllersDeploymentPodSpec">
 CalicoKubeControllersDeploymentPodSpec
 </a>
 </em>
@@ -6414,11 +6414,11 @@ Spec is the calico-kube-controllers Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
 
 </p>
 <p>
@@ -6458,7 +6458,7 @@ If omitted, the calico-kube-controllers Deployment will use its default value fo
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">
 CalicoKubeControllersDeploymentPodTemplateSpec
 </a>
 </em>
@@ -6475,11 +6475,11 @@ Template describes the calico-kube-controllers Deployment pod that will be creat
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</h3>
+<h3 id="CalicoNetworkSpec">CalicoNetworkSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -6498,7 +6498,7 @@ CalicoNetworkSpec specifies configuration options for Calico provided pod networ
 
 <code>linuxDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinuxDataplaneOption">
+<a href="#LinuxDataplaneOption">
 LinuxDataplaneOption
 </a>
 </em>
@@ -6521,7 +6521,7 @@ Default: Iptables
 
 <code>windowsDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsDataplaneOption">
+<a href="#WindowsDataplaneOption">
 WindowsDataplaneOption
 </a>
 </em>
@@ -6544,7 +6544,7 @@ Default: Disabled
 
 <code>bgp</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.BGPOption">
+<a href="#BGPOption">
 BGPOption
 </a>
 </em>
@@ -6564,7 +6564,7 @@ BGP configures whether or not to enable Calico&rsquo;s BGP capabilities.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPPool">
+<a href="#IPPool">
 []IPPool
 </a>
 </em>
@@ -6604,7 +6604,7 @@ If not specified, Calico will perform MTU auto-detection based on the cluster ne
 
 <code>nodeAddressAutodetectionV4</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -6625,7 +6625,7 @@ will use default auto-detection settings to acquire an IPv4 address for each nod
 
 <code>nodeAddressAutodetectionV6</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -6646,7 +6646,7 @@ IPv6 addresses will not be auto-detected.
 
 <code>hostPorts</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HostPortsType">
+<a href="#HostPortsType">
 HostPortsType
 </a>
 </em>
@@ -6667,7 +6667,7 @@ Default: Enabled
 
 <code>multiInterfaceMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MultiInterfaceMode">
+<a href="#MultiInterfaceMode">
 MultiInterfaceMode
 </a>
 </em>
@@ -6689,7 +6689,7 @@ Default: None
 
 <code>containerIPForwarding</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ContainerIPForwardingType">
+<a href="#ContainerIPForwardingType">
 ContainerIPForwardingType
 </a>
 </em>
@@ -6710,7 +6710,7 @@ Default: Disabled
 
 <code>sysctl</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Sysctl">
+<a href="#Sysctl">
 []Sysctl
 </a>
 </em>
@@ -6757,11 +6757,11 @@ Default: 0
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
+<h3 id="CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -6780,7 +6780,7 @@ CalicoNodeDaemonSet is the configuration for the calico-node DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -6800,7 +6800,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">
+<a href="#CalicoNodeDaemonSetSpec">
 CalicoNodeDaemonSetSpec
 </a>
 </em>
@@ -6821,11 +6821,11 @@ Spec is the specification of the calico-node DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
+<h3 id="CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6882,11 +6882,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -6943,11 +6943,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6966,7 +6966,7 @@ CalicoNodeDaemonSetPodSpec is the calico-node DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">
+<a href="#CalicoNodeDaemonSetInitContainer">
 []CalicoNodeDaemonSetInitContainer
 </a>
 </em>
@@ -6988,7 +6988,7 @@ If omitted, the calico-node DaemonSet will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetContainer">
+<a href="#CalicoNodeDaemonSetContainer">
 []CalicoNodeDaemonSetContainer
 </a>
 </em>
@@ -7075,11 +7075,11 @@ WARNING: Please note that this field will override the default calico-node Daemo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
+<a href="#CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7098,7 +7098,7 @@ CalicoNodeDaemonSetPodTemplateSpec is the calico-node DaemonSet&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7119,7 +7119,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">
+<a href="#CalicoNodeDaemonSetPodSpec">
 CalicoNodeDaemonSetPodSpec
 </a>
 </em>
@@ -7140,11 +7140,11 @@ Spec is the calico-node DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
+<h3 id="CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
 
 </p>
 <p>
@@ -7184,7 +7184,7 @@ If omitted, the calico-node DaemonSet will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">
 CalicoNodeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -7201,11 +7201,11 @@ Template describes the calico-node DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
+<h3 id="CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7224,7 +7224,7 @@ CalicoNodeWindowsDaemonSet is the configuration for the calico-node-windows Daem
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7244,7 +7244,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">
+<a href="#CalicoNodeWindowsDaemonSetSpec">
 CalicoNodeWindowsDaemonSetSpec
 </a>
 </em>
@@ -7265,11 +7265,11 @@ Spec is the specification of the calico-node-windows DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -7326,11 +7326,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -7387,11 +7387,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7410,7 +7410,7 @@ CalicoNodeWindowsDaemonSetPodSpec is the calico-node-windows DaemonSet&rsquo;s P
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">
+<a href="#CalicoNodeWindowsDaemonSetInitContainer">
 []CalicoNodeWindowsDaemonSetInitContainer
 </a>
 </em>
@@ -7432,7 +7432,7 @@ If omitted, the calico-node-windows DaemonSet will use its default values for it
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">
+<a href="#CalicoNodeWindowsDaemonSetContainer">
 []CalicoNodeWindowsDaemonSetContainer
 </a>
 </em>
@@ -7519,11 +7519,11 @@ WARNING: Please note that this field will override the default calico-node-windo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7542,7 +7542,7 @@ CalicoNodeWindowsDaemonSetPodTemplateSpec is the calico-node-windows DaemonSet&r
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7563,7 +7563,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">
 CalicoNodeWindowsDaemonSetPodSpec
 </a>
 </em>
@@ -7584,11 +7584,11 @@ Spec is the calico-node-windows DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
 
 </p>
 <p>
@@ -7628,7 +7628,7 @@ If omitted, the calico-node-windows DaemonSet will use its default value for min
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">
 CalicoNodeWindowsDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -7645,11 +7645,11 @@ Template describes the calico-node-windows DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7669,7 +7669,7 @@ CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrad
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7689,7 +7689,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">
 CalicoWindowsUpgradeDaemonSetSpec
 </a>
 </em>
@@ -7710,11 +7710,11 @@ Spec is the specification of the calico-windows-upgrade DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -7769,11 +7769,11 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7792,7 +7792,7 @@ CalicoWindowsUpgradeDaemonSetPodSpec is the calico-windows-upgrade DaemonSet&rsq
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">
+<a href="#CalicoWindowsUpgradeDaemonSetContainer">
 []CalicoWindowsUpgradeDaemonSetContainer
 </a>
 </em>
@@ -7879,11 +7879,11 @@ WARNING: Please note that this field will override the default calico-windows-up
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -7902,7 +7902,7 @@ CalicoWindowsUpgradeDaemonSetPodTemplateSpec is the calico-windows-upgrade Daemo
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7923,7 +7923,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">
 CalicoWindowsUpgradeDaemonSetPodSpec
 </a>
 </em>
@@ -7944,11 +7944,11 @@ Spec is the calico-windows-upgrade DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
 
 </p>
 <p>
@@ -7988,7 +7988,7 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
 CalicoWindowsUpgradeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -8005,11 +8005,11 @@ Template describes the calico-windows-upgrade DaemonSet pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CertificateManagement">CertificateManagement</h3>
+<h3 id="CertificateManagement">CertificateManagement</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -8101,19 +8101,19 @@ Default: SHA256WithRSA
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CollectProcessPathOption">CollectProcessPathOption
+<h3 id="CollectProcessPathOption">CollectProcessPathOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.CommonPrometheusFields">CommonPrometheusFields</h3>
+<h3 id="CommonPrometheusFields">CommonPrometheusFields</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PrometheusSpec">PrometheusSpec</a>)
+<a href="#PrometheusSpec">PrometheusSpec</a>)
 
 </p>
 <table>
@@ -8129,7 +8129,7 @@ Default: SHA256WithRSA
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PrometheusContainer">
+<a href="#PrometheusContainer">
 []PrometheusContainer
 </a>
 </em>
@@ -8167,11 +8167,11 @@ Define resources requests and limits for single Pods.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</h3>
+<h3 id="ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -8190,7 +8190,7 @@ ComplianceBenchmarkerDaemonSet is the configuration for the Compliance Benchmark
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetSpec">
+<a href="#ComplianceBenchmarkerDaemonSetSpec">
 ComplianceBenchmarkerDaemonSetSpec
 </a>
 </em>
@@ -8211,11 +8211,11 @@ Spec is the specification of the Compliance Benchmarker DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetContainer">ComplianceBenchmarkerDaemonSetContainer</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetContainer">ComplianceBenchmarkerDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -8271,11 +8271,11 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetInitContainer">ComplianceBenchmarkerDaemonSetInitContainer</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetInitContainer">ComplianceBenchmarkerDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -8331,11 +8331,11 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetPodSpec">ComplianceBenchmarkerDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8354,7 +8354,7 @@ ComplianceBenchmarkerDaemonSetPodSpec is the Compliance Benchmarker DaemonSet&rs
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetInitContainer">
+<a href="#ComplianceBenchmarkerDaemonSetInitContainer">
 []ComplianceBenchmarkerDaemonSetInitContainer
 </a>
 </em>
@@ -8376,7 +8376,7 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default values for
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetContainer">
+<a href="#ComplianceBenchmarkerDaemonSetContainer">
 []ComplianceBenchmarkerDaemonSetContainer
 </a>
 </em>
@@ -8395,11 +8395,11 @@ If omitted, the Compliance Benchmarker DaemonSet will use its default values for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetPodTemplateSpec">ComplianceBenchmarkerDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</a>)
+<a href="#ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -8418,7 +8418,7 @@ ComplianceBenchmarkerDaemonSetPodTemplateSpec is the Compliance Benchmarker Daem
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodSpec">
+<a href="#ComplianceBenchmarkerDaemonSetPodSpec">
 ComplianceBenchmarkerDaemonSetPodSpec
 </a>
 </em>
@@ -8439,11 +8439,11 @@ Spec is the Compliance Benchmarker DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</h3>
+<h3 id="ComplianceBenchmarkerDaemonSetSpec">ComplianceBenchmarkerDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</a>)
+<a href="#ComplianceBenchmarkerDaemonSet">ComplianceBenchmarkerDaemonSet</a>)
 
 </p>
 <p>
@@ -8462,7 +8462,7 @@ ComplianceBenchmarkerDaemonSetSpec defines configuration for the Compliance Benc
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSetPodTemplateSpec">
+<a href="#ComplianceBenchmarkerDaemonSetPodTemplateSpec">
 ComplianceBenchmarkerDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -8479,11 +8479,11 @@ Template describes the Compliance Benchmarker DaemonSet pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeployment">ComplianceControllerDeployment</h3>
+<h3 id="ComplianceControllerDeployment">ComplianceControllerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -8502,7 +8502,7 @@ ComplianceControllerDeployment is the configuration for the compliance controlle
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentSpec">
+<a href="#ComplianceControllerDeploymentSpec">
 ComplianceControllerDeploymentSpec
 </a>
 </em>
@@ -8523,11 +8523,11 @@ Spec is the specification of the compliance controller Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentContainer">ComplianceControllerDeploymentContainer</h3>
+<h3 id="ComplianceControllerDeploymentContainer">ComplianceControllerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
+<a href="#ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -8583,11 +8583,11 @@ If omitted, the compliance controller Deployment will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentInitContainer">ComplianceControllerDeploymentInitContainer</h3>
+<h3 id="ComplianceControllerDeploymentInitContainer">ComplianceControllerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
+<a href="#ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -8643,11 +8643,11 @@ If omitted, the compliance controller Deployment will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</h3>
+<h3 id="ComplianceControllerDeploymentPodSpec">ComplianceControllerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</a>)
+<a href="#ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8666,7 +8666,7 @@ ComplianceControllerDeploymentPodSpec is the compliance controller Deployment&rs
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentInitContainer">
+<a href="#ComplianceControllerDeploymentInitContainer">
 []ComplianceControllerDeploymentInitContainer
 </a>
 </em>
@@ -8688,7 +8688,7 @@ If omitted, the compliance controller Deployment will use its default values for
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentContainer">
+<a href="#ComplianceControllerDeploymentContainer">
 []ComplianceControllerDeploymentContainer
 </a>
 </em>
@@ -8707,11 +8707,11 @@ If omitted, the compliance controller Deployment will use its default values for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</h3>
+<h3 id="ComplianceControllerDeploymentPodTemplateSpec">ComplianceControllerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</a>)
+<a href="#ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -8730,7 +8730,7 @@ ComplianceControllerDeploymentPodTemplateSpec is the compliance controller Deplo
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodSpec">
+<a href="#ComplianceControllerDeploymentPodSpec">
 ComplianceControllerDeploymentPodSpec
 </a>
 </em>
@@ -8751,11 +8751,11 @@ Spec is the compliance controller Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</h3>
+<h3 id="ComplianceControllerDeploymentSpec">ComplianceControllerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeployment">ComplianceControllerDeployment</a>)
+<a href="#ComplianceControllerDeployment">ComplianceControllerDeployment</a>)
 
 </p>
 <p>
@@ -8774,7 +8774,7 @@ ComplianceControllerDeploymentSpec defines configuration for the compliance cont
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeploymentPodTemplateSpec">
+<a href="#ComplianceControllerDeploymentPodTemplateSpec">
 ComplianceControllerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -8791,11 +8791,11 @@ Template describes the compliance controller Deployment pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodSpec">ComplianceReporterPodSpec</h3>
+<h3 id="ComplianceReporterPodSpec">ComplianceReporterPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</a>)
+<a href="#ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8814,7 +8814,7 @@ ComplianceReporterPodSpec is the ComplianceReporter PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateInitContainer">
+<a href="#ComplianceReporterPodTemplateInitContainer">
 []ComplianceReporterPodTemplateInitContainer
 </a>
 </em>
@@ -8836,7 +8836,7 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateContainer">
+<a href="#ComplianceReporterPodTemplateContainer">
 []ComplianceReporterPodTemplateContainer
 </a>
 </em>
@@ -8855,11 +8855,11 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</h3>
+<h3 id="ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -8878,7 +8878,7 @@ ComplianceReporterPodTemplate is the configuration for the ComplianceReporter Po
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplateSpec">
+<a href="#ComplianceReporterPodTemplateSpec">
 ComplianceReporterPodTemplateSpec
 </a>
 </em>
@@ -8895,11 +8895,11 @@ Spec is the specification of the ComplianceReporter PodTemplateSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplateContainer">ComplianceReporterPodTemplateContainer</h3>
+<h3 id="ComplianceReporterPodTemplateContainer">ComplianceReporterPodTemplateContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
+<a href="#ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
 
 </p>
 <p>
@@ -8955,11 +8955,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplateInitContainer">ComplianceReporterPodTemplateInitContainer</h3>
+<h3 id="ComplianceReporterPodTemplateInitContainer">ComplianceReporterPodTemplateInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
+<a href="#ComplianceReporterPodSpec">ComplianceReporterPodSpec</a>)
 
 </p>
 <p>
@@ -9015,11 +9015,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</h3>
+<h3 id="ComplianceReporterPodTemplateSpec">ComplianceReporterPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</a>)
+<a href="#ComplianceReporterPodTemplate">ComplianceReporterPodTemplate</a>)
 
 </p>
 <p>
@@ -9038,7 +9038,7 @@ ComplianceReporterPodTemplateSpec is the ComplianceReporter PodTemplateSpec.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodSpec">
+<a href="#ComplianceReporterPodSpec">
 ComplianceReporterPodSpec
 </a>
 </em>
@@ -9059,11 +9059,11 @@ Spec is the ComplianceReporter PodTemplate&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeployment">ComplianceServerDeployment</h3>
+<h3 id="ComplianceServerDeployment">ComplianceServerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -9082,7 +9082,7 @@ ComplianceServerDeployment is the configuration for the ComplianceServer Deploym
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentSpec">
+<a href="#ComplianceServerDeploymentSpec">
 ComplianceServerDeploymentSpec
 </a>
 </em>
@@ -9103,11 +9103,11 @@ Spec is the specification of the ComplianceServer Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentContainer">ComplianceServerDeploymentContainer</h3>
+<h3 id="ComplianceServerDeploymentContainer">ComplianceServerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
+<a href="#ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9163,11 +9163,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentInitContainer">ComplianceServerDeploymentInitContainer</h3>
+<h3 id="ComplianceServerDeploymentInitContainer">ComplianceServerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
+<a href="#ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9223,11 +9223,11 @@ If omitted, the ComplianceServer Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</h3>
+<h3 id="ComplianceServerDeploymentPodSpec">ComplianceServerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</a>)
+<a href="#ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -9246,7 +9246,7 @@ ComplianceServerDeploymentPodSpec is the ComplianceServer Deployment&rsquo;s Pod
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentInitContainer">
+<a href="#ComplianceServerDeploymentInitContainer">
 []ComplianceServerDeploymentInitContainer
 </a>
 </em>
@@ -9268,7 +9268,7 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentContainer">
+<a href="#ComplianceServerDeploymentContainer">
 []ComplianceServerDeploymentContainer
 </a>
 </em>
@@ -9287,11 +9287,11 @@ If omitted, the ComplianceServer Deployment will use its default values for its 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</h3>
+<h3 id="ComplianceServerDeploymentPodTemplateSpec">ComplianceServerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</a>)
+<a href="#ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -9310,7 +9310,7 @@ ComplianceServerDeploymentPodTemplateSpec is the ComplianceServer Deployment&rsq
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodSpec">
+<a href="#ComplianceServerDeploymentPodSpec">
 ComplianceServerDeploymentPodSpec
 </a>
 </em>
@@ -9331,11 +9331,11 @@ Spec is the ComplianceServer Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</h3>
+<h3 id="ComplianceServerDeploymentSpec">ComplianceServerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeployment">ComplianceServerDeployment</a>)
+<a href="#ComplianceServerDeployment">ComplianceServerDeployment</a>)
 
 </p>
 <p>
@@ -9354,7 +9354,7 @@ ComplianceServerDeploymentSpec defines configuration for the ComplianceServer De
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeploymentPodTemplateSpec">
+<a href="#ComplianceServerDeploymentPodTemplateSpec">
 ComplianceServerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -9371,11 +9371,11 @@ Template describes the ComplianceServer Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</h3>
+<h3 id="ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</a>)
+<a href="#ComplianceSpec">ComplianceSpec</a>)
 
 </p>
 <p>
@@ -9394,7 +9394,7 @@ ComplianceSnapshotterDeployment is the configuration for the compliance snapshot
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentSpec">
+<a href="#ComplianceSnapshotterDeploymentSpec">
 ComplianceSnapshotterDeploymentSpec
 </a>
 </em>
@@ -9415,11 +9415,11 @@ Spec is the specification of the compliance snapshotter Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentContainer">ComplianceSnapshotterDeploymentContainer</h3>
+<h3 id="ComplianceSnapshotterDeploymentContainer">ComplianceSnapshotterDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9475,11 +9475,11 @@ If omitted, the compliance snapshotter Deployment will use its default value for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentInitContainer">ComplianceSnapshotterDeploymentInitContainer</h3>
+<h3 id="ComplianceSnapshotterDeploymentInitContainer">ComplianceSnapshotterDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9535,11 +9535,11 @@ If omitted, the compliance snapshotter Deployment will use its default value for
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</h3>
+<h3 id="ComplianceSnapshotterDeploymentPodSpec">ComplianceSnapshotterDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -9558,7 +9558,7 @@ ComplianceSnapshotterDeploymentPodSpec is the compliance snapshotter Deployment&
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentInitContainer">
+<a href="#ComplianceSnapshotterDeploymentInitContainer">
 []ComplianceSnapshotterDeploymentInitContainer
 </a>
 </em>
@@ -9580,7 +9580,7 @@ If omitted, the compliance snapshotter Deployment will use its default values fo
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentContainer">
+<a href="#ComplianceSnapshotterDeploymentContainer">
 []ComplianceSnapshotterDeploymentContainer
 </a>
 </em>
@@ -9599,11 +9599,11 @@ If omitted, the compliance snapshotter Deployment will use its default values fo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</h3>
+<h3 id="ComplianceSnapshotterDeploymentPodTemplateSpec">ComplianceSnapshotterDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</a>)
+<a href="#ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</a>)
 
 </p>
 <p>
@@ -9622,7 +9622,7 @@ ComplianceSnapshotterDeploymentPodTemplateSpec is the compliance snapshotter Dep
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodSpec">
+<a href="#ComplianceSnapshotterDeploymentPodSpec">
 ComplianceSnapshotterDeploymentPodSpec
 </a>
 </em>
@@ -9643,11 +9643,11 @@ Spec is the compliance snapshotter Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</h3>
+<h3 id="ComplianceSnapshotterDeploymentSpec">ComplianceSnapshotterDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</a>)
+<a href="#ComplianceSnapshotterDeployment">ComplianceSnapshotterDeployment</a>)
 
 </p>
 <p>
@@ -9666,7 +9666,7 @@ ComplianceSnapshotterDeploymentSpec defines configuration for the compliance sna
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeploymentPodTemplateSpec">
+<a href="#ComplianceSnapshotterDeploymentPodTemplateSpec">
 ComplianceSnapshotterDeploymentPodTemplateSpec
 </a>
 </em>
@@ -9683,11 +9683,11 @@ Template describes the compliance snapshotter Deployment pod that will be create
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceSpec">ComplianceSpec</h3>
+<h3 id="ComplianceSpec">ComplianceSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>)
+<a href="#Compliance">Compliance</a>)
 
 </p>
 <p>
@@ -9706,7 +9706,7 @@ ComplianceSpec defines the desired state of Tigera compliance reporting capabili
 
 <code>complianceControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceControllerDeployment">
+<a href="#ComplianceControllerDeployment">
 ComplianceControllerDeployment
 </a>
 </em>
@@ -9726,7 +9726,7 @@ ComplianceControllerDeployment configures the Compliance Controller Deployment.
 
 <code>complianceSnapshotterDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceSnapshotterDeployment">
+<a href="#ComplianceSnapshotterDeployment">
 ComplianceSnapshotterDeployment
 </a>
 </em>
@@ -9746,7 +9746,7 @@ ComplianceSnapshotterDeployment configures the Compliance Snapshotter Deployment
 
 <code>complianceBenchmarkerDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet">
+<a href="#ComplianceBenchmarkerDaemonSet">
 ComplianceBenchmarkerDaemonSet
 </a>
 </em>
@@ -9766,7 +9766,7 @@ ComplianceBenchmarkerDaemonSet configures the Compliance Benchmarker DaemonSet.
 
 <code>complianceServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceServerDeployment">
+<a href="#ComplianceServerDeployment">
 ComplianceServerDeployment
 </a>
 </em>
@@ -9786,7 +9786,7 @@ ComplianceServerDeployment configures the Compliance Server Deployment.
 
 <code>complianceReporterPodTemplate</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComplianceReporterPodTemplate">
+<a href="#ComplianceReporterPodTemplate">
 ComplianceReporterPodTemplate
 </a>
 </em>
@@ -9803,11 +9803,11 @@ ComplianceReporterPodTemplate configures the Compliance Reporter PodTemplate.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComplianceStatus">ComplianceStatus</h3>
+<h3 id="ComplianceStatus">ComplianceStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Compliance">Compliance</a>)
+<a href="#Compliance">Compliance</a>)
 
 </p>
 <p>
@@ -9861,12 +9861,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComponentName">ComponentName
+<h3 id="ComponentName">ComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComponentResource">ComponentResource</a>)
+<a href="#ComponentResource">ComponentResource</a>)
 
 </p>
 <p>
@@ -9875,11 +9875,11 @@ ComponentName represents a single component.
 <p>
 One of: Node, Typha, KubeControllers
 </p>
-<h3 id="operator.tigera.io/v1.ComponentResource">ComponentResource</h3>
+<h3 id="ComponentResource">ComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -9899,7 +9899,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentName">
+<a href="#ComponentName">
 ComponentName
 </a>
 </em>
@@ -9934,33 +9934,33 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ConditionStatus">ConditionStatus
+<h3 id="ConditionStatus">ConditionStatus
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 ConditionStatus represents the status of a particular condition. A condition may be one of: True, False, Unknown.
 </p>
-<h3 id="operator.tigera.io/v1.ContainerIPForwardingType">ContainerIPForwardingType
+<h3 id="ContainerIPForwardingType">ContainerIPForwardingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
 ContainerIPForwardingType specifies whether the CNI config for container ip forwarding is enabled.
 </p>
-<h3 id="operator.tigera.io/v1.DashboardsJob">DashboardsJob</h3>
+<h3 id="DashboardsJob">DashboardsJob</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -9979,7 +9979,7 @@ DashboardsJob is the configuration for the Dashboards job.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobSpec">
+<a href="#DashboardsJobSpec">
 DashboardsJobSpec
 </a>
 </em>
@@ -10000,11 +10000,11 @@ Spec is the specification of the dashboards job.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobContainer">DashboardsJobContainer</h3>
+<h3 id="DashboardsJobContainer">DashboardsJobContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodSpec">DashboardsJobPodSpec</a>)
+<a href="#DashboardsJobPodSpec">DashboardsJobPodSpec</a>)
 
 </p>
 <p>
@@ -10060,11 +10060,11 @@ If omitted, the Dashboard Job will use its default value for this container&rsqu
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobPodSpec">DashboardsJobPodSpec</h3>
+<h3 id="DashboardsJobPodSpec">DashboardsJobPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</a>)
+<a href="#DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -10083,7 +10083,7 @@ DashboardsJobPodSpec is the Dashboards job&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobContainer">
+<a href="#DashboardsJobContainer">
 []DashboardsJobContainer
 </a>
 </em>
@@ -10102,11 +10102,11 @@ If omitted, the Dashboard job will use its default values for its containers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</h3>
+<h3 id="DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobSpec">DashboardsJobSpec</a>)
+<a href="#DashboardsJobSpec">DashboardsJobSpec</a>)
 
 </p>
 <p>
@@ -10125,7 +10125,7 @@ DashboardsJobPodTemplateSpec is the Dashboards job&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodSpec">
+<a href="#DashboardsJobPodSpec">
 DashboardsJobPodSpec
 </a>
 </em>
@@ -10146,11 +10146,11 @@ Spec is the Dashboard job&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobSpec">DashboardsJobSpec</h3>
+<h3 id="DashboardsJobSpec">DashboardsJobSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJob">DashboardsJob</a>)
+<a href="#DashboardsJob">DashboardsJob</a>)
 
 </p>
 <p>
@@ -10169,7 +10169,7 @@ DashboardsJobSpec defines configuration for the Dashboards job.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodTemplateSpec">
+<a href="#DashboardsJobPodTemplateSpec">
 DashboardsJobPodTemplateSpec
 </a>
 </em>
@@ -10186,22 +10186,22 @@ Template describes the Dashboards job pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DataType">DataType
+<h3 id="DataType">DataType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Index">Index</a>)
+<a href="#Index">Index</a>)
 
 </p>
 <p>
 DataType represent the type of data stored
 </p>
-<h3 id="operator.tigera.io/v1.DexDeployment">DexDeployment</h3>
+<h3 id="DexDeployment">DexDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationSpec">AuthenticationSpec</a>)
+<a href="#AuthenticationSpec">AuthenticationSpec</a>)
 
 </p>
 <p>
@@ -10220,7 +10220,7 @@ DexDeployment is the configuration for the Dex Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentSpec">
+<a href="#DexDeploymentSpec">
 DexDeploymentSpec
 </a>
 </em>
@@ -10241,11 +10241,11 @@ Spec is the specification of the Dex Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentContainer">DexDeploymentContainer</h3>
+<h3 id="DexDeploymentContainer">DexDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
+<a href="#DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10301,11 +10301,11 @@ If omitted, the Dex Deployment will use its default value for this container&rsq
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentInitContainer">DexDeploymentInitContainer</h3>
+<h3 id="DexDeploymentInitContainer">DexDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
+<a href="#DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10361,11 +10361,11 @@ If omitted, the Dex Deployment will use its default value for this init containe
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentPodSpec">DexDeploymentPodSpec</h3>
+<h3 id="DexDeploymentPodSpec">DexDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</a>)
+<a href="#DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -10384,7 +10384,7 @@ DexDeploymentPodSpec is the Dex Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentInitContainer">
+<a href="#DexDeploymentInitContainer">
 []DexDeploymentInitContainer
 </a>
 </em>
@@ -10406,7 +10406,7 @@ If omitted, the Dex Deployment will use its default values for its init containe
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentContainer">
+<a href="#DexDeploymentContainer">
 []DexDeploymentContainer
 </a>
 </em>
@@ -10425,11 +10425,11 @@ If omitted, the Dex Deployment will use its default values for its containers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</h3>
+<h3 id="DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentSpec">DexDeploymentSpec</a>)
+<a href="#DexDeploymentSpec">DexDeploymentSpec</a>)
 
 </p>
 <p>
@@ -10448,7 +10448,7 @@ DexDeploymentPodTemplateSpec is the Dex Deployment&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodSpec">
+<a href="#DexDeploymentPodSpec">
 DexDeploymentPodSpec
 </a>
 </em>
@@ -10469,11 +10469,11 @@ Spec is the Dex Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentSpec">DexDeploymentSpec</h3>
+<h3 id="DexDeploymentSpec">DexDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeployment">DexDeployment</a>)
+<a href="#DexDeployment">DexDeployment</a>)
 
 </p>
 <p>
@@ -10492,7 +10492,7 @@ DexDeploymentSpec defines configuration for the Dex Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodTemplateSpec">
+<a href="#DexDeploymentPodTemplateSpec">
 DexDeploymentPodTemplateSpec
 </a>
 </em>
@@ -10509,11 +10509,11 @@ Template describes the Dex Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSet">ECKOperatorStatefulSet</h3>
+<h3 id="ECKOperatorStatefulSet">ECKOperatorStatefulSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -10532,7 +10532,7 @@ ECKOperatorStatefulSet is the configuration for the ECKOperator StatefulSet.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetSpec">
+<a href="#ECKOperatorStatefulSetSpec">
 ECKOperatorStatefulSetSpec
 </a>
 </em>
@@ -10553,11 +10553,11 @@ Spec is the specification of the ECKOperator StatefulSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetContainer">ECKOperatorStatefulSetContainer</h3>
+<h3 id="ECKOperatorStatefulSetContainer">ECKOperatorStatefulSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
+<a href="#ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
 
 </p>
 <p>
@@ -10613,11 +10613,11 @@ If omitted, the ECKOperator StatefulSet will use its default value for this cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetInitContainer">ECKOperatorStatefulSetInitContainer</h3>
+<h3 id="ECKOperatorStatefulSetInitContainer">ECKOperatorStatefulSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
+<a href="#ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
 
 </p>
 <p>
@@ -10672,11 +10672,11 @@ If omitted, the ECKOperator StatefulSet will use its default value for this init
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</h3>
+<h3 id="ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</a>)
+<a href="#ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -10695,7 +10695,7 @@ ECKOperatorStatefulSetPodSpec is the ECKOperator StatefulSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetInitContainer">
+<a href="#ECKOperatorStatefulSetInitContainer">
 []ECKOperatorStatefulSetInitContainer
 </a>
 </em>
@@ -10717,7 +10717,7 @@ If omitted, the ECKOperator StatefulSet will use its default values for its init
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetContainer">
+<a href="#ECKOperatorStatefulSetContainer">
 []ECKOperatorStatefulSetContainer
 </a>
 </em>
@@ -10736,11 +10736,11 @@ If omitted, the ECKOperator StatefulSet will use its default values for its cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</h3>
+<h3 id="ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</a>)
+<a href="#ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</a>)
 
 </p>
 <p>
@@ -10759,7 +10759,7 @@ ECKOperatorStatefulSetPodTemplateSpec is the ECKOperator StatefulSet&rsquo;s Pod
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">
+<a href="#ECKOperatorStatefulSetPodSpec">
 ECKOperatorStatefulSetPodSpec
 </a>
 </em>
@@ -10780,11 +10780,11 @@ Spec is the ECKOperator StatefulSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</h3>
+<h3 id="ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSet">ECKOperatorStatefulSet</a>)
+<a href="#ECKOperatorStatefulSet">ECKOperatorStatefulSet</a>)
 
 </p>
 <p>
@@ -10803,7 +10803,7 @@ ECKOperatorStatefulSetSpec defines configuration for the ECKOperator StatefulSet
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodTemplateSpec">
+<a href="#ECKOperatorStatefulSetPodTemplateSpec">
 ECKOperatorStatefulSetPodTemplateSpec
 </a>
 </em>
@@ -10820,11 +10820,11 @@ Template describes the ECKOperator StatefulSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentContainer">EGWDeploymentContainer</h3>
+<h3 id="EGWDeploymentContainer">EGWDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10881,11 +10881,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
+<h3 id="EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10942,11 +10942,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeployment">EKSLogForwarderDeployment</h3>
+<h3 id="EKSLogForwarderDeployment">EKSLogForwarderDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <p>
@@ -10965,7 +10965,7 @@ EKSLogForwarderDeployment is the configuration for the EKSLogForwarder Deploymen
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentSpec">
+<a href="#EKSLogForwarderDeploymentSpec">
 EKSLogForwarderDeploymentSpec
 </a>
 </em>
@@ -10986,11 +10986,11 @@ Spec is the specification of the EKSLogForwarder Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentContainer">EKSLogForwarderDeploymentContainer</h3>
+<h3 id="EKSLogForwarderDeploymentContainer">EKSLogForwarderDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
+<a href="#EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -11046,11 +11046,11 @@ If omitted, the EKSLogForwarder Deployment will use its default value for this c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentInitContainer">EKSLogForwarderDeploymentInitContainer</h3>
+<h3 id="EKSLogForwarderDeploymentInitContainer">EKSLogForwarderDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
+<a href="#EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -11106,11 +11106,11 @@ If omitted, the EKSLogForwarder Deployment will use its default value for this i
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</h3>
+<h3 id="EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</a>)
+<a href="#EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11129,7 +11129,7 @@ EKSLogForwarderDeploymentPodSpec is the EKSLogForwarder Deployment&rsquo;s PodSp
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentInitContainer">
+<a href="#EKSLogForwarderDeploymentInitContainer">
 []EKSLogForwarderDeploymentInitContainer
 </a>
 </em>
@@ -11151,7 +11151,7 @@ If omitted, the EKSLogForwarder Deployment will use its default values for its i
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentContainer">
+<a href="#EKSLogForwarderDeploymentContainer">
 []EKSLogForwarderDeploymentContainer
 </a>
 </em>
@@ -11170,11 +11170,11 @@ If omitted, the EKSLogForwarder Deployment will use its default values for its c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</h3>
+<h3 id="EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</a>)
+<a href="#EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</a>)
 
 </p>
 <p>
@@ -11193,7 +11193,7 @@ EKSLogForwarderDeploymentPodTemplateSpec is the EKSLogForwarder Deployment&rsquo
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">
+<a href="#EKSLogForwarderDeploymentPodSpec">
 EKSLogForwarderDeploymentPodSpec
 </a>
 </em>
@@ -11214,11 +11214,11 @@ Spec is the EKSLogForwarder Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</h3>
+<h3 id="EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeployment">EKSLogForwarderDeployment</a>)
+<a href="#EKSLogForwarderDeployment">EKSLogForwarderDeployment</a>)
 
 </p>
 <p>
@@ -11237,7 +11237,7 @@ EKSLogForwarderDeploymentSpec defines configuration for the EKSLogForwarder Depl
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodTemplateSpec">
+<a href="#EKSLogForwarderDeploymentPodTemplateSpec">
 EKSLogForwarderDeploymentPodTemplateSpec
 </a>
 </em>
@@ -11254,11 +11254,11 @@ Template describes the EKSLogForwarder Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
+<h3 id="EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11277,7 +11277,7 @@ EgressGatewayDeploymentPodSpec is the Egress Gateway Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentInitContainer">
+<a href="#EGWDeploymentInitContainer">
 []EGWDeploymentInitContainer
 </a>
 </em>
@@ -11299,7 +11299,7 @@ If omitted, the EGW Deployment will use its default values for its init containe
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentContainer">
+<a href="#EGWDeploymentContainer">
 []EGWDeploymentContainer
 </a>
 </em>
@@ -11434,11 +11434,11 @@ PriorityClassName allows to specify a PriorityClass resource to be used.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
+<h3 id="EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -11457,7 +11457,7 @@ EgressGatewayDeploymentPodTemplateSpec is the EGW Deployment&rsquo;s PodTemplate
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayMetadata">
+<a href="#EgressGatewayMetadata">
 EgressGatewayMetadata
 </a>
 </em>
@@ -11478,7 +11478,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">
+<a href="#EgressGatewayDeploymentPodSpec">
 EgressGatewayDeploymentPodSpec
 </a>
 </em>
@@ -11499,11 +11499,11 @@ Spec is the EGW Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
+<h3 id="EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -11544,7 +11544,7 @@ Default: 90
 
 <code>icmpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ICMPProbe">
+<a href="#ICMPProbe">
 ICMPProbe
 </a>
 </em>
@@ -11566,7 +11566,7 @@ fail. Timeout must be greater than interval.
 
 <code>httpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HTTPProbe">
+<a href="#HTTPProbe">
 HTTPProbe
 </a>
 </em>
@@ -11585,11 +11585,11 @@ fail. Timeout must be greater than interval.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayIPPool">EgressGatewayIPPool</h3>
+<h3 id="EgressGatewayIPPool">EgressGatewayIPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <table>
@@ -11638,11 +11638,11 @@ CIDR is the IPPool CIDR that the Egress Gateways can use.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayMetadata">EgressGatewayMetadata</h3>
+<h3 id="EgressGatewayMetadata">EgressGatewayMetadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11700,11 +11700,11 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</h3>
+<h3 id="EgressGatewaySpec">EgressGatewaySpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -11741,7 +11741,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -11782,7 +11782,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -11803,7 +11803,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -11823,7 +11823,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -11847,7 +11847,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -11864,11 +11864,11 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayStatus">EgressGatewayStatus</h3>
+<h3 id="EgressGatewayStatus">EgressGatewayStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -11922,11 +11922,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EksCloudwatchLogsSpec">EksCloudwatchLogsSpec</h3>
+<h3 id="EksCloudwatchLogsSpec">EksCloudwatchLogsSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">AdditionalLogSourceSpec</a>)
+<a href="#AdditionalLogSourceSpec">AdditionalLogSourceSpec</a>)
 
 </p>
 <p>
@@ -12014,11 +12014,11 @@ Default: 60
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</h3>
+<h3 id="ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -12037,7 +12037,7 @@ ElasticsearchMetricsDeployment is the configuration for the tigera-elasticsearch
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentSpec">
+<a href="#ElasticsearchMetricsDeploymentSpec">
 ElasticsearchMetricsDeploymentSpec
 </a>
 </em>
@@ -12058,11 +12058,11 @@ Spec is the specification of the ElasticsearchMetrics Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentContainer">ElasticsearchMetricsDeploymentContainer</h3>
+<h3 id="ElasticsearchMetricsDeploymentContainer">ElasticsearchMetricsDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -12118,11 +12118,11 @@ If omitted, the ElasticsearchMetrics Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentInitContainer">ElasticsearchMetricsDeploymentInitContainer</h3>
+<h3 id="ElasticsearchMetricsDeploymentInitContainer">ElasticsearchMetricsDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -12178,11 +12178,11 @@ If omitted, the ElasticsearchMetrics Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</h3>
+<h3 id="ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -12201,7 +12201,7 @@ ElasticsearchMetricsDeploymentPodSpec is the tElasticsearchMetricsDeployment&rsq
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentInitContainer">
+<a href="#ElasticsearchMetricsDeploymentInitContainer">
 []ElasticsearchMetricsDeploymentInitContainer
 </a>
 </em>
@@ -12223,7 +12223,7 @@ If omitted, the ElasticsearchMetrics Deployment will use its default values for 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentContainer">
+<a href="#ElasticsearchMetricsDeploymentContainer">
 []ElasticsearchMetricsDeploymentContainer
 </a>
 </em>
@@ -12242,11 +12242,11 @@ If omitted, the ElasticsearchMetrics Deployment will use its default values for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</h3>
+<h3 id="ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</a>)
 
 </p>
 <p>
@@ -12265,7 +12265,7 @@ ElasticsearchMetricsDeploymentPodTemplateSpec is the ElasticsearchMetricsDeploym
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">
+<a href="#ElasticsearchMetricsDeploymentPodSpec">
 ElasticsearchMetricsDeploymentPodSpec
 </a>
 </em>
@@ -12286,11 +12286,11 @@ Spec is the ElasticsearchMetrics Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</h3>
+<h3 id="ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</a>)
+<a href="#ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</a>)
 
 </p>
 <p>
@@ -12309,7 +12309,7 @@ ElasticsearchMetricsDeploymentSpec defines configuration for the ElasticsearchMe
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodTemplateSpec">
+<a href="#ElasticsearchMetricsDeploymentPodTemplateSpec">
 ElasticsearchMetricsDeploymentPodTemplateSpec
 </a>
 </em>
@@ -12326,20 +12326,20 @@ Template describes the ElasticsearchMetrics Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EmailVerificationType">EmailVerificationType
+<h3 id="EmailVerificationType">EmailVerificationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.EncapsulationType">EncapsulationType
+<h3 id="EncapsulationType">EncapsulationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -12348,12 +12348,12 @@ EncapsulationType is the type of encapsulation to use on an IP pool.
 <p>
 One of: IPIP, VXLAN, IPIPCrossSubnet, VXLANCrossSubnet, None
 </p>
-<h3 id="operator.tigera.io/v1.EncryptionOption">EncryptionOption
+<h3 id="EncryptionOption">EncryptionOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</a>)
+<a href="#SyslogStoreSpec">SyslogStoreSpec</a>)
 
 </p>
 <p>
@@ -12362,11 +12362,11 @@ EncryptionOption specifies the traffic encryption mode when connecting to a Sysl
 <p>
 One of: None, TLS
 </p>
-<h3 id="operator.tigera.io/v1.Endpoint">Endpoint</h3>
+<h3 id="Endpoint">Endpoint</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ServiceMonitor">ServiceMonitor</a>)
+<a href="#ServiceMonitor">ServiceMonitor</a>)
 
 </p>
 <p>
@@ -12527,11 +12527,11 @@ More info: <a href="https://prometheus.io/docs/prometheus/latest/configuration/c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EnvoySettings">EnvoySettings</h3>
+<h3 id="EnvoySettings">EnvoySettings</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -12584,11 +12584,11 @@ manipulating various headers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ExternalPrometheus">ExternalPrometheus</h3>
+<h3 id="ExternalPrometheus">ExternalPrometheus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.MonitorSpec">MonitorSpec</a>)
+<a href="#MonitorSpec">MonitorSpec</a>)
 
 </p>
 <table>
@@ -12604,7 +12604,7 @@ manipulating various headers.
 
 <code>serviceMonitor</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ServiceMonitor">
+<a href="#ServiceMonitor">
 ServiceMonitor
 </a>
 </em>
@@ -12644,19 +12644,19 @@ must be created before the operator will create Prometheus resources.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FIPSMode">FIPSMode
+<h3 id="FIPSMode">FIPSMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSet">FluentdDaemonSet</h3>
+<h3 id="FluentdDaemonSet">FluentdDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</a>)
+<a href="#LogCollectorSpec">LogCollectorSpec</a>)
 
 </p>
 <p>
@@ -12675,7 +12675,7 @@ FluentdDaemonSet is the configuration for the Fluentd DaemonSet.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetSpec">
+<a href="#FluentdDaemonSetSpec">
 FluentdDaemonSetSpec
 </a>
 </em>
@@ -12696,11 +12696,11 @@ Spec is the specification of the Fluentd DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetContainer">FluentdDaemonSetContainer</h3>
+<h3 id="FluentdDaemonSetContainer">FluentdDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
+<a href="#FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -12756,11 +12756,11 @@ If omitted, the Fluentd DaemonSet will use its default value for this container&
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetInitContainer">FluentdDaemonSetInitContainer</h3>
+<h3 id="FluentdDaemonSetInitContainer">FluentdDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
+<a href="#FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -12816,11 +12816,11 @@ If omitted, the Fluentd DaemonSet will use its default value for this init conta
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</h3>
+<h3 id="FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</a>)
+<a href="#FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -12839,7 +12839,7 @@ FluentdDaemonSetPodSpec is the Fluentd DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetInitContainer">
+<a href="#FluentdDaemonSetInitContainer">
 []FluentdDaemonSetInitContainer
 </a>
 </em>
@@ -12861,7 +12861,7 @@ If omitted, the Fluentd DaemonSet will use its default values for its init conta
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetContainer">
+<a href="#FluentdDaemonSetContainer">
 []FluentdDaemonSetContainer
 </a>
 </em>
@@ -12880,11 +12880,11 @@ If omitted, the Fluentd DaemonSet will use its default values for its containers
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</h3>
+<h3 id="FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetSpec">FluentdDaemonSetSpec</a>)
+<a href="#FluentdDaemonSetSpec">FluentdDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -12903,7 +12903,7 @@ FluentdDaemonSetPodTemplateSpec is the Fluentd DaemonSet&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodSpec">
+<a href="#FluentdDaemonSetPodSpec">
 FluentdDaemonSetPodSpec
 </a>
 </em>
@@ -12924,11 +12924,11 @@ Spec is the Fluentd DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetSpec">FluentdDaemonSetSpec</h3>
+<h3 id="FluentdDaemonSetSpec">FluentdDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSet">FluentdDaemonSet</a>)
+<a href="#FluentdDaemonSet">FluentdDaemonSet</a>)
 
 </p>
 <p>
@@ -12947,7 +12947,7 @@ FluentdDaemonSetSpec defines configuration for the Fluentd DaemonSet.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodTemplateSpec">
+<a href="#FluentdDaemonSetPodTemplateSpec">
 FluentdDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -12964,11 +12964,11 @@ Template describes the Fluentd DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GroupSearch">GroupSearch</h3>
+<h3 id="GroupSearch">GroupSearch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</a>)
+<a href="#AuthenticationLDAP">AuthenticationLDAP</a>)
 
 </p>
 <p>
@@ -13040,7 +13040,7 @@ The attribute of the group that represents its name. This attribute can be used 
 
 <code>userMatchers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.UserMatch">
+<a href="#UserMatch">
 []UserMatch
 </a>
 </em>
@@ -13058,11 +13058,11 @@ attribute value.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeployment">GuardianDeployment</h3>
+<h3 id="GuardianDeployment">GuardianDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
+<a href="#ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
 
 </p>
 <p>
@@ -13081,7 +13081,7 @@ GuardianDeployment is the configuration for the guardian Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentSpec">
+<a href="#GuardianDeploymentSpec">
 GuardianDeploymentSpec
 </a>
 </em>
@@ -13102,11 +13102,11 @@ Spec is the specification of the guardian Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentContainer">GuardianDeploymentContainer</h3>
+<h3 id="GuardianDeploymentContainer">GuardianDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
+<a href="#GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -13162,11 +13162,11 @@ If omitted, the guardian Deployment will use its default value for this containe
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentInitContainer">GuardianDeploymentInitContainer</h3>
+<h3 id="GuardianDeploymentInitContainer">GuardianDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
+<a href="#GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -13221,11 +13221,11 @@ If omitted, the guardian Deployment will use its default value for this init con
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</h3>
+<h3 id="GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</a>)
+<a href="#GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -13244,7 +13244,7 @@ GuardianDeploymentPodSpec is the guardian Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentInitContainer">
+<a href="#GuardianDeploymentInitContainer">
 []GuardianDeploymentInitContainer
 </a>
 </em>
@@ -13266,7 +13266,7 @@ If omitted, the guardian Deployment will use its default values for its init con
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentContainer">
+<a href="#GuardianDeploymentContainer">
 []GuardianDeploymentContainer
 </a>
 </em>
@@ -13285,11 +13285,11 @@ If omitted, the guardian Deployment will use its default values for its containe
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</h3>
+<h3 id="GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentSpec">GuardianDeploymentSpec</a>)
+<a href="#GuardianDeploymentSpec">GuardianDeploymentSpec</a>)
 
 </p>
 <p>
@@ -13308,7 +13308,7 @@ GuardianDeploymentPodTemplateSpec is the guardian Deployment&rsquo;s PodTemplate
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodSpec">
+<a href="#GuardianDeploymentPodSpec">
 GuardianDeploymentPodSpec
 </a>
 </em>
@@ -13329,11 +13329,11 @@ Spec is the guardian Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentSpec">GuardianDeploymentSpec</h3>
+<h3 id="GuardianDeploymentSpec">GuardianDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeployment">GuardianDeployment</a>)
+<a href="#GuardianDeployment">GuardianDeployment</a>)
 
 </p>
 <p>
@@ -13352,7 +13352,7 @@ GuardianDeploymentSpec defines configuration for the guardian Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodTemplateSpec">
+<a href="#GuardianDeploymentPodTemplateSpec">
 GuardianDeploymentPodTemplateSpec
 </a>
 </em>
@@ -13369,11 +13369,11 @@ Template describes the guardian Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HTTPProbe">HTTPProbe</h3>
+<h3 id="HTTPProbe">HTTPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -13445,12 +13445,12 @@ Default: 30
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HostPortsType">HostPortsType
+<h3 id="HostPortsType">HostPortsType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -13459,11 +13459,11 @@ HostPortsType specifies host port support.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.ICMPProbe">ICMPProbe</h3>
+<h3 id="ICMPProbe">ICMPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -13535,19 +13535,19 @@ Default: 15
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPAMPluginType">IPAMPluginType
+<h3 id="IPAMPluginType">IPAMPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPAMSpec">IPAMSpec</a>)
+<a href="#IPAMSpec">IPAMSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IPAMSpec">IPAMSpec</h3>
+<h3 id="IPAMSpec">IPAMSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -13566,7 +13566,7 @@ IPAMSpec contains configuration for pod IP address management.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMPluginType">
+<a href="#IPAMPluginType">
 IPAMPluginType
 </a>
 </em>
@@ -13594,11 +13594,11 @@ Default: Calico
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPPool">IPPool</h3>
+<h3 id="IPPool">IPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -13648,7 +13648,7 @@ CIDR contains the address range for the IP Pool in classless inter-domain routin
 
 <code>encapsulation</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncapsulationType">
+<a href="#EncapsulationType">
 EncapsulationType
 </a>
 </em>
@@ -13670,7 +13670,7 @@ Default: IPIP
 
 <code>natOutgoing</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NATOutgoingType">
+<a href="#NATOutgoingType">
 NATOutgoingType
 </a>
 </em>
@@ -13749,7 +13749,7 @@ Default: false
 
 <code>allowedUses</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPPoolAllowedUse">
+<a href="#IPPoolAllowedUse">
 []IPPoolAllowedUse
 </a>
 </em>
@@ -13766,19 +13766,19 @@ AllowedUse controls what the IP pool will be used for.  If not specified or empt
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPPoolAllowedUse">IPPoolAllowedUse
+<h3 id="IPPoolAllowedUse">IPPoolAllowedUse
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.Image">Image</h3>
+<h3 id="Image">Image</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</a>)
+<a href="#ImageSetSpec">ImageSetSpec</a>)
 
 </p>
 <table>
@@ -13829,11 +13829,11 @@ The field should not include a leading <code>@</code> and must be prefixed with 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</h3>
+<h3 id="ImageSetSpec">ImageSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>)
+<a href="#ImageSet">ImageSet</a>)
 
 </p>
 <p>
@@ -13852,7 +13852,7 @@ ImageSetSpec defines the desired state of ImageSet.
 
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -13869,11 +13869,11 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Index">Index</h3>
+<h3 id="Index">Index</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -13911,7 +13911,7 @@ excludes the numerical identifier suffix)
 
 <code>dataType</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DataType">
+<a href="#DataType">
 DataType
 </a>
 </em>
@@ -13927,11 +13927,11 @@ DataType represents the type of data stored in the defined index
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Indices">Indices</h3>
+<h3 id="Indices">Indices</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -13965,12 +13965,12 @@ Replicas defines how many replicas each index will have. See <a href="https://ww
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationSpec">InstallationSpec</h3>
+<h3 id="InstallationSpec">InstallationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#Installation">Installation</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -13989,7 +13989,7 @@ InstallationSpec defines configuration for a Calico or Calico Enterprise install
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -14117,7 +14117,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -14140,7 +14140,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -14160,7 +14160,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -14180,7 +14180,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -14359,7 +14359,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -14381,7 +14381,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -14403,7 +14403,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -14423,7 +14423,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -14443,7 +14443,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -14462,7 +14462,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -14482,7 +14482,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -14502,7 +14502,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -14522,7 +14522,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -14541,7 +14541,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -14562,7 +14562,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -14582,7 +14582,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -14617,11 +14617,11 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationStatus">InstallationStatus</h3>
+<h3 id="InstallationStatus">InstallationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>)
+<a href="#Installation">Installation</a>)
 
 </p>
 <p>
@@ -14640,7 +14640,7 @@ InstallationStatus defines the observed state of the Calico or Calico Enterprise
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -14696,7 +14696,7 @@ that is being used. If an ImageSet is not being used then this will not be set.
 
 <code>computed</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -14753,19 +14753,19 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionComponentName">IntrusionDetectionComponentName
+<h3 id="IntrusionDetectionComponentName">IntrusionDetectionComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</a>)
+<a href="#IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</h3>
+<h3 id="IntrusionDetectionComponentResource">IntrusionDetectionComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <p>
@@ -14784,7 +14784,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentName">
+<a href="#IntrusionDetectionComponentName">
 IntrusionDetectionComponentName
 </a>
 </em>
@@ -14819,11 +14819,11 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</h3>
+<h3 id="IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
+<a href="#IntrusionDetectionSpec">IntrusionDetectionSpec</a>)
 
 </p>
 <p>
@@ -14842,7 +14842,7 @@ IntrusionDetectionControllerDeployment is the configuration for the IntrusionDet
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentSpec">
+<a href="#IntrusionDetectionControllerDeploymentSpec">
 IntrusionDetectionControllerDeploymentSpec
 </a>
 </em>
@@ -14863,11 +14863,11 @@ Spec is the specification of the IntrusionDetectionController Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentContainer">IntrusionDetectionControllerDeploymentContainer</h3>
+<h3 id="IntrusionDetectionControllerDeploymentContainer">IntrusionDetectionControllerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -14923,11 +14923,11 @@ If omitted, the IntrusionDetection Deployment will use its default value for thi
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentInitContainer">IntrusionDetectionControllerDeploymentInitContainer</h3>
+<h3 id="IntrusionDetectionControllerDeploymentInitContainer">IntrusionDetectionControllerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -14983,11 +14983,11 @@ If omitted, the IntrusionDetectionController Deployment will use its default val
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</h3>
+<h3 id="IntrusionDetectionControllerDeploymentPodSpec">IntrusionDetectionControllerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -15006,7 +15006,7 @@ IntrusionDetectionControllerDeploymentPodSpec is the IntrusionDetectionControlle
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentInitContainer">
+<a href="#IntrusionDetectionControllerDeploymentInitContainer">
 []IntrusionDetectionControllerDeploymentInitContainer
 </a>
 </em>
@@ -15028,7 +15028,7 @@ If omitted, the IntrusionDetectionController Deployment will use its default val
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentContainer">
+<a href="#IntrusionDetectionControllerDeploymentContainer">
 []IntrusionDetectionControllerDeploymentContainer
 </a>
 </em>
@@ -15047,11 +15047,11 @@ If omitted, the IntrusionDetectionController Deployment will use its default val
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</h3>
+<h3 id="IntrusionDetectionControllerDeploymentPodTemplateSpec">IntrusionDetectionControllerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</a>)
+<a href="#IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -15070,7 +15070,7 @@ IntrusionDetectionControllerDeploymentPodTemplateSpec is the IntrusionDetectionC
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodSpec">
+<a href="#IntrusionDetectionControllerDeploymentPodSpec">
 IntrusionDetectionControllerDeploymentPodSpec
 </a>
 </em>
@@ -15091,11 +15091,11 @@ Spec is the IntrusionDetectionController Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</h3>
+<h3 id="IntrusionDetectionControllerDeploymentSpec">IntrusionDetectionControllerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</a>)
+<a href="#IntrusionDetectionControllerDeployment">IntrusionDetectionControllerDeployment</a>)
 
 </p>
 <p>
@@ -15114,7 +15114,7 @@ IntrusionDetectionControllerDeploymentSpec defines configuration for the Intrusi
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeploymentPodTemplateSpec">
+<a href="#IntrusionDetectionControllerDeploymentPodTemplateSpec">
 IntrusionDetectionControllerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -15131,11 +15131,11 @@ Template describes the IntrusionDetectionController Deployment pod that will be 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionSpec">IntrusionDetectionSpec</h3>
+<h3 id="IntrusionDetectionSpec">IntrusionDetectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>)
+<a href="#IntrusionDetection">IntrusionDetection</a>)
 
 </p>
 <p>
@@ -15154,7 +15154,7 @@ IntrusionDetectionSpec defines the desired state of Tigera intrusion detection c
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionComponentResource">
+<a href="#IntrusionDetectionComponentResource">
 []IntrusionDetectionComponentResource
 </a>
 </em>
@@ -15175,7 +15175,7 @@ Only DeepPacketInspection is supported for this spec.
 
 <code>anomalyDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AnomalyDetectionSpec">
+<a href="#AnomalyDetectionSpec">
 AnomalyDetectionSpec
 </a>
 </em>
@@ -15195,7 +15195,7 @@ AnomalyDetection is now deprecated, and configuring it has no effect.
 
 <code>intrusionDetectionControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IntrusionDetectionControllerDeployment">
+<a href="#IntrusionDetectionControllerDeployment">
 IntrusionDetectionControllerDeployment
 </a>
 </em>
@@ -15212,11 +15212,11 @@ IntrusionDetectionControllerDeployment configures the IntrusionDetection Control
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IntrusionDetectionStatus">IntrusionDetectionStatus</h3>
+<h3 id="IntrusionDetectionStatus">IntrusionDetectionStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IntrusionDetection">IntrusionDetection</a>)
+<a href="#IntrusionDetection">IntrusionDetection</a>)
 
 </p>
 <p>
@@ -15270,11 +15270,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Kibana">Kibana</h3>
+<h3 id="Kibana">Kibana</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -15293,7 +15293,7 @@ Kibana is the configuration for the Kibana.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaSpec">
+<a href="#KibanaSpec">
 KibanaSpec
 </a>
 </em>
@@ -15314,11 +15314,11 @@ Spec is the specification of the Kibana.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaContainer">KibanaContainer</h3>
+<h3 id="KibanaContainer">KibanaContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaPodSpec">KibanaPodSpec</a>)
+<a href="#KibanaPodSpec">KibanaPodSpec</a>)
 
 </p>
 <p>
@@ -15374,11 +15374,11 @@ If omitted, the Kibana will use its default value for this container&rsquo;s res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaInitContainer">KibanaInitContainer</h3>
+<h3 id="KibanaInitContainer">KibanaInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaPodSpec">KibanaPodSpec</a>)
+<a href="#KibanaPodSpec">KibanaPodSpec</a>)
 
 </p>
 <p>
@@ -15435,11 +15435,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaPodSpec">KibanaPodSpec</h3>
+<h3 id="KibanaPodSpec">KibanaPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaPodTemplateSpec">KibanaPodTemplateSpec</a>)
+<a href="#KibanaPodTemplateSpec">KibanaPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -15458,7 +15458,7 @@ KibanaPodSpec is the Kibana Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaInitContainer">
+<a href="#KibanaInitContainer">
 []KibanaInitContainer
 </a>
 </em>
@@ -15480,7 +15480,7 @@ If omitted, the Kibana Deployment will use its default values for its init conta
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaContainer">
+<a href="#KibanaContainer">
 []KibanaContainer
 </a>
 </em>
@@ -15499,11 +15499,11 @@ If omitted, the Kibana Deployment will use its default values for its containers
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaPodTemplateSpec">KibanaPodTemplateSpec</h3>
+<h3 id="KibanaPodTemplateSpec">KibanaPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaSpec">KibanaSpec</a>)
+<a href="#KibanaSpec">KibanaSpec</a>)
 
 </p>
 <p>
@@ -15522,7 +15522,7 @@ KibanaPodTemplateSpec is the Kibana&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaPodSpec">
+<a href="#KibanaPodSpec">
 KibanaPodSpec
 </a>
 </em>
@@ -15543,11 +15543,11 @@ Spec is the Kibana&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaSpec">KibanaSpec</h3>
+<h3 id="KibanaSpec">KibanaSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Kibana">Kibana</a>)
+<a href="#Kibana">Kibana</a>)
 
 </p>
 <table>
@@ -15563,7 +15563,7 @@ Spec is the Kibana&rsquo;s PodSpec.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaPodTemplateSpec">
+<a href="#KibanaPodTemplateSpec">
 KibanaPodTemplateSpec
 </a>
 </em>
@@ -15580,12 +15580,12 @@ Template describes the Kibana pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
+<h3 id="KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</a>)
+<a href="#NodeAddressAutodetection">NodeAddressAutodetection</a>)
 
 </p>
 <p>
@@ -15594,11 +15594,11 @@ KubernetesAutodetectionMethod is a method of detecting an IP address based on th
 <p>
 One of: NodeInternalIP
 </p>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</h3>
+<h3 id="L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <p>
@@ -15617,7 +15617,7 @@ L7LogCollectorDaemonSet is the configuration for the L7LogCollector DaemonSet.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetSpec">
+<a href="#L7LogCollectorDaemonSetSpec">
 L7LogCollectorDaemonSetSpec
 </a>
 </em>
@@ -15638,11 +15638,11 @@ Spec is the specification of the L7LogCollector DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetContainer">L7LogCollectorDaemonSetContainer</h3>
+<h3 id="L7LogCollectorDaemonSetContainer">L7LogCollectorDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
+<a href="#L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -15698,11 +15698,11 @@ If omitted, the L7LogCollector DaemonSet will use its default value for this con
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetInitContainer">L7LogCollectorDaemonSetInitContainer</h3>
+<h3 id="L7LogCollectorDaemonSetInitContainer">L7LogCollectorDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
+<a href="#L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -15757,11 +15757,11 @@ If omitted, the L7LogCollector DaemonSet will use its default value for this ini
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</h3>
+<h3 id="L7LogCollectorDaemonSetPodSpec">L7LogCollectorDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</a>)
+<a href="#L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -15780,7 +15780,7 @@ L7LogCollectorDaemonSetPodSpec is the L7LogCollector DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetInitContainer">
+<a href="#L7LogCollectorDaemonSetInitContainer">
 []L7LogCollectorDaemonSetInitContainer
 </a>
 </em>
@@ -15802,7 +15802,7 @@ If omitted, the L7LogCollector DaemonSet will use its default values for its ini
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetContainer">
+<a href="#L7LogCollectorDaemonSetContainer">
 []L7LogCollectorDaemonSetContainer
 </a>
 </em>
@@ -15821,11 +15821,11 @@ If omitted, the L7LogCollector DaemonSet will use its default values for its con
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</h3>
+<h3 id="L7LogCollectorDaemonSetPodTemplateSpec">L7LogCollectorDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</a>)
+<a href="#L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -15844,7 +15844,7 @@ L7LogCollectorDaemonSetPodTemplateSpec is the L7LogCollector DaemonSet&rsquo;s P
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodSpec">
+<a href="#L7LogCollectorDaemonSetPodSpec">
 L7LogCollectorDaemonSetPodSpec
 </a>
 </em>
@@ -15865,11 +15865,11 @@ Spec is the L7LogCollector DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</h3>
+<h3 id="L7LogCollectorDaemonSetSpec">L7LogCollectorDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</a>)
+<a href="#L7LogCollectorDaemonSet">L7LogCollectorDaemonSet</a>)
 
 </p>
 <p>
@@ -15888,7 +15888,7 @@ L7LogCollectorDaemonSetSpec defines configuration for the L7LogCollector DaemonS
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSetPodTemplateSpec">
+<a href="#L7LogCollectorDaemonSetPodTemplateSpec">
 L7LogCollectorDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -15905,12 +15905,12 @@ Template describes the L7LogCollector DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeployment">LinseedDeployment</h3>
+<h3 id="LinseedDeployment">LinseedDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>, 
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>, 
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -15929,7 +15929,7 @@ LinseedDeployment is the configuration for the linseed Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentSpec">
+<a href="#LinseedDeploymentSpec">
 LinseedDeploymentSpec
 </a>
 </em>
@@ -15950,11 +15950,11 @@ Spec is the specification of the linseed Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentContainer">LinseedDeploymentContainer</h3>
+<h3 id="LinseedDeploymentContainer">LinseedDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
+<a href="#LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -16010,11 +16010,11 @@ If omitted, the linseed Deployment will use its default value for this container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentInitContainer">LinseedDeploymentInitContainer</h3>
+<h3 id="LinseedDeploymentInitContainer">LinseedDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
+<a href="#LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -16070,11 +16070,11 @@ If omitted, the linseed Deployment will use its default value for this init cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</h3>
+<h3 id="LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</a>)
+<a href="#LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -16093,7 +16093,7 @@ LinseedDeploymentPodSpec is the linseed Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentInitContainer">
+<a href="#LinseedDeploymentInitContainer">
 []LinseedDeploymentInitContainer
 </a>
 </em>
@@ -16115,7 +16115,7 @@ If omitted, the linseed Deployment will use its default values for its init cont
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentContainer">
+<a href="#LinseedDeploymentContainer">
 []LinseedDeploymentContainer
 </a>
 </em>
@@ -16134,11 +16134,11 @@ If omitted, the linseed Deployment will use its default values for its container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</h3>
+<h3 id="LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentSpec">LinseedDeploymentSpec</a>)
+<a href="#LinseedDeploymentSpec">LinseedDeploymentSpec</a>)
 
 </p>
 <p>
@@ -16157,7 +16157,7 @@ LinseedDeploymentPodTemplateSpec is the linseed Deployment&rsquo;s PodTemplateSp
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">
+<a href="#LinseedDeploymentPodSpec">
 LinseedDeploymentPodSpec
 </a>
 </em>
@@ -16178,11 +16178,11 @@ Spec is the linseed Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentSpec">LinseedDeploymentSpec</h3>
+<h3 id="LinseedDeploymentSpec">LinseedDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">LinseedDeployment</a>)
+<a href="#LinseedDeployment">LinseedDeployment</a>)
 
 </p>
 <p>
@@ -16201,7 +16201,7 @@ LinseedDeploymentSpec defines configuration for the linseed Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">
+<a href="#LinseedDeploymentPodTemplateSpec">
 LinseedDeploymentPodTemplateSpec
 </a>
 </em>
@@ -16218,12 +16218,12 @@ Template describes the linseed Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinuxDataplaneOption">LinuxDataplaneOption
+<h3 id="LinuxDataplaneOption">LinuxDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -16232,11 +16232,11 @@ LinuxDataplaneOption controls which dataplane is to be used on Linux nodes.
 <p>
 One of: Iptables, BPF
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</h3>
+<h3 id="LogCollectionSpec">LogCollectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -16252,7 +16252,7 @@ One of: Iptables, BPF
 
 <code>collectLogs</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionStatusType">
+<a href="#LogCollectionStatusType">
 LogCollectionStatusType
 </a>
 </em>
@@ -16310,19 +16310,19 @@ Default: -1
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectionStatusType">LogCollectionStatusType
+<h3 id="LogCollectionStatusType">LogCollectionStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</a>)
+<a href="#LogCollectionSpec">LogCollectionSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectorSpec">LogCollectorSpec</h3>
+<h3 id="LogCollectorSpec">LogCollectorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>)
+<a href="#LogCollector">LogCollector</a>)
 
 </p>
 <p>
@@ -16341,7 +16341,7 @@ LogCollectorSpec defines the desired state of Tigera flow, audit, and DNS log co
 
 <code>additionalStores</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">
+<a href="#AdditionalLogStoreSpec">
 AdditionalLogStoreSpec
 </a>
 </em>
@@ -16361,7 +16361,7 @@ Configuration for exporting flow, audit, and DNS logs to external storage.
 
 <code>additionalSources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AdditionalLogSourceSpec">
+<a href="#AdditionalLogSourceSpec">
 AdditionalLogSourceSpec
 </a>
 </em>
@@ -16381,7 +16381,7 @@ Configuration for importing audit logs from managed kubernetes cluster log sourc
 
 <code>collectProcessPath</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CollectProcessPathOption">
+<a href="#CollectProcessPathOption">
 CollectProcessPathOption
 </a>
 </em>
@@ -16422,7 +16422,7 @@ the management cluster&rsquo;s tenant services are running.
 
 <code>fluentdDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSet">
+<a href="#FluentdDaemonSet">
 FluentdDaemonSet
 </a>
 </em>
@@ -16441,7 +16441,7 @@ FluentdDaemonSet configures the Fluentd DaemonSet.
 
 <code>eksLogForwarderDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeployment">
+<a href="#EKSLogForwarderDeployment">
 EKSLogForwarderDeployment
 </a>
 </em>
@@ -16458,11 +16458,11 @@ EKSLogForwarderDeployment configures the EKSLogForwarderDeployment Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectorStatus">LogCollectorStatus</h3>
+<h3 id="LogCollectorStatus">LogCollectorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollector">LogCollector</a>)
+<a href="#LogCollector">LogCollector</a>)
 
 </p>
 <p>
@@ -16516,31 +16516,31 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogLevel">LogLevel
+<h3 id="LogLevel">LogLevel
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNILogging">CNILogging</a>, 
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#CNILogging">CNILogging</a>, 
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogStorageComponentName">LogStorageComponentName
+<h3 id="LogStorageComponentName">LogStorageComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">LogStorageComponentResource</a>)
+<a href="#LogStorageComponentResource">LogStorageComponentResource</a>)
 
 </p>
 <p>
 LogStorageComponentName CRD enum
 </p>
-<h3 id="operator.tigera.io/v1.LogStorageComponentResource">LogStorageComponentResource</h3>
+<h3 id="LogStorageComponentResource">LogStorageComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -16559,7 +16559,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentName">
+<a href="#LogStorageComponentName">
 LogStorageComponentName
 </a>
 </em>
@@ -16595,11 +16595,11 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</h3>
+<h3 id="LogStorageSpec">LogStorageSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>)
+<a href="#LogStorage">LogStorage</a>)
 
 </p>
 <p>
@@ -16618,7 +16618,7 @@ LogStorageSpec defines the desired state of Tigera flow and DNS log storage.
 
 <code>nodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Nodes">
+<a href="#Nodes">
 Nodes
 </a>
 </em>
@@ -16637,7 +16637,7 @@ Nodes defines the configuration for a set of identical Elasticsearch cluster nod
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Indices">
+<a href="#Indices">
 Indices
 </a>
 </em>
@@ -16657,7 +16657,7 @@ Index defines the configuration for the indices in the Elasticsearch cluster.
 
 <code>retention</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Retention">
+<a href="#Retention">
 Retention
 </a>
 </em>
@@ -16719,7 +16719,7 @@ each of the indicated key-value pairs as labels as well as access to the specifi
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogStorageComponentResource">
+<a href="#LogStorageComponentResource">
 []LogStorageComponentResource
 </a>
 </em>
@@ -16740,7 +16740,7 @@ Only ECKOperator is supported for this spec.
 
 <code>eckOperatorStatefulSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSet">
+<a href="#ECKOperatorStatefulSet">
 ECKOperatorStatefulSet
 </a>
 </em>
@@ -16761,7 +16761,7 @@ ComponentResources, then these overrides take precedence.
 
 <code>kibana</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Kibana">
+<a href="#Kibana">
 Kibana
 </a>
 </em>
@@ -16781,7 +16781,7 @@ Kibana configures the Kibana Spec.
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -16800,7 +16800,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>elasticsearchMetricsDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeployment">
+<a href="#ElasticsearchMetricsDeployment">
 ElasticsearchMetricsDeployment
 </a>
 </em>
@@ -16816,11 +16816,11 @@ ElasticsearchMetricsDeployment configures the tigera-elasticsearch-metric Deploy
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogStorageStatus">LogStorageStatus</h3>
+<h3 id="LogStorageStatus">LogStorageStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorage">LogStorage</a>)
+<a href="#LogStorage">LogStorage</a>)
 
 </p>
 <p>
@@ -16910,11 +16910,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Logging">Logging</h3>
+<h3 id="Logging">Logging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>
@@ -16930,7 +16930,7 @@ Ready, Progressing, Degraded or other customer types.
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNILogging">
+<a href="#CNILogging">
 CNILogging
 </a>
 </em>
@@ -16947,11 +16947,11 @@ Customized logging specification for calico-cni plugin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</h3>
+<h3 id="ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>)
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>)
 
 </p>
 <p>
@@ -16989,7 +16989,7 @@ should be able to access this address. This field is used by managed clusters on
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagementClusterTLS">
+<a href="#ManagementClusterTLS">
 ManagementClusterTLS
 </a>
 </em>
@@ -17009,7 +17009,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>guardianDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeployment">
+<a href="#GuardianDeployment">
 GuardianDeployment
 </a>
 </em>
@@ -17025,11 +17025,11 @@ GuardianDeployment configures the guardian Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterConnectionStatus">ManagementClusterConnectionStatus</h3>
+<h3 id="ManagementClusterConnectionStatus">ManagementClusterConnectionStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnection">ManagementClusterConnection</a>)
+<a href="#ManagementClusterConnection">ManagementClusterConnection</a>)
 
 </p>
 <p>
@@ -17066,11 +17066,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterSpec">ManagementClusterSpec</h3>
+<h3 id="ManagementClusterSpec">ManagementClusterSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementCluster">ManagementCluster</a>)
+<a href="#ManagementCluster">ManagementCluster</a>)
 
 </p>
 <p>
@@ -17109,7 +17109,7 @@ Valid examples are: &ldquo;0.0.0.0:31000&rdquo;, &ldquo;example.com:32000&rdquo;
 
 <code>tls</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLS">
+<a href="#TLS">
 TLS
 </a>
 </em>
@@ -17126,11 +17126,11 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagementClusterTLS">ManagementClusterTLS</h3>
+<h3 id="ManagementClusterTLS">ManagementClusterTLS</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
+<a href="#ManagementClusterConnectionSpec">ManagementClusterConnectionSpec</a>)
 
 </p>
 <table>
@@ -17146,7 +17146,7 @@ TLS provides options for configuring how Managed Clusters can establish an mTLS 
 
 <code>ca</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CAType">
+<a href="#CAType">
 CAType
 </a>
 </em>
@@ -17172,11 +17172,11 @@ Default: Tigera
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeployment">ManagerDeployment</h3>
+<h3 id="ManagerDeployment">ManagerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerSpec">ManagerSpec</a>)
+<a href="#ManagerSpec">ManagerSpec</a>)
 
 </p>
 <p>
@@ -17195,7 +17195,7 @@ ManagerDeployment is the configuration for the Manager Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentSpec">
+<a href="#ManagerDeploymentSpec">
 ManagerDeploymentSpec
 </a>
 </em>
@@ -17216,11 +17216,11 @@ Spec is the specification of the Manager Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentContainer">ManagerDeploymentContainer</h3>
+<h3 id="ManagerDeploymentContainer">ManagerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
+<a href="#ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -17276,11 +17276,11 @@ If omitted, the Manager Deployment will use its default value for this container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentInitContainer">ManagerDeploymentInitContainer</h3>
+<h3 id="ManagerDeploymentInitContainer">ManagerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
+<a href="#ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -17337,11 +17337,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</h3>
+<h3 id="ManagerDeploymentPodSpec">ManagerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</a>)
+<a href="#ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -17360,7 +17360,7 @@ ManagerDeploymentPodSpec is the Manager Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentInitContainer">
+<a href="#ManagerDeploymentInitContainer">
 []ManagerDeploymentInitContainer
 </a>
 </em>
@@ -17382,7 +17382,7 @@ If omitted, the Manager Deployment will use its default values for its init cont
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentContainer">
+<a href="#ManagerDeploymentContainer">
 []ManagerDeploymentContainer
 </a>
 </em>
@@ -17401,11 +17401,11 @@ If omitted, the Manager Deployment will use its default values for its container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</h3>
+<h3 id="ManagerDeploymentPodTemplateSpec">ManagerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentSpec">ManagerDeploymentSpec</a>)
+<a href="#ManagerDeploymentSpec">ManagerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -17424,7 +17424,7 @@ ManagerDeploymentPodTemplateSpec is the Manager Deployment&rsquo;s PodTemplateSp
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodSpec">
+<a href="#ManagerDeploymentPodSpec">
 ManagerDeploymentPodSpec
 </a>
 </em>
@@ -17445,11 +17445,11 @@ Spec is the Manager Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerDeploymentSpec">ManagerDeploymentSpec</h3>
+<h3 id="ManagerDeploymentSpec">ManagerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagerDeployment">ManagerDeployment</a>)
+<a href="#ManagerDeployment">ManagerDeployment</a>)
 
 </p>
 <p>
@@ -17468,7 +17468,7 @@ ManagerDeploymentSpec defines configuration for the Manager Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeploymentPodTemplateSpec">
+<a href="#ManagerDeploymentPodTemplateSpec">
 ManagerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -17485,11 +17485,11 @@ Template describes the Manager Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerSpec">ManagerSpec</h3>
+<h3 id="ManagerSpec">ManagerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>)
+<a href="#Manager">Manager</a>)
 
 </p>
 <p>
@@ -17508,7 +17508,7 @@ ManagerSpec defines configuration for the Calico Enterprise manager GUI.
 
 <code>managerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ManagerDeployment">
+<a href="#ManagerDeployment">
 ManagerDeployment
 </a>
 </em>
@@ -17525,11 +17525,11 @@ ManagerDeployment configures the Manager Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ManagerStatus">ManagerStatus</h3>
+<h3 id="ManagerStatus">ManagerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Manager">Manager</a>)
+<a href="#Manager">Manager</a>)
 
 </p>
 <p>
@@ -17583,24 +17583,24 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Metadata">Metadata</h3>
+<h3 id="Metadata">Metadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>, 
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>, 
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
+<a href="#TyphaDeployment">TyphaDeployment</a>, 
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -17656,11 +17656,11 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MonitorSpec">MonitorSpec</h3>
+<h3 id="MonitorSpec">MonitorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -17679,7 +17679,7 @@ MonitorSpec defines the desired state of Tigera monitor.
 
 <code>externalPrometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">
+<a href="#ExternalPrometheus">
 ExternalPrometheus
 </a>
 </em>
@@ -17700,7 +17700,7 @@ scraping from git-ops tools without the need of post-installation steps.
 
 <code>prometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Prometheus">
+<a href="#Prometheus">
 Prometheus
 </a>
 </em>
@@ -17720,7 +17720,7 @@ Prometheus is the configuration for the Prometheus.
 
 <code>alertManager</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AlertManager">
+<a href="#AlertManager">
 AlertManager
 </a>
 </em>
@@ -17737,11 +17737,11 @@ AlertManager is the configuration for the AlertManager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MonitorStatus">MonitorStatus</h3>
+<h3 id="MonitorStatus">MonitorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -17795,12 +17795,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MultiInterfaceMode">MultiInterfaceMode
+<h3 id="MultiInterfaceMode">MultiInterfaceMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -17809,12 +17809,12 @@ MultiInterfaceMode describes the method of providing multiple pod interfaces.
 <p>
 One of: None, Multus
 </p>
-<h3 id="operator.tigera.io/v1.NATOutgoingType">NATOutgoingType
+<h3 id="NATOutgoingType">NATOutgoingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -17823,23 +17823,23 @@ NATOutgoingType describe the type of outgoing NAT to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.NativeIP">NativeIP
+<h3 id="NativeIP">NativeIP
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</a>)
+<a href="#AWSEgressGateway">AWSEgressGateway</a>)
 
 </p>
 <p>
 NativeIP defines if Egress Gateway pods should have AWS IPs.
 When NativeIP is enabled, the IPPools should be backed by AWS subnet.
 </p>
-<h3 id="operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</h3>
+<h3 id="NodeAddressAutodetection">NodeAddressAutodetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -17879,7 +17879,7 @@ filtering based on well-known interface names.
 
 <code>kubernetes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KubernetesAutodetectionMethod">
+<a href="#KubernetesAutodetectionMethod">
 KubernetesAutodetectionMethod
 </a>
 </em>
@@ -17970,11 +17970,11 @@ one of the provided CIDRs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeAffinity">NodeAffinity</h3>
+<h3 id="NodeAffinity">NodeAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</a>)
+<a href="#TyphaAffinity">TyphaAffinity</a>)
 
 </p>
 <p>
@@ -18043,11 +18043,11 @@ may or may not try to eventually evict the pod from its node.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeSet">NodeSet</h3>
+<h3 id="NodeSet">NodeSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Nodes">Nodes</a>)
+<a href="#Nodes">Nodes</a>)
 
 </p>
 <p>
@@ -18066,7 +18066,7 @@ NodeSets defines configuration specific to each Elasticsearch Node Set
 
 <code>selectionAttributes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeSetSelectionAttribute">
+<a href="#NodeSetSelectionAttribute">
 []NodeSetSelectionAttribute
 </a>
 </em>
@@ -18084,11 +18084,11 @@ to define Node Affinities and set the node awareness configuration in the runnin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeSetSelectionAttribute">NodeSetSelectionAttribute</h3>
+<h3 id="NodeSetSelectionAttribute">NodeSetSelectionAttribute</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeSet">NodeSet</a>)
+<a href="#NodeSet">NodeSet</a>)
 
 </p>
 <p>
@@ -18148,11 +18148,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Nodes">Nodes</h3>
+<h3 id="Nodes">Nodes</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -18188,7 +18188,7 @@ Count defines the number of nodes in the Elasticsearch cluster.
 
 <code>nodeSets</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeSet">
+<a href="#NodeSet">
 []NodeSet
 </a>
 </em>
@@ -18225,12 +18225,12 @@ ResourceRequirements defines the resource limits and requirements for the Elasti
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NonPrivilegedType">NonPrivilegedType
+<h3 id="NonPrivilegedType">NonPrivilegedType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -18239,12 +18239,12 @@ NonPrivilegedType specifies whether Calico runs as permissioned or not
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.OIDCType">OIDCType
+<h3 id="OIDCType">OIDCType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
 <p>
@@ -18252,11 +18252,11 @@ OIDCType defines how OIDC is configured for Tigera Enterprise. Dex should be the
 The Tigera option can help in specific use-cases, for instance, when you are unable to configure a client secret.
 One of: Dex, Tigera
 </p>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</h3>
+<h3 id="PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPISpec">PacketCaptureAPISpec</a>)
+<a href="#PacketCaptureAPISpec">PacketCaptureAPISpec</a>)
 
 </p>
 <p>
@@ -18275,7 +18275,7 @@ PacketCaptureAPIDeployment is the configuration for the PacketCaptureAPI Deploym
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentSpec">
+<a href="#PacketCaptureAPIDeploymentSpec">
 PacketCaptureAPIDeploymentSpec
 </a>
 </em>
@@ -18296,11 +18296,11 @@ Spec is the specification of the PacketCaptureAPI Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentContainer">PacketCaptureAPIDeploymentContainer</h3>
+<h3 id="PacketCaptureAPIDeploymentContainer">PacketCaptureAPIDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
+<a href="#PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18356,11 +18356,11 @@ If omitted, the PacketCaptureAPI Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentInitContainer">PacketCaptureAPIDeploymentInitContainer</h3>
+<h3 id="PacketCaptureAPIDeploymentInitContainer">PacketCaptureAPIDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
+<a href="#PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18416,11 +18416,11 @@ If omitted, the PacketCaptureAPI Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</h3>
+<h3 id="PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</a>)
+<a href="#PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -18439,7 +18439,7 @@ PacketCaptureAPIDeploymentPodSpec is the PacketCaptureAPI Deployment&rsquo;s Pod
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentInitContainer">
+<a href="#PacketCaptureAPIDeploymentInitContainer">
 []PacketCaptureAPIDeploymentInitContainer
 </a>
 </em>
@@ -18461,7 +18461,7 @@ If omitted, the PacketCaptureAPI Deployment will use its default values for its 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentContainer">
+<a href="#PacketCaptureAPIDeploymentContainer">
 []PacketCaptureAPIDeploymentContainer
 </a>
 </em>
@@ -18480,11 +18480,11 @@ If omitted, the PacketCaptureAPI Deployment will use its default values for its 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</h3>
+<h3 id="PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</a>)
+<a href="#PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</a>)
 
 </p>
 <p>
@@ -18503,7 +18503,7 @@ PacketCaptureAPIDeploymentPodTemplateSpec is the PacketCaptureAPI Deployment&rsq
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">
+<a href="#PacketCaptureAPIDeploymentPodSpec">
 PacketCaptureAPIDeploymentPodSpec
 </a>
 </em>
@@ -18524,11 +18524,11 @@ Spec is the PacketCaptureAPI Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</h3>
+<h3 id="PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</a>)
+<a href="#PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</a>)
 
 </p>
 <p>
@@ -18547,7 +18547,7 @@ PacketCaptureAPIDeploymentSpec defines configuration for the PacketCaptureAPI De
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodTemplateSpec">
+<a href="#PacketCaptureAPIDeploymentPodTemplateSpec">
 PacketCaptureAPIDeploymentPodTemplateSpec
 </a>
 </em>
@@ -18564,11 +18564,11 @@ Template describes the PacketCaptureAPI Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPISpec">PacketCaptureAPISpec</h3>
+<h3 id="PacketCaptureAPISpec">PacketCaptureAPISpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</a>)
+<a href="#PacketCaptureAPI">PacketCaptureAPI</a>)
 
 </p>
 <p>
@@ -18587,7 +18587,7 @@ PacketCaptureAPISpec defines configuration for the Packet Capture API.
 
 <code>packetCaptureAPIDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeployment">
+<a href="#PacketCaptureAPIDeployment">
 PacketCaptureAPIDeployment
 </a>
 </em>
@@ -18604,11 +18604,11 @@ PacketCaptureAPIDeployment configures the PacketCaptureAPI Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIStatus">PacketCaptureAPIStatus</h3>
+<h3 id="PacketCaptureAPIStatus">PacketCaptureAPIStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</a>)
+<a href="#PacketCaptureAPI">PacketCaptureAPI</a>)
 
 </p>
 <p>
@@ -18662,11 +18662,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PathMatch">PathMatch</h3>
+<h3 id="PathMatch">PathMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
+<a href="#TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
 
 </p>
 <table>
@@ -18732,11 +18732,11 @@ PathReplace if not nil will be used to replace PathRegexp matches.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeployment">PolicyRecommendationDeployment</h3>
+<h3 id="PolicyRecommendationDeployment">PolicyRecommendationDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationSpec">PolicyRecommendationSpec</a>)
+<a href="#PolicyRecommendationSpec">PolicyRecommendationSpec</a>)
 
 </p>
 <p>
@@ -18755,7 +18755,7 @@ PolicyRecommendationDeployment is the configuration for the PolicyRecommendation
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentSpec">
+<a href="#PolicyRecommendationDeploymentSpec">
 PolicyRecommendationDeploymentSpec
 </a>
 </em>
@@ -18776,11 +18776,11 @@ Spec is the specification of the PolicyRecommendation Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentContainer">PolicyRecommendationDeploymentContainer</h3>
+<h3 id="PolicyRecommendationDeploymentContainer">PolicyRecommendationDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
+<a href="#PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18836,11 +18836,11 @@ If omitted, the PolicyRecommendation Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentInitContainer">PolicyRecommendationDeploymentInitContainer</h3>
+<h3 id="PolicyRecommendationDeploymentInitContainer">PolicyRecommendationDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
+<a href="#PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -18895,11 +18895,11 @@ If omitted, the PolicyRecommendation Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</h3>
+<h3 id="PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</a>)
+<a href="#PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -18918,7 +18918,7 @@ PolicyRecommendationDeploymentPodSpec is the PolicyRecommendation Deployment&rsq
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentInitContainer">
+<a href="#PolicyRecommendationDeploymentInitContainer">
 []PolicyRecommendationDeploymentInitContainer
 </a>
 </em>
@@ -18940,7 +18940,7 @@ If omitted, the PolicyRecommendation Deployment will use its default values for 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentContainer">
+<a href="#PolicyRecommendationDeploymentContainer">
 []PolicyRecommendationDeploymentContainer
 </a>
 </em>
@@ -18959,11 +18959,11 @@ If omitted, the PolicyRecommendation Deployment will use its default values for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</h3>
+<h3 id="PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</a>)
+<a href="#PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</a>)
 
 </p>
 <p>
@@ -18982,7 +18982,7 @@ PolicyRecommendationDeploymentPodTemplateSpec is the PolicyRecommendation Deploy
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">
+<a href="#PolicyRecommendationDeploymentPodSpec">
 PolicyRecommendationDeploymentPodSpec
 </a>
 </em>
@@ -19003,11 +19003,11 @@ Spec is the PolicyRecommendation Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</h3>
+<h3 id="PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeployment">PolicyRecommendationDeployment</a>)
+<a href="#PolicyRecommendationDeployment">PolicyRecommendationDeployment</a>)
 
 </p>
 <p>
@@ -19026,7 +19026,7 @@ PolicyRecommendationDeploymentSpec defines configuration for the PolicyRecommend
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodTemplateSpec">
+<a href="#PolicyRecommendationDeploymentPodTemplateSpec">
 PolicyRecommendationDeploymentPodTemplateSpec
 </a>
 </em>
@@ -19043,11 +19043,11 @@ Template describes the PolicyRecommendation Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
+<h3 id="PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
@@ -19067,7 +19067,7 @@ service.
 
 <code>policyRecommendationDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeployment">
+<a href="#PolicyRecommendationDeployment">
 PolicyRecommendationDeployment
 </a>
 </em>
@@ -19084,11 +19084,11 @@ PolicyRecommendation configures the PolicyRecommendation Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
+<h3 id="PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
@@ -19121,13 +19121,13 @@ State provides user-readable status.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ProductVariant">ProductVariant
+<h3 id="ProductVariant">ProductVariant
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#InstallationSpec">InstallationSpec</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -19136,11 +19136,11 @@ ProductVariant represents the variant of the product.
 <p>
 One of: Calico, TigeraSecureEnterprise
 </p>
-<h3 id="operator.tigera.io/v1.Prometheus">Prometheus</h3>
+<h3 id="Prometheus">Prometheus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.MonitorSpec">MonitorSpec</a>)
+<a href="#MonitorSpec">MonitorSpec</a>)
 
 </p>
 <table>
@@ -19156,7 +19156,7 @@ One of: Calico, TigeraSecureEnterprise
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PrometheusSpec">
+<a href="#PrometheusSpec">
 PrometheusSpec
 </a>
 </em>
@@ -19177,11 +19177,11 @@ Spec is the specification of the Prometheus.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PrometheusContainer">PrometheusContainer</h3>
+<h3 id="PrometheusContainer">PrometheusContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CommonPrometheusFields">CommonPrometheusFields</a>)
+<a href="#CommonPrometheusFields">CommonPrometheusFields</a>)
 
 </p>
 <p>
@@ -19237,11 +19237,11 @@ If omitted, the Prometheus will use its default value for this container&rsquo;s
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PrometheusSpec">PrometheusSpec</h3>
+<h3 id="PrometheusSpec">PrometheusSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Prometheus">Prometheus</a>)
+<a href="#Prometheus">Prometheus</a>)
 
 </p>
 <table>
@@ -19257,7 +19257,7 @@ If omitted, the Prometheus will use its default value for this container&rsquo;s
 
 <code>commonPrometheusFields</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CommonPrometheusFields">
+<a href="#CommonPrometheusFields">
 CommonPrometheusFields
 </a>
 </em>
@@ -19273,12 +19273,12 @@ CommonPrometheusFields are the options available to both the Prometheus server a
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PromptType">PromptType
+<h3 id="PromptType">PromptType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationOIDC">AuthenticationOIDC</a>)
+<a href="#AuthenticationOIDC">AuthenticationOIDC</a>)
 
 </p>
 <p>
@@ -19286,23 +19286,23 @@ PromptType is a value that specifies whether the identity provider prompts the e
 consent.
 One of: None, Login, Consent, SelectAccount.
 </p>
-<h3 id="operator.tigera.io/v1.Provider">Provider
+<h3 id="Provider">Provider
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
 Provider represents a particular provider or flavor of Kubernetes. Valid options
 are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG.
 </p>
-<h3 id="operator.tigera.io/v1.Retention">Retention</h3>
+<h3 id="Retention">Retention</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogStorageSpec">LogStorageSpec</a>)
+<a href="#LogStorageSpec">LogStorageSpec</a>)
 
 </p>
 <p>
@@ -19444,11 +19444,11 @@ Default: 8
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.S3StoreSpec">S3StoreSpec</h3>
+<h3 id="S3StoreSpec">S3StoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -19515,11 +19515,11 @@ Path in the S3 bucket where to send logs
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SNIMatch">SNIMatch</h3>
+<h3 id="SNIMatch">SNIMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>)
+<a href="#TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>)
 
 </p>
 <table>
@@ -19549,11 +19549,11 @@ ServerName is used to match the server name for the request.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ServiceMonitor">ServiceMonitor</h3>
+<h3 id="ServiceMonitor">ServiceMonitor</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">ExternalPrometheus</a>)
+<a href="#ExternalPrometheus">ExternalPrometheus</a>)
 
 </p>
 <table>
@@ -19588,7 +19588,7 @@ Default: k8s-app=tigera-prometheus
 
 <code>endpoints</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Endpoint">
+<a href="#Endpoint">
 []Endpoint
 </a>
 </em>
@@ -19605,11 +19605,11 @@ related to connecting to our Prometheus server are automatically set by the oper
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SplunkStoreSpec">SplunkStoreSpec</h3>
+<h3 id="SplunkStoreSpec">SplunkStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -19642,22 +19642,22 @@ Location for splunk&rsquo;s http event collector end point. example <code>https:
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.StatusConditionType">StatusConditionType
+<h3 id="StatusConditionType">StatusConditionType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 StatusConditionType is a type of condition that may apply to a particular component.
 </p>
-<h3 id="operator.tigera.io/v1.Sysctl">Sysctl</h3>
+<h3 id="Sysctl">Sysctl</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -19698,12 +19698,12 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.SyslogLogType">SyslogLogType
+<h3 id="SyslogLogType">SyslogLogType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</a>)
+<a href="#SyslogStoreSpec">SyslogStoreSpec</a>)
 
 </p>
 <p>
@@ -19714,11 +19714,11 @@ Allowable values are Audit, DNS, Flows and IDSEvents.
 * Flows corresponds to flow logs generated by Calico node.
 * IDSEvents corresponds to event logs for the intrusion detection system (anomaly detection, suspicious IPs, suspicious domains and global alerts).
 </p>
-<h3 id="operator.tigera.io/v1.SyslogStoreSpec">SyslogStoreSpec</h3>
+<h3 id="SyslogStoreSpec">SyslogStoreSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
+<a href="#AdditionalLogStoreSpec">AdditionalLogStoreSpec</a>)
 
 </p>
 <p>
@@ -19774,7 +19774,7 @@ Default: 1024
 
 <code>logTypes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SyslogLogType">
+<a href="#SyslogLogType">
 []SyslogLogType
 </a>
 </em>
@@ -19794,7 +19794,7 @@ Default: Audit, DNS, Flows
 
 <code>encryption</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncryptionOption">
+<a href="#EncryptionOption">
 EncryptionOption
 </a>
 </em>
@@ -19812,11 +19812,11 @@ Default: None
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLS">TLS</h3>
+<h3 id="TLS">TLS</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ManagementClusterSpec">ManagementClusterSpec</a>)
+<a href="#ManagementClusterSpec">ManagementClusterSpec</a>)
 
 </p>
 <table>
@@ -19866,11 +19866,11 @@ Default: tigera-management-cluster-connection
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</h3>
+<h3 id="TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRoute">TLSPassThroughRoute</a>)
+<a href="#TLSPassThroughRoute">TLSPassThroughRoute</a>)
 
 </p>
 <table>
@@ -19886,7 +19886,7 @@ Default: tigera-management-cluster-connection
 
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -19902,7 +19902,7 @@ TargetType
 
 <code>sniMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SNIMatch">
+<a href="#SNIMatch">
 SNIMatch
 </a>
 </em>
@@ -19936,11 +19936,11 @@ Destination is the destination url to proxy the request to.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</h3>
+<h3 id="TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSTerminatedRoute">TLSTerminatedRoute</a>)
+<a href="#TLSTerminatedRoute">TLSTerminatedRoute</a>)
 
 </p>
 <table>
@@ -19956,7 +19956,7 @@ Destination is the destination url to proxy the request to.
 
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -19972,7 +19972,7 @@ TargetType
 
 <code>pathMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PathMatch">
+<a href="#PathMatch">
 PathMatch
 </a>
 </em>
@@ -20087,20 +20087,20 @@ is UI.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TargetType">TargetType
+<h3 id="TargetType">TargetType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>, 
-<a href="#operator.tigera.io/v1.TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
+<a href="#TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>, 
+<a href="#TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.TenantElasticSpec">TenantElasticSpec</h3>
+<h3 id="TenantElasticSpec">TenantElasticSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <table>
@@ -20155,11 +20155,11 @@ bool
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantSpec">TenantSpec</h3>
+<h3 id="TenantSpec">TenantSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
 <table>
@@ -20209,7 +20209,7 @@ Name is a human readable name for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -20228,7 +20228,7 @@ Indices defines the how to store a tenant&rsquo;s data
 
 <code>elastic</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantElasticSpec">
+<a href="#TenantElasticSpec">
 TenantElasticSpec
 </a>
 </em>
@@ -20267,7 +20267,7 @@ in the Tenant&rsquo;s namespace. Defaults to the controlPlaneReplicas in Install
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -20286,7 +20286,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>esKubeControllerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -20305,7 +20305,7 @@ ESKubeControllerDeployment configures the ESKubeController Deployment.
 
 <code>dashboardsJob</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJob">
+<a href="#DashboardsJob">
 DashboardsJob
 </a>
 </em>
@@ -20321,18 +20321,18 @@ DashboardsJob configures the Dashboards job
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantStatus">TenantStatus</h3>
+<h3 id="TenantStatus">TenantStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</h3>
+<h3 id="TigeraStatusCondition">TigeraStatusCondition</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</a>)
+<a href="#TigeraStatusStatus">TigeraStatusStatus</a>)
 
 </p>
 <p>
@@ -20351,7 +20351,7 @@ TigeraStatusCondition represents a condition attached to a particular component.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.StatusConditionType">
+<a href="#StatusConditionType">
 StatusConditionType
 </a>
 </em>
@@ -20370,7 +20370,7 @@ The type of condition. May be Available, Progressing, or Degraded.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ConditionStatus">
+<a href="#ConditionStatus">
 ConditionStatus
 </a>
 </em>
@@ -20459,26 +20459,26 @@ with respect to the current state of the instance.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatusReason">TigeraStatusReason
+<h3 id="TigeraStatusReason">TigeraStatusReason
 (<code>string</code> alias)</h3>
 <p>
 TigeraStatusReason represents the reason for a particular condition.
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusSpec">TigeraStatusSpec</h3>
+<h3 id="TigeraStatusSpec">TigeraStatusSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
 TigeraStatusSpec defines the desired state of TigeraStatus
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</h3>
+<h3 id="TigeraStatusStatus">TigeraStatusStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
@@ -20497,7 +20497,7 @@ TigeraStatusStatus defines the observed state of TigeraStatus
 
 <code>conditions</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">
+<a href="#TigeraStatusCondition">
 []TigeraStatusCondition
 </a>
 </em>
@@ -20514,11 +20514,11 @@ Available, Progressing, or Degraded.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</h3>
+<h3 id="TyphaAffinity">TyphaAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -20538,7 +20538,7 @@ TyphaAffinity allows configuration of node affinity characteristics for Typha po
 
 <code>nodeAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAffinity">
+<a href="#NodeAffinity">
 NodeAffinity
 </a>
 </em>
@@ -20555,11 +20555,11 @@ NodeAffinity describes node affinity scheduling rules for typha.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</h3>
+<h3 id="TyphaDeployment">TyphaDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -20578,7 +20578,7 @@ TyphaDeployment is the configuration for the typha Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -20598,7 +20598,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">
+<a href="#TyphaDeploymentSpec">
 TyphaDeploymentSpec
 </a>
 </em>
@@ -20619,11 +20619,11 @@ Spec is the specification of the typha Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
+<h3 id="TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -20680,11 +20680,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
+<h3 id="TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -20741,11 +20741,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
+<h3 id="TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -20764,7 +20764,7 @@ TyphaDeploymentPodSpec is the typha Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentInitContainer">
+<a href="#TyphaDeploymentInitContainer">
 []TyphaDeploymentInitContainer
 </a>
 </em>
@@ -20786,7 +20786,7 @@ If omitted, the typha Deployment will use its default values for its init contai
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentContainer">
+<a href="#TyphaDeploymentContainer">
 []TyphaDeploymentContainer
 </a>
 </em>
@@ -20920,11 +20920,11 @@ WARNING: Please note that this field will override the default calico-typha Depl
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
+<h3 id="TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -20943,7 +20943,7 @@ TyphaDeploymentPodTemplateSpec is the typha Deployment&rsquo;s PodTemplateSpec
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -20964,7 +20964,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">
+<a href="#TyphaDeploymentPodSpec">
 TyphaDeploymentPodSpec
 </a>
 </em>
@@ -20985,11 +20985,11 @@ Spec is the typha Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
+<h3 id="TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>)
+<a href="#TyphaDeployment">TyphaDeployment</a>)
 
 </p>
 <p>
@@ -21029,7 +21029,7 @@ If omitted, the typha Deployment will use its default value for minReadySeconds.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">
+<a href="#TyphaDeploymentPodTemplateSpec">
 TyphaDeploymentPodTemplateSpec
 </a>
 </em>
@@ -21049,7 +21049,7 @@ Template describes the typha Deployment pod that will be created.
 
 <code>strategy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentStrategy">
+<a href="#TyphaDeploymentStrategy">
 TyphaDeploymentStrategy
 </a>
 </em>
@@ -21066,11 +21066,11 @@ The deployment strategy to use to replace existing pods with new ones.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
+<h3 id="TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -21109,11 +21109,11 @@ to be.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.UserMatch">UserMatch</h3>
+<h3 id="UserMatch">UserMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GroupSearch">GroupSearch</a>)
+<a href="#GroupSearch">GroupSearch</a>)
 
 </p>
 <p>
@@ -21163,11 +21163,11 @@ The attribute of a group that links it to a user.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.UserSearch">UserSearch</h3>
+<h3 id="UserSearch">UserSearch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AuthenticationLDAP">AuthenticationLDAP</a>)
+<a href="#AuthenticationLDAP">AuthenticationLDAP</a>)
 
 </p>
 <p>
@@ -21237,27 +21237,27 @@ Default: uid
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.WAFStatusType">WAFStatusType
+<h3 id="WAFStatusType">WAFStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsDataplaneOption">WindowsDataplaneOption
+<h3 id="WindowsDataplaneOption">WindowsDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsNodeSpec">WindowsNodeSpec</h3>
+<h3 id="WindowsNodeSpec">WindowsNodeSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>

--- a/calico-enterprise_versioned_docs/version-3.20-1/reference/installation/helm_customization.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/reference/installation/helm_customization.mdx
@@ -8,18 +8,18 @@ import variables from '@site/calico-enterprise_versioned_docs/version-3.20-1/var
 
 You can customize the following resources and settings during {variables.prodname} Helm-based installation using the file, `values.yaml`.
 
-- [Installation](api.mdx#operator.tigera.io/v1.InstallationSpec)
-- [Api server](api.mdx#operator.tigera.io/v1.APIServerSpec)
-- [Compliance](api.mdx#operator.tigera.io/v1.ComplianceSpec)
-- [Intrusion detection](api.mdx#operator.tigera.io/v1.IntrusionDetectionSpec)
-- [Log collector](api.mdx#operator.tigera.io/v1.LogCollectorSpec)
-- [Log storage](api.mdx#operator.tigera.io/v1.LogStorageSpec)
-- [Manager](api.mdx#operator.tigera.io/v1.ManagerSpec)
-- [Monitor](api.mdx#operator.tigera.io/v1.MonitorSpec)
-- [Policy recommendation](api.mdx#operator.tigera.io/v1.PolicyRecommendationSpec)
-- [Authentication](api.mdx#operator.tigera.io/v1.AuthenticationSpec)
-- [Application layer](api.mdx#operator.tigera.io/v1.ApplicationLayerSpec)
-- [Amazon cloud integration](api.mdx#operator.tigera.io/v1.AmazonCloudIntegrationSpec)
+- [Installation](api.mdx#InstallationSpec
+- [Api server](api.mdx#APIServerSpec
+- [Compliance](api.mdx#ComplianceSpec
+- [Intrusion detection](api.mdx#IntrusionDetectionSpec
+- [Log collector](api.mdx#LogCollectorSpec
+- [Log storage](api.mdx#LogStorageSpec
+- [Manager](api.mdx#ManagerSpec
+- [Monitor](api.mdx#MonitorSpec
+- [Policy recommendation](api.mdx#PolicyRecommendationSpec
+- [Authentication](api.mdx#AuthenticationSpec
+- [Application layer](api.mdx#ApplicationLayerSpec
+- [Amazon cloud integration](api.mdx#AmazonCloudIntegrationSpec
 - [Default felix configuration](../resources/felixconfig.mdx#spec)
 
 :::note
@@ -94,7 +94,7 @@ Common customizations that you might want to configure are number of replicas, p
 
 ### Number of replicas
 This setting defines the number of replicas for {variables.prodname} components that can run simultaneously in multiple instances.
-To configure this setting, see [controlPlaneReplicas](api.mdx#operator.tigera.io/v1.InstallationSpec).
+To configure this setting, see [controlPlaneReplicas](api.mdx#InstallationSpec.
 The components for the replicas are:
 
 - tigera-manager

--- a/calico-enterprise_versioned_docs/version-3.20-1/threat/deeppacketinspection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/threat/deeppacketinspection.mdx
@@ -76,7 +76,7 @@ spec:
 
 ### Configure resource requirements
 
-Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionComponentResource).
+Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#IntrusionDetectionComponentResource.
 
 For a data transfer rate of 1GB/sec on workload endpoints being monitored, we recommend a minimum of 1 CPU and 1GB RAM.
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/threat/web-application-firewall.mdx
@@ -359,9 +359,9 @@ kubectl delete applicationlayer tigera-secure
 
 #### Keep some ApplicationLayer features enabled
 
-To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) custom resource.
+To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#ApplicationLayer custom resource.
 
-Note that the [ApplicationLayer Specification](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerSpec) can specify configuration for [Application Logging](../reference/installation/api#operator.tigera.io/v1.LogCollectionSpec) and [Application Layer Policy](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerPolicyStatusType) also. 
+Note that the [ApplicationLayer Specification](../reference/installation/api#ApplicationLayerSpec can specify configuration for [Application Logging](../reference/installation/api#LogCollectionSpec and [Application Layer Policy](../reference/installation/api#ApplicationLayerPolicyStatusType also. 
 
 For the ApplicationLayer custom resource to be valid, at least one of these features have to be enabled, for example:
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/visibility/elastic/archive-storage.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/visibility/elastic/archive-storage.mdx
@@ -48,8 +48,8 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
     -n tigera-operator
    ```
 
-3. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#operator.tigera.io/v1.S3StoreSpec)
+3. Update the [LogCollector](../../reference/installation/api.mdx#LogCollector
+   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#S3StoreSpec
    with your information noted from above.
    Example:
 
@@ -76,8 +76,8 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
 </TabItem>
 <TabItem label="Syslog" value="Syslog-1">
 
-1. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+1. Update the [LogCollector](../../reference/installation/api.mdx#LogCollector
+   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec
    with your syslog information.
    Example:
    ```yaml
@@ -104,7 +104,7 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    kubectl edit logcollector tigera-secure
    ```
 2. You can control which types of {variables.prodname} log data you would like to send to syslog.
-   The [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+   The [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec
    contains a field called `logTypes` which allows you to list which log types you would like to include.
    The allowable log types are:
 
@@ -113,11 +113,11 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    - Flows
    - IDSEvents
 
-   Refer to the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec) for more details on what data each log type represents.
+   Refer to the [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec for more details on what data each log type represents.
 
    :::note
 
-   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
+   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#LogStorage configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
 
    :::
 
@@ -125,7 +125,7 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
 
 **TLS configuration**
 
-3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec).
+3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#SyslogStoreSpec.
 
    ```yaml
    apiVersion: operator.tigera.io/v1
@@ -180,9 +180,9 @@ Because {variables.prodname} and Kubernetes logs are integral to {variables.prod
    ```
 
 3. Update the
-   [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
+   [LogCollector](../../reference/installation/api.mdx#LogCollector
    resource named `tigera-secure` to include
-   a [Splunk section](../../reference/installation/api.mdx#operator.tigera.io/v1.SplunkStoreSpec)
+   a [Splunk section](../../reference/installation/api.mdx#SplunkStoreSpec
    with your Splunk information.
    Example:
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/visibility/elastic/l7/configure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/visibility/elastic/l7/configure.mdx
@@ -73,7 +73,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
 
 **Configure the ApplicationLayer resource for L7 logs**
 
-1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) resource named, `tigera-secure` to include a logCollection section of the file, `_api.html` [here](../../../reference/installation/api.mdx).
+1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#ApplicationLayer resource named, `tigera-secure` to include a logCollection section of the file, `_api.html` [here](../../../reference/installation/api.mdx).
 
 1. Ensure that the `collectLogs` field is set to `Enabled`.
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/visibility/elastic/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/visibility/elastic/overview.mdx
@@ -93,7 +93,7 @@ verbs: ['get']
 - Global network policies
 - Network sets
 
-{variables.prodname} also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec).
+{variables.prodname} also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#LogCollectorSpec.
 
 ## Additional resources
 
@@ -104,4 +104,4 @@ verbs: ['get']
 - [BGP logs](bgp.mdx)
 - [DNS logs](dns/dns-logs.mdx)
 - [Archive logs](archive-storage.mdx)
-- [Log collection options](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../reference/installation/api.mdx#LogCollectorSpec

--- a/calico-enterprise_versioned_docs/version-3.20-1/visibility/elastic/rbac-elasticsearch.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/visibility/elastic/rbac-elasticsearch.mdx
@@ -213,4 +213,4 @@ status:
 ## Additional resources
 
 - Configure [RBAC for tiered policies](../../network-policy/policy-tiers/rbac-tiered-policies.mdx).
-- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) resource.
+- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#ManagementCluster resource.

--- a/calico-enterprise_versioned_docs/version-3.20-1/visibility/elastic/retention.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/visibility/elastic/retention.mdx
@@ -12,7 +12,7 @@ Configure how long to retain logs and compliance reports.
 
 ## Before you begin...
 
-Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#operator.tigera.io/v1.Retention) and determine the appropriate values for your deployment.
+Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#Retention and determine the appropriate values for your deployment.
 
 :::note
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/visibility/elastic/troubleshoot.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/visibility/elastic/troubleshoot.mdx
@@ -10,7 +10,7 @@ import variables from '@site/calico-enterprise_versioned_docs/version-3.20-1/var
 
 The following user-configured resources are related to Elasticsearch:
 
-- [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage). It has settings for:
+- [LogStorage](../../reference/installation/api.mdx#LogStorage. It has settings for:
 
   - Elasticsearch (for example, nodeCount and replicas)
   - Kubernetes (for example, resourceRequirements, storage and nodeSelectors)
@@ -113,7 +113,7 @@ As a last resort, create a new [Elasticsearch cluster](#how-to-create-a-new-clus
 
 ### Elasticsearch is slow
 
-**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorageSpec).
+**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#LogStorageSpec.
 
 ### Elasticsearch crashes during booting
 

--- a/calico/getting-started/kubernetes/helm.mdx
+++ b/calico/getting-started/kubernetes/helm.mdx
@@ -49,7 +49,7 @@ helm repo add projectcalico https://docs.tigera.io/calico/charts
 
 If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), or you need to customize TLS certificates, you **must** customize this Helm chart by creating a `values.yaml` file. Otherwise, you can skip this step.
 
-1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#operator.tigera.io/v1.Provider). For example:
+1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#Provider. For example:
 
    ```
    echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico/getting-started/kubernetes/self-managed-onprem/config-options.mdx
+++ b/calico/getting-started/kubernetes/self-managed-onprem/config-options.mdx
@@ -36,9 +36,9 @@ installed directly on the cluster as a Deployment, and is configured through one
 Operator installations read their configuration from a specific set of Kubernetes APIs. These APIs are installed on the cluster
 as part of `tigera-operator.yaml` in the `operator.tigera.io/v1` API group.
 
-- [Installation](../../../reference/installation/api.mdx#operator.tigera.io/v1.Installation): a singleton resource with name "default" that
+- [Installation](../../../reference/installation/api.mdx#Installation: a singleton resource with name "default" that
   configures common installation parameters for a {variables.prodname} cluster.
-- [APIServer](../../../reference/installation/api.mdx#operator.tigera.io/v1.Installation): a singleton resource with name "default" that
+- [APIServer](../../../reference/installation/api.mdx#Installation: a singleton resource with name "default" that
   configures installation of the {variables.prodname} API server extension.
 
 ### Configure the pod IP range

--- a/calico/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -38,7 +38,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#BGPOption.
 
 :::
 

--- a/calico/networking/ipam/ip-autodetection.mdx
+++ b/calico/networking/ipam/ip-autodetection.mdx
@@ -65,7 +65,7 @@ For more details on autodetection methods, see [node configuration](../../refere
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-As noted previously, the default autodetection method is **first valid interface found** (first-found). To use a different autodetection method, edit the default [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation) custom resource, specifying the method. Below are examples of the supported autodetection methods:
+As noted previously, the default autodetection method is **first valid interface found** (first-found). To use a different autodetection method, edit the default [Installation](../../reference/installation/api.mdx#Installation custom resource, specifying the method. Below are examples of the supported autodetection methods:
 
 :::note
 

--- a/calico/operations/certificate-management.mdx
+++ b/calico/operations/certificate-management.mdx
@@ -31,7 +31,7 @@ certificate issuance, {variables.prodname} provides a simple configuration optio
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../reference/installation/api.mdx#Installation
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
 ```yaml

--- a/calico/operations/image-options/imageset.mdx
+++ b/calico/operations/image-options/imageset.mdx
@@ -78,7 +78,7 @@ sed -ie "s|\(image: .*/operator\):.*|?\1@<put-digest-here>|" tigera-operator.yam
 
 ### Create an ImageSet
 
-Create an [ImageSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ImageSet) manifest file named `imageset.yaml` like the following:
+Create an [ImageSet](../../reference/installation/api.mdx#ImageSet manifest file named `imageset.yaml` like the following:
 
 <CodeBlock language='yaml'>
 apiVersion: operator.tigera.io/v1
@@ -142,7 +142,7 @@ You can create an ImageSet manifest manually or by script.
       docker pull <repo/image:tag> && docker inspect <repo/image:tag> -f '{{range .RepoDigests}}{{printf "%s\n" .}}{{end}}'
       ```
    1. Use the digest from the image that matches the repo/image you will use.
-      If you are using a private registry or have specified an [imagePath](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+      If you are using a private registry or have specified an [imagePath](../../reference/installation/api.mdx#Installation
       you will still use the "default" `<owner>/<image>` in the `image` field, for example if you your node image is coming from
       `example.com/registry/imagepath/node` you will still use `calico/node` in the image field of the ImageSet.
       :::note
@@ -228,7 +228,7 @@ Apply the created `imageset.yaml` to your cluster.
 
 ### Create new ImageSet when upgrading or downgrading
 
-Before upgrading to a new release or downgrading, you must create a new [ImageSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ImageSet)
+Before upgrading to a new release or downgrading, you must create a new [ImageSet](../../reference/installation/api.mdx#ImageSet
 with updated image references and names for the new release. This must be done prior
 to upgrading the cluster so when the new manifests are applied, the appropriate ImageSet is available.
 
@@ -236,7 +236,7 @@ to upgrading the cluster so when the new manifests are applied, the appropriate 
 
 ### Why does the Installation Resource status not include my ImageSet?
 
-The [status.imageset](../../reference/installation/api.mdx#operator.tigera.io/v1.InstallationStatus) field of
+The [status.imageset](../../reference/installation/api.mdx#InstallationStatus field of
 the Installation Resource will not be updated until the `calico` component has fully been deployed. `calico` is
 fully deployed when `kubectl get tigerastatus calico` reports Available True with Progressing and Degraded as False.
 

--- a/calico/reference/configure-cni-plugins.mdx
+++ b/calico/reference/configure-cni-plugins.mdx
@@ -262,7 +262,7 @@ By enabling this feature, you can avoid errors that can occur when a pod tries t
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](installation/api#operator.tigera.io/v1.CalicoNetworkSpec) of the default `operator.tigera.io/v1/installation` resource.
+The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](installation/api#CalicoNetworkSpec of the default `operator.tigera.io/v1/installation` resource.
 
 The following example configures the CNI to delay a pod from starting its containers for up to 10 seconds, or until the pod's dataplane has been programmed:
 
@@ -332,7 +332,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](installation/api.mdx#Installation API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico/reference/configure-resources.mdx
+++ b/calico/reference/configure-resources.mdx
@@ -16,11 +16,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../reference/installation/api.mdx#APIServer CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the APIServer CR using the below command:
+To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#APIServerDeployment, patch the APIServer CR using the below command:
 
 ```bash
 kubectl patch apiserver default  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -59,7 +59,7 @@ The [Installation CR](../reference/installation/api.mdx) provides a way to confi
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../reference/installation/api.mdx#TyphaDeployment, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -95,7 +95,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../reference/installation/api.mdx#calicoNodeDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -130,7 +130,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../reference/installation/api.mdx#calicoNodeWindowsDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -165,7 +165,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../reference/installation/api.mdx#CalicoKubeControllersDeployment component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -201,7 +201,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../reference/installation/api.mdx#CSINodeDriverDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -258,11 +258,11 @@ The provided example illustrates configuring the apiserver component. Follow a s
 
 ### APIServer custom resource
 
-The [APIServer](../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
+The [APIServer](../reference/installation/api.mdx#APIServer CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
 
 #### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), update values.yaml with the appropriate resource values.
+To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#APIServerDeployment, update values.yaml with the appropriate resource values.
 
 ```bash
 apiServer:

--- a/calico/reference/installation/_api.mdx
+++ b/calico/reference/installation/_api.mdx
@@ -15,25 +15,25 @@ API Schema definitions for configuring the installation of Calico and Calico Ent
 </p>
 Resource Types:
 <ul><li>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>
+<a href="#APIServer">APIServer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>
+<a href="#ApplicationLayer">ApplicationLayer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>
+<a href="#EgressGateway">EgressGateway</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>
+<a href="#ImageSet">ImageSet</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>
+<a href="#Installation">Installation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>
+<a href="#Monitor">Monitor</a>
 </li><li>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>
+<a href="#PolicyRecommendation">PolicyRecommendation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>
+<a href="#Tenant">Tenant</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>
+<a href="#TigeraStatus">TigeraStatus</a>
 </li></ul>
-<h3 id="operator.tigera.io/v1.APIServer">APIServer</h3>
+<h3 id="APIServer">APIServer</h3>
 <p>
 APIServer installs the Tigera API server and related resources. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo; or &ldquo;tigera-secure&rdquo;.
@@ -94,7 +94,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerSpec">
+<a href="#APIServerSpec">
 APIServerSpec
 </a>
 </em>
@@ -112,7 +112,7 @@ Specification of the desired state for the Tigera API server.
 <td>
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -136,7 +136,7 @@ take precedence.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerStatus">
+<a href="#APIServerStatus">
 APIServerStatus
 </a>
 </em>
@@ -152,7 +152,7 @@ Most recently observed status for the Tigera API server.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</h3>
+<h3 id="ApplicationLayer">ApplicationLayer</h3>
 <p>
 ApplicationLayer is the Schema for the applicationlayers API
 </p>
@@ -212,7 +212,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">
+<a href="#ApplicationLayerSpec">
 ApplicationLayerSpec
 </a>
 </em>
@@ -227,7 +227,7 @@ ApplicationLayerSpec
 <td>
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -247,7 +247,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -266,7 +266,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -286,7 +286,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -308,7 +308,7 @@ User-configurable settings for the Envoy proxy.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerStatus">
+<a href="#ApplicationLayerStatus">
 ApplicationLayerStatus
 </a>
 </em>
@@ -321,7 +321,7 @@ ApplicationLayerStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGateway">EgressGateway</h3>
+<h3 id="EgressGateway">EgressGateway</h3>
 <p>
 EgressGateway is the Schema for the egressgateways API
 </p>
@@ -381,7 +381,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">
+<a href="#EgressGatewaySpec">
 EgressGatewaySpec
 </a>
 </em>
@@ -414,7 +414,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -455,7 +455,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -476,7 +476,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -496,7 +496,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -520,7 +520,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -543,7 +543,7 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayStatus">
+<a href="#EgressGatewayStatus">
 EgressGatewayStatus
 </a>
 </em>
@@ -556,7 +556,7 @@ EgressGatewayStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSet">ImageSet</h3>
+<h3 id="ImageSet">ImageSet</h3>
 <p>
 ImageSet is used to specify image digests for the images that the operator deploys.
 The name of the ImageSet is expected to be in the format <code>&lt;variant&gt;-&lt;release&gt;</code>.
@@ -621,7 +621,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">
+<a href="#ImageSetSpec">
 ImageSetSpec
 </a>
 </em>
@@ -636,7 +636,7 @@ ImageSetSpec
 <td>
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -656,7 +656,7 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Installation">Installation</h3>
+<h3 id="Installation">Installation</h3>
 <p>
 Installation configures an installation of Calico or Calico Enterprise. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo;. The Installation API installs core networking
@@ -718,7 +718,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -736,7 +736,7 @@ Specification of the desired state for the Calico or Calico Enterprise installat
 <td>
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -864,7 +864,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -887,7 +887,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -907,7 +907,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -927,7 +927,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -1106,7 +1106,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -1128,7 +1128,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -1150,7 +1150,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -1170,7 +1170,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -1190,7 +1190,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -1209,7 +1209,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -1229,7 +1229,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -1249,7 +1249,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -1269,7 +1269,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -1288,7 +1288,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -1309,7 +1309,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -1329,7 +1329,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -1370,7 +1370,7 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationStatus">
+<a href="#InstallationStatus">
 InstallationStatus
 </a>
 </em>
@@ -1386,7 +1386,7 @@ Most recently observed state for the Calico or Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Monitor">Monitor</h3>
+<h3 id="Monitor">Monitor</h3>
 <p>
 Monitor is the Schema for the monitor API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -1447,7 +1447,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorSpec">
+<a href="#MonitorSpec">
 MonitorSpec
 </a>
 </em>
@@ -1467,7 +1467,7 @@ MonitorSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorStatus">
+<a href="#MonitorStatus">
 MonitorStatus
 </a>
 </em>
@@ -1480,7 +1480,7 @@ MonitorStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</h3>
+<h3 id="PolicyRecommendation">PolicyRecommendation</h3>
 <p>
 PolicyRecommendation is the Schema for the policy recommendation API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -1541,7 +1541,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationSpec">
+<a href="#PolicyRecommendationSpec">
 PolicyRecommendationSpec
 </a>
 </em>
@@ -1561,7 +1561,7 @@ PolicyRecommendationSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationStatus">
+<a href="#PolicyRecommendationStatus">
 PolicyRecommendationStatus
 </a>
 </em>
@@ -1574,7 +1574,7 @@ PolicyRecommendationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Tenant">Tenant</h3>
+<h3 id="Tenant">Tenant</h3>
 <p>
 Tenant is the Schema for the tenants API
 </p>
@@ -1634,7 +1634,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantSpec">
+<a href="#TenantSpec">
 TenantSpec
 </a>
 </em>
@@ -1666,7 +1666,7 @@ ID is the unique identifier for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -1688,7 +1688,7 @@ Indices defines the how to store a tenant&rsquo;s data
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantStatus">
+<a href="#TenantStatus">
 TenantStatus
 </a>
 </em>
@@ -1701,7 +1701,7 @@ TenantStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatus">TigeraStatus</h3>
+<h3 id="TigeraStatus">TigeraStatus</h3>
 <p>
 TigeraStatus represents the most recently observed status for Calico or a Calico Enterprise functional area.
 </p>
@@ -1761,7 +1761,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusSpec">
+<a href="#TigeraStatusSpec">
 TigeraStatusSpec
 </a>
 </em>
@@ -1781,7 +1781,7 @@ TigeraStatusSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">
+<a href="#TigeraStatusStatus">
 TigeraStatusStatus
 </a>
 </em>
@@ -1794,11 +1794,11 @@ TigeraStatusStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</h3>
+<h3 id="APIServerDeployment">APIServerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerSpec">APIServerSpec</a>)
+<a href="#APIServerSpec">APIServerSpec</a>)
 
 </p>
 <p>
@@ -1817,7 +1817,7 @@ APIServerDeployment is the configuration for the API server Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -1837,7 +1837,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">
+<a href="#APIServerDeploymentSpec">
 APIServerDeploymentSpec
 </a>
 </em>
@@ -1858,11 +1858,11 @@ Spec is the specification of the API server Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
+<h3 id="APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -1918,11 +1918,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
+<h3 id="APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -1977,11 +1977,11 @@ If omitted, the API server Deployment will use its default value for this init c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
+<h3 id="APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -2000,7 +2000,7 @@ APIServerDeploymentDeploymentPodSpec is the API server Deployment&rsquo;s PodSpe
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentInitContainer">
+<a href="#APIServerDeploymentInitContainer">
 []APIServerDeploymentInitContainer
 </a>
 </em>
@@ -2022,7 +2022,7 @@ If omitted, the API server Deployment will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentContainer">
+<a href="#APIServerDeploymentContainer">
 []APIServerDeploymentContainer
 </a>
 </em>
@@ -2133,11 +2133,11 @@ WARNING: Please note that this field will override the default API server Deploy
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
+<h3 id="APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
+<a href="#APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -2156,7 +2156,7 @@ APIServerDeploymentPodTemplateSpec is the API server Deployment&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -2177,7 +2177,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">
+<a href="#APIServerDeploymentPodSpec">
 APIServerDeploymentPodSpec
 </a>
 </em>
@@ -2198,11 +2198,11 @@ Spec is the API server Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
+<h3 id="APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>)
 
 </p>
 <p>
@@ -2242,7 +2242,7 @@ If omitted, the API server Deployment will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">
+<a href="#APIServerDeploymentPodTemplateSpec">
 APIServerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -2259,11 +2259,11 @@ Template describes the API server Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerSpec">APIServerSpec</h3>
+<h3 id="APIServerSpec">APIServerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -2282,7 +2282,7 @@ APIServerSpec defines the desired state of Tigera API server.
 
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -2300,11 +2300,11 @@ take precedence.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerStatus">APIServerStatus</h3>
+<h3 id="APIServerStatus">APIServerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -2358,11 +2358,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</h3>
+<h3 id="AWSEgressGateway">AWSEgressGateway</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -2381,7 +2381,7 @@ AWSEgressGateway defines the configurations for deploying EgressGateway in AWS
 
 <code>nativeIP</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NativeIP">
+<a href="#NativeIP">
 NativeIP
 </a>
 </em>
@@ -2418,7 +2418,7 @@ NativeIP must be Enabled if elastic IPs are set.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
+<h3 id="AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
 <table>
 <thead>
 <tr>
@@ -2447,19 +2447,19 @@ StorageClassName is now deprecated, and configuring it has no effect.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
+<h3 id="ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</h3>
+<h3 id="ApplicationLayerSpec">ApplicationLayerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -2478,7 +2478,7 @@ ApplicationLayerSpec defines the desired state of ApplicationLayer
 
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -2498,7 +2498,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -2517,7 +2517,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -2537,7 +2537,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -2553,11 +2553,11 @@ User-configurable settings for the Envoy proxy.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerStatus">ApplicationLayerStatus</h3>
+<h3 id="ApplicationLayerStatus">ApplicationLayerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -2611,12 +2611,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.BGPOption">BGPOption
+<h3 id="BGPOption">BGPOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -2625,7 +2625,7 @@ BGPOption describes the mode of BGP to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.CAType">CAType
+<h3 id="CAType">CAType
 (<code>string</code> alias)</h3>
 <p>
 CAType specifies which verification method the tunnel client should use to verify the tunnel server&rsquo;s identity.
@@ -2633,11 +2633,11 @@ CAType specifies which verification method the tunnel client should use to verif
 <p>
 One of: Tigera, Public
 </p>
-<h3 id="operator.tigera.io/v1.CNILogging">CNILogging</h3>
+<h3 id="CNILogging">CNILogging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Logging">Logging</a>)
+<a href="#Logging">Logging</a>)
 
 </p>
 <table>
@@ -2653,7 +2653,7 @@ One of: Tigera, Public
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -2724,12 +2724,12 @@ Default: 10
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CNIPluginType">CNIPluginType
+<h3 id="CNIPluginType">CNIPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -2738,11 +2738,11 @@ CNIPluginType describes the type of CNI plugin used.
 <p>
 One of: Calico, GKE, AmazonVPC, AzureVNET
 </p>
-<h3 id="operator.tigera.io/v1.CNISpec">CNISpec</h3>
+<h3 id="CNISpec">CNISpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -2761,7 +2761,7 @@ CNISpec contains configuration for the CNI plugin.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNIPluginType">
+<a href="#CNIPluginType">
 CNIPluginType
 </a>
 </em>
@@ -2793,7 +2793,7 @@ Default: Calico
 
 <code>ipam</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMSpec">
+<a href="#IPAMSpec">
 IPAMSpec
 </a>
 </em>
@@ -2811,11 +2811,11 @@ Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
+<h3 id="CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -2834,7 +2834,7 @@ CSINodeDriverDaemonSet is the configuration for the csi-node-driver DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -2854,7 +2854,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">
+<a href="#CSINodeDriverDaemonSetSpec">
 CSINodeDriverDaemonSetSpec
 </a>
 </em>
@@ -2875,11 +2875,11 @@ Spec is the specification of the csi-node-driver DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
+<h3 id="CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -2934,11 +2934,11 @@ If omitted, the csi-node-driver DaemonSet will use its default value for this co
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -2957,7 +2957,7 @@ CSINodeDriverDaemonSetPodSpec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">
+<a href="#CSINodeDriverDaemonSetContainer">
 []CSINodeDriverDaemonSetContainer
 </a>
 </em>
@@ -3044,11 +3044,11 @@ WARNING: Please note that this field will override the default csi-node-driver D
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
+<a href="#CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -3067,7 +3067,7 @@ CSINodeDriverDaemonSetPodTemplateSpec is the csi-node-driver DaemonSet&rsquo;s P
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3088,7 +3088,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">
+<a href="#CSINodeDriverDaemonSetPodSpec">
 CSINodeDriverDaemonSetPodSpec
 </a>
 </em>
@@ -3109,11 +3109,11 @@ Spec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
+<h3 id="CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
 
 </p>
 <p>
@@ -3153,7 +3153,7 @@ If omitted, the csi-node-driver DaemonSet will use its default value for minRead
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">
 CSINodeDriverDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -3170,11 +3170,11 @@ Template describes the csi-node-driver DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
+<h3 id="CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -3193,7 +3193,7 @@ CalicoKubeControllersDeployment is the configuration for the calico-kube-control
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3213,7 +3213,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">
+<a href="#CalicoKubeControllersDeploymentSpec">
 CalicoKubeControllersDeploymentSpec
 </a>
 </em>
@@ -3234,11 +3234,11 @@ Spec is the specification of the calico-kube-controllers Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
+<h3 id="CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -3294,11 +3294,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -3317,7 +3317,7 @@ CalicoKubeControllersDeploymentPodSpec is the calico-kube-controller Deployment&
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">
+<a href="#CalicoKubeControllersDeploymentContainer">
 []CalicoKubeControllersDeploymentContainer
 </a>
 </em>
@@ -3406,11 +3406,11 @@ WARNING: Please note that this field will override the default calico-kube-contr
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
+<a href="#CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
 
 </p>
 <p>
@@ -3429,7 +3429,7 @@ CalicoKubeControllersDeploymentPodTemplateSpec is the calico-kube-controllers De
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3450,7 +3450,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">
+<a href="#CalicoKubeControllersDeploymentPodSpec">
 CalicoKubeControllersDeploymentPodSpec
 </a>
 </em>
@@ -3471,11 +3471,11 @@ Spec is the calico-kube-controllers Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
 
 </p>
 <p>
@@ -3515,7 +3515,7 @@ If omitted, the calico-kube-controllers Deployment will use its default value fo
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">
 CalicoKubeControllersDeploymentPodTemplateSpec
 </a>
 </em>
@@ -3532,11 +3532,11 @@ Template describes the calico-kube-controllers Deployment pod that will be creat
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</h3>
+<h3 id="CalicoNetworkSpec">CalicoNetworkSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -3555,7 +3555,7 @@ CalicoNetworkSpec specifies configuration options for Calico provided pod networ
 
 <code>linuxDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinuxDataplaneOption">
+<a href="#LinuxDataplaneOption">
 LinuxDataplaneOption
 </a>
 </em>
@@ -3578,7 +3578,7 @@ Default: Iptables
 
 <code>windowsDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsDataplaneOption">
+<a href="#WindowsDataplaneOption">
 WindowsDataplaneOption
 </a>
 </em>
@@ -3601,7 +3601,7 @@ Default: Disabled
 
 <code>bgp</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.BGPOption">
+<a href="#BGPOption">
 BGPOption
 </a>
 </em>
@@ -3621,7 +3621,7 @@ BGP configures whether or not to enable Calico&rsquo;s BGP capabilities.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPPool">
+<a href="#IPPool">
 []IPPool
 </a>
 </em>
@@ -3661,7 +3661,7 @@ If not specified, Calico will perform MTU auto-detection based on the cluster ne
 
 <code>nodeAddressAutodetectionV4</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -3682,7 +3682,7 @@ will use default auto-detection settings to acquire an IPv4 address for each nod
 
 <code>nodeAddressAutodetectionV6</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -3703,7 +3703,7 @@ IPv6 addresses will not be auto-detected.
 
 <code>hostPorts</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HostPortsType">
+<a href="#HostPortsType">
 HostPortsType
 </a>
 </em>
@@ -3724,7 +3724,7 @@ Default: Enabled
 
 <code>multiInterfaceMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MultiInterfaceMode">
+<a href="#MultiInterfaceMode">
 MultiInterfaceMode
 </a>
 </em>
@@ -3746,7 +3746,7 @@ Default: None
 
 <code>containerIPForwarding</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ContainerIPForwardingType">
+<a href="#ContainerIPForwardingType">
 ContainerIPForwardingType
 </a>
 </em>
@@ -3764,11 +3764,11 @@ Default: Disabled
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
+<h3 id="CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -3787,7 +3787,7 @@ CalicoNodeDaemonSet is the configuration for the calico-node DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3807,7 +3807,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">
+<a href="#CalicoNodeDaemonSetSpec">
 CalicoNodeDaemonSetSpec
 </a>
 </em>
@@ -3828,11 +3828,11 @@ Spec is the specification of the calico-node DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
+<h3 id="CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -3888,11 +3888,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -3948,11 +3948,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -3971,7 +3971,7 @@ CalicoNodeDaemonSetPodSpec is the calico-node DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">
+<a href="#CalicoNodeDaemonSetInitContainer">
 []CalicoNodeDaemonSetInitContainer
 </a>
 </em>
@@ -3993,7 +3993,7 @@ If omitted, the calico-node DaemonSet will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetContainer">
+<a href="#CalicoNodeDaemonSetContainer">
 []CalicoNodeDaemonSetContainer
 </a>
 </em>
@@ -4080,11 +4080,11 @@ WARNING: Please note that this field will override the default calico-node Daemo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
+<a href="#CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -4103,7 +4103,7 @@ CalicoNodeDaemonSetPodTemplateSpec is the calico-node DaemonSet&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4124,7 +4124,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">
+<a href="#CalicoNodeDaemonSetPodSpec">
 CalicoNodeDaemonSetPodSpec
 </a>
 </em>
@@ -4145,11 +4145,11 @@ Spec is the calico-node DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
+<h3 id="CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
 
 </p>
 <p>
@@ -4189,7 +4189,7 @@ If omitted, the calico-node DaemonSet will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">
 CalicoNodeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -4206,11 +4206,11 @@ Template describes the calico-node DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
+<h3 id="CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -4229,7 +4229,7 @@ CalicoNodeWindowsDaemonSet is the configuration for the calico-node-windows Daem
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4249,7 +4249,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">
+<a href="#CalicoNodeWindowsDaemonSetSpec">
 CalicoNodeWindowsDaemonSetSpec
 </a>
 </em>
@@ -4270,11 +4270,11 @@ Spec is the specification of the calico-node-windows DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -4330,11 +4330,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -4390,11 +4390,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -4413,7 +4413,7 @@ CalicoNodeWindowsDaemonSetPodSpec is the calico-node-windows DaemonSet&rsquo;s P
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">
+<a href="#CalicoNodeWindowsDaemonSetInitContainer">
 []CalicoNodeWindowsDaemonSetInitContainer
 </a>
 </em>
@@ -4435,7 +4435,7 @@ If omitted, the calico-node-windows DaemonSet will use its default values for it
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">
+<a href="#CalicoNodeWindowsDaemonSetContainer">
 []CalicoNodeWindowsDaemonSetContainer
 </a>
 </em>
@@ -4522,11 +4522,11 @@ WARNING: Please note that this field will override the default calico-node-windo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -4545,7 +4545,7 @@ CalicoNodeWindowsDaemonSetPodTemplateSpec is the calico-node-windows DaemonSet&r
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4566,7 +4566,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">
 CalicoNodeWindowsDaemonSetPodSpec
 </a>
 </em>
@@ -4587,11 +4587,11 @@ Spec is the calico-node-windows DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
 
 </p>
 <p>
@@ -4631,7 +4631,7 @@ If omitted, the calico-node-windows DaemonSet will use its default value for min
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">
 CalicoNodeWindowsDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -4648,11 +4648,11 @@ Template describes the calico-node-windows DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -4672,7 +4672,7 @@ CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrad
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4692,7 +4692,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">
 CalicoWindowsUpgradeDaemonSetSpec
 </a>
 </em>
@@ -4713,11 +4713,11 @@ Spec is the specification of the calico-windows-upgrade DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -4772,11 +4772,11 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -4795,7 +4795,7 @@ CalicoWindowsUpgradeDaemonSetPodSpec is the calico-windows-upgrade DaemonSet&rsq
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">
+<a href="#CalicoWindowsUpgradeDaemonSetContainer">
 []CalicoWindowsUpgradeDaemonSetContainer
 </a>
 </em>
@@ -4882,11 +4882,11 @@ WARNING: Please note that this field will override the default calico-windows-up
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -4905,7 +4905,7 @@ CalicoWindowsUpgradeDaemonSetPodTemplateSpec is the calico-windows-upgrade Daemo
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4926,7 +4926,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">
 CalicoWindowsUpgradeDaemonSetPodSpec
 </a>
 </em>
@@ -4947,11 +4947,11 @@ Spec is the calico-windows-upgrade DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
 
 </p>
 <p>
@@ -4991,7 +4991,7 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
 CalicoWindowsUpgradeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -5008,11 +5008,11 @@ Template describes the calico-windows-upgrade DaemonSet pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CertificateManagement">CertificateManagement</h3>
+<h3 id="CertificateManagement">CertificateManagement</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5104,14 +5104,14 @@ Default: SHA256WithRSA
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CollectProcessPathOption">CollectProcessPathOption
+<h3 id="CollectProcessPathOption">CollectProcessPathOption
 (<code>string</code> alias)</h3>
-<h3 id="operator.tigera.io/v1.ComponentName">ComponentName
+<h3 id="ComponentName">ComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComponentResource">ComponentResource</a>)
+<a href="#ComponentResource">ComponentResource</a>)
 
 </p>
 <p>
@@ -5120,11 +5120,11 @@ ComponentName represents a single component.
 <p>
 One of: Node, Typha, KubeControllers
 </p>
-<h3 id="operator.tigera.io/v1.ComponentResource">ComponentResource</h3>
+<h3 id="ComponentResource">ComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5144,7 +5144,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentName">
+<a href="#ComponentName">
 ComponentName
 </a>
 </em>
@@ -5179,44 +5179,44 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ConditionStatus">ConditionStatus
+<h3 id="ConditionStatus">ConditionStatus
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 ConditionStatus represents the status of a particular condition. A condition may be one of: True, False, Unknown.
 </p>
-<h3 id="operator.tigera.io/v1.ContainerIPForwardingType">ContainerIPForwardingType
+<h3 id="ContainerIPForwardingType">ContainerIPForwardingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
 ContainerIPForwardingType specifies whether the CNI config for container ip forwarding is enabled.
 </p>
-<h3 id="operator.tigera.io/v1.DataType">DataType
+<h3 id="DataType">DataType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Index">Index</a>)
+<a href="#Index">Index</a>)
 
 </p>
 <p>
 DataType represent the type of data stored
 </p>
-<h3 id="operator.tigera.io/v1.EGWDeploymentContainer">EGWDeploymentContainer</h3>
+<h3 id="EGWDeploymentContainer">EGWDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -5272,11 +5272,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
+<h3 id="EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -5332,11 +5332,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
+<h3 id="EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -5355,7 +5355,7 @@ EgressGatewayDeploymentPodSpec is the Egress Gateway Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentInitContainer">
+<a href="#EGWDeploymentInitContainer">
 []EGWDeploymentInitContainer
 </a>
 </em>
@@ -5377,7 +5377,7 @@ If omitted, the EGW Deployment will use its default values for its init containe
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentContainer">
+<a href="#EGWDeploymentContainer">
 []EGWDeploymentContainer
 </a>
 </em>
@@ -5494,11 +5494,11 @@ If omitted, the EGW Deployment will use its default value for tolerations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
+<h3 id="EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -5517,7 +5517,7 @@ EgressGatewayDeploymentPodTemplateSpec is the EGW Deployment&rsquo;s PodTemplate
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayMetadata">
+<a href="#EgressGatewayMetadata">
 EgressGatewayMetadata
 </a>
 </em>
@@ -5538,7 +5538,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">
+<a href="#EgressGatewayDeploymentPodSpec">
 EgressGatewayDeploymentPodSpec
 </a>
 </em>
@@ -5559,11 +5559,11 @@ Spec is the EGW Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
+<h3 id="EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -5604,7 +5604,7 @@ Default: 90
 
 <code>icmpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ICMPProbe">
+<a href="#ICMPProbe">
 ICMPProbe
 </a>
 </em>
@@ -5626,7 +5626,7 @@ fail. Timeout must be greater than interval.
 
 <code>httpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HTTPProbe">
+<a href="#HTTPProbe">
 HTTPProbe
 </a>
 </em>
@@ -5645,11 +5645,11 @@ fail. Timeout must be greater than interval.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayIPPool">EgressGatewayIPPool</h3>
+<h3 id="EgressGatewayIPPool">EgressGatewayIPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <table>
@@ -5698,11 +5698,11 @@ CIDR is the IPPool CIDR that the Egress Gateways can use.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayMetadata">EgressGatewayMetadata</h3>
+<h3 id="EgressGatewayMetadata">EgressGatewayMetadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -5760,11 +5760,11 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</h3>
+<h3 id="EgressGatewaySpec">EgressGatewaySpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -5801,7 +5801,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -5842,7 +5842,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -5863,7 +5863,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -5883,7 +5883,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -5907,7 +5907,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -5924,11 +5924,11 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayStatus">EgressGatewayStatus</h3>
+<h3 id="EgressGatewayStatus">EgressGatewayStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -5982,12 +5982,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EncapsulationType">EncapsulationType
+<h3 id="EncapsulationType">EncapsulationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -5996,7 +5996,7 @@ EncapsulationType is the type of encapsulation to use on an IP pool.
 <p>
 One of: IPIP, VXLAN, IPIPCrossSubnet, VXLANCrossSubnet, None
 </p>
-<h3 id="operator.tigera.io/v1.EncryptionOption">EncryptionOption
+<h3 id="EncryptionOption">EncryptionOption
 (<code>string</code> alias)</h3>
 <p>
 EncryptionOption specifies the traffic encryption mode when connecting to a Syslog server.
@@ -6004,11 +6004,11 @@ EncryptionOption specifies the traffic encryption mode when connecting to a Sysl
 <p>
 One of: None, TLS
 </p>
-<h3 id="operator.tigera.io/v1.EnvoySettings">EnvoySettings</h3>
+<h3 id="EnvoySettings">EnvoySettings</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -6061,19 +6061,19 @@ manipulating various headers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FIPSMode">FIPSMode
+<h3 id="FIPSMode">FIPSMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.HTTPProbe">HTTPProbe</h3>
+<h3 id="HTTPProbe">HTTPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -6145,12 +6145,12 @@ Default: 30
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HostPortsType">HostPortsType
+<h3 id="HostPortsType">HostPortsType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -6159,11 +6159,11 @@ HostPortsType specifies host port support.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.ICMPProbe">ICMPProbe</h3>
+<h3 id="ICMPProbe">ICMPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -6235,19 +6235,19 @@ Default: 15
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPAMPluginType">IPAMPluginType
+<h3 id="IPAMPluginType">IPAMPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPAMSpec">IPAMSpec</a>)
+<a href="#IPAMSpec">IPAMSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IPAMSpec">IPAMSpec</h3>
+<h3 id="IPAMSpec">IPAMSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -6266,7 +6266,7 @@ IPAMSpec contains configuration for pod IP address management.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMPluginType">
+<a href="#IPAMPluginType">
 IPAMPluginType
 </a>
 </em>
@@ -6294,11 +6294,11 @@ Default: Calico
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPPool">IPPool</h3>
+<h3 id="IPPool">IPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -6331,7 +6331,7 @@ CIDR contains the address range for the IP Pool in classless inter-domain routin
 
 <code>encapsulation</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncapsulationType">
+<a href="#EncapsulationType">
 EncapsulationType
 </a>
 </em>
@@ -6353,7 +6353,7 @@ Default: IPIP
 
 <code>natOutgoing</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NATOutgoingType">
+<a href="#NATOutgoingType">
 NATOutgoingType
 </a>
 </em>
@@ -6429,11 +6429,11 @@ Default: false
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Image">Image</h3>
+<h3 id="Image">Image</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</a>)
+<a href="#ImageSetSpec">ImageSetSpec</a>)
 
 </p>
 <table>
@@ -6484,11 +6484,11 @@ The field should not include a leading <code>@</code> and must be prefixed with 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</h3>
+<h3 id="ImageSetSpec">ImageSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>)
+<a href="#ImageSet">ImageSet</a>)
 
 </p>
 <p>
@@ -6507,7 +6507,7 @@ ImageSetSpec defines the desired state of ImageSet.
 
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -6524,11 +6524,11 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Index">Index</h3>
+<h3 id="Index">Index</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -6566,7 +6566,7 @@ excludes the numerical identifier suffix)
 
 <code>dataType</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DataType">
+<a href="#DataType">
 DataType
 </a>
 </em>
@@ -6582,12 +6582,12 @@ DataType represents the type of data stored in the defined index
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationSpec">InstallationSpec</h3>
+<h3 id="InstallationSpec">InstallationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#Installation">Installation</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -6606,7 +6606,7 @@ InstallationSpec defines configuration for a Calico or Calico Enterprise install
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -6734,7 +6734,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -6757,7 +6757,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -6777,7 +6777,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -6797,7 +6797,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -6976,7 +6976,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -6998,7 +6998,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -7020,7 +7020,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -7040,7 +7040,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -7060,7 +7060,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -7079,7 +7079,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -7099,7 +7099,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -7119,7 +7119,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -7139,7 +7139,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -7158,7 +7158,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -7179,7 +7179,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -7199,7 +7199,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -7234,11 +7234,11 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationStatus">InstallationStatus</h3>
+<h3 id="InstallationStatus">InstallationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>)
+<a href="#Installation">Installation</a>)
 
 </p>
 <p>
@@ -7257,7 +7257,7 @@ InstallationStatus defines the observed state of the Calico or Calico Enterprise
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -7313,7 +7313,7 @@ that is being used. If an ImageSet is not being used then this will not be set.
 
 <code>computed</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -7370,12 +7370,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
+<h3 id="KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</a>)
+<a href="#NodeAddressAutodetection">NodeAddressAutodetection</a>)
 
 </p>
 <p>
@@ -7384,12 +7384,12 @@ KubernetesAutodetectionMethod is a method of detecting an IP address based on th
 <p>
 One of: NodeInternalIP
 </p>
-<h3 id="operator.tigera.io/v1.LinuxDataplaneOption">LinuxDataplaneOption
+<h3 id="LinuxDataplaneOption">LinuxDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -7398,11 +7398,11 @@ LinuxDataplaneOption controls which dataplane is to be used on Linux nodes.
 <p>
 One of: Iptables, BPF
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</h3>
+<h3 id="LogCollectionSpec">LogCollectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -7418,7 +7418,7 @@ One of: Iptables, BPF
 
 <code>collectLogs</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionStatusType">
+<a href="#LogCollectionStatusType">
 LogCollectionStatusType
 </a>
 </em>
@@ -7476,28 +7476,28 @@ Default: -1
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectionStatusType">LogCollectionStatusType
+<h3 id="LogCollectionStatusType">LogCollectionStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</a>)
+<a href="#LogCollectionSpec">LogCollectionSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogLevel">LogLevel
+<h3 id="LogLevel">LogLevel
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNILogging">CNILogging</a>, 
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#CNILogging">CNILogging</a>, 
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.Logging">Logging</h3>
+<h3 id="Logging">Logging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>
@@ -7513,7 +7513,7 @@ Default: -1
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNILogging">
+<a href="#CNILogging">
 CNILogging
 </a>
 </em>
@@ -7530,24 +7530,24 @@ Customized logging specification for calico-cni plugin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Metadata">Metadata</h3>
+<h3 id="Metadata">Metadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>, 
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>, 
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
+<a href="#TyphaDeployment">TyphaDeployment</a>, 
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7603,21 +7603,21 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MonitorSpec">MonitorSpec</h3>
+<h3 id="MonitorSpec">MonitorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
 MonitorSpec defines the desired state of Tigera monitor.
 </p>
-<h3 id="operator.tigera.io/v1.MonitorStatus">MonitorStatus</h3>
+<h3 id="MonitorStatus">MonitorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -7671,12 +7671,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MultiInterfaceMode">MultiInterfaceMode
+<h3 id="MultiInterfaceMode">MultiInterfaceMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -7685,12 +7685,12 @@ MultiInterfaceMode describes the method of providing multiple pod interfaces.
 <p>
 One of: None, Multus
 </p>
-<h3 id="operator.tigera.io/v1.NATOutgoingType">NATOutgoingType
+<h3 id="NATOutgoingType">NATOutgoingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -7699,23 +7699,23 @@ NATOutgoingType describe the type of outgoing NAT to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.NativeIP">NativeIP
+<h3 id="NativeIP">NativeIP
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</a>)
+<a href="#AWSEgressGateway">AWSEgressGateway</a>)
 
 </p>
 <p>
 NativeIP defines if Egress Gateway pods should have AWS IPs.
 When NativeIP is enabled, the IPPools should be backed by AWS subnet.
 </p>
-<h3 id="operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</h3>
+<h3 id="NodeAddressAutodetection">NodeAddressAutodetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -7755,7 +7755,7 @@ filtering based on well-known interface names.
 
 <code>kubernetes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KubernetesAutodetectionMethod">
+<a href="#KubernetesAutodetectionMethod">
 KubernetesAutodetectionMethod
 </a>
 </em>
@@ -7846,11 +7846,11 @@ one of the provided CIDRs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeAffinity">NodeAffinity</h3>
+<h3 id="NodeAffinity">NodeAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</a>)
+<a href="#TyphaAffinity">TyphaAffinity</a>)
 
 </p>
 <p>
@@ -7919,12 +7919,12 @@ may or may not try to eventually evict the pod from its node.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NonPrivilegedType">NonPrivilegedType
+<h3 id="NonPrivilegedType">NonPrivilegedType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7933,29 +7933,29 @@ NonPrivilegedType specifies whether Calico runs as permissioned or not
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.OIDCType">OIDCType
+<h3 id="OIDCType">OIDCType
 (<code>string</code> alias)</h3>
 <p>
 OIDCType defines how OIDC is configured for Tigera Enterprise. Dex should be the best option for most use-cases.
 The Tigera option can help in specific use-cases, for instance, when you are unable to configure a client secret.
 One of: Dex, Tigera
 </p>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
+<h3 id="PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
 PolicyRecommendationSpec defines configuration for the Calico Enterprise Policy Recommendation
 service.
 </p>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
+<h3 id="PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
@@ -7988,13 +7988,13 @@ State provides user-readable status.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ProductVariant">ProductVariant
+<h3 id="ProductVariant">ProductVariant
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#InstallationSpec">InstallationSpec</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -8003,37 +8003,37 @@ ProductVariant represents the variant of the product.
 <p>
 One of: Calico, TigeraSecureEnterprise
 </p>
-<h3 id="operator.tigera.io/v1.PromptType">PromptType
+<h3 id="PromptType">PromptType
 (<code>string</code> alias)</h3>
 <p>
 PromptType is a value that specifies whether the identity provider prompts the end user for re-authentication and
 consent.
 One of: None, Login, Consent, SelectAccount.
 </p>
-<h3 id="operator.tigera.io/v1.Provider">Provider
+<h3 id="Provider">Provider
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
 Provider represents a particular provider or flavor of Kubernetes. Valid options
 are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise.
 </p>
-<h3 id="operator.tigera.io/v1.StatusConditionType">StatusConditionType
+<h3 id="StatusConditionType">StatusConditionType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 StatusConditionType is a type of condition that may apply to a particular component.
 </p>
-<h3 id="operator.tigera.io/v1.TLS">TLS</h3>
+<h3 id="TLS">TLS</h3>
 <table>
 <thead>
 <tr>
@@ -8081,11 +8081,11 @@ Default: tigera-management-cluster-connection
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantSpec">TenantSpec</h3>
+<h3 id="TenantSpec">TenantSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
 <table>
@@ -8118,7 +8118,7 @@ ID is the unique identifier for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -8134,18 +8134,18 @@ Indices defines the how to store a tenant&rsquo;s data
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantStatus">TenantStatus</h3>
+<h3 id="TenantStatus">TenantStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</h3>
+<h3 id="TigeraStatusCondition">TigeraStatusCondition</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</a>)
+<a href="#TigeraStatusStatus">TigeraStatusStatus</a>)
 
 </p>
 <p>
@@ -8164,7 +8164,7 @@ TigeraStatusCondition represents a condition attached to a particular component.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.StatusConditionType">
+<a href="#StatusConditionType">
 StatusConditionType
 </a>
 </em>
@@ -8183,7 +8183,7 @@ The type of condition. May be Available, Progressing, or Degraded.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ConditionStatus">
+<a href="#ConditionStatus">
 ConditionStatus
 </a>
 </em>
@@ -8272,26 +8272,26 @@ with respect to the current state of the instance.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatusReason">TigeraStatusReason
+<h3 id="TigeraStatusReason">TigeraStatusReason
 (<code>string</code> alias)</h3>
 <p>
 TigeraStatusReason represents the reason for a particular condition.
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusSpec">TigeraStatusSpec</h3>
+<h3 id="TigeraStatusSpec">TigeraStatusSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
 TigeraStatusSpec defines the desired state of TigeraStatus
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</h3>
+<h3 id="TigeraStatusStatus">TigeraStatusStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
@@ -8310,7 +8310,7 @@ TigeraStatusStatus defines the observed state of TigeraStatus
 
 <code>conditions</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">
+<a href="#TigeraStatusCondition">
 []TigeraStatusCondition
 </a>
 </em>
@@ -8327,11 +8327,11 @@ Available, Progressing, or Degraded.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</h3>
+<h3 id="TyphaAffinity">TyphaAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -8351,7 +8351,7 @@ TyphaAffinity allows configuration of node affinity characteristics for Typha po
 
 <code>nodeAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAffinity">
+<a href="#NodeAffinity">
 NodeAffinity
 </a>
 </em>
@@ -8368,11 +8368,11 @@ NodeAffinity describes node affinity scheduling rules for typha.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</h3>
+<h3 id="TyphaDeployment">TyphaDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -8391,7 +8391,7 @@ TyphaDeployment is the configuration for the typha Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -8411,7 +8411,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">
+<a href="#TyphaDeploymentSpec">
 TyphaDeploymentSpec
 </a>
 </em>
@@ -8432,11 +8432,11 @@ Spec is the specification of the typha Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
+<h3 id="TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -8492,11 +8492,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
+<h3 id="TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -8552,11 +8552,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
+<h3 id="TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8575,7 +8575,7 @@ TyphaDeploymentPodSpec is the typha Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentInitContainer">
+<a href="#TyphaDeploymentInitContainer">
 []TyphaDeploymentInitContainer
 </a>
 </em>
@@ -8597,7 +8597,7 @@ If omitted, the typha Deployment will use its default values for its init contai
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentContainer">
+<a href="#TyphaDeploymentContainer">
 []TyphaDeploymentContainer
 </a>
 </em>
@@ -8731,11 +8731,11 @@ WARNING: Please note that this field will override the default calico-typha Depl
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
+<h3 id="TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -8754,7 +8754,7 @@ TyphaDeploymentPodTemplateSpec is the typha Deployment&rsquo;s PodTemplateSpec
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -8775,7 +8775,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">
+<a href="#TyphaDeploymentPodSpec">
 TyphaDeploymentPodSpec
 </a>
 </em>
@@ -8796,11 +8796,11 @@ Spec is the typha Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
+<h3 id="TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>)
+<a href="#TyphaDeployment">TyphaDeployment</a>)
 
 </p>
 <p>
@@ -8840,7 +8840,7 @@ If omitted, the typha Deployment will use its default value for minReadySeconds.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">
+<a href="#TyphaDeploymentPodTemplateSpec">
 TyphaDeploymentPodTemplateSpec
 </a>
 </em>
@@ -8860,7 +8860,7 @@ Template describes the typha Deployment pod that will be created.
 
 <code>strategy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentStrategy">
+<a href="#TyphaDeploymentStrategy">
 TyphaDeploymentStrategy
 </a>
 </em>
@@ -8877,11 +8877,11 @@ The deployment strategy to use to replace existing pods with new ones.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
+<h3 id="TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -8920,27 +8920,27 @@ to be.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.WAFStatusType">WAFStatusType
+<h3 id="WAFStatusType">WAFStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsDataplaneOption">WindowsDataplaneOption
+<h3 id="WindowsDataplaneOption">WindowsDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsNodeSpec">WindowsNodeSpec</h3>
+<h3 id="WindowsNodeSpec">WindowsNodeSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>

--- a/calico/reference/installation/helm_customization.mdx
+++ b/calico/reference/installation/helm_customization.mdx
@@ -8,7 +8,7 @@ import variables from '@site/calico/variables';
 
 You can customize the following resources and settings during {variables.prodname} Helm-based installation using the file, `values.yaml`.
 
-- [Installation](api.mdx#operator.tigera.io/v1.InstallationSpec)
+- [Installation](api.mdx#InstallationSpec
 - [Default felix configuration](../resources/felixconfig.mdx#spec)
 
 :::note

--- a/calico_versioned_docs/version-3.26/getting-started/kubernetes/helm.mdx
+++ b/calico_versioned_docs/version-3.26/getting-started/kubernetes/helm.mdx
@@ -49,7 +49,7 @@ helm repo add projectcalico https://docs.tigera.io/calico/charts
 
 If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), or you need to customize TLS certificates, you **must** customize this Helm chart by creating a `values.yaml` file. Otherwise, you can skip this step.
 
-1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#operator.tigera.io/v1.Provider). For example:
+1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#Provider. For example:
 
    ```
    echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico_versioned_docs/version-3.26/getting-started/kubernetes/self-managed-onprem/config-options.mdx
+++ b/calico_versioned_docs/version-3.26/getting-started/kubernetes/self-managed-onprem/config-options.mdx
@@ -36,9 +36,9 @@ installed directly on the cluster as a Deployment, and is configured through one
 Operator installations read their configuration from a specific set of Kubernetes APIs. These APIs are installed on the cluster
 as part of `tigera-operator.yaml` in the `operator.tigera.io/v1` API group.
 
-- [Installation](../../../reference/installation/api.mdx#operator.tigera.io/v1.Installation): a singleton resource with name "default" that
+- [Installation](../../../reference/installation/api.mdx#Installation: a singleton resource with name "default" that
   configures common installation parameters for a {variables.prodname} cluster.
-- [APIServer](../../../reference/installation/api.mdx#operator.tigera.io/v1.Installation): a singleton resource with name "default" that
+- [APIServer](../../../reference/installation/api.mdx#Installation: a singleton resource with name "default" that
   configures installation of the {variables.prodname} API server extension.
 
 ### Configure the pod IP range

--- a/calico_versioned_docs/version-3.26/getting-started/kubernetes/windows-calico/kubernetes/requirements.mdx
+++ b/calico_versioned_docs/version-3.26/getting-started/kubernetes/windows-calico/kubernetes/requirements.mdx
@@ -38,7 +38,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../../reference/installation/api.mdx#BGPOption.
 
 :::
 

--- a/calico_versioned_docs/version-3.26/networking/ipam/ip-autodetection.mdx
+++ b/calico_versioned_docs/version-3.26/networking/ipam/ip-autodetection.mdx
@@ -65,7 +65,7 @@ For more details on autodetection methods, see [node configuration](../../refere
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-As noted previously, the default autodetection method is **first valid interface found** (first-found). To use a different autodetection method, edit the default [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation) custom resource, specifying the method. Below are examples of the supported autodetection methods:
+As noted previously, the default autodetection method is **first valid interface found** (first-found). To use a different autodetection method, edit the default [Installation](../../reference/installation/api.mdx#Installation custom resource, specifying the method. Below are examples of the supported autodetection methods:
 
 :::note
 

--- a/calico_versioned_docs/version-3.26/operations/certificate-management.mdx
+++ b/calico_versioned_docs/version-3.26/operations/certificate-management.mdx
@@ -31,7 +31,7 @@ certificate issuance, {variables.prodname} provides a simple configuration optio
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../reference/installation/api.mdx#Installation
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
 ```yaml

--- a/calico_versioned_docs/version-3.26/operations/image-options/imageset.mdx
+++ b/calico_versioned_docs/version-3.26/operations/image-options/imageset.mdx
@@ -78,7 +78,7 @@ sed -ie "s|\(image: .*/operator\):.*|?\1@<put-digest-here>|" tigera-operator.yam
 
 ### Create an ImageSet
 
-Create an [ImageSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ImageSet) manifest file named `imageset.yaml` like the following:
+Create an [ImageSet](../../reference/installation/api.mdx#ImageSet manifest file named `imageset.yaml` like the following:
 
 <CodeBlock language='yaml'>
 apiVersion: operator.tigera.io/v1
@@ -142,7 +142,7 @@ You can create an ImageSet manifest manually or by script.
       docker pull <repo/image:tag> && docker inspect <repo/image:tag> -f '{{range .RepoDigests}}{{printf "%s\n" .}}{{end}}'
       ```
    1. Use the digest from the image that matches the repo/image you will use.
-      If you are using a private registry or have specified an [imagePath](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+      If you are using a private registry or have specified an [imagePath](../../reference/installation/api.mdx#Installation
       you will still use the "default" `<owner>/<image>` in the `image` field, for example if you your node image is coming from
       `example.com/registry/imagepath/node` you will still use `calico/node` in the image field of the ImageSet.
       :::note
@@ -228,7 +228,7 @@ Apply the created `imageset.yaml` to your cluster.
 
 ### Create new ImageSet when upgrading or downgrading
 
-Before upgrading to a new release or downgrading, you must create a new [ImageSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ImageSet)
+Before upgrading to a new release or downgrading, you must create a new [ImageSet](../../reference/installation/api.mdx#ImageSet
 with updated image references and names for the new release. This must be done prior
 to upgrading the cluster so when the new manifests are applied, the appropriate ImageSet is available.
 
@@ -236,7 +236,7 @@ to upgrading the cluster so when the new manifests are applied, the appropriate 
 
 ### Why does the Installation Resource status not include my ImageSet?
 
-The [status.imageset](../../reference/installation/api.mdx#operator.tigera.io/v1.InstallationStatus) field of
+The [status.imageset](../../reference/installation/api.mdx#InstallationStatus field of
 the Installation Resource will not be updated until the `calico` component has fully been deployed. `calico` is
 fully deployed when `kubectl get tigerastatus calico` reports Available True with Progressing and Degraded as False.
 

--- a/calico_versioned_docs/version-3.26/reference/configure-cni-plugins.mdx
+++ b/calico_versioned_docs/version-3.26/reference/configure-cni-plugins.mdx
@@ -264,7 +264,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](installation/api.mdx#Installation API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico_versioned_docs/version-3.26/reference/installation/_api.mdx
+++ b/calico_versioned_docs/version-3.26/reference/installation/_api.mdx
@@ -15,23 +15,23 @@ API Schema definitions for configuring the installation of Calico and Calico Ent
 </p>
 Resource Types:
 <ul><li>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>
+<a href="#APIServer">APIServer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>
+<a href="#ApplicationLayer">ApplicationLayer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>
+<a href="#EgressGateway">EgressGateway</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>
+<a href="#ImageSet">ImageSet</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>
+<a href="#Installation">Installation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>
+<a href="#Monitor">Monitor</a>
 </li><li>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>
+<a href="#PolicyRecommendation">PolicyRecommendation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>
+<a href="#TigeraStatus">TigeraStatus</a>
 </li></ul>
-<h3 id="operator.tigera.io/v1.APIServer">APIServer</h3>
+<h3 id="APIServer">APIServer</h3>
 <p>
 APIServer installs the Tigera API server and related resources. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo; or &ldquo;tigera-secure&rdquo;.
@@ -92,7 +92,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerSpec">
+<a href="#APIServerSpec">
 APIServerSpec
 </a>
 </em>
@@ -110,7 +110,7 @@ Specification of the desired state for the Tigera API server.
 <td>
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -134,7 +134,7 @@ take precedence.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerStatus">
+<a href="#APIServerStatus">
 APIServerStatus
 </a>
 </em>
@@ -150,7 +150,7 @@ Most recently observed status for the Tigera API server.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</h3>
+<h3 id="ApplicationLayer">ApplicationLayer</h3>
 <p>
 ApplicationLayer is the Schema for the applicationlayers API
 </p>
@@ -210,7 +210,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">
+<a href="#ApplicationLayerSpec">
 ApplicationLayerSpec
 </a>
 </em>
@@ -225,7 +225,7 @@ ApplicationLayerSpec
 <td>
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -245,7 +245,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -264,7 +264,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -284,7 +284,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -306,7 +306,7 @@ User-configurable settings for the Envoy proxy.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerStatus">
+<a href="#ApplicationLayerStatus">
 ApplicationLayerStatus
 </a>
 </em>
@@ -319,7 +319,7 @@ ApplicationLayerStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGateway">EgressGateway</h3>
+<h3 id="EgressGateway">EgressGateway</h3>
 <p>
 EgressGateway is the Schema for the egressgateways API
 </p>
@@ -379,7 +379,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">
+<a href="#EgressGatewaySpec">
 EgressGatewaySpec
 </a>
 </em>
@@ -412,7 +412,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -453,7 +453,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -474,7 +474,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -494,7 +494,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -518,7 +518,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -541,7 +541,7 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayStatus">
+<a href="#EgressGatewayStatus">
 EgressGatewayStatus
 </a>
 </em>
@@ -554,7 +554,7 @@ EgressGatewayStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSet">ImageSet</h3>
+<h3 id="ImageSet">ImageSet</h3>
 <p>
 ImageSet is used to specify image digests for the images that the operator deploys.
 The name of the ImageSet is expected to be in the format <code>&lt;variant&gt;-&lt;release&gt;</code>.
@@ -619,7 +619,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">
+<a href="#ImageSetSpec">
 ImageSetSpec
 </a>
 </em>
@@ -634,7 +634,7 @@ ImageSetSpec
 <td>
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -654,7 +654,7 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Installation">Installation</h3>
+<h3 id="Installation">Installation</h3>
 <p>
 Installation configures an installation of Calico or Calico Enterprise. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo;. The Installation API installs core networking
@@ -716,7 +716,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -734,7 +734,7 @@ Specification of the desired state for the Calico or Calico Enterprise installat
 <td>
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -862,7 +862,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -885,7 +885,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -905,7 +905,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -925,7 +925,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -1104,7 +1104,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -1126,7 +1126,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -1148,7 +1148,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -1168,7 +1168,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -1188,7 +1188,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -1207,7 +1207,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -1227,7 +1227,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -1247,7 +1247,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -1266,7 +1266,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -1287,7 +1287,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -1310,7 +1310,7 @@ Logging Configuration for Components
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationStatus">
+<a href="#InstallationStatus">
 InstallationStatus
 </a>
 </em>
@@ -1326,7 +1326,7 @@ Most recently observed state for the Calico or Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Monitor">Monitor</h3>
+<h3 id="Monitor">Monitor</h3>
 <p>
 Monitor is the Schema for the monitor API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -1387,7 +1387,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorSpec">
+<a href="#MonitorSpec">
 MonitorSpec
 </a>
 </em>
@@ -1407,7 +1407,7 @@ MonitorSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorStatus">
+<a href="#MonitorStatus">
 MonitorStatus
 </a>
 </em>
@@ -1420,7 +1420,7 @@ MonitorStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</h3>
+<h3 id="PolicyRecommendation">PolicyRecommendation</h3>
 <p>
 PolicyRecommendation is the Schema for the policy recommendation API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -1481,7 +1481,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationSpec">
+<a href="#PolicyRecommendationSpec">
 PolicyRecommendationSpec
 </a>
 </em>
@@ -1501,7 +1501,7 @@ PolicyRecommendationSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationStatus">
+<a href="#PolicyRecommendationStatus">
 PolicyRecommendationStatus
 </a>
 </em>
@@ -1514,7 +1514,7 @@ PolicyRecommendationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatus">TigeraStatus</h3>
+<h3 id="TigeraStatus">TigeraStatus</h3>
 <p>
 TigeraStatus represents the most recently observed status for Calico or a Calico Enterprise functional area.
 </p>
@@ -1574,7 +1574,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusSpec">
+<a href="#TigeraStatusSpec">
 TigeraStatusSpec
 </a>
 </em>
@@ -1594,7 +1594,7 @@ TigeraStatusSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">
+<a href="#TigeraStatusStatus">
 TigeraStatusStatus
 </a>
 </em>
@@ -1607,11 +1607,11 @@ TigeraStatusStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</h3>
+<h3 id="APIServerDeployment">APIServerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerSpec">APIServerSpec</a>)
+<a href="#APIServerSpec">APIServerSpec</a>)
 
 </p>
 <p>
@@ -1630,7 +1630,7 @@ APIServerDeployment is the configuration for the API server Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -1650,7 +1650,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">
+<a href="#APIServerDeploymentSpec">
 APIServerDeploymentSpec
 </a>
 </em>
@@ -1671,11 +1671,11 @@ Spec is the specification of the API server Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
+<h3 id="APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -1731,11 +1731,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
+<h3 id="APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -1790,11 +1790,11 @@ If omitted, the API server Deployment will use its default value for this init c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
+<h3 id="APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -1813,7 +1813,7 @@ APIServerDeploymentDeploymentPodSpec is the API server Deployment&rsquo;s PodSpe
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentInitContainer">
+<a href="#APIServerDeploymentInitContainer">
 []APIServerDeploymentInitContainer
 </a>
 </em>
@@ -1835,7 +1835,7 @@ If omitted, the API server Deployment will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentContainer">
+<a href="#APIServerDeploymentContainer">
 []APIServerDeploymentContainer
 </a>
 </em>
@@ -1946,11 +1946,11 @@ WARNING: Please note that this field will override the default API server Deploy
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
+<h3 id="APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
+<a href="#APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -1969,7 +1969,7 @@ APIServerDeploymentPodTemplateSpec is the API server Deployment&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -1990,7 +1990,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">
+<a href="#APIServerDeploymentPodSpec">
 APIServerDeploymentPodSpec
 </a>
 </em>
@@ -2011,11 +2011,11 @@ Spec is the API server Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
+<h3 id="APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>)
 
 </p>
 <p>
@@ -2055,7 +2055,7 @@ If omitted, the API server Deployment will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">
+<a href="#APIServerDeploymentPodTemplateSpec">
 APIServerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -2072,11 +2072,11 @@ Template describes the API server Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerSpec">APIServerSpec</h3>
+<h3 id="APIServerSpec">APIServerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -2095,7 +2095,7 @@ APIServerSpec defines the desired state of Tigera API server.
 
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -2113,11 +2113,11 @@ take precedence.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerStatus">APIServerStatus</h3>
+<h3 id="APIServerStatus">APIServerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -2171,11 +2171,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</h3>
+<h3 id="AWSEgressGateway">AWSEgressGateway</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -2194,7 +2194,7 @@ AWSEgressGateway defines the configurations for deploying EgressGateway in AWS
 
 <code>nativeIP</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NativeIP">
+<a href="#NativeIP">
 NativeIP
 </a>
 </em>
@@ -2231,7 +2231,7 @@ NativeIP must be Enabled if elastic IPs are set.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
+<h3 id="AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
 <table>
 <thead>
 <tr>
@@ -2266,19 +2266,19 @@ This field is not used for managed clusters in a Multi-cluster management setup.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
+<h3 id="ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</h3>
+<h3 id="ApplicationLayerSpec">ApplicationLayerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -2297,7 +2297,7 @@ ApplicationLayerSpec defines the desired state of ApplicationLayer
 
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -2317,7 +2317,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -2336,7 +2336,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -2356,7 +2356,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -2372,11 +2372,11 @@ User-configurable settings for the Envoy proxy.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerStatus">ApplicationLayerStatus</h3>
+<h3 id="ApplicationLayerStatus">ApplicationLayerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -2430,12 +2430,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.BGPOption">BGPOption
+<h3 id="BGPOption">BGPOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -2444,7 +2444,7 @@ BGPOption describes the mode of BGP to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.CAType">CAType
+<h3 id="CAType">CAType
 (<code>string</code> alias)</h3>
 <p>
 CAType specifies which verification method the tunnel client should use to verify the tunnel server&rsquo;s identity.
@@ -2452,11 +2452,11 @@ CAType specifies which verification method the tunnel client should use to verif
 <p>
 One of: Tigera, Public
 </p>
-<h3 id="operator.tigera.io/v1.CNILogging">CNILogging</h3>
+<h3 id="CNILogging">CNILogging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Logging">Logging</a>)
+<a href="#Logging">Logging</a>)
 
 </p>
 <table>
@@ -2472,7 +2472,7 @@ One of: Tigera, Public
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -2543,12 +2543,12 @@ Default: 10
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CNIPluginType">CNIPluginType
+<h3 id="CNIPluginType">CNIPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -2557,11 +2557,11 @@ CNIPluginType describes the type of CNI plugin used.
 <p>
 One of: Calico, GKE, AmazonVPC, AzureVNET
 </p>
-<h3 id="operator.tigera.io/v1.CNISpec">CNISpec</h3>
+<h3 id="CNISpec">CNISpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -2580,7 +2580,7 @@ CNISpec contains configuration for the CNI plugin.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNIPluginType">
+<a href="#CNIPluginType">
 CNIPluginType
 </a>
 </em>
@@ -2612,7 +2612,7 @@ Default: Calico
 
 <code>ipam</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMSpec">
+<a href="#IPAMSpec">
 IPAMSpec
 </a>
 </em>
@@ -2630,11 +2630,11 @@ Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
+<h3 id="CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -2653,7 +2653,7 @@ CSINodeDriverDaemonSet is the configuration for the csi-node-driver DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -2673,7 +2673,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">
+<a href="#CSINodeDriverDaemonSetSpec">
 CSINodeDriverDaemonSetSpec
 </a>
 </em>
@@ -2694,11 +2694,11 @@ Spec is the specification of the csi-node-driver DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
+<h3 id="CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -2753,11 +2753,11 @@ If omitted, the csi-node-driver DaemonSet will use its default value for this co
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -2776,7 +2776,7 @@ CSINodeDriverDaemonSetPodSpec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">
+<a href="#CSINodeDriverDaemonSetContainer">
 []CSINodeDriverDaemonSetContainer
 </a>
 </em>
@@ -2863,11 +2863,11 @@ WARNING: Please note that this field will override the default csi-node-driver D
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
+<a href="#CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -2886,7 +2886,7 @@ CSINodeDriverDaemonSetPodTemplateSpec is the csi-node-driver DaemonSet&rsquo;s P
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -2907,7 +2907,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">
+<a href="#CSINodeDriverDaemonSetPodSpec">
 CSINodeDriverDaemonSetPodSpec
 </a>
 </em>
@@ -2928,11 +2928,11 @@ Spec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
+<h3 id="CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
 
 </p>
 <p>
@@ -2972,7 +2972,7 @@ If omitted, the csi-node-driver DaemonSet will use its default value for minRead
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">
 CSINodeDriverDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -2989,11 +2989,11 @@ Template describes the csi-node-driver DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
+<h3 id="CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -3012,7 +3012,7 @@ CalicoKubeControllersDeployment is the configuration for the calico-kube-control
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3032,7 +3032,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">
+<a href="#CalicoKubeControllersDeploymentSpec">
 CalicoKubeControllersDeploymentSpec
 </a>
 </em>
@@ -3053,11 +3053,11 @@ Spec is the specification of the calico-kube-controllers Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
+<h3 id="CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -3113,11 +3113,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -3136,7 +3136,7 @@ CalicoKubeControllersDeploymentPodSpec is the calico-kube-controller Deployment&
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">
+<a href="#CalicoKubeControllersDeploymentContainer">
 []CalicoKubeControllersDeploymentContainer
 </a>
 </em>
@@ -3225,11 +3225,11 @@ WARNING: Please note that this field will override the default calico-kube-contr
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
+<a href="#CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
 
 </p>
 <p>
@@ -3248,7 +3248,7 @@ CalicoKubeControllersDeploymentPodTemplateSpec is the calico-kube-controllers De
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3269,7 +3269,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">
+<a href="#CalicoKubeControllersDeploymentPodSpec">
 CalicoKubeControllersDeploymentPodSpec
 </a>
 </em>
@@ -3290,11 +3290,11 @@ Spec is the calico-kube-controllers Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
 
 </p>
 <p>
@@ -3334,7 +3334,7 @@ If omitted, the calico-kube-controllers Deployment will use its default value fo
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">
 CalicoKubeControllersDeploymentPodTemplateSpec
 </a>
 </em>
@@ -3351,11 +3351,11 @@ Template describes the calico-kube-controllers Deployment pod that will be creat
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</h3>
+<h3 id="CalicoNetworkSpec">CalicoNetworkSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -3374,7 +3374,7 @@ CalicoNetworkSpec specifies configuration options for Calico provided pod networ
 
 <code>linuxDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinuxDataplaneOption">
+<a href="#LinuxDataplaneOption">
 LinuxDataplaneOption
 </a>
 </em>
@@ -3397,7 +3397,7 @@ Default: Iptables
 
 <code>bgp</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.BGPOption">
+<a href="#BGPOption">
 BGPOption
 </a>
 </em>
@@ -3417,7 +3417,7 @@ BGP configures whether or not to enable Calico&rsquo;s BGP capabilities.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPPool">
+<a href="#IPPool">
 []IPPool
 </a>
 </em>
@@ -3457,7 +3457,7 @@ If not specified, Calico will perform MTU auto-detection based on the cluster ne
 
 <code>nodeAddressAutodetectionV4</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -3478,7 +3478,7 @@ will use default auto-detection settings to acquire an IPv4 address for each nod
 
 <code>nodeAddressAutodetectionV6</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -3499,7 +3499,7 @@ IPv6 addresses will not be auto-detected.
 
 <code>hostPorts</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HostPortsType">
+<a href="#HostPortsType">
 HostPortsType
 </a>
 </em>
@@ -3520,7 +3520,7 @@ Default: Enabled
 
 <code>multiInterfaceMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MultiInterfaceMode">
+<a href="#MultiInterfaceMode">
 MultiInterfaceMode
 </a>
 </em>
@@ -3542,7 +3542,7 @@ Default: None
 
 <code>containerIPForwarding</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ContainerIPForwardingType">
+<a href="#ContainerIPForwardingType">
 ContainerIPForwardingType
 </a>
 </em>
@@ -3560,11 +3560,11 @@ Default: Disabled
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
+<h3 id="CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -3583,7 +3583,7 @@ CalicoNodeDaemonSet is the configuration for the calico-node DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3603,7 +3603,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">
+<a href="#CalicoNodeDaemonSetSpec">
 CalicoNodeDaemonSetSpec
 </a>
 </em>
@@ -3624,11 +3624,11 @@ Spec is the specification of the calico-node DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
+<h3 id="CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -3684,11 +3684,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -3744,11 +3744,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -3767,7 +3767,7 @@ CalicoNodeDaemonSetPodSpec is the calico-node DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">
+<a href="#CalicoNodeDaemonSetInitContainer">
 []CalicoNodeDaemonSetInitContainer
 </a>
 </em>
@@ -3789,7 +3789,7 @@ If omitted, the calico-node DaemonSet will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetContainer">
+<a href="#CalicoNodeDaemonSetContainer">
 []CalicoNodeDaemonSetContainer
 </a>
 </em>
@@ -3876,11 +3876,11 @@ WARNING: Please note that this field will override the default calico-node Daemo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
+<a href="#CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -3899,7 +3899,7 @@ CalicoNodeDaemonSetPodTemplateSpec is the calico-node DaemonSet&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3920,7 +3920,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">
+<a href="#CalicoNodeDaemonSetPodSpec">
 CalicoNodeDaemonSetPodSpec
 </a>
 </em>
@@ -3941,11 +3941,11 @@ Spec is the calico-node DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
+<h3 id="CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
 
 </p>
 <p>
@@ -3985,7 +3985,7 @@ If omitted, the calico-node DaemonSet will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">
 CalicoNodeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -4002,11 +4002,11 @@ Template describes the calico-node DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -4025,7 +4025,7 @@ CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrad
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4045,7 +4045,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">
 CalicoWindowsUpgradeDaemonSetSpec
 </a>
 </em>
@@ -4066,11 +4066,11 @@ Spec is the specification of the calico-windows-upgrade DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -4125,11 +4125,11 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -4148,7 +4148,7 @@ CalicoWindowsUpgradeDaemonSetPodSpec is the calico-windows-upgrade DaemonSet&rsq
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">
+<a href="#CalicoWindowsUpgradeDaemonSetContainer">
 []CalicoWindowsUpgradeDaemonSetContainer
 </a>
 </em>
@@ -4235,11 +4235,11 @@ WARNING: Please note that this field will override the default calico-windows-up
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -4258,7 +4258,7 @@ CalicoWindowsUpgradeDaemonSetPodTemplateSpec is the calico-windows-upgrade Daemo
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4279,7 +4279,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">
 CalicoWindowsUpgradeDaemonSetPodSpec
 </a>
 </em>
@@ -4300,11 +4300,11 @@ Spec is the calico-windows-upgrade DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
 
 </p>
 <p>
@@ -4344,7 +4344,7 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
 CalicoWindowsUpgradeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -4361,11 +4361,11 @@ Template describes the calico-windows-upgrade DaemonSet pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CertificateManagement">CertificateManagement</h3>
+<h3 id="CertificateManagement">CertificateManagement</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -4457,14 +4457,14 @@ Default: SHA256WithRSA
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CollectProcessPathOption">CollectProcessPathOption
+<h3 id="CollectProcessPathOption">CollectProcessPathOption
 (<code>string</code> alias)</h3>
-<h3 id="operator.tigera.io/v1.ComponentName">ComponentName
+<h3 id="ComponentName">ComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComponentResource">ComponentResource</a>)
+<a href="#ComponentResource">ComponentResource</a>)
 
 </p>
 <p>
@@ -4473,11 +4473,11 @@ ComponentName represents a single component.
 <p>
 One of: Node, Typha, KubeControllers
 </p>
-<h3 id="operator.tigera.io/v1.ComponentResource">ComponentResource</h3>
+<h3 id="ComponentResource">ComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -4497,7 +4497,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentName">
+<a href="#ComponentName">
 ComponentName
 </a>
 </em>
@@ -4532,33 +4532,33 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ConditionStatus">ConditionStatus
+<h3 id="ConditionStatus">ConditionStatus
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 ConditionStatus represents the status of a particular condition. A condition may be one of: True, False, Unknown.
 </p>
-<h3 id="operator.tigera.io/v1.ContainerIPForwardingType">ContainerIPForwardingType
+<h3 id="ContainerIPForwardingType">ContainerIPForwardingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
 ContainerIPForwardingType specifies whether the CNI config for container ip forwarding is enabled.
 </p>
-<h3 id="operator.tigera.io/v1.EGWDeploymentContainer">EGWDeploymentContainer</h3>
+<h3 id="EGWDeploymentContainer">EGWDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -4614,11 +4614,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
+<h3 id="EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -4674,11 +4674,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
+<h3 id="EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -4697,7 +4697,7 @@ EgressGatewayDeploymentPodSpec is the Egress Gateway Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentInitContainer">
+<a href="#EGWDeploymentInitContainer">
 []EGWDeploymentInitContainer
 </a>
 </em>
@@ -4719,7 +4719,7 @@ If omitted, the EGW Deployment will use its default values for its init containe
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentContainer">
+<a href="#EGWDeploymentContainer">
 []EGWDeploymentContainer
 </a>
 </em>
@@ -4854,11 +4854,11 @@ PriorityClassName allows to specify a PriorityClass resource to be used.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
+<h3 id="EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -4877,7 +4877,7 @@ EgressGatewayDeploymentPodTemplateSpec is the EGW Deployment&rsquo;s PodTemplate
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayMetadata">
+<a href="#EgressGatewayMetadata">
 EgressGatewayMetadata
 </a>
 </em>
@@ -4898,7 +4898,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">
+<a href="#EgressGatewayDeploymentPodSpec">
 EgressGatewayDeploymentPodSpec
 </a>
 </em>
@@ -4919,11 +4919,11 @@ Spec is the EGW Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
+<h3 id="EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -4964,7 +4964,7 @@ Default: 90
 
 <code>icmpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ICMPProbe">
+<a href="#ICMPProbe">
 ICMPProbe
 </a>
 </em>
@@ -4986,7 +4986,7 @@ fail. Timeout must be greater than interval.
 
 <code>httpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HTTPProbe">
+<a href="#HTTPProbe">
 HTTPProbe
 </a>
 </em>
@@ -5005,11 +5005,11 @@ fail. Timeout must be greater than interval.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayIPPool">EgressGatewayIPPool</h3>
+<h3 id="EgressGatewayIPPool">EgressGatewayIPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <table>
@@ -5058,11 +5058,11 @@ CIDR is the IPPool CIDR that the Egress Gateways can use.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayMetadata">EgressGatewayMetadata</h3>
+<h3 id="EgressGatewayMetadata">EgressGatewayMetadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -5120,11 +5120,11 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</h3>
+<h3 id="EgressGatewaySpec">EgressGatewaySpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -5161,7 +5161,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -5202,7 +5202,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -5223,7 +5223,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -5243,7 +5243,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -5267,7 +5267,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -5284,11 +5284,11 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayStatus">EgressGatewayStatus</h3>
+<h3 id="EgressGatewayStatus">EgressGatewayStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -5342,12 +5342,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EncapsulationType">EncapsulationType
+<h3 id="EncapsulationType">EncapsulationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -5356,7 +5356,7 @@ EncapsulationType is the type of encapsulation to use on an IP pool.
 <p>
 One of: IPIP, VXLAN, IPIPCrossSubnet, VXLANCrossSubnet, None
 </p>
-<h3 id="operator.tigera.io/v1.EncryptionOption">EncryptionOption
+<h3 id="EncryptionOption">EncryptionOption
 (<code>string</code> alias)</h3>
 <p>
 EncryptionOption specifies the traffic encryption mode when connecting to a Syslog server.
@@ -5364,11 +5364,11 @@ EncryptionOption specifies the traffic encryption mode when connecting to a Sysl
 <p>
 One of: None, TLS
 </p>
-<h3 id="operator.tigera.io/v1.EnvoySettings">EnvoySettings</h3>
+<h3 id="EnvoySettings">EnvoySettings</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -5421,19 +5421,19 @@ manipulating various headers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FIPSMode">FIPSMode
+<h3 id="FIPSMode">FIPSMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.HTTPProbe">HTTPProbe</h3>
+<h3 id="HTTPProbe">HTTPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -5505,12 +5505,12 @@ Default: 30
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HostPortsType">HostPortsType
+<h3 id="HostPortsType">HostPortsType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -5519,11 +5519,11 @@ HostPortsType specifies host port support.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.ICMPProbe">ICMPProbe</h3>
+<h3 id="ICMPProbe">ICMPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -5595,19 +5595,19 @@ Default: 15
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPAMPluginType">IPAMPluginType
+<h3 id="IPAMPluginType">IPAMPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPAMSpec">IPAMSpec</a>)
+<a href="#IPAMSpec">IPAMSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IPAMSpec">IPAMSpec</h3>
+<h3 id="IPAMSpec">IPAMSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -5626,7 +5626,7 @@ IPAMSpec contains configuration for pod IP address management.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMPluginType">
+<a href="#IPAMPluginType">
 IPAMPluginType
 </a>
 </em>
@@ -5654,11 +5654,11 @@ Default: Calico
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPPool">IPPool</h3>
+<h3 id="IPPool">IPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -5691,7 +5691,7 @@ CIDR contains the address range for the IP Pool in classless inter-domain routin
 
 <code>encapsulation</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncapsulationType">
+<a href="#EncapsulationType">
 EncapsulationType
 </a>
 </em>
@@ -5713,7 +5713,7 @@ Default: IPIP
 
 <code>natOutgoing</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NATOutgoingType">
+<a href="#NATOutgoingType">
 NATOutgoingType
 </a>
 </em>
@@ -5789,11 +5789,11 @@ Default: false
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Image">Image</h3>
+<h3 id="Image">Image</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</a>)
+<a href="#ImageSetSpec">ImageSetSpec</a>)
 
 </p>
 <table>
@@ -5844,11 +5844,11 @@ The field should not include a leading <code>@</code> and must be prefixed with 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</h3>
+<h3 id="ImageSetSpec">ImageSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>)
+<a href="#ImageSet">ImageSet</a>)
 
 </p>
 <p>
@@ -5867,7 +5867,7 @@ ImageSetSpec defines the desired state of ImageSet.
 
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -5884,12 +5884,12 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationSpec">InstallationSpec</h3>
+<h3 id="InstallationSpec">InstallationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#Installation">Installation</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -5908,7 +5908,7 @@ InstallationSpec defines configuration for a Calico or Calico Enterprise install
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -6036,7 +6036,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -6059,7 +6059,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -6079,7 +6079,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -6099,7 +6099,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -6278,7 +6278,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -6300,7 +6300,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -6322,7 +6322,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -6342,7 +6342,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -6362,7 +6362,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -6381,7 +6381,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -6401,7 +6401,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -6421,7 +6421,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -6440,7 +6440,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -6461,7 +6461,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -6478,11 +6478,11 @@ Logging Configuration for Components
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationStatus">InstallationStatus</h3>
+<h3 id="InstallationStatus">InstallationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>)
+<a href="#Installation">Installation</a>)
 
 </p>
 <p>
@@ -6501,7 +6501,7 @@ InstallationStatus defines the observed state of the Calico or Calico Enterprise
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -6557,7 +6557,7 @@ that is being used. If an ImageSet is not being used then this will not be set.
 
 <code>computed</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -6614,12 +6614,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
+<h3 id="KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</a>)
+<a href="#NodeAddressAutodetection">NodeAddressAutodetection</a>)
 
 </p>
 <p>
@@ -6628,12 +6628,12 @@ KubernetesAutodetectionMethod is a method of detecting an IP address based on th
 <p>
 One of: NodeInternalIP
 </p>
-<h3 id="operator.tigera.io/v1.LinuxDataplaneOption">LinuxDataplaneOption
+<h3 id="LinuxDataplaneOption">LinuxDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -6642,11 +6642,11 @@ LinuxDataplaneOption controls which dataplane is to be used on Linux nodes.
 <p>
 One of: Iptables, BPF
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</h3>
+<h3 id="LogCollectionSpec">LogCollectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -6662,7 +6662,7 @@ One of: Iptables, BPF
 
 <code>collectLogs</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionStatusType">
+<a href="#LogCollectionStatusType">
 LogCollectionStatusType
 </a>
 </em>
@@ -6720,28 +6720,28 @@ Default: -1
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectionStatusType">LogCollectionStatusType
+<h3 id="LogCollectionStatusType">LogCollectionStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</a>)
+<a href="#LogCollectionSpec">LogCollectionSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogLevel">LogLevel
+<h3 id="LogLevel">LogLevel
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNILogging">CNILogging</a>, 
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#CNILogging">CNILogging</a>, 
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.Logging">Logging</h3>
+<h3 id="Logging">Logging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>
@@ -6757,7 +6757,7 @@ Default: -1
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNILogging">
+<a href="#CNILogging">
 CNILogging
 </a>
 </em>
@@ -6774,22 +6774,22 @@ Customized logging specification for calico-cni plugin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Metadata">Metadata</h3>
+<h3 id="Metadata">Metadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>, 
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>, 
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
+<a href="#TyphaDeployment">TyphaDeployment</a>, 
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6845,21 +6845,21 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MonitorSpec">MonitorSpec</h3>
+<h3 id="MonitorSpec">MonitorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
 MonitorSpec defines the desired state of Tigera monitor.
 </p>
-<h3 id="operator.tigera.io/v1.MonitorStatus">MonitorStatus</h3>
+<h3 id="MonitorStatus">MonitorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -6913,12 +6913,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MultiInterfaceMode">MultiInterfaceMode
+<h3 id="MultiInterfaceMode">MultiInterfaceMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -6927,12 +6927,12 @@ MultiInterfaceMode describes the method of providing multiple pod interfaces.
 <p>
 One of: None, Multus
 </p>
-<h3 id="operator.tigera.io/v1.NATOutgoingType">NATOutgoingType
+<h3 id="NATOutgoingType">NATOutgoingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -6941,23 +6941,23 @@ NATOutgoingType describe the type of outgoing NAT to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.NativeIP">NativeIP
+<h3 id="NativeIP">NativeIP
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</a>)
+<a href="#AWSEgressGateway">AWSEgressGateway</a>)
 
 </p>
 <p>
 NativeIP defines if Egress Gateway pods should have AWS IPs.
 When NativeIP is enabled, the IPPools should be backed by AWS subnet.
 </p>
-<h3 id="operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</h3>
+<h3 id="NodeAddressAutodetection">NodeAddressAutodetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -6997,7 +6997,7 @@ filtering based on well-known interface names.
 
 <code>kubernetes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KubernetesAutodetectionMethod">
+<a href="#KubernetesAutodetectionMethod">
 KubernetesAutodetectionMethod
 </a>
 </em>
@@ -7088,11 +7088,11 @@ one of the provided CIDRs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeAffinity">NodeAffinity</h3>
+<h3 id="NodeAffinity">NodeAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</a>)
+<a href="#TyphaAffinity">TyphaAffinity</a>)
 
 </p>
 <p>
@@ -7161,12 +7161,12 @@ may or may not try to eventually evict the pod from its node.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NonPrivilegedType">NonPrivilegedType
+<h3 id="NonPrivilegedType">NonPrivilegedType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7175,29 +7175,29 @@ NonPrivilegedType specifies whether Calico runs as permissioned or not
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.OIDCType">OIDCType
+<h3 id="OIDCType">OIDCType
 (<code>string</code> alias)</h3>
 <p>
 OIDCType defines how OIDC is configured for Tigera Enterprise. Dex should be the best option for most use-cases.
 The Tigera option can help in specific use-cases, for instance, when you are unable to configure a client secret.
 One of: Dex, Tigera
 </p>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
+<h3 id="PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
 PolicyRecommendationSpec defines configuration for the Calico Enterprise Policy Recommendation
 service.
 </p>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
+<h3 id="PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
@@ -7230,13 +7230,13 @@ State provides user-readable status.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ProductVariant">ProductVariant
+<h3 id="ProductVariant">ProductVariant
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#InstallationSpec">InstallationSpec</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -7245,37 +7245,37 @@ ProductVariant represents the variant of the product.
 <p>
 One of: Calico, TigeraSecureEnterprise
 </p>
-<h3 id="operator.tigera.io/v1.PromptType">PromptType
+<h3 id="PromptType">PromptType
 (<code>string</code> alias)</h3>
 <p>
 PromptType is a value that specifies whether the identity provider prompts the end user for re-authentication and
 consent.
 One of: None, Login, Consent, SelectAccount.
 </p>
-<h3 id="operator.tigera.io/v1.Provider">Provider
+<h3 id="Provider">Provider
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
 Provider represents a particular provider or flavor of Kubernetes. Valid options
 are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise.
 </p>
-<h3 id="operator.tigera.io/v1.StatusConditionType">StatusConditionType
+<h3 id="StatusConditionType">StatusConditionType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 StatusConditionType is a type of condition that may apply to a particular component.
 </p>
-<h3 id="operator.tigera.io/v1.TLS">TLS</h3>
+<h3 id="TLS">TLS</h3>
 <table>
 <thead>
 <tr>
@@ -7323,11 +7323,11 @@ Default: tigera-management-cluster-connection
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</h3>
+<h3 id="TigeraStatusCondition">TigeraStatusCondition</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</a>)
+<a href="#TigeraStatusStatus">TigeraStatusStatus</a>)
 
 </p>
 <p>
@@ -7346,7 +7346,7 @@ TigeraStatusCondition represents a condition attached to a particular component.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.StatusConditionType">
+<a href="#StatusConditionType">
 StatusConditionType
 </a>
 </em>
@@ -7365,7 +7365,7 @@ The type of condition. May be Available, Progressing, or Degraded.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ConditionStatus">
+<a href="#ConditionStatus">
 ConditionStatus
 </a>
 </em>
@@ -7454,26 +7454,26 @@ with respect to the current state of the instance.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatusReason">TigeraStatusReason
+<h3 id="TigeraStatusReason">TigeraStatusReason
 (<code>string</code> alias)</h3>
 <p>
 TigeraStatusReason represents the reason for a particular condition.
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusSpec">TigeraStatusSpec</h3>
+<h3 id="TigeraStatusSpec">TigeraStatusSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
 TigeraStatusSpec defines the desired state of TigeraStatus
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</h3>
+<h3 id="TigeraStatusStatus">TigeraStatusStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
@@ -7492,7 +7492,7 @@ TigeraStatusStatus defines the observed state of TigeraStatus
 
 <code>conditions</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">
+<a href="#TigeraStatusCondition">
 []TigeraStatusCondition
 </a>
 </em>
@@ -7509,11 +7509,11 @@ Available, Progressing, or Degraded.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</h3>
+<h3 id="TyphaAffinity">TyphaAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7533,7 +7533,7 @@ TyphaAffinity allows configuration of node affinity characteristics for Typha po
 
 <code>nodeAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAffinity">
+<a href="#NodeAffinity">
 NodeAffinity
 </a>
 </em>
@@ -7550,11 +7550,11 @@ NodeAffinity describes node affinity scheduling rules for typha.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</h3>
+<h3 id="TyphaDeployment">TyphaDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7573,7 +7573,7 @@ TyphaDeployment is the configuration for the typha Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7593,7 +7593,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">
+<a href="#TyphaDeploymentSpec">
 TyphaDeploymentSpec
 </a>
 </em>
@@ -7614,11 +7614,11 @@ Spec is the specification of the typha Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
+<h3 id="TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -7674,11 +7674,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
+<h3 id="TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -7734,11 +7734,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
+<h3 id="TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7757,7 +7757,7 @@ TyphaDeploymentPodSpec is the typha Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentInitContainer">
+<a href="#TyphaDeploymentInitContainer">
 []TyphaDeploymentInitContainer
 </a>
 </em>
@@ -7779,7 +7779,7 @@ If omitted, the typha Deployment will use its default values for its init contai
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentContainer">
+<a href="#TyphaDeploymentContainer">
 []TyphaDeploymentContainer
 </a>
 </em>
@@ -7913,11 +7913,11 @@ WARNING: Please note that this field will override the default calico-typha Depl
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
+<h3 id="TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -7936,7 +7936,7 @@ TyphaDeploymentPodTemplateSpec is the typha Deployment&rsquo;s PodTemplateSpec
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -7957,7 +7957,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">
+<a href="#TyphaDeploymentPodSpec">
 TyphaDeploymentPodSpec
 </a>
 </em>
@@ -7978,11 +7978,11 @@ Spec is the typha Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
+<h3 id="TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>)
+<a href="#TyphaDeployment">TyphaDeployment</a>)
 
 </p>
 <p>
@@ -8022,7 +8022,7 @@ If omitted, the typha Deployment will use its default value for minReadySeconds.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">
+<a href="#TyphaDeploymentPodTemplateSpec">
 TyphaDeploymentPodTemplateSpec
 </a>
 </em>
@@ -8042,7 +8042,7 @@ Template describes the typha Deployment pod that will be created.
 
 <code>strategy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentStrategy">
+<a href="#TyphaDeploymentStrategy">
 TyphaDeploymentStrategy
 </a>
 </em>
@@ -8059,11 +8059,11 @@ The deployment strategy to use to replace existing pods with new ones.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
+<h3 id="TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -8102,12 +8102,12 @@ to be.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.WAFStatusType">WAFStatusType
+<h3 id="WAFStatusType">WAFStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <hr/>

--- a/calico_versioned_docs/version-3.27/getting-started/kubernetes/helm.mdx
+++ b/calico_versioned_docs/version-3.27/getting-started/kubernetes/helm.mdx
@@ -49,7 +49,7 @@ helm repo add projectcalico https://docs.tigera.io/calico/charts
 
 If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), or you need to customize TLS certificates, you **must** customize this Helm chart by creating a `values.yaml` file. Otherwise, you can skip this step.
 
-1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#operator.tigera.io/v1.Provider). For example:
+1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#Provider. For example:
 
    ```
    echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico_versioned_docs/version-3.27/getting-started/kubernetes/self-managed-onprem/config-options.mdx
+++ b/calico_versioned_docs/version-3.27/getting-started/kubernetes/self-managed-onprem/config-options.mdx
@@ -36,9 +36,9 @@ installed directly on the cluster as a Deployment, and is configured through one
 Operator installations read their configuration from a specific set of Kubernetes APIs. These APIs are installed on the cluster
 as part of `tigera-operator.yaml` in the `operator.tigera.io/v1` API group.
 
-- [Installation](../../../reference/installation/api.mdx#operator.tigera.io/v1.Installation): a singleton resource with name "default" that
+- [Installation](../../../reference/installation/api.mdx#Installation: a singleton resource with name "default" that
   configures common installation parameters for a {variables.prodname} cluster.
-- [APIServer](../../../reference/installation/api.mdx#operator.tigera.io/v1.Installation): a singleton resource with name "default" that
+- [APIServer](../../../reference/installation/api.mdx#Installation: a singleton resource with name "default" that
   configures installation of the {variables.prodname} API server extension.
 
 ### Configure the pod IP range

--- a/calico_versioned_docs/version-3.27/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico_versioned_docs/version-3.27/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -38,7 +38,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#BGPOption.
 
 :::
 

--- a/calico_versioned_docs/version-3.27/networking/ipam/ip-autodetection.mdx
+++ b/calico_versioned_docs/version-3.27/networking/ipam/ip-autodetection.mdx
@@ -65,7 +65,7 @@ For more details on autodetection methods, see [node configuration](../../refere
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-As noted previously, the default autodetection method is **first valid interface found** (first-found). To use a different autodetection method, edit the default [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation) custom resource, specifying the method. Below are examples of the supported autodetection methods:
+As noted previously, the default autodetection method is **first valid interface found** (first-found). To use a different autodetection method, edit the default [Installation](../../reference/installation/api.mdx#Installation custom resource, specifying the method. Below are examples of the supported autodetection methods:
 
 :::note
 

--- a/calico_versioned_docs/version-3.27/operations/certificate-management.mdx
+++ b/calico_versioned_docs/version-3.27/operations/certificate-management.mdx
@@ -31,7 +31,7 @@ certificate issuance, {variables.prodname} provides a simple configuration optio
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../reference/installation/api.mdx#Installation
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
 ```yaml

--- a/calico_versioned_docs/version-3.27/operations/image-options/imageset.mdx
+++ b/calico_versioned_docs/version-3.27/operations/image-options/imageset.mdx
@@ -78,7 +78,7 @@ sed -ie "s|\(image: .*/operator\):.*|?\1@<put-digest-here>|" tigera-operator.yam
 
 ### Create an ImageSet
 
-Create an [ImageSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ImageSet) manifest file named `imageset.yaml` like the following:
+Create an [ImageSet](../../reference/installation/api.mdx#ImageSet manifest file named `imageset.yaml` like the following:
 
 <CodeBlock language='yaml'>
 apiVersion: operator.tigera.io/v1
@@ -142,7 +142,7 @@ You can create an ImageSet manifest manually or by script.
       docker pull <repo/image:tag> && docker inspect <repo/image:tag> -f '{{range .RepoDigests}}{{printf "%s\n" .}}{{end}}'
       ```
    1. Use the digest from the image that matches the repo/image you will use.
-      If you are using a private registry or have specified an [imagePath](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+      If you are using a private registry or have specified an [imagePath](../../reference/installation/api.mdx#Installation
       you will still use the "default" `<owner>/<image>` in the `image` field, for example if you your node image is coming from
       `example.com/registry/imagepath/node` you will still use `calico/node` in the image field of the ImageSet.
       :::note
@@ -228,7 +228,7 @@ Apply the created `imageset.yaml` to your cluster.
 
 ### Create new ImageSet when upgrading or downgrading
 
-Before upgrading to a new release or downgrading, you must create a new [ImageSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ImageSet)
+Before upgrading to a new release or downgrading, you must create a new [ImageSet](../../reference/installation/api.mdx#ImageSet
 with updated image references and names for the new release. This must be done prior
 to upgrading the cluster so when the new manifests are applied, the appropriate ImageSet is available.
 
@@ -236,7 +236,7 @@ to upgrading the cluster so when the new manifests are applied, the appropriate 
 
 ### Why does the Installation Resource status not include my ImageSet?
 
-The [status.imageset](../../reference/installation/api.mdx#operator.tigera.io/v1.InstallationStatus) field of
+The [status.imageset](../../reference/installation/api.mdx#InstallationStatus field of
 the Installation Resource will not be updated until the `calico` component has fully been deployed. `calico` is
 fully deployed when `kubectl get tigerastatus calico` reports Available True with Progressing and Degraded as False.
 

--- a/calico_versioned_docs/version-3.27/reference/configure-cni-plugins.mdx
+++ b/calico_versioned_docs/version-3.27/reference/configure-cni-plugins.mdx
@@ -264,7 +264,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](installation/api.mdx#Installation API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico_versioned_docs/version-3.27/reference/installation/_api.mdx
+++ b/calico_versioned_docs/version-3.27/reference/installation/_api.mdx
@@ -15,25 +15,25 @@ API Schema definitions for configuring the installation of Calico and Calico Ent
 </p>
 Resource Types:
 <ul><li>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>
+<a href="#APIServer">APIServer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>
+<a href="#ApplicationLayer">ApplicationLayer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>
+<a href="#EgressGateway">EgressGateway</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>
+<a href="#ImageSet">ImageSet</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>
+<a href="#Installation">Installation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>
+<a href="#Monitor">Monitor</a>
 </li><li>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>
+<a href="#PolicyRecommendation">PolicyRecommendation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>
+<a href="#Tenant">Tenant</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>
+<a href="#TigeraStatus">TigeraStatus</a>
 </li></ul>
-<h3 id="operator.tigera.io/v1.APIServer">APIServer</h3>
+<h3 id="APIServer">APIServer</h3>
 <p>
 APIServer installs the Tigera API server and related resources. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo; or &ldquo;tigera-secure&rdquo;.
@@ -94,7 +94,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerSpec">
+<a href="#APIServerSpec">
 APIServerSpec
 </a>
 </em>
@@ -112,7 +112,7 @@ Specification of the desired state for the Tigera API server.
 <td>
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -136,7 +136,7 @@ take precedence.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerStatus">
+<a href="#APIServerStatus">
 APIServerStatus
 </a>
 </em>
@@ -152,7 +152,7 @@ Most recently observed status for the Tigera API server.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</h3>
+<h3 id="ApplicationLayer">ApplicationLayer</h3>
 <p>
 ApplicationLayer is the Schema for the applicationlayers API
 </p>
@@ -212,7 +212,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">
+<a href="#ApplicationLayerSpec">
 ApplicationLayerSpec
 </a>
 </em>
@@ -227,7 +227,7 @@ ApplicationLayerSpec
 <td>
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -247,7 +247,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -266,7 +266,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -286,7 +286,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -308,7 +308,7 @@ User-configurable settings for the Envoy proxy.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerStatus">
+<a href="#ApplicationLayerStatus">
 ApplicationLayerStatus
 </a>
 </em>
@@ -321,7 +321,7 @@ ApplicationLayerStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGateway">EgressGateway</h3>
+<h3 id="EgressGateway">EgressGateway</h3>
 <p>
 EgressGateway is the Schema for the egressgateways API
 </p>
@@ -381,7 +381,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">
+<a href="#EgressGatewaySpec">
 EgressGatewaySpec
 </a>
 </em>
@@ -414,7 +414,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -455,7 +455,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -476,7 +476,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -496,7 +496,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -520,7 +520,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -543,7 +543,7 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayStatus">
+<a href="#EgressGatewayStatus">
 EgressGatewayStatus
 </a>
 </em>
@@ -556,7 +556,7 @@ EgressGatewayStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSet">ImageSet</h3>
+<h3 id="ImageSet">ImageSet</h3>
 <p>
 ImageSet is used to specify image digests for the images that the operator deploys.
 The name of the ImageSet is expected to be in the format <code>&lt;variant&gt;-&lt;release&gt;</code>.
@@ -621,7 +621,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">
+<a href="#ImageSetSpec">
 ImageSetSpec
 </a>
 </em>
@@ -636,7 +636,7 @@ ImageSetSpec
 <td>
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -656,7 +656,7 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Installation">Installation</h3>
+<h3 id="Installation">Installation</h3>
 <p>
 Installation configures an installation of Calico or Calico Enterprise. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo;. The Installation API installs core networking
@@ -718,7 +718,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -736,7 +736,7 @@ Specification of the desired state for the Calico or Calico Enterprise installat
 <td>
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -864,7 +864,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -887,7 +887,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -907,7 +907,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -927,7 +927,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -1106,7 +1106,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -1128,7 +1128,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -1150,7 +1150,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -1170,7 +1170,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -1190,7 +1190,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -1209,7 +1209,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -1229,7 +1229,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -1249,7 +1249,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -1269,7 +1269,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -1288,7 +1288,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -1309,7 +1309,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -1329,7 +1329,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -1370,7 +1370,7 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationStatus">
+<a href="#InstallationStatus">
 InstallationStatus
 </a>
 </em>
@@ -1386,7 +1386,7 @@ Most recently observed state for the Calico or Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Monitor">Monitor</h3>
+<h3 id="Monitor">Monitor</h3>
 <p>
 Monitor is the Schema for the monitor API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -1447,7 +1447,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorSpec">
+<a href="#MonitorSpec">
 MonitorSpec
 </a>
 </em>
@@ -1467,7 +1467,7 @@ MonitorSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorStatus">
+<a href="#MonitorStatus">
 MonitorStatus
 </a>
 </em>
@@ -1480,7 +1480,7 @@ MonitorStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</h3>
+<h3 id="PolicyRecommendation">PolicyRecommendation</h3>
 <p>
 PolicyRecommendation is the Schema for the policy recommendation API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -1541,7 +1541,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationSpec">
+<a href="#PolicyRecommendationSpec">
 PolicyRecommendationSpec
 </a>
 </em>
@@ -1561,7 +1561,7 @@ PolicyRecommendationSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationStatus">
+<a href="#PolicyRecommendationStatus">
 PolicyRecommendationStatus
 </a>
 </em>
@@ -1574,7 +1574,7 @@ PolicyRecommendationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Tenant">Tenant</h3>
+<h3 id="Tenant">Tenant</h3>
 <p>
 Tenant is the Schema for the tenants API
 </p>
@@ -1634,7 +1634,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantSpec">
+<a href="#TenantSpec">
 TenantSpec
 </a>
 </em>
@@ -1666,7 +1666,7 @@ ID is the unique identifier for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -1688,7 +1688,7 @@ Indices defines the how to store a tenant&rsquo;s data
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantStatus">
+<a href="#TenantStatus">
 TenantStatus
 </a>
 </em>
@@ -1701,7 +1701,7 @@ TenantStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatus">TigeraStatus</h3>
+<h3 id="TigeraStatus">TigeraStatus</h3>
 <p>
 TigeraStatus represents the most recently observed status for Calico or a Calico Enterprise functional area.
 </p>
@@ -1761,7 +1761,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusSpec">
+<a href="#TigeraStatusSpec">
 TigeraStatusSpec
 </a>
 </em>
@@ -1781,7 +1781,7 @@ TigeraStatusSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">
+<a href="#TigeraStatusStatus">
 TigeraStatusStatus
 </a>
 </em>
@@ -1794,11 +1794,11 @@ TigeraStatusStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</h3>
+<h3 id="APIServerDeployment">APIServerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerSpec">APIServerSpec</a>)
+<a href="#APIServerSpec">APIServerSpec</a>)
 
 </p>
 <p>
@@ -1817,7 +1817,7 @@ APIServerDeployment is the configuration for the API server Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -1837,7 +1837,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">
+<a href="#APIServerDeploymentSpec">
 APIServerDeploymentSpec
 </a>
 </em>
@@ -1858,11 +1858,11 @@ Spec is the specification of the API server Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
+<h3 id="APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -1918,11 +1918,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
+<h3 id="APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -1977,11 +1977,11 @@ If omitted, the API server Deployment will use its default value for this init c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
+<h3 id="APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -2000,7 +2000,7 @@ APIServerDeploymentDeploymentPodSpec is the API server Deployment&rsquo;s PodSpe
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentInitContainer">
+<a href="#APIServerDeploymentInitContainer">
 []APIServerDeploymentInitContainer
 </a>
 </em>
@@ -2022,7 +2022,7 @@ If omitted, the API server Deployment will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentContainer">
+<a href="#APIServerDeploymentContainer">
 []APIServerDeploymentContainer
 </a>
 </em>
@@ -2133,11 +2133,11 @@ WARNING: Please note that this field will override the default API server Deploy
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
+<h3 id="APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
+<a href="#APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -2156,7 +2156,7 @@ APIServerDeploymentPodTemplateSpec is the API server Deployment&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -2177,7 +2177,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">
+<a href="#APIServerDeploymentPodSpec">
 APIServerDeploymentPodSpec
 </a>
 </em>
@@ -2198,11 +2198,11 @@ Spec is the API server Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
+<h3 id="APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>)
 
 </p>
 <p>
@@ -2242,7 +2242,7 @@ If omitted, the API server Deployment will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">
+<a href="#APIServerDeploymentPodTemplateSpec">
 APIServerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -2259,11 +2259,11 @@ Template describes the API server Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerSpec">APIServerSpec</h3>
+<h3 id="APIServerSpec">APIServerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -2282,7 +2282,7 @@ APIServerSpec defines the desired state of Tigera API server.
 
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -2300,11 +2300,11 @@ take precedence.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerStatus">APIServerStatus</h3>
+<h3 id="APIServerStatus">APIServerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -2358,11 +2358,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</h3>
+<h3 id="AWSEgressGateway">AWSEgressGateway</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -2381,7 +2381,7 @@ AWSEgressGateway defines the configurations for deploying EgressGateway in AWS
 
 <code>nativeIP</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NativeIP">
+<a href="#NativeIP">
 NativeIP
 </a>
 </em>
@@ -2418,7 +2418,7 @@ NativeIP must be Enabled if elastic IPs are set.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
+<h3 id="AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
 <table>
 <thead>
 <tr>
@@ -2447,19 +2447,19 @@ StorageClassName is now deprecated, and configuring it has no effect.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
+<h3 id="ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</h3>
+<h3 id="ApplicationLayerSpec">ApplicationLayerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -2478,7 +2478,7 @@ ApplicationLayerSpec defines the desired state of ApplicationLayer
 
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -2498,7 +2498,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -2517,7 +2517,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -2537,7 +2537,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -2553,11 +2553,11 @@ User-configurable settings for the Envoy proxy.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerStatus">ApplicationLayerStatus</h3>
+<h3 id="ApplicationLayerStatus">ApplicationLayerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -2611,12 +2611,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.BGPOption">BGPOption
+<h3 id="BGPOption">BGPOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -2625,7 +2625,7 @@ BGPOption describes the mode of BGP to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.CAType">CAType
+<h3 id="CAType">CAType
 (<code>string</code> alias)</h3>
 <p>
 CAType specifies which verification method the tunnel client should use to verify the tunnel server&rsquo;s identity.
@@ -2633,11 +2633,11 @@ CAType specifies which verification method the tunnel client should use to verif
 <p>
 One of: Tigera, Public
 </p>
-<h3 id="operator.tigera.io/v1.CNILogging">CNILogging</h3>
+<h3 id="CNILogging">CNILogging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Logging">Logging</a>)
+<a href="#Logging">Logging</a>)
 
 </p>
 <table>
@@ -2653,7 +2653,7 @@ One of: Tigera, Public
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -2724,12 +2724,12 @@ Default: 10
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CNIPluginType">CNIPluginType
+<h3 id="CNIPluginType">CNIPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -2738,11 +2738,11 @@ CNIPluginType describes the type of CNI plugin used.
 <p>
 One of: Calico, GKE, AmazonVPC, AzureVNET
 </p>
-<h3 id="operator.tigera.io/v1.CNISpec">CNISpec</h3>
+<h3 id="CNISpec">CNISpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -2761,7 +2761,7 @@ CNISpec contains configuration for the CNI plugin.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNIPluginType">
+<a href="#CNIPluginType">
 CNIPluginType
 </a>
 </em>
@@ -2793,7 +2793,7 @@ Default: Calico
 
 <code>ipam</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMSpec">
+<a href="#IPAMSpec">
 IPAMSpec
 </a>
 </em>
@@ -2811,11 +2811,11 @@ Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
+<h3 id="CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -2834,7 +2834,7 @@ CSINodeDriverDaemonSet is the configuration for the csi-node-driver DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -2854,7 +2854,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">
+<a href="#CSINodeDriverDaemonSetSpec">
 CSINodeDriverDaemonSetSpec
 </a>
 </em>
@@ -2875,11 +2875,11 @@ Spec is the specification of the csi-node-driver DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
+<h3 id="CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -2934,11 +2934,11 @@ If omitted, the csi-node-driver DaemonSet will use its default value for this co
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -2957,7 +2957,7 @@ CSINodeDriverDaemonSetPodSpec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">
+<a href="#CSINodeDriverDaemonSetContainer">
 []CSINodeDriverDaemonSetContainer
 </a>
 </em>
@@ -3044,11 +3044,11 @@ WARNING: Please note that this field will override the default csi-node-driver D
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
+<a href="#CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -3067,7 +3067,7 @@ CSINodeDriverDaemonSetPodTemplateSpec is the csi-node-driver DaemonSet&rsquo;s P
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3088,7 +3088,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">
+<a href="#CSINodeDriverDaemonSetPodSpec">
 CSINodeDriverDaemonSetPodSpec
 </a>
 </em>
@@ -3109,11 +3109,11 @@ Spec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
+<h3 id="CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
 
 </p>
 <p>
@@ -3153,7 +3153,7 @@ If omitted, the csi-node-driver DaemonSet will use its default value for minRead
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">
 CSINodeDriverDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -3170,11 +3170,11 @@ Template describes the csi-node-driver DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
+<h3 id="CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -3193,7 +3193,7 @@ CalicoKubeControllersDeployment is the configuration for the calico-kube-control
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3213,7 +3213,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">
+<a href="#CalicoKubeControllersDeploymentSpec">
 CalicoKubeControllersDeploymentSpec
 </a>
 </em>
@@ -3234,11 +3234,11 @@ Spec is the specification of the calico-kube-controllers Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
+<h3 id="CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -3294,11 +3294,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -3317,7 +3317,7 @@ CalicoKubeControllersDeploymentPodSpec is the calico-kube-controller Deployment&
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">
+<a href="#CalicoKubeControllersDeploymentContainer">
 []CalicoKubeControllersDeploymentContainer
 </a>
 </em>
@@ -3406,11 +3406,11 @@ WARNING: Please note that this field will override the default calico-kube-contr
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
+<a href="#CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
 
 </p>
 <p>
@@ -3429,7 +3429,7 @@ CalicoKubeControllersDeploymentPodTemplateSpec is the calico-kube-controllers De
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3450,7 +3450,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">
+<a href="#CalicoKubeControllersDeploymentPodSpec">
 CalicoKubeControllersDeploymentPodSpec
 </a>
 </em>
@@ -3471,11 +3471,11 @@ Spec is the calico-kube-controllers Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
 
 </p>
 <p>
@@ -3515,7 +3515,7 @@ If omitted, the calico-kube-controllers Deployment will use its default value fo
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">
 CalicoKubeControllersDeploymentPodTemplateSpec
 </a>
 </em>
@@ -3532,11 +3532,11 @@ Template describes the calico-kube-controllers Deployment pod that will be creat
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</h3>
+<h3 id="CalicoNetworkSpec">CalicoNetworkSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -3555,7 +3555,7 @@ CalicoNetworkSpec specifies configuration options for Calico provided pod networ
 
 <code>linuxDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinuxDataplaneOption">
+<a href="#LinuxDataplaneOption">
 LinuxDataplaneOption
 </a>
 </em>
@@ -3578,7 +3578,7 @@ Default: Iptables
 
 <code>windowsDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsDataplaneOption">
+<a href="#WindowsDataplaneOption">
 WindowsDataplaneOption
 </a>
 </em>
@@ -3601,7 +3601,7 @@ Default: Disabled
 
 <code>bgp</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.BGPOption">
+<a href="#BGPOption">
 BGPOption
 </a>
 </em>
@@ -3621,7 +3621,7 @@ BGP configures whether or not to enable Calico&rsquo;s BGP capabilities.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPPool">
+<a href="#IPPool">
 []IPPool
 </a>
 </em>
@@ -3661,7 +3661,7 @@ If not specified, Calico will perform MTU auto-detection based on the cluster ne
 
 <code>nodeAddressAutodetectionV4</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -3682,7 +3682,7 @@ will use default auto-detection settings to acquire an IPv4 address for each nod
 
 <code>nodeAddressAutodetectionV6</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -3703,7 +3703,7 @@ IPv6 addresses will not be auto-detected.
 
 <code>hostPorts</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HostPortsType">
+<a href="#HostPortsType">
 HostPortsType
 </a>
 </em>
@@ -3724,7 +3724,7 @@ Default: Enabled
 
 <code>multiInterfaceMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MultiInterfaceMode">
+<a href="#MultiInterfaceMode">
 MultiInterfaceMode
 </a>
 </em>
@@ -3746,7 +3746,7 @@ Default: None
 
 <code>containerIPForwarding</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ContainerIPForwardingType">
+<a href="#ContainerIPForwardingType">
 ContainerIPForwardingType
 </a>
 </em>
@@ -3764,11 +3764,11 @@ Default: Disabled
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
+<h3 id="CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -3787,7 +3787,7 @@ CalicoNodeDaemonSet is the configuration for the calico-node DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3807,7 +3807,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">
+<a href="#CalicoNodeDaemonSetSpec">
 CalicoNodeDaemonSetSpec
 </a>
 </em>
@@ -3828,11 +3828,11 @@ Spec is the specification of the calico-node DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
+<h3 id="CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -3888,11 +3888,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -3948,11 +3948,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -3971,7 +3971,7 @@ CalicoNodeDaemonSetPodSpec is the calico-node DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">
+<a href="#CalicoNodeDaemonSetInitContainer">
 []CalicoNodeDaemonSetInitContainer
 </a>
 </em>
@@ -3993,7 +3993,7 @@ If omitted, the calico-node DaemonSet will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetContainer">
+<a href="#CalicoNodeDaemonSetContainer">
 []CalicoNodeDaemonSetContainer
 </a>
 </em>
@@ -4080,11 +4080,11 @@ WARNING: Please note that this field will override the default calico-node Daemo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
+<a href="#CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -4103,7 +4103,7 @@ CalicoNodeDaemonSetPodTemplateSpec is the calico-node DaemonSet&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4124,7 +4124,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">
+<a href="#CalicoNodeDaemonSetPodSpec">
 CalicoNodeDaemonSetPodSpec
 </a>
 </em>
@@ -4145,11 +4145,11 @@ Spec is the calico-node DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
+<h3 id="CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
 
 </p>
 <p>
@@ -4189,7 +4189,7 @@ If omitted, the calico-node DaemonSet will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">
 CalicoNodeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -4206,11 +4206,11 @@ Template describes the calico-node DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
+<h3 id="CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -4229,7 +4229,7 @@ CalicoNodeWindowsDaemonSet is the configuration for the calico-node-windows Daem
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4249,7 +4249,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">
+<a href="#CalicoNodeWindowsDaemonSetSpec">
 CalicoNodeWindowsDaemonSetSpec
 </a>
 </em>
@@ -4270,11 +4270,11 @@ Spec is the specification of the calico-node-windows DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -4330,11 +4330,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -4390,11 +4390,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -4413,7 +4413,7 @@ CalicoNodeWindowsDaemonSetPodSpec is the calico-node-windows DaemonSet&rsquo;s P
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">
+<a href="#CalicoNodeWindowsDaemonSetInitContainer">
 []CalicoNodeWindowsDaemonSetInitContainer
 </a>
 </em>
@@ -4435,7 +4435,7 @@ If omitted, the calico-node-windows DaemonSet will use its default values for it
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">
+<a href="#CalicoNodeWindowsDaemonSetContainer">
 []CalicoNodeWindowsDaemonSetContainer
 </a>
 </em>
@@ -4522,11 +4522,11 @@ WARNING: Please note that this field will override the default calico-node-windo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -4545,7 +4545,7 @@ CalicoNodeWindowsDaemonSetPodTemplateSpec is the calico-node-windows DaemonSet&r
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4566,7 +4566,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">
 CalicoNodeWindowsDaemonSetPodSpec
 </a>
 </em>
@@ -4587,11 +4587,11 @@ Spec is the calico-node-windows DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
 
 </p>
 <p>
@@ -4631,7 +4631,7 @@ If omitted, the calico-node-windows DaemonSet will use its default value for min
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">
 CalicoNodeWindowsDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -4648,11 +4648,11 @@ Template describes the calico-node-windows DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -4672,7 +4672,7 @@ CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrad
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4692,7 +4692,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">
 CalicoWindowsUpgradeDaemonSetSpec
 </a>
 </em>
@@ -4713,11 +4713,11 @@ Spec is the specification of the calico-windows-upgrade DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -4772,11 +4772,11 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -4795,7 +4795,7 @@ CalicoWindowsUpgradeDaemonSetPodSpec is the calico-windows-upgrade DaemonSet&rsq
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">
+<a href="#CalicoWindowsUpgradeDaemonSetContainer">
 []CalicoWindowsUpgradeDaemonSetContainer
 </a>
 </em>
@@ -4882,11 +4882,11 @@ WARNING: Please note that this field will override the default calico-windows-up
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -4905,7 +4905,7 @@ CalicoWindowsUpgradeDaemonSetPodTemplateSpec is the calico-windows-upgrade Daemo
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4926,7 +4926,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">
 CalicoWindowsUpgradeDaemonSetPodSpec
 </a>
 </em>
@@ -4947,11 +4947,11 @@ Spec is the calico-windows-upgrade DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
 
 </p>
 <p>
@@ -4991,7 +4991,7 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
 CalicoWindowsUpgradeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -5008,11 +5008,11 @@ Template describes the calico-windows-upgrade DaemonSet pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CertificateManagement">CertificateManagement</h3>
+<h3 id="CertificateManagement">CertificateManagement</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5104,14 +5104,14 @@ Default: SHA256WithRSA
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CollectProcessPathOption">CollectProcessPathOption
+<h3 id="CollectProcessPathOption">CollectProcessPathOption
 (<code>string</code> alias)</h3>
-<h3 id="operator.tigera.io/v1.ComponentName">ComponentName
+<h3 id="ComponentName">ComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComponentResource">ComponentResource</a>)
+<a href="#ComponentResource">ComponentResource</a>)
 
 </p>
 <p>
@@ -5120,11 +5120,11 @@ ComponentName represents a single component.
 <p>
 One of: Node, Typha, KubeControllers
 </p>
-<h3 id="operator.tigera.io/v1.ComponentResource">ComponentResource</h3>
+<h3 id="ComponentResource">ComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5144,7 +5144,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentName">
+<a href="#ComponentName">
 ComponentName
 </a>
 </em>
@@ -5179,44 +5179,44 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ConditionStatus">ConditionStatus
+<h3 id="ConditionStatus">ConditionStatus
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 ConditionStatus represents the status of a particular condition. A condition may be one of: True, False, Unknown.
 </p>
-<h3 id="operator.tigera.io/v1.ContainerIPForwardingType">ContainerIPForwardingType
+<h3 id="ContainerIPForwardingType">ContainerIPForwardingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
 ContainerIPForwardingType specifies whether the CNI config for container ip forwarding is enabled.
 </p>
-<h3 id="operator.tigera.io/v1.DataType">DataType
+<h3 id="DataType">DataType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Index">Index</a>)
+<a href="#Index">Index</a>)
 
 </p>
 <p>
 DataType represent the type of data stored
 </p>
-<h3 id="operator.tigera.io/v1.EGWDeploymentContainer">EGWDeploymentContainer</h3>
+<h3 id="EGWDeploymentContainer">EGWDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -5272,11 +5272,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
+<h3 id="EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -5332,11 +5332,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
+<h3 id="EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -5355,7 +5355,7 @@ EgressGatewayDeploymentPodSpec is the Egress Gateway Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentInitContainer">
+<a href="#EGWDeploymentInitContainer">
 []EGWDeploymentInitContainer
 </a>
 </em>
@@ -5377,7 +5377,7 @@ If omitted, the EGW Deployment will use its default values for its init containe
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentContainer">
+<a href="#EGWDeploymentContainer">
 []EGWDeploymentContainer
 </a>
 </em>
@@ -5512,11 +5512,11 @@ PriorityClassName allows to specify a PriorityClass resource to be used.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
+<h3 id="EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -5535,7 +5535,7 @@ EgressGatewayDeploymentPodTemplateSpec is the EGW Deployment&rsquo;s PodTemplate
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayMetadata">
+<a href="#EgressGatewayMetadata">
 EgressGatewayMetadata
 </a>
 </em>
@@ -5556,7 +5556,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">
+<a href="#EgressGatewayDeploymentPodSpec">
 EgressGatewayDeploymentPodSpec
 </a>
 </em>
@@ -5577,11 +5577,11 @@ Spec is the EGW Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
+<h3 id="EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -5622,7 +5622,7 @@ Default: 90
 
 <code>icmpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ICMPProbe">
+<a href="#ICMPProbe">
 ICMPProbe
 </a>
 </em>
@@ -5644,7 +5644,7 @@ fail. Timeout must be greater than interval.
 
 <code>httpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HTTPProbe">
+<a href="#HTTPProbe">
 HTTPProbe
 </a>
 </em>
@@ -5663,11 +5663,11 @@ fail. Timeout must be greater than interval.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayIPPool">EgressGatewayIPPool</h3>
+<h3 id="EgressGatewayIPPool">EgressGatewayIPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <table>
@@ -5716,11 +5716,11 @@ CIDR is the IPPool CIDR that the Egress Gateways can use.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayMetadata">EgressGatewayMetadata</h3>
+<h3 id="EgressGatewayMetadata">EgressGatewayMetadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -5778,11 +5778,11 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</h3>
+<h3 id="EgressGatewaySpec">EgressGatewaySpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -5819,7 +5819,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -5860,7 +5860,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -5881,7 +5881,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -5901,7 +5901,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -5925,7 +5925,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -5942,11 +5942,11 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayStatus">EgressGatewayStatus</h3>
+<h3 id="EgressGatewayStatus">EgressGatewayStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -6000,12 +6000,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EncapsulationType">EncapsulationType
+<h3 id="EncapsulationType">EncapsulationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -6014,7 +6014,7 @@ EncapsulationType is the type of encapsulation to use on an IP pool.
 <p>
 One of: IPIP, VXLAN, IPIPCrossSubnet, VXLANCrossSubnet, None
 </p>
-<h3 id="operator.tigera.io/v1.EncryptionOption">EncryptionOption
+<h3 id="EncryptionOption">EncryptionOption
 (<code>string</code> alias)</h3>
 <p>
 EncryptionOption specifies the traffic encryption mode when connecting to a Syslog server.
@@ -6022,11 +6022,11 @@ EncryptionOption specifies the traffic encryption mode when connecting to a Sysl
 <p>
 One of: None, TLS
 </p>
-<h3 id="operator.tigera.io/v1.EnvoySettings">EnvoySettings</h3>
+<h3 id="EnvoySettings">EnvoySettings</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -6079,19 +6079,19 @@ manipulating various headers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FIPSMode">FIPSMode
+<h3 id="FIPSMode">FIPSMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.HTTPProbe">HTTPProbe</h3>
+<h3 id="HTTPProbe">HTTPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -6163,12 +6163,12 @@ Default: 30
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HostPortsType">HostPortsType
+<h3 id="HostPortsType">HostPortsType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -6177,11 +6177,11 @@ HostPortsType specifies host port support.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.ICMPProbe">ICMPProbe</h3>
+<h3 id="ICMPProbe">ICMPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -6253,19 +6253,19 @@ Default: 15
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPAMPluginType">IPAMPluginType
+<h3 id="IPAMPluginType">IPAMPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPAMSpec">IPAMSpec</a>)
+<a href="#IPAMSpec">IPAMSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IPAMSpec">IPAMSpec</h3>
+<h3 id="IPAMSpec">IPAMSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -6284,7 +6284,7 @@ IPAMSpec contains configuration for pod IP address management.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMPluginType">
+<a href="#IPAMPluginType">
 IPAMPluginType
 </a>
 </em>
@@ -6312,11 +6312,11 @@ Default: Calico
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPPool">IPPool</h3>
+<h3 id="IPPool">IPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -6349,7 +6349,7 @@ CIDR contains the address range for the IP Pool in classless inter-domain routin
 
 <code>encapsulation</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncapsulationType">
+<a href="#EncapsulationType">
 EncapsulationType
 </a>
 </em>
@@ -6371,7 +6371,7 @@ Default: IPIP
 
 <code>natOutgoing</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NATOutgoingType">
+<a href="#NATOutgoingType">
 NATOutgoingType
 </a>
 </em>
@@ -6447,11 +6447,11 @@ Default: false
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Image">Image</h3>
+<h3 id="Image">Image</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</a>)
+<a href="#ImageSetSpec">ImageSetSpec</a>)
 
 </p>
 <table>
@@ -6502,11 +6502,11 @@ The field should not include a leading <code>@</code> and must be prefixed with 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</h3>
+<h3 id="ImageSetSpec">ImageSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>)
+<a href="#ImageSet">ImageSet</a>)
 
 </p>
 <p>
@@ -6525,7 +6525,7 @@ ImageSetSpec defines the desired state of ImageSet.
 
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -6542,11 +6542,11 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Index">Index</h3>
+<h3 id="Index">Index</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -6584,7 +6584,7 @@ excludes the numerical identifier suffix)
 
 <code>dataType</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DataType">
+<a href="#DataType">
 DataType
 </a>
 </em>
@@ -6600,12 +6600,12 @@ DataType represents the type of data stored in the defined index
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationSpec">InstallationSpec</h3>
+<h3 id="InstallationSpec">InstallationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#Installation">Installation</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -6624,7 +6624,7 @@ InstallationSpec defines configuration for a Calico or Calico Enterprise install
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -6752,7 +6752,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -6775,7 +6775,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -6795,7 +6795,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -6815,7 +6815,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -6994,7 +6994,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -7016,7 +7016,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -7038,7 +7038,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -7058,7 +7058,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -7078,7 +7078,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -7097,7 +7097,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -7117,7 +7117,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -7137,7 +7137,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -7157,7 +7157,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -7176,7 +7176,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -7197,7 +7197,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -7217,7 +7217,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -7252,11 +7252,11 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationStatus">InstallationStatus</h3>
+<h3 id="InstallationStatus">InstallationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>)
+<a href="#Installation">Installation</a>)
 
 </p>
 <p>
@@ -7275,7 +7275,7 @@ InstallationStatus defines the observed state of the Calico or Calico Enterprise
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -7331,7 +7331,7 @@ that is being used. If an ImageSet is not being used then this will not be set.
 
 <code>computed</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -7388,12 +7388,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
+<h3 id="KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</a>)
+<a href="#NodeAddressAutodetection">NodeAddressAutodetection</a>)
 
 </p>
 <p>
@@ -7402,12 +7402,12 @@ KubernetesAutodetectionMethod is a method of detecting an IP address based on th
 <p>
 One of: NodeInternalIP
 </p>
-<h3 id="operator.tigera.io/v1.LinuxDataplaneOption">LinuxDataplaneOption
+<h3 id="LinuxDataplaneOption">LinuxDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -7416,11 +7416,11 @@ LinuxDataplaneOption controls which dataplane is to be used on Linux nodes.
 <p>
 One of: Iptables, BPF
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</h3>
+<h3 id="LogCollectionSpec">LogCollectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -7436,7 +7436,7 @@ One of: Iptables, BPF
 
 <code>collectLogs</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionStatusType">
+<a href="#LogCollectionStatusType">
 LogCollectionStatusType
 </a>
 </em>
@@ -7494,28 +7494,28 @@ Default: -1
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectionStatusType">LogCollectionStatusType
+<h3 id="LogCollectionStatusType">LogCollectionStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</a>)
+<a href="#LogCollectionSpec">LogCollectionSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogLevel">LogLevel
+<h3 id="LogLevel">LogLevel
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNILogging">CNILogging</a>, 
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#CNILogging">CNILogging</a>, 
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.Logging">Logging</h3>
+<h3 id="Logging">Logging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>
@@ -7531,7 +7531,7 @@ Default: -1
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNILogging">
+<a href="#CNILogging">
 CNILogging
 </a>
 </em>
@@ -7548,24 +7548,24 @@ Customized logging specification for calico-cni plugin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Metadata">Metadata</h3>
+<h3 id="Metadata">Metadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>, 
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>, 
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
+<a href="#TyphaDeployment">TyphaDeployment</a>, 
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7621,21 +7621,21 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MonitorSpec">MonitorSpec</h3>
+<h3 id="MonitorSpec">MonitorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
 MonitorSpec defines the desired state of Tigera monitor.
 </p>
-<h3 id="operator.tigera.io/v1.MonitorStatus">MonitorStatus</h3>
+<h3 id="MonitorStatus">MonitorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -7689,12 +7689,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MultiInterfaceMode">MultiInterfaceMode
+<h3 id="MultiInterfaceMode">MultiInterfaceMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -7703,12 +7703,12 @@ MultiInterfaceMode describes the method of providing multiple pod interfaces.
 <p>
 One of: None, Multus
 </p>
-<h3 id="operator.tigera.io/v1.NATOutgoingType">NATOutgoingType
+<h3 id="NATOutgoingType">NATOutgoingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -7717,23 +7717,23 @@ NATOutgoingType describe the type of outgoing NAT to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.NativeIP">NativeIP
+<h3 id="NativeIP">NativeIP
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</a>)
+<a href="#AWSEgressGateway">AWSEgressGateway</a>)
 
 </p>
 <p>
 NativeIP defines if Egress Gateway pods should have AWS IPs.
 When NativeIP is enabled, the IPPools should be backed by AWS subnet.
 </p>
-<h3 id="operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</h3>
+<h3 id="NodeAddressAutodetection">NodeAddressAutodetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -7773,7 +7773,7 @@ filtering based on well-known interface names.
 
 <code>kubernetes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KubernetesAutodetectionMethod">
+<a href="#KubernetesAutodetectionMethod">
 KubernetesAutodetectionMethod
 </a>
 </em>
@@ -7864,11 +7864,11 @@ one of the provided CIDRs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeAffinity">NodeAffinity</h3>
+<h3 id="NodeAffinity">NodeAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</a>)
+<a href="#TyphaAffinity">TyphaAffinity</a>)
 
 </p>
 <p>
@@ -7937,12 +7937,12 @@ may or may not try to eventually evict the pod from its node.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NonPrivilegedType">NonPrivilegedType
+<h3 id="NonPrivilegedType">NonPrivilegedType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -7951,29 +7951,29 @@ NonPrivilegedType specifies whether Calico runs as permissioned or not
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.OIDCType">OIDCType
+<h3 id="OIDCType">OIDCType
 (<code>string</code> alias)</h3>
 <p>
 OIDCType defines how OIDC is configured for Tigera Enterprise. Dex should be the best option for most use-cases.
 The Tigera option can help in specific use-cases, for instance, when you are unable to configure a client secret.
 One of: Dex, Tigera
 </p>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
+<h3 id="PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
 PolicyRecommendationSpec defines configuration for the Calico Enterprise Policy Recommendation
 service.
 </p>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
+<h3 id="PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
@@ -8006,13 +8006,13 @@ State provides user-readable status.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ProductVariant">ProductVariant
+<h3 id="ProductVariant">ProductVariant
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#InstallationSpec">InstallationSpec</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -8021,37 +8021,37 @@ ProductVariant represents the variant of the product.
 <p>
 One of: Calico, TigeraSecureEnterprise
 </p>
-<h3 id="operator.tigera.io/v1.PromptType">PromptType
+<h3 id="PromptType">PromptType
 (<code>string</code> alias)</h3>
 <p>
 PromptType is a value that specifies whether the identity provider prompts the end user for re-authentication and
 consent.
 One of: None, Login, Consent, SelectAccount.
 </p>
-<h3 id="operator.tigera.io/v1.Provider">Provider
+<h3 id="Provider">Provider
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
 Provider represents a particular provider or flavor of Kubernetes. Valid options
 are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG.
 </p>
-<h3 id="operator.tigera.io/v1.StatusConditionType">StatusConditionType
+<h3 id="StatusConditionType">StatusConditionType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 StatusConditionType is a type of condition that may apply to a particular component.
 </p>
-<h3 id="operator.tigera.io/v1.TLS">TLS</h3>
+<h3 id="TLS">TLS</h3>
 <table>
 <thead>
 <tr>
@@ -8099,11 +8099,11 @@ Default: tigera-management-cluster-connection
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantSpec">TenantSpec</h3>
+<h3 id="TenantSpec">TenantSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
 <table>
@@ -8136,7 +8136,7 @@ ID is the unique identifier for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -8152,18 +8152,18 @@ Indices defines the how to store a tenant&rsquo;s data
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantStatus">TenantStatus</h3>
+<h3 id="TenantStatus">TenantStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</h3>
+<h3 id="TigeraStatusCondition">TigeraStatusCondition</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</a>)
+<a href="#TigeraStatusStatus">TigeraStatusStatus</a>)
 
 </p>
 <p>
@@ -8182,7 +8182,7 @@ TigeraStatusCondition represents a condition attached to a particular component.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.StatusConditionType">
+<a href="#StatusConditionType">
 StatusConditionType
 </a>
 </em>
@@ -8201,7 +8201,7 @@ The type of condition. May be Available, Progressing, or Degraded.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ConditionStatus">
+<a href="#ConditionStatus">
 ConditionStatus
 </a>
 </em>
@@ -8290,26 +8290,26 @@ with respect to the current state of the instance.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatusReason">TigeraStatusReason
+<h3 id="TigeraStatusReason">TigeraStatusReason
 (<code>string</code> alias)</h3>
 <p>
 TigeraStatusReason represents the reason for a particular condition.
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusSpec">TigeraStatusSpec</h3>
+<h3 id="TigeraStatusSpec">TigeraStatusSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
 TigeraStatusSpec defines the desired state of TigeraStatus
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</h3>
+<h3 id="TigeraStatusStatus">TigeraStatusStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
@@ -8328,7 +8328,7 @@ TigeraStatusStatus defines the observed state of TigeraStatus
 
 <code>conditions</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">
+<a href="#TigeraStatusCondition">
 []TigeraStatusCondition
 </a>
 </em>
@@ -8345,11 +8345,11 @@ Available, Progressing, or Degraded.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</h3>
+<h3 id="TyphaAffinity">TyphaAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -8369,7 +8369,7 @@ TyphaAffinity allows configuration of node affinity characteristics for Typha po
 
 <code>nodeAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAffinity">
+<a href="#NodeAffinity">
 NodeAffinity
 </a>
 </em>
@@ -8386,11 +8386,11 @@ NodeAffinity describes node affinity scheduling rules for typha.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</h3>
+<h3 id="TyphaDeployment">TyphaDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -8409,7 +8409,7 @@ TyphaDeployment is the configuration for the typha Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -8429,7 +8429,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">
+<a href="#TyphaDeploymentSpec">
 TyphaDeploymentSpec
 </a>
 </em>
@@ -8450,11 +8450,11 @@ Spec is the specification of the typha Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
+<h3 id="TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -8510,11 +8510,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
+<h3 id="TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -8570,11 +8570,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
+<h3 id="TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8593,7 +8593,7 @@ TyphaDeploymentPodSpec is the typha Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentInitContainer">
+<a href="#TyphaDeploymentInitContainer">
 []TyphaDeploymentInitContainer
 </a>
 </em>
@@ -8615,7 +8615,7 @@ If omitted, the typha Deployment will use its default values for its init contai
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentContainer">
+<a href="#TyphaDeploymentContainer">
 []TyphaDeploymentContainer
 </a>
 </em>
@@ -8749,11 +8749,11 @@ WARNING: Please note that this field will override the default calico-typha Depl
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
+<h3 id="TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -8772,7 +8772,7 @@ TyphaDeploymentPodTemplateSpec is the typha Deployment&rsquo;s PodTemplateSpec
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -8793,7 +8793,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">
+<a href="#TyphaDeploymentPodSpec">
 TyphaDeploymentPodSpec
 </a>
 </em>
@@ -8814,11 +8814,11 @@ Spec is the typha Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
+<h3 id="TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>)
+<a href="#TyphaDeployment">TyphaDeployment</a>)
 
 </p>
 <p>
@@ -8858,7 +8858,7 @@ If omitted, the typha Deployment will use its default value for minReadySeconds.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">
+<a href="#TyphaDeploymentPodTemplateSpec">
 TyphaDeploymentPodTemplateSpec
 </a>
 </em>
@@ -8878,7 +8878,7 @@ Template describes the typha Deployment pod that will be created.
 
 <code>strategy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentStrategy">
+<a href="#TyphaDeploymentStrategy">
 TyphaDeploymentStrategy
 </a>
 </em>
@@ -8895,11 +8895,11 @@ The deployment strategy to use to replace existing pods with new ones.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
+<h3 id="TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -8938,27 +8938,27 @@ to be.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.WAFStatusType">WAFStatusType
+<h3 id="WAFStatusType">WAFStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsDataplaneOption">WindowsDataplaneOption
+<h3 id="WindowsDataplaneOption">WindowsDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsNodeSpec">WindowsNodeSpec</h3>
+<h3 id="WindowsNodeSpec">WindowsNodeSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>

--- a/calico_versioned_docs/version-3.28/getting-started/kubernetes/helm.mdx
+++ b/calico_versioned_docs/version-3.28/getting-started/kubernetes/helm.mdx
@@ -49,7 +49,7 @@ helm repo add projectcalico https://docs.tigera.io/calico/charts
 
 If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), or you need to customize TLS certificates, you **must** customize this Helm chart by creating a `values.yaml` file. Otherwise, you can skip this step.
 
-1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#operator.tigera.io/v1.Provider). For example:
+1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#Provider. For example:
 
    ```
    echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico_versioned_docs/version-3.28/getting-started/kubernetes/self-managed-onprem/config-options.mdx
+++ b/calico_versioned_docs/version-3.28/getting-started/kubernetes/self-managed-onprem/config-options.mdx
@@ -36,9 +36,9 @@ installed directly on the cluster as a Deployment, and is configured through one
 Operator installations read their configuration from a specific set of Kubernetes APIs. These APIs are installed on the cluster
 as part of `tigera-operator.yaml` in the `operator.tigera.io/v1` API group.
 
-- [Installation](../../../reference/installation/api.mdx#operator.tigera.io/v1.Installation): a singleton resource with name "default" that
+- [Installation](../../../reference/installation/api.mdx#Installation: a singleton resource with name "default" that
   configures common installation parameters for a {variables.prodname} cluster.
-- [APIServer](../../../reference/installation/api.mdx#operator.tigera.io/v1.Installation): a singleton resource with name "default" that
+- [APIServer](../../../reference/installation/api.mdx#Installation: a singleton resource with name "default" that
   configures installation of the {variables.prodname} API server extension.
 
 ### Configure the pod IP range

--- a/calico_versioned_docs/version-3.28/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico_versioned_docs/version-3.28/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -38,7 +38,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#BGPOption.
 
 :::
 

--- a/calico_versioned_docs/version-3.28/networking/ipam/ip-autodetection.mdx
+++ b/calico_versioned_docs/version-3.28/networking/ipam/ip-autodetection.mdx
@@ -65,7 +65,7 @@ For more details on autodetection methods, see [node configuration](../../refere
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-As noted previously, the default autodetection method is **first valid interface found** (first-found). To use a different autodetection method, edit the default [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation) custom resource, specifying the method. Below are examples of the supported autodetection methods:
+As noted previously, the default autodetection method is **first valid interface found** (first-found). To use a different autodetection method, edit the default [Installation](../../reference/installation/api.mdx#Installation custom resource, specifying the method. Below are examples of the supported autodetection methods:
 
 :::note
 

--- a/calico_versioned_docs/version-3.28/operations/certificate-management.mdx
+++ b/calico_versioned_docs/version-3.28/operations/certificate-management.mdx
@@ -31,7 +31,7 @@ certificate issuance, {variables.prodname} provides a simple configuration optio
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../reference/installation/api.mdx#Installation
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
 ```yaml

--- a/calico_versioned_docs/version-3.28/operations/image-options/imageset.mdx
+++ b/calico_versioned_docs/version-3.28/operations/image-options/imageset.mdx
@@ -78,7 +78,7 @@ sed -ie "s|\(image: .*/operator\):.*|?\1@<put-digest-here>|" tigera-operator.yam
 
 ### Create an ImageSet
 
-Create an [ImageSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ImageSet) manifest file named `imageset.yaml` like the following:
+Create an [ImageSet](../../reference/installation/api.mdx#ImageSet manifest file named `imageset.yaml` like the following:
 
 <CodeBlock language='yaml'>
 apiVersion: operator.tigera.io/v1
@@ -142,7 +142,7 @@ You can create an ImageSet manifest manually or by script.
       docker pull <repo/image:tag> && docker inspect <repo/image:tag> -f '{{range .RepoDigests}}{{printf "%s\n" .}}{{end}}'
       ```
    1. Use the digest from the image that matches the repo/image you will use.
-      If you are using a private registry or have specified an [imagePath](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+      If you are using a private registry or have specified an [imagePath](../../reference/installation/api.mdx#Installation
       you will still use the "default" `<owner>/<image>` in the `image` field, for example if you your node image is coming from
       `example.com/registry/imagepath/node` you will still use `calico/node` in the image field of the ImageSet.
       :::note
@@ -228,7 +228,7 @@ Apply the created `imageset.yaml` to your cluster.
 
 ### Create new ImageSet when upgrading or downgrading
 
-Before upgrading to a new release or downgrading, you must create a new [ImageSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ImageSet)
+Before upgrading to a new release or downgrading, you must create a new [ImageSet](../../reference/installation/api.mdx#ImageSet
 with updated image references and names for the new release. This must be done prior
 to upgrading the cluster so when the new manifests are applied, the appropriate ImageSet is available.
 
@@ -236,7 +236,7 @@ to upgrading the cluster so when the new manifests are applied, the appropriate 
 
 ### Why does the Installation Resource status not include my ImageSet?
 
-The [status.imageset](../../reference/installation/api.mdx#operator.tigera.io/v1.InstallationStatus) field of
+The [status.imageset](../../reference/installation/api.mdx#InstallationStatus field of
 the Installation Resource will not be updated until the `calico` component has fully been deployed. `calico` is
 fully deployed when `kubectl get tigerastatus calico` reports Available True with Progressing and Degraded as False.
 

--- a/calico_versioned_docs/version-3.28/reference/configure-cni-plugins.mdx
+++ b/calico_versioned_docs/version-3.28/reference/configure-cni-plugins.mdx
@@ -262,7 +262,7 @@ By enabling this feature, you can avoid errors that can occur when a pod tries t
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](installation/api#operator.tigera.io/v1.CalicoNetworkSpec) of the default `operator.tigera.io/v1/installation` resource.
+The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](installation/api#CalicoNetworkSpec of the default `operator.tigera.io/v1/installation` resource.
 
 The following example configures the CNI to delay a pod from starting its containers for up to 10 seconds, or until the pod's dataplane has been programmed:
 
@@ -332,7 +332,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](installation/api.mdx#Installation API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico_versioned_docs/version-3.28/reference/configure-resources.mdx
+++ b/calico_versioned_docs/version-3.28/reference/configure-resources.mdx
@@ -16,11 +16,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../reference/installation/api.mdx#APIServer CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the APIServer CR using the below command:
+To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#APIServerDeployment, patch the APIServer CR using the below command:
 
 ```bash
 kubectl patch apiserver default  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -59,7 +59,7 @@ The [Installation CR](../reference/installation/api.mdx) provides a way to confi
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../reference/installation/api.mdx#TyphaDeployment, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -95,7 +95,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../reference/installation/api.mdx#calicoNodeDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -130,7 +130,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../reference/installation/api.mdx#calicoNodeWindowsDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -165,7 +165,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../reference/installation/api.mdx#CalicoKubeControllersDeployment component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -201,7 +201,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../reference/installation/api.mdx#CSINodeDriverDaemonSet component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -258,11 +258,11 @@ The provided example illustrates configuring the apiserver component. Follow a s
 
 ## APIServer custom resource
 
-The [APIServer](../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
+The [APIServer](../reference/installation/api.mdx#APIServer CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), update values.yaml with the appropriate resource values.
+To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#APIServerDeployment, update values.yaml with the appropriate resource values.
 
 ```bash
 apiServer:

--- a/calico_versioned_docs/version-3.28/reference/installation/_api.mdx
+++ b/calico_versioned_docs/version-3.28/reference/installation/_api.mdx
@@ -15,31 +15,31 @@ API Schema definitions for configuring the installation of Calico and Calico Ent
 </p>
 Resource Types:
 <ul><li>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>
+<a href="#APIServer">APIServer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>
+<a href="#ApplicationLayer">ApplicationLayer</a>
 </li><li>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>
+<a href="#EgressGateway">EgressGateway</a>
 </li><li>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>
+<a href="#ImageSet">ImageSet</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>
+<a href="#Installation">Installation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>
+<a href="#Monitor">Monitor</a>
 </li><li>
-<a href="#operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</a>
+<a href="#PacketCaptureAPI">PacketCaptureAPI</a>
 </li><li>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>
+<a href="#PolicyRecommendation">PolicyRecommendation</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TLSPassThroughRoute">TLSPassThroughRoute</a>
+<a href="#TLSPassThroughRoute">TLSPassThroughRoute</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TLSTerminatedRoute">TLSTerminatedRoute</a>
+<a href="#TLSTerminatedRoute">TLSTerminatedRoute</a>
 </li><li>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>
+<a href="#Tenant">Tenant</a>
 </li><li>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>
+<a href="#TigeraStatus">TigeraStatus</a>
 </li></ul>
-<h3 id="operator.tigera.io/v1.APIServer">APIServer</h3>
+<h3 id="APIServer">APIServer</h3>
 <p>
 APIServer installs the Tigera API server and related resources. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo; or &ldquo;tigera-secure&rdquo;.
@@ -100,7 +100,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerSpec">
+<a href="#APIServerSpec">
 APIServerSpec
 </a>
 </em>
@@ -118,7 +118,7 @@ Specification of the desired state for the Tigera API server.
 <td>
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -142,7 +142,7 @@ take precedence.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerStatus">
+<a href="#APIServerStatus">
 APIServerStatus
 </a>
 </em>
@@ -158,7 +158,7 @@ Most recently observed status for the Tigera API server.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</h3>
+<h3 id="ApplicationLayer">ApplicationLayer</h3>
 <p>
 ApplicationLayer is the Schema for the applicationlayers API
 </p>
@@ -218,7 +218,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">
+<a href="#ApplicationLayerSpec">
 ApplicationLayerSpec
 </a>
 </em>
@@ -233,7 +233,7 @@ ApplicationLayerSpec
 <td>
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -253,7 +253,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -272,7 +272,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -292,7 +292,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -311,7 +311,7 @@ User-configurable settings for the Envoy proxy.
 
 <code>l7LogCollectorDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSet">
+<a href="#L7LogCollectorDaemonSet">
 L7LogCollectorDaemonSet
 </a>
 </em>
@@ -334,7 +334,7 @@ L7LogCollectorDaemonSet configures the L7LogCollector DaemonSet.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerStatus">
+<a href="#ApplicationLayerStatus">
 ApplicationLayerStatus
 </a>
 </em>
@@ -347,7 +347,7 @@ ApplicationLayerStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGateway">EgressGateway</h3>
+<h3 id="EgressGateway">EgressGateway</h3>
 <p>
 EgressGateway is the Schema for the egressgateways API
 </p>
@@ -407,7 +407,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">
+<a href="#EgressGatewaySpec">
 EgressGatewaySpec
 </a>
 </em>
@@ -440,7 +440,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -481,7 +481,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -502,7 +502,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -522,7 +522,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -546,7 +546,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -569,7 +569,7 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayStatus">
+<a href="#EgressGatewayStatus">
 EgressGatewayStatus
 </a>
 </em>
@@ -582,7 +582,7 @@ EgressGatewayStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSet">ImageSet</h3>
+<h3 id="ImageSet">ImageSet</h3>
 <p>
 ImageSet is used to specify image digests for the images that the operator deploys.
 The name of the ImageSet is expected to be in the format <code>&lt;variant&gt;-&lt;release&gt;</code>.
@@ -647,7 +647,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">
+<a href="#ImageSetSpec">
 ImageSetSpec
 </a>
 </em>
@@ -662,7 +662,7 @@ ImageSetSpec
 <td>
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -682,7 +682,7 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Installation">Installation</h3>
+<h3 id="Installation">Installation</h3>
 <p>
 Installation configures an installation of Calico or Calico Enterprise. At most one instance
 of this resource is supported. It must be named &ldquo;default&rdquo;. The Installation API installs core networking
@@ -744,7 +744,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -762,7 +762,7 @@ Specification of the desired state for the Calico or Calico Enterprise installat
 <td>
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -890,7 +890,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -913,7 +913,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -933,7 +933,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -953,7 +953,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -1132,7 +1132,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -1154,7 +1154,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -1176,7 +1176,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -1196,7 +1196,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -1216,7 +1216,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -1235,7 +1235,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -1255,7 +1255,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -1275,7 +1275,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -1295,7 +1295,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -1314,7 +1314,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -1335,7 +1335,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -1355,7 +1355,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -1396,7 +1396,7 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationStatus">
+<a href="#InstallationStatus">
 InstallationStatus
 </a>
 </em>
@@ -1412,7 +1412,7 @@ Most recently observed state for the Calico or Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Monitor">Monitor</h3>
+<h3 id="Monitor">Monitor</h3>
 <p>
 Monitor is the Schema for the monitor API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -1473,7 +1473,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorSpec">
+<a href="#MonitorSpec">
 MonitorSpec
 </a>
 </em>
@@ -1488,7 +1488,7 @@ MonitorSpec
 <td>
 <code>externalPrometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">
+<a href="#ExternalPrometheus">
 ExternalPrometheus
 </a>
 </em>
@@ -1509,7 +1509,7 @@ scraping from git-ops tools without the need of post-installation steps.
 
 <code>prometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Prometheus">
+<a href="#Prometheus">
 Prometheus
 </a>
 </em>
@@ -1529,7 +1529,7 @@ Prometheus is the configuration for the Prometheus.
 
 <code>alertManager</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AlertManager">
+<a href="#AlertManager">
 AlertManager
 </a>
 </em>
@@ -1552,7 +1552,7 @@ AlertManager is the configuration for the AlertManager.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MonitorStatus">
+<a href="#MonitorStatus">
 MonitorStatus
 </a>
 </em>
@@ -1565,7 +1565,7 @@ MonitorStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</h3>
+<h3 id="PacketCaptureAPI">PacketCaptureAPI</h3>
 <p>
 PacketCaptureAPI is used to configure the resource requirement for PacketCaptureAPI deployment. It must be named &ldquo;tigera-secure&rdquo;.
 </p>
@@ -1625,7 +1625,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPISpec">
+<a href="#PacketCaptureAPISpec">
 PacketCaptureAPISpec
 </a>
 </em>
@@ -1643,7 +1643,7 @@ Specification of the desired state for the PacketCaptureAPI.
 <td>
 <code>packetCaptureAPIDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeployment">
+<a href="#PacketCaptureAPIDeployment">
 PacketCaptureAPIDeployment
 </a>
 </em>
@@ -1666,7 +1666,7 @@ PacketCaptureAPIDeployment configures the PacketCaptureAPI Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIStatus">
+<a href="#PacketCaptureAPIStatus">
 PacketCaptureAPIStatus
 </a>
 </em>
@@ -1682,7 +1682,7 @@ Most recently observed state for the PacketCaptureAPI.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</h3>
+<h3 id="PolicyRecommendation">PolicyRecommendation</h3>
 <p>
 PolicyRecommendation is the Schema for the policy recommendation API. At most one instance
 of this resource is supported. It must be named &ldquo;tigera-secure&rdquo;.
@@ -1743,7 +1743,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationSpec">
+<a href="#PolicyRecommendationSpec">
 PolicyRecommendationSpec
 </a>
 </em>
@@ -1758,7 +1758,7 @@ PolicyRecommendationSpec
 <td>
 <code>policyRecommendationDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeployment">
+<a href="#PolicyRecommendationDeployment">
 PolicyRecommendationDeployment
 </a>
 </em>
@@ -1781,7 +1781,7 @@ PolicyRecommendation configures the PolicyRecommendation Deployment.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationStatus">
+<a href="#PolicyRecommendationStatus">
 PolicyRecommendationStatus
 </a>
 </em>
@@ -1794,7 +1794,7 @@ PolicyRecommendationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSPassThroughRoute">TLSPassThroughRoute</h3>
+<h3 id="TLSPassThroughRoute">TLSPassThroughRoute</h3>
 <table>
 <thead>
 <tr>
@@ -1851,7 +1851,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRouteSpec">
+<a href="#TLSPassThroughRouteSpec">
 TLSPassThroughRouteSpec
 </a>
 </em>
@@ -1869,7 +1869,7 @@ Dest is the destination URL
 <td>
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -1885,7 +1885,7 @@ TargetType
 
 <code>sniMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SNIMatch">
+<a href="#SNIMatch">
 SNIMatch
 </a>
 </em>
@@ -1922,7 +1922,7 @@ Destination is the destination url to proxy the request to.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSTerminatedRoute">TLSTerminatedRoute</h3>
+<h3 id="TLSTerminatedRoute">TLSTerminatedRoute</h3>
 <table>
 <thead>
 <tr>
@@ -1979,7 +1979,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TLSTerminatedRouteSpec">
+<a href="#TLSTerminatedRouteSpec">
 TLSTerminatedRouteSpec
 </a>
 </em>
@@ -1994,7 +1994,7 @@ TLSTerminatedRouteSpec
 <td>
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -2010,7 +2010,7 @@ TargetType
 
 <code>pathMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PathMatch">
+<a href="#PathMatch">
 PathMatch
 </a>
 </em>
@@ -2128,7 +2128,7 @@ is UI.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Tenant">Tenant</h3>
+<h3 id="Tenant">Tenant</h3>
 <p>
 Tenant is the Schema for the tenants API
 </p>
@@ -2188,7 +2188,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantSpec">
+<a href="#TenantSpec">
 TenantSpec
 </a>
 </em>
@@ -2237,7 +2237,7 @@ Name is a human readable name for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -2256,7 +2256,7 @@ Indices defines the how to store a tenant&rsquo;s data
 
 <code>elastic</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantElasticSpec">
+<a href="#TenantElasticSpec">
 TenantElasticSpec
 </a>
 </em>
@@ -2295,7 +2295,7 @@ in the Tenant&rsquo;s namespace. Defaults to the controlPlaneReplicas in Install
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -2314,7 +2314,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>dashboardsJob</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJob">
+<a href="#DashboardsJob">
 DashboardsJob
 </a>
 </em>
@@ -2336,7 +2336,7 @@ DashboardsJob configures the Dashboards job
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantStatus">
+<a href="#TenantStatus">
 TenantStatus
 </a>
 </em>
@@ -2349,7 +2349,7 @@ TenantStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatus">TigeraStatus</h3>
+<h3 id="TigeraStatus">TigeraStatus</h3>
 <p>
 TigeraStatus represents the most recently observed status for Calico or a Calico Enterprise functional area.
 </p>
@@ -2409,7 +2409,7 @@ Refer to the Kubernetes API documentation for the fields of the
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusSpec">
+<a href="#TigeraStatusSpec">
 TigeraStatusSpec
 </a>
 </em>
@@ -2429,7 +2429,7 @@ TigeraStatusSpec
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">
+<a href="#TigeraStatusStatus">
 TigeraStatusStatus
 </a>
 </em>
@@ -2442,11 +2442,11 @@ TigeraStatusStatus
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</h3>
+<h3 id="APIServerDeployment">APIServerDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerSpec">APIServerSpec</a>)
+<a href="#APIServerSpec">APIServerSpec</a>)
 
 </p>
 <p>
@@ -2465,7 +2465,7 @@ APIServerDeployment is the configuration for the API server Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -2485,7 +2485,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">
+<a href="#APIServerDeploymentSpec">
 APIServerDeploymentSpec
 </a>
 </em>
@@ -2506,11 +2506,11 @@ Spec is the specification of the API server Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
+<h3 id="APIServerDeploymentContainer">APIServerDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -2567,11 +2567,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
+<h3 id="APIServerDeploymentInitContainer">APIServerDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
+<a href="#APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -2627,11 +2627,11 @@ If omitted, the API server Deployment will use its default value for this init c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
+<h3 id="APIServerDeploymentPodSpec">APIServerDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -2650,7 +2650,7 @@ APIServerDeploymentDeploymentPodSpec is the API server Deployment&rsquo;s PodSpe
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentInitContainer">
+<a href="#APIServerDeploymentInitContainer">
 []APIServerDeploymentInitContainer
 </a>
 </em>
@@ -2672,7 +2672,7 @@ If omitted, the API server Deployment will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentContainer">
+<a href="#APIServerDeploymentContainer">
 []APIServerDeploymentContainer
 </a>
 </em>
@@ -2783,11 +2783,11 @@ WARNING: Please note that this field will override the default API server Deploy
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
+<h3 id="APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
+<a href="#APIServerDeploymentSpec">APIServerDeploymentSpec</a>)
 
 </p>
 <p>
@@ -2806,7 +2806,7 @@ APIServerDeploymentPodTemplateSpec is the API server Deployment&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -2827,7 +2827,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodSpec">
+<a href="#APIServerDeploymentPodSpec">
 APIServerDeploymentPodSpec
 </a>
 </em>
@@ -2848,11 +2848,11 @@ Spec is the API server Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
+<h3 id="APIServerDeploymentSpec">APIServerDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>)
 
 </p>
 <p>
@@ -2892,7 +2892,7 @@ If omitted, the API server Deployment will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">
+<a href="#APIServerDeploymentPodTemplateSpec">
 APIServerDeploymentPodTemplateSpec
 </a>
 </em>
@@ -2909,11 +2909,11 @@ Template describes the API server Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerSpec">APIServerSpec</h3>
+<h3 id="APIServerSpec">APIServerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -2932,7 +2932,7 @@ APIServerSpec defines the desired state of Tigera API server.
 
 <code>apiServerDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">
+<a href="#APIServerDeployment">
 APIServerDeployment
 </a>
 </em>
@@ -2950,11 +2950,11 @@ take precedence.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.APIServerStatus">APIServerStatus</h3>
+<h3 id="APIServerStatus">APIServerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServer">APIServer</a>)
+<a href="#APIServer">APIServer</a>)
 
 </p>
 <p>
@@ -3008,11 +3008,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</h3>
+<h3 id="AWSEgressGateway">AWSEgressGateway</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -3031,7 +3031,7 @@ AWSEgressGateway defines the configurations for deploying EgressGateway in AWS
 
 <code>nativeIP</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NativeIP">
+<a href="#NativeIP">
 NativeIP
 </a>
 </em>
@@ -3068,7 +3068,7 @@ NativeIP must be Enabled if elastic IPs are set.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
+<h3 id="AnomalyDetectionSpec">AnomalyDetectionSpec</h3>
 <table>
 <thead>
 <tr>
@@ -3097,19 +3097,19 @@ StorageClassName is now deprecated, and configuring it has no effect.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
+<h3 id="ApplicationLayerPolicyStatusType">ApplicationLayerPolicyStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</h3>
+<h3 id="ApplicationLayerSpec">ApplicationLayerSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -3128,7 +3128,7 @@ ApplicationLayerSpec defines the desired state of ApplicationLayer
 
 <code>webApplicationFirewall</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WAFStatusType">
+<a href="#WAFStatusType">
 WAFStatusType
 </a>
 </em>
@@ -3148,7 +3148,7 @@ When enabled, Services may opt-in to having ingress traffic examed by ModSecurit
 
 <code>logCollection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">
+<a href="#LogCollectionSpec">
 LogCollectionSpec
 </a>
 </em>
@@ -3167,7 +3167,7 @@ Specification for application layer (L7) log collection.
 
 <code>applicationLayerPolicy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ApplicationLayerPolicyStatusType">
+<a href="#ApplicationLayerPolicyStatusType">
 ApplicationLayerPolicyStatusType
 </a>
 </em>
@@ -3187,7 +3187,7 @@ When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in wor
 
 <code>envoy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EnvoySettings">
+<a href="#EnvoySettings">
 EnvoySettings
 </a>
 </em>
@@ -3206,7 +3206,7 @@ User-configurable settings for the Envoy proxy.
 
 <code>l7LogCollectorDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.L7LogCollectorDaemonSet">
+<a href="#L7LogCollectorDaemonSet">
 L7LogCollectorDaemonSet
 </a>
 </em>
@@ -3223,11 +3223,11 @@ L7LogCollectorDaemonSet configures the L7LogCollector DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ApplicationLayerStatus">ApplicationLayerStatus</h3>
+<h3 id="ApplicationLayerStatus">ApplicationLayerStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayer">ApplicationLayer</a>)
+<a href="#ApplicationLayer">ApplicationLayer</a>)
 
 </p>
 <p>
@@ -3281,12 +3281,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.BGPOption">BGPOption
+<h3 id="BGPOption">BGPOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -3295,7 +3295,7 @@ BGPOption describes the mode of BGP to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.CAType">CAType
+<h3 id="CAType">CAType
 (<code>string</code> alias)</h3>
 <p>
 CAType specifies which verification method the tunnel client should use to verify the tunnel server&rsquo;s identity.
@@ -3303,11 +3303,11 @@ CAType specifies which verification method the tunnel client should use to verif
 <p>
 One of: Tigera, Public
 </p>
-<h3 id="operator.tigera.io/v1.CNILogging">CNILogging</h3>
+<h3 id="CNILogging">CNILogging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Logging">Logging</a>)
+<a href="#Logging">Logging</a>)
 
 </p>
 <table>
@@ -3323,7 +3323,7 @@ One of: Tigera, Public
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -3394,12 +3394,12 @@ Default: 10
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CNIPluginType">CNIPluginType
+<h3 id="CNIPluginType">CNIPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -3408,11 +3408,11 @@ CNIPluginType describes the type of CNI plugin used.
 <p>
 One of: Calico, GKE, AmazonVPC, AzureVNET
 </p>
-<h3 id="operator.tigera.io/v1.CNISpec">CNISpec</h3>
+<h3 id="CNISpec">CNISpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -3431,7 +3431,7 @@ CNISpec contains configuration for the CNI plugin.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNIPluginType">
+<a href="#CNIPluginType">
 CNIPluginType
 </a>
 </em>
@@ -3463,7 +3463,7 @@ Default: Calico
 
 <code>ipam</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMSpec">
+<a href="#IPAMSpec">
 IPAMSpec
 </a>
 </em>
@@ -3481,11 +3481,11 @@ Calico Enterprise installation.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
+<h3 id="CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -3504,7 +3504,7 @@ CSINodeDriverDaemonSet is the configuration for the csi-node-driver DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3524,7 +3524,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">
+<a href="#CSINodeDriverDaemonSetSpec">
 CSINodeDriverDaemonSetSpec
 </a>
 </em>
@@ -3545,11 +3545,11 @@ Spec is the specification of the csi-node-driver DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
+<h3 id="CSINodeDriverDaemonSetContainer">CSINodeDriverDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -3605,11 +3605,11 @@ If omitted, the csi-node-driver DaemonSet will use its default value for this co
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodSpec">CSINodeDriverDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -3628,7 +3628,7 @@ CSINodeDriverDaemonSetPodSpec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetContainer">
+<a href="#CSINodeDriverDaemonSetContainer">
 []CSINodeDriverDaemonSetContainer
 </a>
 </em>
@@ -3715,11 +3715,11 @@ WARNING: Please note that this field will override the default csi-node-driver D
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
+<h3 id="CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
+<a href="#CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -3738,7 +3738,7 @@ CSINodeDriverDaemonSetPodTemplateSpec is the csi-node-driver DaemonSet&rsquo;s P
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3759,7 +3759,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodSpec">
+<a href="#CSINodeDriverDaemonSetPodSpec">
 CSINodeDriverDaemonSetPodSpec
 </a>
 </em>
@@ -3780,11 +3780,11 @@ Spec is the csi-node-driver DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
+<h3 id="CSINodeDriverDaemonSetSpec">CSINodeDriverDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>)
 
 </p>
 <p>
@@ -3824,7 +3824,7 @@ If omitted, the csi-node-driver DaemonSet will use its default value for minRead
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">
 CSINodeDriverDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -3841,11 +3841,11 @@ Template describes the csi-node-driver DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
+<h3 id="CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -3864,7 +3864,7 @@ CalicoKubeControllersDeployment is the configuration for the calico-kube-control
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -3884,7 +3884,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">
+<a href="#CalicoKubeControllersDeploymentSpec">
 CalicoKubeControllersDeploymentSpec
 </a>
 </em>
@@ -3905,11 +3905,11 @@ Spec is the specification of the calico-kube-controllers Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
+<h3 id="CalicoKubeControllersDeploymentContainer">CalicoKubeControllersDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -3966,11 +3966,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodSpec">CalicoKubeControllersDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -3989,7 +3989,7 @@ CalicoKubeControllersDeploymentPodSpec is the calico-kube-controller Deployment&
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentContainer">
+<a href="#CalicoKubeControllersDeploymentContainer">
 []CalicoKubeControllersDeploymentContainer
 </a>
 </em>
@@ -4078,11 +4078,11 @@ WARNING: Please note that this field will override the default calico-kube-contr
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
+<a href="#CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</a>)
 
 </p>
 <p>
@@ -4101,7 +4101,7 @@ CalicoKubeControllersDeploymentPodTemplateSpec is the calico-kube-controllers De
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4122,7 +4122,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodSpec">
+<a href="#CalicoKubeControllersDeploymentPodSpec">
 CalicoKubeControllersDeploymentPodSpec
 </a>
 </em>
@@ -4143,11 +4143,11 @@ Spec is the calico-kube-controllers Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
+<h3 id="CalicoKubeControllersDeploymentSpec">CalicoKubeControllersDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>)
 
 </p>
 <p>
@@ -4187,7 +4187,7 @@ If omitted, the calico-kube-controllers Deployment will use its default value fo
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">
 CalicoKubeControllersDeploymentPodTemplateSpec
 </a>
 </em>
@@ -4204,11 +4204,11 @@ Template describes the calico-kube-controllers Deployment pod that will be creat
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</h3>
+<h3 id="CalicoNetworkSpec">CalicoNetworkSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -4227,7 +4227,7 @@ CalicoNetworkSpec specifies configuration options for Calico provided pod networ
 
 <code>linuxDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinuxDataplaneOption">
+<a href="#LinuxDataplaneOption">
 LinuxDataplaneOption
 </a>
 </em>
@@ -4250,7 +4250,7 @@ Default: Iptables
 
 <code>windowsDataplane</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsDataplaneOption">
+<a href="#WindowsDataplaneOption">
 WindowsDataplaneOption
 </a>
 </em>
@@ -4273,7 +4273,7 @@ Default: Disabled
 
 <code>bgp</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.BGPOption">
+<a href="#BGPOption">
 BGPOption
 </a>
 </em>
@@ -4293,7 +4293,7 @@ BGP configures whether or not to enable Calico&rsquo;s BGP capabilities.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPPool">
+<a href="#IPPool">
 []IPPool
 </a>
 </em>
@@ -4333,7 +4333,7 @@ If not specified, Calico will perform MTU auto-detection based on the cluster ne
 
 <code>nodeAddressAutodetectionV4</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -4354,7 +4354,7 @@ will use default auto-detection settings to acquire an IPv4 address for each nod
 
 <code>nodeAddressAutodetectionV6</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">
+<a href="#NodeAddressAutodetection">
 NodeAddressAutodetection
 </a>
 </em>
@@ -4375,7 +4375,7 @@ IPv6 addresses will not be auto-detected.
 
 <code>hostPorts</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HostPortsType">
+<a href="#HostPortsType">
 HostPortsType
 </a>
 </em>
@@ -4396,7 +4396,7 @@ Default: Enabled
 
 <code>multiInterfaceMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.MultiInterfaceMode">
+<a href="#MultiInterfaceMode">
 MultiInterfaceMode
 </a>
 </em>
@@ -4418,7 +4418,7 @@ Default: None
 
 <code>containerIPForwarding</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ContainerIPForwardingType">
+<a href="#ContainerIPForwardingType">
 ContainerIPForwardingType
 </a>
 </em>
@@ -4439,7 +4439,7 @@ Default: Disabled
 
 <code>sysctl</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Sysctl">
+<a href="#Sysctl">
 []Sysctl
 </a>
 </em>
@@ -4486,11 +4486,11 @@ Default: 0
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
+<h3 id="CalicoNodeDaemonSet">CalicoNodeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -4509,7 +4509,7 @@ CalicoNodeDaemonSet is the configuration for the calico-node DaemonSet.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4529,7 +4529,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">
+<a href="#CalicoNodeDaemonSetSpec">
 CalicoNodeDaemonSetSpec
 </a>
 </em>
@@ -4550,11 +4550,11 @@ Spec is the specification of the calico-node DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
+<h3 id="CalicoNodeDaemonSetContainer">CalicoNodeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -4611,11 +4611,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeDaemonSetInitContainer">CalicoNodeDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
+<a href="#CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -4672,11 +4672,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodSpec">CalicoNodeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -4695,7 +4695,7 @@ CalicoNodeDaemonSetPodSpec is the calico-node DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetInitContainer">
+<a href="#CalicoNodeDaemonSetInitContainer">
 []CalicoNodeDaemonSetInitContainer
 </a>
 </em>
@@ -4717,7 +4717,7 @@ If omitted, the calico-node DaemonSet will use its default values for its init c
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetContainer">
+<a href="#CalicoNodeDaemonSetContainer">
 []CalicoNodeDaemonSetContainer
 </a>
 </em>
@@ -4804,11 +4804,11 @@ WARNING: Please note that this field will override the default calico-node Daemo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
+<a href="#CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -4827,7 +4827,7 @@ CalicoNodeDaemonSetPodTemplateSpec is the calico-node DaemonSet&rsquo;s PodTempl
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4848,7 +4848,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodSpec">
+<a href="#CalicoNodeDaemonSetPodSpec">
 CalicoNodeDaemonSetPodSpec
 </a>
 </em>
@@ -4869,11 +4869,11 @@ Spec is the calico-node DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
+<h3 id="CalicoNodeDaemonSetSpec">CalicoNodeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>)
 
 </p>
 <p>
@@ -4913,7 +4913,7 @@ If omitted, the calico-node DaemonSet will use its default value for minReadySec
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">
 CalicoNodeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -4930,11 +4930,11 @@ Template describes the calico-node DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
+<h3 id="CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -4953,7 +4953,7 @@ CalicoNodeWindowsDaemonSet is the configuration for the calico-node-windows Daem
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -4973,7 +4973,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">
+<a href="#CalicoNodeWindowsDaemonSetSpec">
 CalicoNodeWindowsDaemonSetSpec
 </a>
 </em>
@@ -4994,11 +4994,11 @@ Spec is the specification of the calico-node-windows DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetContainer">CalicoNodeWindowsDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -5055,11 +5055,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
+<h3 id="CalicoNodeWindowsDaemonSetInitContainer">CalicoNodeWindowsDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -5116,11 +5116,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodSpec">CalicoNodeWindowsDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -5139,7 +5139,7 @@ CalicoNodeWindowsDaemonSetPodSpec is the calico-node-windows DaemonSet&rsquo;s P
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetInitContainer">
+<a href="#CalicoNodeWindowsDaemonSetInitContainer">
 []CalicoNodeWindowsDaemonSetInitContainer
 </a>
 </em>
@@ -5161,7 +5161,7 @@ If omitted, the calico-node-windows DaemonSet will use its default values for it
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetContainer">
+<a href="#CalicoNodeWindowsDaemonSetContainer">
 []CalicoNodeWindowsDaemonSetContainer
 </a>
 </em>
@@ -5248,11 +5248,11 @@ WARNING: Please note that this field will override the default calico-node-windo
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
+<a href="#CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -5271,7 +5271,7 @@ CalicoNodeWindowsDaemonSetPodTemplateSpec is the calico-node-windows DaemonSet&r
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5292,7 +5292,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodSpec">
 CalicoNodeWindowsDaemonSetPodSpec
 </a>
 </em>
@@ -5313,11 +5313,11 @@ Spec is the calico-node-windows DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
+<h3 id="CalicoNodeWindowsDaemonSetSpec">CalicoNodeWindowsDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>)
 
 </p>
 <p>
@@ -5357,7 +5357,7 @@ If omitted, the calico-node-windows DaemonSet will use its default value for min
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">
 CalicoNodeWindowsDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -5374,11 +5374,11 @@ Template describes the calico-node-windows DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5398,7 +5398,7 @@ CalicoWindowsUpgradeDaemonSet is the configuration for the calico-windows-upgrad
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5418,7 +5418,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">
 CalicoWindowsUpgradeDaemonSetSpec
 </a>
 </em>
@@ -5439,11 +5439,11 @@ Spec is the specification of the calico-windows-upgrade DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetContainer">CalicoWindowsUpgradeDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -5498,11 +5498,11 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodSpec">CalicoWindowsUpgradeDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -5521,7 +5521,7 @@ CalicoWindowsUpgradeDaemonSetPodSpec is the calico-windows-upgrade DaemonSet&rsq
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetContainer">
+<a href="#CalicoWindowsUpgradeDaemonSetContainer">
 []CalicoWindowsUpgradeDaemonSetContainer
 </a>
 </em>
@@ -5608,11 +5608,11 @@ WARNING: Please note that this field will override the default calico-windows-up
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
+<a href="#CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -5631,7 +5631,7 @@ CalicoWindowsUpgradeDaemonSetPodTemplateSpec is the calico-windows-upgrade Daemo
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -5652,7 +5652,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodSpec">
 CalicoWindowsUpgradeDaemonSetPodSpec
 </a>
 </em>
@@ -5673,11 +5673,11 @@ Spec is the calico-windows-upgrade DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
+<h3 id="CalicoWindowsUpgradeDaemonSetSpec">CalicoWindowsUpgradeDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>)
 
 </p>
 <p>
@@ -5717,7 +5717,7 @@ If omitted, the calico-windows-upgrade DaemonSet will use its default value for 
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">
 CalicoWindowsUpgradeDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -5734,11 +5734,11 @@ Template describes the calico-windows-upgrade DaemonSet pod that will be created
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CertificateManagement">CertificateManagement</h3>
+<h3 id="CertificateManagement">CertificateManagement</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5830,13 +5830,13 @@ Default: SHA256WithRSA
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.CollectProcessPathOption">CollectProcessPathOption
+<h3 id="CollectProcessPathOption">CollectProcessPathOption
 (<code>string</code> alias)</h3>
-<h3 id="operator.tigera.io/v1.CommonPrometheusFields">CommonPrometheusFields</h3>
+<h3 id="CommonPrometheusFields">CommonPrometheusFields</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PrometheusSpec">PrometheusSpec</a>)
+<a href="#PrometheusSpec">PrometheusSpec</a>)
 
 </p>
 <table>
@@ -5852,7 +5852,7 @@ Default: SHA256WithRSA
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PrometheusContainer">
+<a href="#PrometheusContainer">
 []PrometheusContainer
 </a>
 </em>
@@ -5890,12 +5890,12 @@ Define resources requests and limits for single Pods.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ComponentName">ComponentName
+<h3 id="ComponentName">ComponentName
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ComponentResource">ComponentResource</a>)
+<a href="#ComponentResource">ComponentResource</a>)
 
 </p>
 <p>
@@ -5904,11 +5904,11 @@ ComponentName represents a single component.
 <p>
 One of: Node, Typha, KubeControllers
 </p>
-<h3 id="operator.tigera.io/v1.ComponentResource">ComponentResource</h3>
+<h3 id="ComponentResource">ComponentResource</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -5928,7 +5928,7 @@ The ComponentResource struct associates a ResourceRequirements with a component 
 
 <code>componentName</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentName">
+<a href="#ComponentName">
 ComponentName
 </a>
 </em>
@@ -5963,33 +5963,33 @@ ResourceRequirements allows customization of limits and requests for compute res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ConditionStatus">ConditionStatus
+<h3 id="ConditionStatus">ConditionStatus
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 ConditionStatus represents the status of a particular condition. A condition may be one of: True, False, Unknown.
 </p>
-<h3 id="operator.tigera.io/v1.ContainerIPForwardingType">ContainerIPForwardingType
+<h3 id="ContainerIPForwardingType">ContainerIPForwardingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
 ContainerIPForwardingType specifies whether the CNI config for container ip forwarding is enabled.
 </p>
-<h3 id="operator.tigera.io/v1.DashboardsJob">DashboardsJob</h3>
+<h3 id="DashboardsJob">DashboardsJob</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -6008,7 +6008,7 @@ DashboardsJob is the configuration for the Dashboards job.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobSpec">
+<a href="#DashboardsJobSpec">
 DashboardsJobSpec
 </a>
 </em>
@@ -6029,11 +6029,11 @@ Spec is the specification of the dashboards job.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobContainer">DashboardsJobContainer</h3>
+<h3 id="DashboardsJobContainer">DashboardsJobContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodSpec">DashboardsJobPodSpec</a>)
+<a href="#DashboardsJobPodSpec">DashboardsJobPodSpec</a>)
 
 </p>
 <p>
@@ -6089,11 +6089,11 @@ If omitted, the Dashboard Job will use its default value for this container&rsqu
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobPodSpec">DashboardsJobPodSpec</h3>
+<h3 id="DashboardsJobPodSpec">DashboardsJobPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</a>)
+<a href="#DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6112,7 +6112,7 @@ DashboardsJobPodSpec is the Dashboards job&rsquo;s PodSpec.
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobContainer">
+<a href="#DashboardsJobContainer">
 []DashboardsJobContainer
 </a>
 </em>
@@ -6131,11 +6131,11 @@ If omitted, the Dashboard job will use its default values for its containers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</h3>
+<h3 id="DashboardsJobPodTemplateSpec">DashboardsJobPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJobSpec">DashboardsJobSpec</a>)
+<a href="#DashboardsJobSpec">DashboardsJobSpec</a>)
 
 </p>
 <p>
@@ -6154,7 +6154,7 @@ DashboardsJobPodTemplateSpec is the Dashboards job&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodSpec">
+<a href="#DashboardsJobPodSpec">
 DashboardsJobPodSpec
 </a>
 </em>
@@ -6175,11 +6175,11 @@ Spec is the Dashboard job&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DashboardsJobSpec">DashboardsJobSpec</h3>
+<h3 id="DashboardsJobSpec">DashboardsJobSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DashboardsJob">DashboardsJob</a>)
+<a href="#DashboardsJob">DashboardsJob</a>)
 
 </p>
 <p>
@@ -6198,7 +6198,7 @@ DashboardsJobSpec defines configuration for the Dashboards job.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJobPodTemplateSpec">
+<a href="#DashboardsJobPodTemplateSpec">
 DashboardsJobPodTemplateSpec
 </a>
 </em>
@@ -6215,18 +6215,18 @@ Template describes the Dashboards job pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DataType">DataType
+<h3 id="DataType">DataType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Index">Index</a>)
+<a href="#Index">Index</a>)
 
 </p>
 <p>
 DataType represent the type of data stored
 </p>
-<h3 id="operator.tigera.io/v1.DexDeployment">DexDeployment</h3>
+<h3 id="DexDeployment">DexDeployment</h3>
 <p>
 DexDeployment is the configuration for the Dex Deployment.
 </p>
@@ -6243,7 +6243,7 @@ DexDeployment is the configuration for the Dex Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentSpec">
+<a href="#DexDeploymentSpec">
 DexDeploymentSpec
 </a>
 </em>
@@ -6264,11 +6264,11 @@ Spec is the specification of the Dex Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentContainer">DexDeploymentContainer</h3>
+<h3 id="DexDeploymentContainer">DexDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
+<a href="#DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -6324,11 +6324,11 @@ If omitted, the Dex Deployment will use its default value for this container&rsq
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentInitContainer">DexDeploymentInitContainer</h3>
+<h3 id="DexDeploymentInitContainer">DexDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
+<a href="#DexDeploymentPodSpec">DexDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -6384,11 +6384,11 @@ If omitted, the Dex Deployment will use its default value for this init containe
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentPodSpec">DexDeploymentPodSpec</h3>
+<h3 id="DexDeploymentPodSpec">DexDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</a>)
+<a href="#DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6407,7 +6407,7 @@ DexDeploymentPodSpec is the Dex Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentInitContainer">
+<a href="#DexDeploymentInitContainer">
 []DexDeploymentInitContainer
 </a>
 </em>
@@ -6429,7 +6429,7 @@ If omitted, the Dex Deployment will use its default values for its init containe
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentContainer">
+<a href="#DexDeploymentContainer">
 []DexDeploymentContainer
 </a>
 </em>
@@ -6448,11 +6448,11 @@ If omitted, the Dex Deployment will use its default values for its containers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</h3>
+<h3 id="DexDeploymentPodTemplateSpec">DexDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeploymentSpec">DexDeploymentSpec</a>)
+<a href="#DexDeploymentSpec">DexDeploymentSpec</a>)
 
 </p>
 <p>
@@ -6471,7 +6471,7 @@ DexDeploymentPodTemplateSpec is the Dex Deployment&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodSpec">
+<a href="#DexDeploymentPodSpec">
 DexDeploymentPodSpec
 </a>
 </em>
@@ -6492,11 +6492,11 @@ Spec is the Dex Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.DexDeploymentSpec">DexDeploymentSpec</h3>
+<h3 id="DexDeploymentSpec">DexDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.DexDeployment">DexDeployment</a>)
+<a href="#DexDeployment">DexDeployment</a>)
 
 </p>
 <p>
@@ -6515,7 +6515,7 @@ DexDeploymentSpec defines configuration for the Dex Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DexDeploymentPodTemplateSpec">
+<a href="#DexDeploymentPodTemplateSpec">
 DexDeploymentPodTemplateSpec
 </a>
 </em>
@@ -6532,7 +6532,7 @@ Template describes the Dex Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSet">ECKOperatorStatefulSet</h3>
+<h3 id="ECKOperatorStatefulSet">ECKOperatorStatefulSet</h3>
 <p>
 ECKOperatorStatefulSet is the configuration for the ECKOperator StatefulSet.
 </p>
@@ -6549,7 +6549,7 @@ ECKOperatorStatefulSet is the configuration for the ECKOperator StatefulSet.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetSpec">
+<a href="#ECKOperatorStatefulSetSpec">
 ECKOperatorStatefulSetSpec
 </a>
 </em>
@@ -6570,11 +6570,11 @@ Spec is the specification of the ECKOperator StatefulSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetContainer">ECKOperatorStatefulSetContainer</h3>
+<h3 id="ECKOperatorStatefulSetContainer">ECKOperatorStatefulSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
+<a href="#ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
 
 </p>
 <p>
@@ -6630,11 +6630,11 @@ If omitted, the ECKOperator StatefulSet will use its default value for this cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetInitContainer">ECKOperatorStatefulSetInitContainer</h3>
+<h3 id="ECKOperatorStatefulSetInitContainer">ECKOperatorStatefulSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
+<a href="#ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</a>)
 
 </p>
 <p>
@@ -6689,11 +6689,11 @@ If omitted, the ECKOperator StatefulSet will use its default value for this init
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</h3>
+<h3 id="ECKOperatorStatefulSetPodSpec">ECKOperatorStatefulSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</a>)
+<a href="#ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -6712,7 +6712,7 @@ ECKOperatorStatefulSetPodSpec is the ECKOperator StatefulSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetInitContainer">
+<a href="#ECKOperatorStatefulSetInitContainer">
 []ECKOperatorStatefulSetInitContainer
 </a>
 </em>
@@ -6734,7 +6734,7 @@ If omitted, the ECKOperator StatefulSet will use its default values for its init
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetContainer">
+<a href="#ECKOperatorStatefulSetContainer">
 []ECKOperatorStatefulSetContainer
 </a>
 </em>
@@ -6753,11 +6753,11 @@ If omitted, the ECKOperator StatefulSet will use its default values for its cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</h3>
+<h3 id="ECKOperatorStatefulSetPodTemplateSpec">ECKOperatorStatefulSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</a>)
+<a href="#ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</a>)
 
 </p>
 <p>
@@ -6776,7 +6776,7 @@ ECKOperatorStatefulSetPodTemplateSpec is the ECKOperator StatefulSet&rsquo;s Pod
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodSpec">
+<a href="#ECKOperatorStatefulSetPodSpec">
 ECKOperatorStatefulSetPodSpec
 </a>
 </em>
@@ -6797,11 +6797,11 @@ Spec is the ECKOperator StatefulSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</h3>
+<h3 id="ECKOperatorStatefulSetSpec">ECKOperatorStatefulSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSet">ECKOperatorStatefulSet</a>)
+<a href="#ECKOperatorStatefulSet">ECKOperatorStatefulSet</a>)
 
 </p>
 <p>
@@ -6820,7 +6820,7 @@ ECKOperatorStatefulSetSpec defines configuration for the ECKOperator StatefulSet
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ECKOperatorStatefulSetPodTemplateSpec">
+<a href="#ECKOperatorStatefulSetPodTemplateSpec">
 ECKOperatorStatefulSetPodTemplateSpec
 </a>
 </em>
@@ -6837,11 +6837,11 @@ Template describes the ECKOperator StatefulSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentContainer">EGWDeploymentContainer</h3>
+<h3 id="EGWDeploymentContainer">EGWDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -6898,11 +6898,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
+<h3 id="EGWDeploymentInitContainer">EGWDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
+<a href="#EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -6959,7 +6959,7 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeployment">EKSLogForwarderDeployment</h3>
+<h3 id="EKSLogForwarderDeployment">EKSLogForwarderDeployment</h3>
 <p>
 EKSLogForwarderDeployment is the configuration for the EKSLogForwarder Deployment.
 </p>
@@ -6976,7 +6976,7 @@ EKSLogForwarderDeployment is the configuration for the EKSLogForwarder Deploymen
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentSpec">
+<a href="#EKSLogForwarderDeploymentSpec">
 EKSLogForwarderDeploymentSpec
 </a>
 </em>
@@ -6997,11 +6997,11 @@ Spec is the specification of the EKSLogForwarder Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentContainer">EKSLogForwarderDeploymentContainer</h3>
+<h3 id="EKSLogForwarderDeploymentContainer">EKSLogForwarderDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
+<a href="#EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -7057,11 +7057,11 @@ If omitted, the EKSLogForwarder Deployment will use its default value for this c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentInitContainer">EKSLogForwarderDeploymentInitContainer</h3>
+<h3 id="EKSLogForwarderDeploymentInitContainer">EKSLogForwarderDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
+<a href="#EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -7117,11 +7117,11 @@ If omitted, the EKSLogForwarder Deployment will use its default value for this i
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</h3>
+<h3 id="EKSLogForwarderDeploymentPodSpec">EKSLogForwarderDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</a>)
+<a href="#EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7140,7 +7140,7 @@ EKSLogForwarderDeploymentPodSpec is the EKSLogForwarder Deployment&rsquo;s PodSp
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentInitContainer">
+<a href="#EKSLogForwarderDeploymentInitContainer">
 []EKSLogForwarderDeploymentInitContainer
 </a>
 </em>
@@ -7162,7 +7162,7 @@ If omitted, the EKSLogForwarder Deployment will use its default values for its i
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentContainer">
+<a href="#EKSLogForwarderDeploymentContainer">
 []EKSLogForwarderDeploymentContainer
 </a>
 </em>
@@ -7181,11 +7181,11 @@ If omitted, the EKSLogForwarder Deployment will use its default values for its c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</h3>
+<h3 id="EKSLogForwarderDeploymentPodTemplateSpec">EKSLogForwarderDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</a>)
+<a href="#EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</a>)
 
 </p>
 <p>
@@ -7204,7 +7204,7 @@ EKSLogForwarderDeploymentPodTemplateSpec is the EKSLogForwarder Deployment&rsquo
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodSpec">
+<a href="#EKSLogForwarderDeploymentPodSpec">
 EKSLogForwarderDeploymentPodSpec
 </a>
 </em>
@@ -7225,11 +7225,11 @@ Spec is the EKSLogForwarder Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</h3>
+<h3 id="EKSLogForwarderDeploymentSpec">EKSLogForwarderDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeployment">EKSLogForwarderDeployment</a>)
+<a href="#EKSLogForwarderDeployment">EKSLogForwarderDeployment</a>)
 
 </p>
 <p>
@@ -7248,7 +7248,7 @@ EKSLogForwarderDeploymentSpec defines configuration for the EKSLogForwarder Depl
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EKSLogForwarderDeploymentPodTemplateSpec">
+<a href="#EKSLogForwarderDeploymentPodTemplateSpec">
 EKSLogForwarderDeploymentPodTemplateSpec
 </a>
 </em>
@@ -7265,11 +7265,11 @@ Template describes the EKSLogForwarder Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
+<h3 id="EgressGatewayDeploymentPodSpec">EgressGatewayDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7288,7 +7288,7 @@ EgressGatewayDeploymentPodSpec is the Egress Gateway Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentInitContainer">
+<a href="#EGWDeploymentInitContainer">
 []EGWDeploymentInitContainer
 </a>
 </em>
@@ -7310,7 +7310,7 @@ If omitted, the EGW Deployment will use its default values for its init containe
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EGWDeploymentContainer">
+<a href="#EGWDeploymentContainer">
 []EGWDeploymentContainer
 </a>
 </em>
@@ -7445,11 +7445,11 @@ PriorityClassName allows to specify a PriorityClass resource to be used.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
+<h3 id="EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -7468,7 +7468,7 @@ EgressGatewayDeploymentPodTemplateSpec is the EGW Deployment&rsquo;s PodTemplate
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayMetadata">
+<a href="#EgressGatewayMetadata">
 EgressGatewayMetadata
 </a>
 </em>
@@ -7489,7 +7489,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodSpec">
+<a href="#EgressGatewayDeploymentPodSpec">
 EgressGatewayDeploymentPodSpec
 </a>
 </em>
@@ -7510,11 +7510,11 @@ Spec is the EGW Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
+<h3 id="EgressGatewayFailureDetection">EgressGatewayFailureDetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <p>
@@ -7555,7 +7555,7 @@ Default: 90
 
 <code>icmpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ICMPProbe">
+<a href="#ICMPProbe">
 ICMPProbe
 </a>
 </em>
@@ -7577,7 +7577,7 @@ fail. Timeout must be greater than interval.
 
 <code>httpProbe</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.HTTPProbe">
+<a href="#HTTPProbe">
 HTTPProbe
 </a>
 </em>
@@ -7596,11 +7596,11 @@ fail. Timeout must be greater than interval.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayIPPool">EgressGatewayIPPool</h3>
+<h3 id="EgressGatewayIPPool">EgressGatewayIPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
 <table>
@@ -7649,11 +7649,11 @@ CIDR is the IPPool CIDR that the Egress Gateways can use.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayMetadata">EgressGatewayMetadata</h3>
+<h3 id="EgressGatewayMetadata">EgressGatewayMetadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
+<a href="#EgressGatewayDeploymentPodTemplateSpec">EgressGatewayDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -7711,11 +7711,11 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</h3>
+<h3 id="EgressGatewaySpec">EgressGatewaySpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -7752,7 +7752,7 @@ Replicas defines how many instances of the Egress Gateway pod will run.
 
 <code>ipPools</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayIPPool">
+<a href="#EgressGatewayIPPool">
 []EgressGatewayIPPool
 </a>
 </em>
@@ -7793,7 +7793,7 @@ ExternalNetworks must match existing external networks.
 
 <code>logSeverity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogLevel">
+<a href="#LogLevel">
 LogLevel
 </a>
 </em>
@@ -7814,7 +7814,7 @@ Default: Info
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayDeploymentPodTemplateSpec">
+<a href="#EgressGatewayDeploymentPodTemplateSpec">
 EgressGatewayDeploymentPodTemplateSpec
 </a>
 </em>
@@ -7834,7 +7834,7 @@ Template describes the EGW Deployment pod that will be created.
 
 <code>egressGatewayFailureDetection</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">
+<a href="#EgressGatewayFailureDetection">
 EgressGatewayFailureDetection
 </a>
 </em>
@@ -7858,7 +7858,7 @@ ready if configured.
 
 <code>aws</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">
+<a href="#AWSEgressGateway">
 AWSEgressGateway
 </a>
 </em>
@@ -7875,11 +7875,11 @@ AWS defines the additional configuration options for Egress Gateways on AWS.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EgressGatewayStatus">EgressGatewayStatus</h3>
+<h3 id="EgressGatewayStatus">EgressGatewayStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGateway">EgressGateway</a>)
+<a href="#EgressGateway">EgressGateway</a>)
 
 </p>
 <p>
@@ -7933,7 +7933,7 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</h3>
+<h3 id="ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</h3>
 <p>
 ElasticsearchMetricsDeployment is the configuration for the tigera-elasticsearch-metric Deployment.
 </p>
@@ -7950,7 +7950,7 @@ ElasticsearchMetricsDeployment is the configuration for the tigera-elasticsearch
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentSpec">
+<a href="#ElasticsearchMetricsDeploymentSpec">
 ElasticsearchMetricsDeploymentSpec
 </a>
 </em>
@@ -7971,11 +7971,11 @@ Spec is the specification of the ElasticsearchMetrics Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentContainer">ElasticsearchMetricsDeploymentContainer</h3>
+<h3 id="ElasticsearchMetricsDeploymentContainer">ElasticsearchMetricsDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -8031,11 +8031,11 @@ If omitted, the ElasticsearchMetrics Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentInitContainer">ElasticsearchMetricsDeploymentInitContainer</h3>
+<h3 id="ElasticsearchMetricsDeploymentInitContainer">ElasticsearchMetricsDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -8091,11 +8091,11 @@ If omitted, the ElasticsearchMetrics Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</h3>
+<h3 id="ElasticsearchMetricsDeploymentPodSpec">ElasticsearchMetricsDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8114,7 +8114,7 @@ ElasticsearchMetricsDeploymentPodSpec is the tElasticsearchMetricsDeployment&rsq
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentInitContainer">
+<a href="#ElasticsearchMetricsDeploymentInitContainer">
 []ElasticsearchMetricsDeploymentInitContainer
 </a>
 </em>
@@ -8136,7 +8136,7 @@ If omitted, the ElasticsearchMetrics Deployment will use its default values for 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentContainer">
+<a href="#ElasticsearchMetricsDeploymentContainer">
 []ElasticsearchMetricsDeploymentContainer
 </a>
 </em>
@@ -8155,11 +8155,11 @@ If omitted, the ElasticsearchMetrics Deployment will use its default values for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</h3>
+<h3 id="ElasticsearchMetricsDeploymentPodTemplateSpec">ElasticsearchMetricsDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</a>)
+<a href="#ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</a>)
 
 </p>
 <p>
@@ -8178,7 +8178,7 @@ ElasticsearchMetricsDeploymentPodTemplateSpec is the ElasticsearchMetricsDeploym
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodSpec">
+<a href="#ElasticsearchMetricsDeploymentPodSpec">
 ElasticsearchMetricsDeploymentPodSpec
 </a>
 </em>
@@ -8199,11 +8199,11 @@ Spec is the ElasticsearchMetrics Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</h3>
+<h3 id="ElasticsearchMetricsDeploymentSpec">ElasticsearchMetricsDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</a>)
+<a href="#ElasticsearchMetricsDeployment">ElasticsearchMetricsDeployment</a>)
 
 </p>
 <p>
@@ -8222,7 +8222,7 @@ ElasticsearchMetricsDeploymentSpec defines configuration for the ElasticsearchMe
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ElasticsearchMetricsDeploymentPodTemplateSpec">
+<a href="#ElasticsearchMetricsDeploymentPodTemplateSpec">
 ElasticsearchMetricsDeploymentPodTemplateSpec
 </a>
 </em>
@@ -8239,12 +8239,12 @@ Template describes the ElasticsearchMetrics Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EncapsulationType">EncapsulationType
+<h3 id="EncapsulationType">EncapsulationType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -8253,7 +8253,7 @@ EncapsulationType is the type of encapsulation to use on an IP pool.
 <p>
 One of: IPIP, VXLAN, IPIPCrossSubnet, VXLANCrossSubnet, None
 </p>
-<h3 id="operator.tigera.io/v1.EncryptionOption">EncryptionOption
+<h3 id="EncryptionOption">EncryptionOption
 (<code>string</code> alias)</h3>
 <p>
 EncryptionOption specifies the traffic encryption mode when connecting to a Syslog server.
@@ -8261,11 +8261,11 @@ EncryptionOption specifies the traffic encryption mode when connecting to a Sysl
 <p>
 One of: None, TLS
 </p>
-<h3 id="operator.tigera.io/v1.Endpoint">Endpoint</h3>
+<h3 id="Endpoint">Endpoint</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ServiceMonitor">ServiceMonitor</a>)
+<a href="#ServiceMonitor">ServiceMonitor</a>)
 
 </p>
 <p>
@@ -8426,11 +8426,11 @@ More info: <a href="https://prometheus.io/docs/prometheus/latest/configuration/c
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.EnvoySettings">EnvoySettings</h3>
+<h3 id="EnvoySettings">EnvoySettings</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -8483,11 +8483,11 @@ manipulating various headers.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ExternalPrometheus">ExternalPrometheus</h3>
+<h3 id="ExternalPrometheus">ExternalPrometheus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.MonitorSpec">MonitorSpec</a>)
+<a href="#MonitorSpec">MonitorSpec</a>)
 
 </p>
 <table>
@@ -8503,7 +8503,7 @@ manipulating various headers.
 
 <code>serviceMonitor</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ServiceMonitor">
+<a href="#ServiceMonitor">
 ServiceMonitor
 </a>
 </em>
@@ -8543,15 +8543,15 @@ must be created before the operator will create Prometheus resources.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FIPSMode">FIPSMode
+<h3 id="FIPSMode">FIPSMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSet">FluentdDaemonSet</h3>
+<h3 id="FluentdDaemonSet">FluentdDaemonSet</h3>
 <p>
 FluentdDaemonSet is the configuration for the Fluentd DaemonSet.
 </p>
@@ -8568,7 +8568,7 @@ FluentdDaemonSet is the configuration for the Fluentd DaemonSet.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetSpec">
+<a href="#FluentdDaemonSetSpec">
 FluentdDaemonSetSpec
 </a>
 </em>
@@ -8589,11 +8589,11 @@ Spec is the specification of the Fluentd DaemonSet.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetContainer">FluentdDaemonSetContainer</h3>
+<h3 id="FluentdDaemonSetContainer">FluentdDaemonSetContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
+<a href="#FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -8649,11 +8649,11 @@ If omitted, the Fluentd DaemonSet will use its default value for this container&
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetInitContainer">FluentdDaemonSetInitContainer</h3>
+<h3 id="FluentdDaemonSetInitContainer">FluentdDaemonSetInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
+<a href="#FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</a>)
 
 </p>
 <p>
@@ -8709,11 +8709,11 @@ If omitted, the Fluentd DaemonSet will use its default value for this init conta
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</h3>
+<h3 id="FluentdDaemonSetPodSpec">FluentdDaemonSetPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</a>)
+<a href="#FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -8732,7 +8732,7 @@ FluentdDaemonSetPodSpec is the Fluentd DaemonSet&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetInitContainer">
+<a href="#FluentdDaemonSetInitContainer">
 []FluentdDaemonSetInitContainer
 </a>
 </em>
@@ -8754,7 +8754,7 @@ If omitted, the Fluentd DaemonSet will use its default values for its init conta
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetContainer">
+<a href="#FluentdDaemonSetContainer">
 []FluentdDaemonSetContainer
 </a>
 </em>
@@ -8773,11 +8773,11 @@ If omitted, the Fluentd DaemonSet will use its default values for its containers
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</h3>
+<h3 id="FluentdDaemonSetPodTemplateSpec">FluentdDaemonSetPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetSpec">FluentdDaemonSetSpec</a>)
+<a href="#FluentdDaemonSetSpec">FluentdDaemonSetSpec</a>)
 
 </p>
 <p>
@@ -8796,7 +8796,7 @@ FluentdDaemonSetPodTemplateSpec is the Fluentd DaemonSet&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodSpec">
+<a href="#FluentdDaemonSetPodSpec">
 FluentdDaemonSetPodSpec
 </a>
 </em>
@@ -8817,11 +8817,11 @@ Spec is the Fluentd DaemonSet&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.FluentdDaemonSetSpec">FluentdDaemonSetSpec</h3>
+<h3 id="FluentdDaemonSetSpec">FluentdDaemonSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSet">FluentdDaemonSet</a>)
+<a href="#FluentdDaemonSet">FluentdDaemonSet</a>)
 
 </p>
 <p>
@@ -8840,7 +8840,7 @@ FluentdDaemonSetSpec defines configuration for the Fluentd DaemonSet.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FluentdDaemonSetPodTemplateSpec">
+<a href="#FluentdDaemonSetPodTemplateSpec">
 FluentdDaemonSetPodTemplateSpec
 </a>
 </em>
@@ -8857,7 +8857,7 @@ Template describes the Fluentd DaemonSet pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeployment">GuardianDeployment</h3>
+<h3 id="GuardianDeployment">GuardianDeployment</h3>
 <p>
 GuardianDeployment is the configuration for the guardian Deployment.
 </p>
@@ -8874,7 +8874,7 @@ GuardianDeployment is the configuration for the guardian Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentSpec">
+<a href="#GuardianDeploymentSpec">
 GuardianDeploymentSpec
 </a>
 </em>
@@ -8895,11 +8895,11 @@ Spec is the specification of the guardian Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentContainer">GuardianDeploymentContainer</h3>
+<h3 id="GuardianDeploymentContainer">GuardianDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
+<a href="#GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -8955,11 +8955,11 @@ If omitted, the guardian Deployment will use its default value for this containe
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentInitContainer">GuardianDeploymentInitContainer</h3>
+<h3 id="GuardianDeploymentInitContainer">GuardianDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
+<a href="#GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -9014,11 +9014,11 @@ If omitted, the guardian Deployment will use its default value for this init con
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</h3>
+<h3 id="GuardianDeploymentPodSpec">GuardianDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</a>)
+<a href="#GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -9037,7 +9037,7 @@ GuardianDeploymentPodSpec is the guardian Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentInitContainer">
+<a href="#GuardianDeploymentInitContainer">
 []GuardianDeploymentInitContainer
 </a>
 </em>
@@ -9059,7 +9059,7 @@ If omitted, the guardian Deployment will use its default values for its init con
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentContainer">
+<a href="#GuardianDeploymentContainer">
 []GuardianDeploymentContainer
 </a>
 </em>
@@ -9078,11 +9078,11 @@ If omitted, the guardian Deployment will use its default values for its containe
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</h3>
+<h3 id="GuardianDeploymentPodTemplateSpec">GuardianDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentSpec">GuardianDeploymentSpec</a>)
+<a href="#GuardianDeploymentSpec">GuardianDeploymentSpec</a>)
 
 </p>
 <p>
@@ -9101,7 +9101,7 @@ GuardianDeploymentPodTemplateSpec is the guardian Deployment&rsquo;s PodTemplate
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodSpec">
+<a href="#GuardianDeploymentPodSpec">
 GuardianDeploymentPodSpec
 </a>
 </em>
@@ -9122,11 +9122,11 @@ Spec is the guardian Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.GuardianDeploymentSpec">GuardianDeploymentSpec</h3>
+<h3 id="GuardianDeploymentSpec">GuardianDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.GuardianDeployment">GuardianDeployment</a>)
+<a href="#GuardianDeployment">GuardianDeployment</a>)
 
 </p>
 <p>
@@ -9145,7 +9145,7 @@ GuardianDeploymentSpec defines configuration for the guardian Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.GuardianDeploymentPodTemplateSpec">
+<a href="#GuardianDeploymentPodTemplateSpec">
 GuardianDeploymentPodTemplateSpec
 </a>
 </em>
@@ -9162,11 +9162,11 @@ Template describes the guardian Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HTTPProbe">HTTPProbe</h3>
+<h3 id="HTTPProbe">HTTPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -9238,12 +9238,12 @@ Default: 30
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.HostPortsType">HostPortsType
+<h3 id="HostPortsType">HostPortsType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -9252,11 +9252,11 @@ HostPortsType specifies host port support.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.ICMPProbe">ICMPProbe</h3>
+<h3 id="ICMPProbe">ICMPProbe</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
+<a href="#EgressGatewayFailureDetection">EgressGatewayFailureDetection</a>)
 
 </p>
 <p>
@@ -9328,19 +9328,19 @@ Default: 15
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPAMPluginType">IPAMPluginType
+<h3 id="IPAMPluginType">IPAMPluginType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPAMSpec">IPAMSpec</a>)
+<a href="#IPAMSpec">IPAMSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.IPAMSpec">IPAMSpec</h3>
+<h3 id="IPAMSpec">IPAMSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNISpec">CNISpec</a>)
+<a href="#CNISpec">CNISpec</a>)
 
 </p>
 <p>
@@ -9359,7 +9359,7 @@ IPAMSpec contains configuration for pod IP address management.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPAMPluginType">
+<a href="#IPAMPluginType">
 IPAMPluginType
 </a>
 </em>
@@ -9387,11 +9387,11 @@ Default: Calico
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPPool">IPPool</h3>
+<h3 id="IPPool">IPPool</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -9441,7 +9441,7 @@ CIDR contains the address range for the IP Pool in classless inter-domain routin
 
 <code>encapsulation</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.EncapsulationType">
+<a href="#EncapsulationType">
 EncapsulationType
 </a>
 </em>
@@ -9463,7 +9463,7 @@ Default: IPIP
 
 <code>natOutgoing</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NATOutgoingType">
+<a href="#NATOutgoingType">
 NATOutgoingType
 </a>
 </em>
@@ -9542,7 +9542,7 @@ Default: false
 
 <code>allowedUses</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.IPPoolAllowedUse">
+<a href="#IPPoolAllowedUse">
 []IPPoolAllowedUse
 </a>
 </em>
@@ -9559,19 +9559,19 @@ AllowedUse controls what the IP pool will be used for.  If not specified or empt
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.IPPoolAllowedUse">IPPoolAllowedUse
+<h3 id="IPPoolAllowedUse">IPPoolAllowedUse
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.Image">Image</h3>
+<h3 id="Image">Image</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</a>)
+<a href="#ImageSetSpec">ImageSetSpec</a>)
 
 </p>
 <table>
@@ -9622,11 +9622,11 @@ The field should not include a leading <code>@</code> and must be prefixed with 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ImageSetSpec">ImageSetSpec</h3>
+<h3 id="ImageSetSpec">ImageSetSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ImageSet">ImageSet</a>)
+<a href="#ImageSet">ImageSet</a>)
 
 </p>
 <p>
@@ -9645,7 +9645,7 @@ ImageSetSpec defines the desired state of ImageSet.
 
 <code>images</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Image">
+<a href="#Image">
 []Image
 </a>
 </em>
@@ -9662,11 +9662,11 @@ must be specified.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Index">Index</h3>
+<h3 id="Index">Index</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -9704,7 +9704,7 @@ excludes the numerical identifier suffix)
 
 <code>dataType</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DataType">
+<a href="#DataType">
 DataType
 </a>
 </em>
@@ -9720,12 +9720,12 @@ DataType represents the type of data stored in the defined index
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationSpec">InstallationSpec</h3>
+<h3 id="InstallationSpec">InstallationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#Installation">Installation</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -9744,7 +9744,7 @@ InstallationSpec defines configuration for a Calico or Calico Enterprise install
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -9872,7 +9872,7 @@ applied to all images to be pulled.
 
 <code>kubernetesProvider</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Provider">
+<a href="#Provider">
 Provider
 </a>
 </em>
@@ -9895,7 +9895,7 @@ will additionally compare the auto-detected value to the specified value to conf
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNISpec">
+<a href="#CNISpec">
 CNISpec
 </a>
 </em>
@@ -9915,7 +9915,7 @@ CNI specifies the CNI that will be used by this installation.
 
 <code>calicoNetwork</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">
+<a href="#CalicoNetworkSpec">
 CalicoNetworkSpec
 </a>
 </em>
@@ -9935,7 +9935,7 @@ CalicoNetwork specifies networking configuration options for Calico.
 
 <code>typhaAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">
+<a href="#TyphaAffinity">
 TyphaAffinity
 </a>
 </em>
@@ -10114,7 +10114,7 @@ field.
 
 <code>componentResources</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ComponentResource">
+<a href="#ComponentResource">
 []ComponentResource
 </a>
 </em>
@@ -10136,7 +10136,7 @@ Node, Typha, and KubeControllers are supported for installations.
 
 <code>certificateManagement</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CertificateManagement">
+<a href="#CertificateManagement">
 CertificateManagement
 </a>
 </em>
@@ -10158,7 +10158,7 @@ pods will be stuck during initialization.
 
 <code>nonPrivileged</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NonPrivilegedType">
+<a href="#NonPrivilegedType">
 NonPrivilegedType
 </a>
 </em>
@@ -10178,7 +10178,7 @@ NonPrivileged configures Calico to be run in non-privileged containers as non-ro
 
 <code>calicoNodeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">
+<a href="#CalicoNodeDaemonSet">
 CalicoNodeDaemonSet
 </a>
 </em>
@@ -10198,7 +10198,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>csiNodeDriverDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">
+<a href="#CSINodeDriverDaemonSet">
 CSINodeDriverDaemonSet
 </a>
 </em>
@@ -10217,7 +10217,7 @@ CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet.
 
 <code>calicoKubeControllersDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">
+<a href="#CalicoKubeControllersDeployment">
 CalicoKubeControllersDeployment
 </a>
 </em>
@@ -10237,7 +10237,7 @@ conjunction with the deprecated ComponentResources, then these overrides take pr
 
 <code>typhaDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">
+<a href="#TyphaDeployment">
 TyphaDeployment
 </a>
 </em>
@@ -10257,7 +10257,7 @@ ComponentResources or TyphaAffinity, then these overrides take precedence.
 
 <code>calicoWindowsUpgradeDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">
+<a href="#CalicoWindowsUpgradeDaemonSet">
 CalicoWindowsUpgradeDaemonSet
 </a>
 </em>
@@ -10277,7 +10277,7 @@ CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.
 
 <code>calicoNodeWindowsDaemonSet</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">
+<a href="#CalicoNodeWindowsDaemonSet">
 CalicoNodeWindowsDaemonSet
 </a>
 </em>
@@ -10296,7 +10296,7 @@ CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet.
 
 <code>fipsMode</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.FIPSMode">
+<a href="#FIPSMode">
 FIPSMode
 </a>
 </em>
@@ -10317,7 +10317,7 @@ Default: Disabled
 
 <code>logging</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Logging">
+<a href="#Logging">
 Logging
 </a>
 </em>
@@ -10337,7 +10337,7 @@ Logging Configuration for Components
 
 <code>windowsNodes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.WindowsNodeSpec">
+<a href="#WindowsNodeSpec">
 WindowsNodeSpec
 </a>
 </em>
@@ -10372,11 +10372,11 @@ Kubernetes Service CIDRs. Specifying this is required when using Calico for Wind
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.InstallationStatus">InstallationStatus</h3>
+<h3 id="InstallationStatus">InstallationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Installation">Installation</a>)
+<a href="#Installation">Installation</a>)
 
 </p>
 <p>
@@ -10395,7 +10395,7 @@ InstallationStatus defines the observed state of the Calico or Calico Enterprise
 
 <code>variant</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ProductVariant">
+<a href="#ProductVariant">
 ProductVariant
 </a>
 </em>
@@ -10451,7 +10451,7 @@ that is being used. If an ImageSet is not being used then this will not be set.
 
 <code>computed</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.InstallationSpec">
+<a href="#InstallationSpec">
 InstallationSpec
 </a>
 </em>
@@ -10508,7 +10508,7 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Kibana">Kibana</h3>
+<h3 id="Kibana">Kibana</h3>
 <p>
 Kibana is the configuration for the Kibana.
 </p>
@@ -10525,7 +10525,7 @@ Kibana is the configuration for the Kibana.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaSpec">
+<a href="#KibanaSpec">
 KibanaSpec
 </a>
 </em>
@@ -10546,11 +10546,11 @@ Spec is the specification of the Kibana.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaContainer">KibanaContainer</h3>
+<h3 id="KibanaContainer">KibanaContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaPodSpec">KibanaPodSpec</a>)
+<a href="#KibanaPodSpec">KibanaPodSpec</a>)
 
 </p>
 <p>
@@ -10606,11 +10606,11 @@ If omitted, the Kibana will use its default value for this container&rsquo;s res
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaInitContainer">KibanaInitContainer</h3>
+<h3 id="KibanaInitContainer">KibanaInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaPodSpec">KibanaPodSpec</a>)
+<a href="#KibanaPodSpec">KibanaPodSpec</a>)
 
 </p>
 <p>
@@ -10667,11 +10667,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaPodSpec">KibanaPodSpec</h3>
+<h3 id="KibanaPodSpec">KibanaPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaPodTemplateSpec">KibanaPodTemplateSpec</a>)
+<a href="#KibanaPodTemplateSpec">KibanaPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -10690,7 +10690,7 @@ KibanaPodSpec is the Kibana Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaInitContainer">
+<a href="#KibanaInitContainer">
 []KibanaInitContainer
 </a>
 </em>
@@ -10712,7 +10712,7 @@ If omitted, the Kibana Deployment will use its default values for its init conta
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaContainer">
+<a href="#KibanaContainer">
 []KibanaContainer
 </a>
 </em>
@@ -10731,11 +10731,11 @@ If omitted, the Kibana Deployment will use its default values for its containers
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaPodTemplateSpec">KibanaPodTemplateSpec</h3>
+<h3 id="KibanaPodTemplateSpec">KibanaPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.KibanaSpec">KibanaSpec</a>)
+<a href="#KibanaSpec">KibanaSpec</a>)
 
 </p>
 <p>
@@ -10754,7 +10754,7 @@ KibanaPodTemplateSpec is the Kibana&rsquo;s PodTemplateSpec
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaPodSpec">
+<a href="#KibanaPodSpec">
 KibanaPodSpec
 </a>
 </em>
@@ -10775,11 +10775,11 @@ Spec is the Kibana&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KibanaSpec">KibanaSpec</h3>
+<h3 id="KibanaSpec">KibanaSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Kibana">Kibana</a>)
+<a href="#Kibana">Kibana</a>)
 
 </p>
 <table>
@@ -10795,7 +10795,7 @@ Spec is the Kibana&rsquo;s PodSpec.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KibanaPodTemplateSpec">
+<a href="#KibanaPodTemplateSpec">
 KibanaPodTemplateSpec
 </a>
 </em>
@@ -10812,12 +10812,12 @@ Template describes the Kibana pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
+<h3 id="KubernetesAutodetectionMethod">KubernetesAutodetectionMethod
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</a>)
+<a href="#NodeAddressAutodetection">NodeAddressAutodetection</a>)
 
 </p>
 <p>
@@ -10826,11 +10826,11 @@ KubernetesAutodetectionMethod is a method of detecting an IP address based on th
 <p>
 One of: NodeInternalIP
 </p>
-<h3 id="operator.tigera.io/v1.LinseedDeployment">LinseedDeployment</h3>
+<h3 id="LinseedDeployment">LinseedDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <p>
@@ -10849,7 +10849,7 @@ LinseedDeployment is the configuration for the linseed Deployment.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentSpec">
+<a href="#LinseedDeploymentSpec">
 LinseedDeploymentSpec
 </a>
 </em>
@@ -10870,11 +10870,11 @@ Spec is the specification of the linseed Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentContainer">LinseedDeploymentContainer</h3>
+<h3 id="LinseedDeploymentContainer">LinseedDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
+<a href="#LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10930,11 +10930,11 @@ If omitted, the linseed Deployment will use its default value for this container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentInitContainer">LinseedDeploymentInitContainer</h3>
+<h3 id="LinseedDeploymentInitContainer">LinseedDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
+<a href="#LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -10990,11 +10990,11 @@ If omitted, the linseed Deployment will use its default value for this init cont
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</h3>
+<h3 id="LinseedDeploymentPodSpec">LinseedDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</a>)
+<a href="#LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11013,7 +11013,7 @@ LinseedDeploymentPodSpec is the linseed Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentInitContainer">
+<a href="#LinseedDeploymentInitContainer">
 []LinseedDeploymentInitContainer
 </a>
 </em>
@@ -11035,7 +11035,7 @@ If omitted, the linseed Deployment will use its default values for its init cont
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentContainer">
+<a href="#LinseedDeploymentContainer">
 []LinseedDeploymentContainer
 </a>
 </em>
@@ -11054,11 +11054,11 @@ If omitted, the linseed Deployment will use its default values for its container
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</h3>
+<h3 id="LinseedDeploymentPodTemplateSpec">LinseedDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentSpec">LinseedDeploymentSpec</a>)
+<a href="#LinseedDeploymentSpec">LinseedDeploymentSpec</a>)
 
 </p>
 <p>
@@ -11077,7 +11077,7 @@ LinseedDeploymentPodTemplateSpec is the linseed Deployment&rsquo;s PodTemplateSp
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodSpec">
+<a href="#LinseedDeploymentPodSpec">
 LinseedDeploymentPodSpec
 </a>
 </em>
@@ -11098,11 +11098,11 @@ Spec is the linseed Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinseedDeploymentSpec">LinseedDeploymentSpec</h3>
+<h3 id="LinseedDeploymentSpec">LinseedDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">LinseedDeployment</a>)
+<a href="#LinseedDeployment">LinseedDeployment</a>)
 
 </p>
 <p>
@@ -11121,7 +11121,7 @@ LinseedDeploymentSpec defines configuration for the linseed Deployment.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeploymentPodTemplateSpec">
+<a href="#LinseedDeploymentPodTemplateSpec">
 LinseedDeploymentPodTemplateSpec
 </a>
 </em>
@@ -11138,12 +11138,12 @@ Template describes the linseed Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LinuxDataplaneOption">LinuxDataplaneOption
+<h3 id="LinuxDataplaneOption">LinuxDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -11152,11 +11152,11 @@ LinuxDataplaneOption controls which dataplane is to be used on Linux nodes.
 <p>
 One of: Iptables, BPF
 </p>
-<h3 id="operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</h3>
+<h3 id="LogCollectionSpec">LogCollectionSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
 <table>
@@ -11172,7 +11172,7 @@ One of: Iptables, BPF
 
 <code>collectLogs</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LogCollectionStatusType">
+<a href="#LogCollectionStatusType">
 LogCollectionStatusType
 </a>
 </em>
@@ -11230,28 +11230,28 @@ Default: -1
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.LogCollectionStatusType">LogCollectionStatusType
+<h3 id="LogCollectionStatusType">LogCollectionStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.LogCollectionSpec">LogCollectionSpec</a>)
+<a href="#LogCollectionSpec">LogCollectionSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.LogLevel">LogLevel
+<h3 id="LogLevel">LogLevel
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CNILogging">CNILogging</a>, 
-<a href="#operator.tigera.io/v1.EgressGatewaySpec">EgressGatewaySpec</a>)
+<a href="#CNILogging">CNILogging</a>, 
+<a href="#EgressGatewaySpec">EgressGatewaySpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.Logging">Logging</h3>
+<h3 id="Logging">Logging</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>
@@ -11267,7 +11267,7 @@ Default: -1
 
 <code>cni</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CNILogging">
+<a href="#CNILogging">
 CNILogging
 </a>
 </em>
@@ -11284,24 +11284,24 @@ Customized logging specification for calico-cni plugin
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.Metadata">Metadata</h3>
+<h3 id="Metadata">Metadata</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.APIServerDeployment">APIServerDeployment</a>, 
-<a href="#operator.tigera.io/v1.APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
-<a href="#operator.tigera.io/v1.CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
-<a href="#operator.tigera.io/v1.CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>, 
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#APIServerDeployment">APIServerDeployment</a>, 
+<a href="#APIServerDeploymentPodTemplateSpec">APIServerDeploymentPodTemplateSpec</a>, 
+<a href="#CSINodeDriverDaemonSet">CSINodeDriverDaemonSet</a>, 
+<a href="#CSINodeDriverDaemonSetPodTemplateSpec">CSINodeDriverDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoKubeControllersDeployment">CalicoKubeControllersDeployment</a>, 
+<a href="#CalicoKubeControllersDeploymentPodTemplateSpec">CalicoKubeControllersDeploymentPodTemplateSpec</a>, 
+<a href="#CalicoNodeDaemonSet">CalicoNodeDaemonSet</a>, 
+<a href="#CalicoNodeDaemonSetPodTemplateSpec">CalicoNodeDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoNodeWindowsDaemonSet">CalicoNodeWindowsDaemonSet</a>, 
+<a href="#CalicoNodeWindowsDaemonSetPodTemplateSpec">CalicoNodeWindowsDaemonSetPodTemplateSpec</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSet">CalicoWindowsUpgradeDaemonSet</a>, 
+<a href="#CalicoWindowsUpgradeDaemonSetPodTemplateSpec">CalicoWindowsUpgradeDaemonSetPodTemplateSpec</a>, 
+<a href="#TyphaDeployment">TyphaDeployment</a>, 
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11357,11 +11357,11 @@ already exist in the object&rsquo;s annotations.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MonitorSpec">MonitorSpec</h3>
+<h3 id="MonitorSpec">MonitorSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -11380,7 +11380,7 @@ MonitorSpec defines the desired state of Tigera monitor.
 
 <code>externalPrometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">
+<a href="#ExternalPrometheus">
 ExternalPrometheus
 </a>
 </em>
@@ -11401,7 +11401,7 @@ scraping from git-ops tools without the need of post-installation steps.
 
 <code>prometheus</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Prometheus">
+<a href="#Prometheus">
 Prometheus
 </a>
 </em>
@@ -11421,7 +11421,7 @@ Prometheus is the configuration for the Prometheus.
 
 <code>alertManager</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.AlertManager">
+<a href="#AlertManager">
 AlertManager
 </a>
 </em>
@@ -11438,11 +11438,11 @@ AlertManager is the configuration for the AlertManager.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MonitorStatus">MonitorStatus</h3>
+<h3 id="MonitorStatus">MonitorStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Monitor">Monitor</a>)
+<a href="#Monitor">Monitor</a>)
 
 </p>
 <p>
@@ -11496,12 +11496,12 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.MultiInterfaceMode">MultiInterfaceMode
+<h3 id="MultiInterfaceMode">MultiInterfaceMode
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -11510,12 +11510,12 @@ MultiInterfaceMode describes the method of providing multiple pod interfaces.
 <p>
 One of: None, Multus
 </p>
-<h3 id="operator.tigera.io/v1.NATOutgoingType">NATOutgoingType
+<h3 id="NATOutgoingType">NATOutgoingType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.IPPool">IPPool</a>)
+<a href="#IPPool">IPPool</a>)
 
 </p>
 <p>
@@ -11524,23 +11524,23 @@ NATOutgoingType describe the type of outgoing NAT to use.
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.NativeIP">NativeIP
+<h3 id="NativeIP">NativeIP
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.AWSEgressGateway">AWSEgressGateway</a>)
+<a href="#AWSEgressGateway">AWSEgressGateway</a>)
 
 </p>
 <p>
 NativeIP defines if Egress Gateway pods should have AWS IPs.
 When NativeIP is enabled, the IPPools should be backed by AWS subnet.
 </p>
-<h3 id="operator.tigera.io/v1.NodeAddressAutodetection">NodeAddressAutodetection</h3>
+<h3 id="NodeAddressAutodetection">NodeAddressAutodetection</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <p>
@@ -11580,7 +11580,7 @@ filtering based on well-known interface names.
 
 <code>kubernetes</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.KubernetesAutodetectionMethod">
+<a href="#KubernetesAutodetectionMethod">
 KubernetesAutodetectionMethod
 </a>
 </em>
@@ -11671,11 +11671,11 @@ one of the provided CIDRs.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NodeAffinity">NodeAffinity</h3>
+<h3 id="NodeAffinity">NodeAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</a>)
+<a href="#TyphaAffinity">TyphaAffinity</a>)
 
 </p>
 <p>
@@ -11744,12 +11744,12 @@ may or may not try to eventually evict the pod from its node.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.NonPrivilegedType">NonPrivilegedType
+<h3 id="NonPrivilegedType">NonPrivilegedType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -11758,18 +11758,18 @@ NonPrivilegedType specifies whether Calico runs as permissioned or not
 <p>
 One of: Enabled, Disabled
 </p>
-<h3 id="operator.tigera.io/v1.OIDCType">OIDCType
+<h3 id="OIDCType">OIDCType
 (<code>string</code> alias)</h3>
 <p>
 OIDCType defines how OIDC is configured for Tigera Enterprise. Dex should be the best option for most use-cases.
 The Tigera option can help in specific use-cases, for instance, when you are unable to configure a client secret.
 One of: Dex, Tigera
 </p>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</h3>
+<h3 id="PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPISpec">PacketCaptureAPISpec</a>)
+<a href="#PacketCaptureAPISpec">PacketCaptureAPISpec</a>)
 
 </p>
 <p>
@@ -11788,7 +11788,7 @@ PacketCaptureAPIDeployment is the configuration for the PacketCaptureAPI Deploym
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentSpec">
+<a href="#PacketCaptureAPIDeploymentSpec">
 PacketCaptureAPIDeploymentSpec
 </a>
 </em>
@@ -11809,11 +11809,11 @@ Spec is the specification of the PacketCaptureAPI Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentContainer">PacketCaptureAPIDeploymentContainer</h3>
+<h3 id="PacketCaptureAPIDeploymentContainer">PacketCaptureAPIDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
+<a href="#PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -11869,11 +11869,11 @@ If omitted, the PacketCaptureAPI Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentInitContainer">PacketCaptureAPIDeploymentInitContainer</h3>
+<h3 id="PacketCaptureAPIDeploymentInitContainer">PacketCaptureAPIDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
+<a href="#PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -11929,11 +11929,11 @@ If omitted, the PacketCaptureAPI Deployment will use its default value for this 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</h3>
+<h3 id="PacketCaptureAPIDeploymentPodSpec">PacketCaptureAPIDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</a>)
+<a href="#PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -11952,7 +11952,7 @@ PacketCaptureAPIDeploymentPodSpec is the PacketCaptureAPI Deployment&rsquo;s Pod
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentInitContainer">
+<a href="#PacketCaptureAPIDeploymentInitContainer">
 []PacketCaptureAPIDeploymentInitContainer
 </a>
 </em>
@@ -11974,7 +11974,7 @@ If omitted, the PacketCaptureAPI Deployment will use its default values for its 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentContainer">
+<a href="#PacketCaptureAPIDeploymentContainer">
 []PacketCaptureAPIDeploymentContainer
 </a>
 </em>
@@ -11993,11 +11993,11 @@ If omitted, the PacketCaptureAPI Deployment will use its default values for its 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</h3>
+<h3 id="PacketCaptureAPIDeploymentPodTemplateSpec">PacketCaptureAPIDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</a>)
+<a href="#PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</a>)
 
 </p>
 <p>
@@ -12016,7 +12016,7 @@ PacketCaptureAPIDeploymentPodTemplateSpec is the PacketCaptureAPI Deployment&rsq
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodSpec">
+<a href="#PacketCaptureAPIDeploymentPodSpec">
 PacketCaptureAPIDeploymentPodSpec
 </a>
 </em>
@@ -12037,11 +12037,11 @@ Spec is the PacketCaptureAPI Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</h3>
+<h3 id="PacketCaptureAPIDeploymentSpec">PacketCaptureAPIDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</a>)
+<a href="#PacketCaptureAPIDeployment">PacketCaptureAPIDeployment</a>)
 
 </p>
 <p>
@@ -12060,7 +12060,7 @@ PacketCaptureAPIDeploymentSpec defines configuration for the PacketCaptureAPI De
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeploymentPodTemplateSpec">
+<a href="#PacketCaptureAPIDeploymentPodTemplateSpec">
 PacketCaptureAPIDeploymentPodTemplateSpec
 </a>
 </em>
@@ -12077,11 +12077,11 @@ Template describes the PacketCaptureAPI Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPISpec">PacketCaptureAPISpec</h3>
+<h3 id="PacketCaptureAPISpec">PacketCaptureAPISpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</a>)
+<a href="#PacketCaptureAPI">PacketCaptureAPI</a>)
 
 </p>
 <p>
@@ -12100,7 +12100,7 @@ PacketCaptureAPISpec defines configuration for the Packet Capture API.
 
 <code>packetCaptureAPIDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPIDeployment">
+<a href="#PacketCaptureAPIDeployment">
 PacketCaptureAPIDeployment
 </a>
 </em>
@@ -12117,11 +12117,11 @@ PacketCaptureAPIDeployment configures the PacketCaptureAPI Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PacketCaptureAPIStatus">PacketCaptureAPIStatus</h3>
+<h3 id="PacketCaptureAPIStatus">PacketCaptureAPIStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PacketCaptureAPI">PacketCaptureAPI</a>)
+<a href="#PacketCaptureAPI">PacketCaptureAPI</a>)
 
 </p>
 <p>
@@ -12175,11 +12175,11 @@ Ready, Progressing, Degraded or other customer types.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PathMatch">PathMatch</h3>
+<h3 id="PathMatch">PathMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
+<a href="#TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
 
 </p>
 <table>
@@ -12245,11 +12245,11 @@ PathReplace if not nil will be used to replace PathRegexp matches.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeployment">PolicyRecommendationDeployment</h3>
+<h3 id="PolicyRecommendationDeployment">PolicyRecommendationDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationSpec">PolicyRecommendationSpec</a>)
+<a href="#PolicyRecommendationSpec">PolicyRecommendationSpec</a>)
 
 </p>
 <p>
@@ -12268,7 +12268,7 @@ PolicyRecommendationDeployment is the configuration for the PolicyRecommendation
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentSpec">
+<a href="#PolicyRecommendationDeploymentSpec">
 PolicyRecommendationDeploymentSpec
 </a>
 </em>
@@ -12289,11 +12289,11 @@ Spec is the specification of the PolicyRecommendation Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentContainer">PolicyRecommendationDeploymentContainer</h3>
+<h3 id="PolicyRecommendationDeploymentContainer">PolicyRecommendationDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
+<a href="#PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -12349,11 +12349,11 @@ If omitted, the PolicyRecommendation Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentInitContainer">PolicyRecommendationDeploymentInitContainer</h3>
+<h3 id="PolicyRecommendationDeploymentInitContainer">PolicyRecommendationDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
+<a href="#PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -12408,11 +12408,11 @@ If omitted, the PolicyRecommendation Deployment will use its default value for t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</h3>
+<h3 id="PolicyRecommendationDeploymentPodSpec">PolicyRecommendationDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</a>)
+<a href="#PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -12431,7 +12431,7 @@ PolicyRecommendationDeploymentPodSpec is the PolicyRecommendation Deployment&rsq
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentInitContainer">
+<a href="#PolicyRecommendationDeploymentInitContainer">
 []PolicyRecommendationDeploymentInitContainer
 </a>
 </em>
@@ -12453,7 +12453,7 @@ If omitted, the PolicyRecommendation Deployment will use its default values for 
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentContainer">
+<a href="#PolicyRecommendationDeploymentContainer">
 []PolicyRecommendationDeploymentContainer
 </a>
 </em>
@@ -12472,11 +12472,11 @@ If omitted, the PolicyRecommendation Deployment will use its default values for 
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</h3>
+<h3 id="PolicyRecommendationDeploymentPodTemplateSpec">PolicyRecommendationDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</a>)
+<a href="#PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</a>)
 
 </p>
 <p>
@@ -12495,7 +12495,7 @@ PolicyRecommendationDeploymentPodTemplateSpec is the PolicyRecommendation Deploy
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodSpec">
+<a href="#PolicyRecommendationDeploymentPodSpec">
 PolicyRecommendationDeploymentPodSpec
 </a>
 </em>
@@ -12516,11 +12516,11 @@ Spec is the PolicyRecommendation Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</h3>
+<h3 id="PolicyRecommendationDeploymentSpec">PolicyRecommendationDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeployment">PolicyRecommendationDeployment</a>)
+<a href="#PolicyRecommendationDeployment">PolicyRecommendationDeployment</a>)
 
 </p>
 <p>
@@ -12539,7 +12539,7 @@ PolicyRecommendationDeploymentSpec defines configuration for the PolicyRecommend
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeploymentPodTemplateSpec">
+<a href="#PolicyRecommendationDeploymentPodTemplateSpec">
 PolicyRecommendationDeploymentPodTemplateSpec
 </a>
 </em>
@@ -12556,11 +12556,11 @@ Template describes the PolicyRecommendation Deployment pod that will be created.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
+<h3 id="PolicyRecommendationSpec">PolicyRecommendationSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
@@ -12580,7 +12580,7 @@ service.
 
 <code>policyRecommendationDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PolicyRecommendationDeployment">
+<a href="#PolicyRecommendationDeployment">
 PolicyRecommendationDeployment
 </a>
 </em>
@@ -12597,11 +12597,11 @@ PolicyRecommendation configures the PolicyRecommendation Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
+<h3 id="PolicyRecommendationStatus">PolicyRecommendationStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.PolicyRecommendation">PolicyRecommendation</a>)
+<a href="#PolicyRecommendation">PolicyRecommendation</a>)
 
 </p>
 <p>
@@ -12634,13 +12634,13 @@ State provides user-readable status.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ProductVariant">ProductVariant
+<h3 id="ProductVariant">ProductVariant
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>, 
-<a href="#operator.tigera.io/v1.InstallationStatus">InstallationStatus</a>)
+<a href="#InstallationSpec">InstallationSpec</a>, 
+<a href="#InstallationStatus">InstallationStatus</a>)
 
 </p>
 <p>
@@ -12649,11 +12649,11 @@ ProductVariant represents the variant of the product.
 <p>
 One of: Calico, TigeraSecureEnterprise
 </p>
-<h3 id="operator.tigera.io/v1.Prometheus">Prometheus</h3>
+<h3 id="Prometheus">Prometheus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.MonitorSpec">MonitorSpec</a>)
+<a href="#MonitorSpec">MonitorSpec</a>)
 
 </p>
 <table>
@@ -12669,7 +12669,7 @@ One of: Calico, TigeraSecureEnterprise
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PrometheusSpec">
+<a href="#PrometheusSpec">
 PrometheusSpec
 </a>
 </em>
@@ -12690,11 +12690,11 @@ Spec is the specification of the Prometheus.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PrometheusContainer">PrometheusContainer</h3>
+<h3 id="PrometheusContainer">PrometheusContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CommonPrometheusFields">CommonPrometheusFields</a>)
+<a href="#CommonPrometheusFields">CommonPrometheusFields</a>)
 
 </p>
 <p>
@@ -12750,11 +12750,11 @@ If omitted, the Prometheus will use its default value for this container&rsquo;s
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PrometheusSpec">PrometheusSpec</h3>
+<h3 id="PrometheusSpec">PrometheusSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Prometheus">Prometheus</a>)
+<a href="#Prometheus">Prometheus</a>)
 
 </p>
 <table>
@@ -12770,7 +12770,7 @@ If omitted, the Prometheus will use its default value for this container&rsquo;s
 
 <code>commonPrometheusFields</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.CommonPrometheusFields">
+<a href="#CommonPrometheusFields">
 CommonPrometheusFields
 </a>
 </em>
@@ -12786,30 +12786,30 @@ CommonPrometheusFields are the options available to both the Prometheus server a
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.PromptType">PromptType
+<h3 id="PromptType">PromptType
 (<code>string</code> alias)</h3>
 <p>
 PromptType is a value that specifies whether the identity provider prompts the end user for re-authentication and
 consent.
 One of: None, Login, Consent, SelectAccount.
 </p>
-<h3 id="operator.tigera.io/v1.Provider">Provider
+<h3 id="Provider">Provider
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
 Provider represents a particular provider or flavor of Kubernetes. Valid options
 are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG.
 </p>
-<h3 id="operator.tigera.io/v1.SNIMatch">SNIMatch</h3>
+<h3 id="SNIMatch">SNIMatch</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>)
+<a href="#TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>)
 
 </p>
 <table>
@@ -12839,11 +12839,11 @@ ServerName is used to match the server name for the request.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.ServiceMonitor">ServiceMonitor</h3>
+<h3 id="ServiceMonitor">ServiceMonitor</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ExternalPrometheus">ExternalPrometheus</a>)
+<a href="#ExternalPrometheus">ExternalPrometheus</a>)
 
 </p>
 <table>
@@ -12878,7 +12878,7 @@ Default: k8s-app=tigera-prometheus
 
 <code>endpoints</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Endpoint">
+<a href="#Endpoint">
 []Endpoint
 </a>
 </em>
@@ -12895,22 +12895,22 @@ related to connecting to our Prometheus server are automatically set by the oper
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.StatusConditionType">StatusConditionType
+<h3 id="StatusConditionType">StatusConditionType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</a>)
+<a href="#TigeraStatusCondition">TigeraStatusCondition</a>)
 
 </p>
 <p>
 StatusConditionType is a type of condition that may apply to a particular component.
 </p>
-<h3 id="operator.tigera.io/v1.Sysctl">Sysctl</h3>
+<h3 id="Sysctl">Sysctl</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
 <table>
@@ -12951,7 +12951,7 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLS">TLS</h3>
+<h3 id="TLS">TLS</h3>
 <table>
 <thead>
 <tr>
@@ -12999,11 +12999,11 @@ Default: tigera-management-cluster-connection
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</h3>
+<h3 id="TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRoute">TLSPassThroughRoute</a>)
+<a href="#TLSPassThroughRoute">TLSPassThroughRoute</a>)
 
 </p>
 <table>
@@ -13019,7 +13019,7 @@ Default: tigera-management-cluster-connection
 
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -13035,7 +13035,7 @@ TargetType
 
 <code>sniMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.SNIMatch">
+<a href="#SNIMatch">
 SNIMatch
 </a>
 </em>
@@ -13069,11 +13069,11 @@ Destination is the destination url to proxy the request to.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</h3>
+<h3 id="TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSTerminatedRoute">TLSTerminatedRoute</a>)
+<a href="#TLSTerminatedRoute">TLSTerminatedRoute</a>)
 
 </p>
 <table>
@@ -13089,7 +13089,7 @@ Destination is the destination url to proxy the request to.
 
 <code>target</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TargetType">
+<a href="#TargetType">
 TargetType
 </a>
 </em>
@@ -13105,7 +13105,7 @@ TargetType
 
 <code>pathMatch</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.PathMatch">
+<a href="#PathMatch">
 PathMatch
 </a>
 </em>
@@ -13220,20 +13220,20 @@ is UI.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TargetType">TargetType
+<h3 id="TargetType">TargetType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>, 
-<a href="#operator.tigera.io/v1.TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
+<a href="#TLSPassThroughRouteSpec">TLSPassThroughRouteSpec</a>, 
+<a href="#TLSTerminatedRouteSpec">TLSTerminatedRouteSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.TenantElasticSpec">TenantElasticSpec</h3>
+<h3 id="TenantElasticSpec">TenantElasticSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TenantSpec">TenantSpec</a>)
+<a href="#TenantSpec">TenantSpec</a>)
 
 </p>
 <table>
@@ -13288,11 +13288,11 @@ bool
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantSpec">TenantSpec</h3>
+<h3 id="TenantSpec">TenantSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
 <table>
@@ -13342,7 +13342,7 @@ Name is a human readable name for this tenant.
 
 <code>indices</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Index">
+<a href="#Index">
 []Index
 </a>
 </em>
@@ -13361,7 +13361,7 @@ Indices defines the how to store a tenant&rsquo;s data
 
 <code>elastic</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TenantElasticSpec">
+<a href="#TenantElasticSpec">
 TenantElasticSpec
 </a>
 </em>
@@ -13400,7 +13400,7 @@ in the Tenant&rsquo;s namespace. Defaults to the controlPlaneReplicas in Install
 
 <code>linseedDeployment</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.LinseedDeployment">
+<a href="#LinseedDeployment">
 LinseedDeployment
 </a>
 </em>
@@ -13419,7 +13419,7 @@ LinseedDeployment configures the linseed Deployment.
 
 <code>dashboardsJob</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.DashboardsJob">
+<a href="#DashboardsJob">
 DashboardsJob
 </a>
 </em>
@@ -13435,18 +13435,18 @@ DashboardsJob configures the Dashboards job
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TenantStatus">TenantStatus</h3>
+<h3 id="TenantStatus">TenantStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.Tenant">Tenant</a>)
+<a href="#Tenant">Tenant</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusCondition">TigeraStatusCondition</h3>
+<h3 id="TigeraStatusCondition">TigeraStatusCondition</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</a>)
+<a href="#TigeraStatusStatus">TigeraStatusStatus</a>)
 
 </p>
 <p>
@@ -13465,7 +13465,7 @@ TigeraStatusCondition represents a condition attached to a particular component.
 
 <code>type</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.StatusConditionType">
+<a href="#StatusConditionType">
 StatusConditionType
 </a>
 </em>
@@ -13484,7 +13484,7 @@ The type of condition. May be Available, Progressing, or Degraded.
 
 <code>status</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.ConditionStatus">
+<a href="#ConditionStatus">
 ConditionStatus
 </a>
 </em>
@@ -13573,26 +13573,26 @@ with respect to the current state of the instance.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TigeraStatusReason">TigeraStatusReason
+<h3 id="TigeraStatusReason">TigeraStatusReason
 (<code>string</code> alias)</h3>
 <p>
 TigeraStatusReason represents the reason for a particular condition.
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusSpec">TigeraStatusSpec</h3>
+<h3 id="TigeraStatusSpec">TigeraStatusSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
 TigeraStatusSpec defines the desired state of TigeraStatus
 </p>
-<h3 id="operator.tigera.io/v1.TigeraStatusStatus">TigeraStatusStatus</h3>
+<h3 id="TigeraStatusStatus">TigeraStatusStatus</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TigeraStatus">TigeraStatus</a>)
+<a href="#TigeraStatus">TigeraStatus</a>)
 
 </p>
 <p>
@@ -13611,7 +13611,7 @@ TigeraStatusStatus defines the observed state of TigeraStatus
 
 <code>conditions</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TigeraStatusCondition">
+<a href="#TigeraStatusCondition">
 []TigeraStatusCondition
 </a>
 </em>
@@ -13628,11 +13628,11 @@ Available, Progressing, or Degraded.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaAffinity">TyphaAffinity</h3>
+<h3 id="TyphaAffinity">TyphaAffinity</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -13652,7 +13652,7 @@ TyphaAffinity allows configuration of node affinity characteristics for Typha po
 
 <code>nodeAffinity</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.NodeAffinity">
+<a href="#NodeAffinity">
 NodeAffinity
 </a>
 </em>
@@ -13669,11 +13669,11 @@ NodeAffinity describes node affinity scheduling rules for typha.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</h3>
+<h3 id="TyphaDeployment">TyphaDeployment</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <p>
@@ -13692,7 +13692,7 @@ TyphaDeployment is the configuration for the typha Deployment.
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -13712,7 +13712,7 @@ Metadata is a subset of a Kubernetes object&rsquo;s metadata that is added to th
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">
+<a href="#TyphaDeploymentSpec">
 TyphaDeploymentSpec
 </a>
 </em>
@@ -13733,11 +13733,11 @@ Spec is the specification of the typha Deployment.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
+<h3 id="TyphaDeploymentContainer">TyphaDeploymentContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -13794,11 +13794,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
+<h3 id="TyphaDeploymentInitContainer">TyphaDeploymentInitContainer</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
+<a href="#TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</a>)
 
 </p>
 <p>
@@ -13855,11 +13855,11 @@ If used in conjunction with the deprecated ComponentResources, then this value t
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
+<h3 id="TyphaDeploymentPodSpec">TyphaDeploymentPodSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
+<a href="#TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</a>)
 
 </p>
 <p>
@@ -13878,7 +13878,7 @@ TyphaDeploymentPodSpec is the typha Deployment&rsquo;s PodSpec.
 
 <code>initContainers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentInitContainer">
+<a href="#TyphaDeploymentInitContainer">
 []TyphaDeploymentInitContainer
 </a>
 </em>
@@ -13900,7 +13900,7 @@ If omitted, the typha Deployment will use its default values for its init contai
 
 <code>containers</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentContainer">
+<a href="#TyphaDeploymentContainer">
 []TyphaDeploymentContainer
 </a>
 </em>
@@ -14034,11 +14034,11 @@ WARNING: Please note that this field will override the default calico-typha Depl
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
+<h3 id="TyphaDeploymentPodTemplateSpec">TyphaDeploymentPodTemplateSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -14057,7 +14057,7 @@ TyphaDeploymentPodTemplateSpec is the typha Deployment&rsquo;s PodTemplateSpec
 
 <code>metadata</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.Metadata">
+<a href="#Metadata">
 Metadata
 </a>
 </em>
@@ -14078,7 +14078,7 @@ the pod&rsquo;s metadata.
 
 <code>spec</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodSpec">
+<a href="#TyphaDeploymentPodSpec">
 TyphaDeploymentPodSpec
 </a>
 </em>
@@ -14099,11 +14099,11 @@ Spec is the typha Deployment&rsquo;s PodSpec.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
+<h3 id="TyphaDeploymentSpec">TyphaDeploymentSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeployment">TyphaDeployment</a>)
+<a href="#TyphaDeployment">TyphaDeployment</a>)
 
 </p>
 <p>
@@ -14143,7 +14143,7 @@ If omitted, the typha Deployment will use its default value for minReadySeconds.
 
 <code>template</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentPodTemplateSpec">
+<a href="#TyphaDeploymentPodTemplateSpec">
 TyphaDeploymentPodTemplateSpec
 </a>
 </em>
@@ -14163,7 +14163,7 @@ Template describes the typha Deployment pod that will be created.
 
 <code>strategy</code><br/>
 <em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentStrategy">
+<a href="#TyphaDeploymentStrategy">
 TyphaDeploymentStrategy
 </a>
 </em>
@@ -14180,11 +14180,11 @@ The deployment strategy to use to replace existing pods with new ones.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
+<h3 id="TyphaDeploymentStrategy">TyphaDeploymentStrategy</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
+<a href="#TyphaDeploymentSpec">TyphaDeploymentSpec</a>)
 
 </p>
 <p>
@@ -14223,27 +14223,27 @@ to be.
 </tr>
 </tbody>
 </table>
-<h3 id="operator.tigera.io/v1.WAFStatusType">WAFStatusType
+<h3 id="WAFStatusType">WAFStatusType
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.ApplicationLayerSpec">ApplicationLayerSpec</a>)
+<a href="#ApplicationLayerSpec">ApplicationLayerSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsDataplaneOption">WindowsDataplaneOption
+<h3 id="WindowsDataplaneOption">WindowsDataplaneOption
 (<code>string</code> alias)</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.CalicoNetworkSpec">CalicoNetworkSpec</a>)
+<a href="#CalicoNetworkSpec">CalicoNetworkSpec</a>)
 
 </p>
-<h3 id="operator.tigera.io/v1.WindowsNodeSpec">WindowsNodeSpec</h3>
+<h3 id="WindowsNodeSpec">WindowsNodeSpec</h3>
 <p>
 
 (<em>Appears on:</em>
-<a href="#operator.tigera.io/v1.InstallationSpec">InstallationSpec</a>)
+<a href="#InstallationSpec">InstallationSpec</a>)
 
 </p>
 <table>

--- a/calico_versioned_docs/version-3.28/reference/installation/helm_customization.mdx
+++ b/calico_versioned_docs/version-3.28/reference/installation/helm_customization.mdx
@@ -8,7 +8,7 @@ import variables from '@site/calico_versioned_docs/version-3.28/variables';
 
 You can customize the following resources and settings during {variables.prodname} Helm-based installation using the file, `values.yaml`.
 
-- [Installation](api.mdx#operator.tigera.io/v1.InstallationSpec)
+- [Installation](api.mdx#InstallationSpec
 - [Default felix configuration](../resources/felixconfig.mdx#spec)
 
 :::note

--- a/scripts/api-jsx.sh
+++ b/scripts/api-jsx.sh
@@ -15,5 +15,8 @@ perl -0777 -pi -e 's/(<p[^>]*>)([\s\S]*?)(<\/p>)/$1\n$2\n$3/g' ${file}
 perl -0777 -pi -e 's/(<h3[^>]*>)([\s\S]*?)\n(<\/h3>)/$1$2$3/g' ${file}
 # Moves all <td> </td> tags to their own line.
 perl -0777 -pi -e 's/(<td>)([\s\S]*?)(<\/td>)/$1\n$2\n$3/g' ${file}
+# Simplifies anchors for headings
+perl -0777 -pi -e "s/(id=\")(operator\\.tigera\\.io\\/v1\\.)(.+?)(\")/\$1\$3\$4/g" ${file}
+perl -0777 -pi -e "s/(href=\"#)(operator\\.tigera\\.io\\/v1\\.)(.+?)(\")/\$1\$3\$4/g" ${file}
 
 exit


### PR DESCRIPTION
This work addresses broken anchor errors we're getting for our builds.

I never discovered the root cause of the errors, but I suspect it has to do with special characters `/` and `.` in the anchors.

Nevertheless, it seemed a fine solution to simplify all the affected anchors by removing the common lead section: `operator.tigera.io/v1`.

As it happens, this lead text wasn't even part of the headings, which are restricted to the resource name along. For example, `APIServer` rather than `operator.tigera.io/v1.APIServer`.

Changes:
* ids and hrefs in _api.mdx simplified globally
* corresponding links from other pages changed
* changed script that alters autogenerated API docs to continue this modification in future.

This takes care of around half the total broken anchors. 
