### PR TITLE
Remove tech preview in webhooks and CTD

### DIFF
--- a/calico-cloud/threat/configuring-webhooks.mdx
+++ b/calico-cloud/threat/configuring-webhooks.mdx
@@ -1,18 +1,11 @@
 ---
-description: Get security event alerts in Slack or Jira.
-title: Configuring security event alerts in Slack and Jira
+description: Send security event alerts to 3rd party systems.
+title: Webhooks for security events
 ---
 
-# Configuring security event alerts in Slack and Jira
+# Webhooks for security event alerts
 
-:::note
-
-This feature is tech preview. Tech preview features may be subject to significant changes before they become GA.
-
-:::
-
-You can configure {{prodname}} webhooks to post security alerts directly to a Slack channel or to create an issue in your Jira project.
-By configuring webhooks for security alerts, you can make sure that you receive critical alerts without having to sign in to Manager UI.
+You can configure {{prodname}} webhooks to post security alerts directly to Slack, Jira or any custom HTTP endpoint.
 
 ## Before you begin
 

--- a/calico-cloud/threat/configuring-webhooks.mdx
+++ b/calico-cloud/threat/configuring-webhooks.mdx
@@ -1,11 +1,11 @@
 ---
-description: Send security event alerts to 3rd party systems.
+description: Use webhooks to send security event alerts to third-party systems.
 title: Webhooks for security events
 ---
 
 # Webhooks for security event alerts
 
-You can configure {{prodname}} webhooks to post security alerts directly to Slack, Jira or any custom HTTP endpoint.
+You can configure {{prodname}} webhooks to post security alerts directly to Slack, Jira, or any custom HTTP endpoint.
 
 ## Before you begin
 

--- a/calico-cloud/threat/configuring-webhooks.mdx
+++ b/calico-cloud/threat/configuring-webhooks.mdx
@@ -5,7 +5,7 @@ title: Webhooks for security events
 
 # Webhooks for security event alerts
 
-You can configure {{prodname}} webhooks to post security alerts directly to Slack, Jira or any custom HTTP endpoint.
+You can configure {{prodname}} webhooks to post security alerts directly to Slack, Jira, or any custom HTTP endpoint.
 
 ## Before you begin
 

--- a/calico-cloud/threat/configuring-webhooks.mdx
+++ b/calico-cloud/threat/configuring-webhooks.mdx
@@ -1,5 +1,5 @@
 ---
-description: Send security event alerts to 3rd party systems.
+description: Use webhooks to send security event alerts to third-party systems.
 title: Webhooks for security events
 ---
 

--- a/calico-cloud/threat/container-threat-detection.mdx
+++ b/calico-cloud/threat/container-threat-detection.mdx
@@ -6,12 +6,6 @@ redirect_from:
 
 # Container threat detection
 
-:::note
-
-This feature is tech preview. Tech preview features may be subject to significant changes before they become GA.
-
-:::
-
 ## Big picture
 
 Get alerts when security threats, such as malware and other suspicious processes, are detected in your cluster.

--- a/calico-cloud/threat/security-event-management.mdx
+++ b/calico-cloud/threat/security-event-management.mdx
@@ -1,12 +1,10 @@
 ---
-description: Get alerts on threats in a single dashboard.
+description: Manage security events from your cluster in a single place.
 ---
 
 # Security event management
 
-## Big picture
-
-Get alerts on security events in a single dashboard.
+Manage security events from your cluster in a single place.
 
 ## Value
 

--- a/calico-cloud_versioned_docs/version-20-1/threat/configuring-webhooks.mdx
+++ b/calico-cloud_versioned_docs/version-20-1/threat/configuring-webhooks.mdx
@@ -1,18 +1,11 @@
 ---
-description: Get security event alerts in Slack or Jira.
-title: Configuring security event alerts in Slack and Jira
+description: Send security event alerts to 3rd party systems.
+title: Webhooks for security events
 ---
 
-# Configuring security event alerts in Slack and Jira
+# Webhooks for security event alerts
 
-:::note
-
-This feature is tech preview. Tech preview features may be subject to significant changes before they become GA.
-
-:::
-
-You can configure {{prodname}} webhooks to post security alerts directly to a Slack channel or to create an issue in your Jira project.
-By configuring webhooks for security alerts, you can make sure that you receive critical alerts without having to sign in to Manager UI.
+You can configure {{prodname}} webhooks to post security alerts directly to Slack, Jira or any custom HTTP endpoint.
 
 ## Before you begin
 

--- a/calico-cloud_versioned_docs/version-20-1/threat/container-threat-detection.mdx
+++ b/calico-cloud_versioned_docs/version-20-1/threat/container-threat-detection.mdx
@@ -6,15 +6,7 @@ redirect_from:
 
 # Container threat detection
 
-:::note
-
-This feature is tech preview. Tech preview features may be subject to significant changes before they become GA.
-
-:::
-
-## Big picture
-
-Get alerts when security threats, such as malware and other suspicious processes, are detected in your cluster.
+Protect your cluster with our eBPF runtime threat detection engine, which detects malware and suspicious process activity in your containers.  
 
 ## Value
 

--- a/calico-cloud_versioned_docs/version-20-1/threat/security-event-management.mdx
+++ b/calico-cloud_versioned_docs/version-20-1/threat/security-event-management.mdx
@@ -1,12 +1,10 @@
 ---
-description: Get alerts on threats in a single dashboard.
+description: Manage security events from your cluster in a single place.
 ---
 
 # Security event management
 
-## Big picture
-
-Get alerts on security events in a single dashboard.
+Manage security events from your cluster in a single place.
 
 ## Value
 

--- a/calico-enterprise/threat/configuring-webhooks.mdx
+++ b/calico-enterprise/threat/configuring-webhooks.mdx
@@ -1,18 +1,11 @@
 ---
-description: Get security event alerts in Slack or Jira.
-title: Configuring security event alerts in Slack and Jira
+description: Send security event alerts to 3rd party systems.
+title: Webhooks for security events
 ---
 
-# Configuring security event alerts in Slack and Jira
+# Webhooks for security event alerts
 
-:::note
-
-This feature is tech preview. Tech preview features may be subject to significant changes before they become GA.
-
-:::
-
-You can configure {{prodname}} webhooks to post security alerts directly to a Slack channel or to create an issue in your Jira project.
-By configuring webhooks for security alerts, you can make sure that you receive critical alerts without having to sign in to Manager UI.
+You can configure {{prodname}} webhooks to post security alerts directly to Slack, Jira or any custom HTTP endpoint.
 
 ## Before you begin
 

--- a/calico-enterprise/threat/configuring-webhooks.mdx
+++ b/calico-enterprise/threat/configuring-webhooks.mdx
@@ -1,11 +1,11 @@
 ---
-description: Send security event alerts to 3rd party systems.
+description: Use webhooks to send security event alerts to third-party systems.
 title: Webhooks for security events
 ---
 
 # Webhooks for security event alerts
 
-You can configure {{prodname}} webhooks to post security alerts directly to Slack, Jira or any custom HTTP endpoint.
+You can configure {{prodname}} webhooks to post security alerts directly to Slack, Jira, or any custom HTTP endpoint.
 
 ## Before you begin
 

--- a/calico-enterprise/threat/security-event-management.mdx
+++ b/calico-enterprise/threat/security-event-management.mdx
@@ -1,22 +1,14 @@
 ---
-description: Get alerts on threats in a single dashboard.
+description: Manage security events from your cluster in a single place.
 ---
 
 # Security event management
 
-:::note
-
-This feature is tech preview. Tech preview features may be subject to significant changes before they become GA.
-
-:::
-
-## Big picture
-
-Get alerts on security events in a single dashboard.
+Manage security events from your cluster in a single place.
 
 ## Value
 
-Security events indicate that a threat actor may be present in your Kubernetes cluster. For example, a DNS request to a malicious hostname, a triggered WAF rule, or the opening of a sensitive file. {{prodname}} provides security engineers and incident response teams with a single dashboard to manage threat alerts. Benefits include:
+Security events indicate that a threat actor may be present in your cluster. For example, a DNS request to a malicious hostname, a triggered WAF rule, or the opening of a sensitive file. {{prodname}} provides security engineers and incident response teams with a single dashboard to manage threat alerts. Benefits include:
 
 - A filtered list of critical events with recommended remediation
 - Identify impacts on applications

--- a/calico-enterprise_versioned_docs/version-3.20-1/threat/configuring-webhooks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/threat/configuring-webhooks.mdx
@@ -1,18 +1,11 @@
 ---
-description: Get security event alerts in Slack or Jira.
-title: Configuring security event alerts in Slack and Jira
+description: Send security event alerts to 3rd party systems.
+title: Webhooks for security events
 ---
 
-# Configuring security event alerts in Slack and Jira
+# Webhooks for security event alerts
 
-:::note
-
-This feature is tech preview. Tech preview features may be subject to significant changes before they become GA.
-
-:::
-
-You can configure {{prodname}} webhooks to post security alerts directly to a Slack channel or to create an issue in your Jira project.
-By configuring webhooks for security alerts, you can make sure that you receive critical alerts without having to sign in to Manager UI.
+You can configure {{prodname}} webhooks to post security alerts directly to Slack, Jira or any custom HTTP endpoint.
 
 ## Before you begin
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/threat/configuring-webhooks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/threat/configuring-webhooks.mdx
@@ -1,11 +1,11 @@
 ---
-description: Send security event alerts to 3rd party systems.
+description: Use webhooks to send security event alerts to third-party systems.
 title: Webhooks for security events
 ---
 
 # Webhooks for security event alerts
 
-You can configure {{prodname}} webhooks to post security alerts directly to Slack, Jira or any custom HTTP endpoint.
+You can configure {{prodname}} webhooks to post security alerts directly to Slack, Jira, or any custom HTTP endpoint.
 
 ## Before you begin
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/threat/security-event-management.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/threat/security-event-management.mdx
@@ -1,18 +1,10 @@
 ---
-description: Get alerts on threats in a single dashboard.
+description: Manage security events from your cluster in a single place.
 ---
 
 # Security event management
 
-:::note
-
-This feature is tech preview. Tech preview features may be subject to significant changes before they become GA.
-
-:::
-
-## Big picture
-
-Get alerts on security events in a single dashboard.
+Manage security events from your cluster in a single place.
 
 ## Value
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Remove tech preview label from CTD, webhooks and also from Security Events in enterprise docs (missed before).

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->