### PR TITLE
Removing create service step for typha metrics

### DIFF
--- a/calico-enterprise/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-enterprise/operations/monitor/prometheus/byo-prometheus.mdx
@@ -354,26 +354,6 @@ You should see a result similar to:
 installation.operator.tigera.io/default patched
 ```
 
-**Create a service to expose Typha metrics**
-
-```bash
-kubectl apply -f - <<EOF
-apiVersion: v1
-kind: Service
-metadata:
-  name: typha-metrics-svc
-  namespace: calico-system
-  labels:
-    k8s-app: typha-metrics
-spec:
-  selector:
-    k8s-app: calico-typha
-  ports:
-  - port: 9093
-    targetPort: 9093
-EOF
-```
-
 **Create the service monitor**
 
 Apply the ServiceMonitor to the namespace where Prometheus is running.


### PR DESCRIPTION
Changes done to remove create service step
for typha prometheus, as this step is already
automated through code.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
https://tigera.atlassian.net/browse/EV-5195
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->