### PR TITLE
Remove reuse-values flag from helm upgrade

### DIFF
--- a/calico-enterprise/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
@@ -142,13 +142,13 @@ These steps differ based on your cluster type. If you are unsure of your cluster
   <CodeBlock language='bash'>
     {'{{version}}' === 'master'
       ? (
-        `helm upgrade calico-enterprise --reuse-values --values=<path-to-values-yaml> tigera-operator-v0.0.tgz \\
+        `helm upgrade calico-enterprise --values=<path-to-values-yaml> tigera-operator-v0.0.tgz \\
   --set-file imagePullSecrets.tigera-pull-secret=<path-to-pull-secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path-to-pull-secret> \\
   --set-file licenseKeyContent=<path-to-license-file-yaml> \\
   --namespace tigera-operator`
       )
       : (
-        `helm upgrade calico-enterprise --reuse-values --values=<path-to-values-yaml> tigera-operator-{{chart_version_name}}.tgz \\
+        `helm upgrade calico-enterprise --values=<path-to-values-yaml> tigera-operator-{{chart_version_name}}.tgz \\
   --set-file imagePullSecrets.tigera-pull-secret=<path-to-pull-secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path-to-pull-secret> \\
   --set-file licenseKeyContent=<path-to-license-file-yaml> \\
   --namespace tigera-operator`

--- a/calico-enterprise_versioned_docs/version-3.20-1/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
@@ -142,13 +142,13 @@ These steps differ based on your cluster type. If you are unsure of your cluster
   <CodeBlock language='bash'>
     {'{{version}}' === 'master'
       ? (
-        `helm upgrade calico-enterprise --reuse-values --values=<path-to-values-yaml> tigera-operator-v0.0.tgz \\
+        `helm upgrade calico-enterprise --values=<path-to-values-yaml> tigera-operator-v0.0.tgz \\
   --set-file imagePullSecrets.tigera-pull-secret=<path-to-pull-secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path-to-pull-secret> \\
   --set-file licenseKeyContent=<path-to-license-file-yaml> \\
   --namespace tigera-operator`
       )
       : (
-        `helm upgrade calico-enterprise --reuse-values --values=<path-to-values-yaml> tigera-operator-{{chart_version_name}}.tgz \\
+        `helm upgrade calico-enterprise --values=<path-to-values-yaml> tigera-operator-{{chart_version_name}}.tgz \\
   --set-file imagePullSecrets.tigera-pull-secret=<path-to-pull-secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path-to-pull-secret> \\
   --set-file licenseKeyContent=<path-to-license-file-yaml> \\
   --namespace tigera-operator`


### PR DESCRIPTION
https://tigera.atlassian.net/browse/EV-5301
The reuse-values option utilizes the values.yaml file from the parent folder and ignores the values.yaml file of the subchart "prometheus." As a result, the Helm upgrade overlooks the Prometheus values.yaml and retains the settings from the older release version. Therefore, we are removing the reuse-values option since we have already provided clear instructions to the user on updating the values.yaml file to enable the packet capture and compliance features

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->