### PR TITLE
DOCS-2385: add interface verification step for BPF dataplane configuration

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.19-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/operations/ebpf/enabling-ebpf.mdx
@@ -185,6 +185,17 @@ kubectl patch felixconfiguration default --patch='{"spec": {"bpfKubeProxyIptable
 
 If both `kube-proxy` and `BPFKubeProxyIptablesCleanupEnabled` is enabled then `kube-proxy` will write its iptables rules and Felix will try to clean them up resulting in iptables flapping between the two.
 
+### Verify node interface naming pattern
+
+When Calico dataplane is configured in BPF mode, Calico configures `ebpf` programs for the host interfaces that match the regex pattern defined by the `bpfDataIfacePattern` setting in [FelixConfiguration](../../reference/resources/felixconfig.mdx). If your nodes use custom interface naming or have multiple interfaces on the hosts, adjust the regex pattern command to only include interfaces that Kubernetes nodes use for pod communications.
+
+:::note
+
+A common example is when a cluster is configured in an on-prem environment and control-plane nodes are virtualized whith only one network interface, but the worker nodes are bare-metal nodes with multiple interfaces that can be bonded or VLAN devices with sub-interfaces and custom naming patterns. In such cases, the `bpfDataIfacePattern` setting may need to be adjusted to include the interface from the control-plane node and only necessary interface from the worker node.
+For example, it's common that sub-interface from a VLAN main device is used for Kubernetes networking. In such a case, only that sub-interface from the worker node should be matched by the regex command but not other interfaces on the node including its parent interface.
+
+:::
+
 ### Enable eBPF mode
 
 To enable eBPF mode, change the `spec.calicoNetwork.linuxDataplane` parameter in the operator's `Installation`

--- a/calico-enterprise_versioned_docs/version-3.19-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/operations/ebpf/enabling-ebpf.mdx
@@ -187,12 +187,11 @@ If both `kube-proxy` and `BPFKubeProxyIptablesCleanupEnabled` is enabled then `k
 
 ### Verify node interface naming pattern
 
-When Calico dataplane is configured in BPF mode, Calico configures `ebpf` programs for the host interfaces that match the regex pattern defined by the `bpfDataIfacePattern` setting in [FelixConfiguration](../../reference/resources/felixconfig.mdx). If your nodes use custom interface naming or have multiple interfaces on the hosts, adjust the regex pattern command to only include interfaces that Kubernetes nodes use for pod communications.
+When Calico dataplane is configured in BPF mode, Calico configures `ebpf` programs for the host interfaces that match the regex pattern defined by the `bpfDataIfacePattern` setting in [FelixConfiguration](../../reference/resources/felixconfig.mdx). The default regex value tries to match commonly used interface names, but interface names can vary depending on a virtualization solution, a flavor of the operating system, company-specific configuration standards, such as VLAN device naming pattern, etc. The regex command should at least match interfaces that participate in intra-cluster and external (e.g. NodePorts) communications. In scenarios when a node has additional interfaces, you may want to leverage Calico policies to secure some of them or even all of them or speed up forwarding to/from pods that use them. In such cases, the regex command should match all interfaces that you want to be managed by Calico.
 
 :::note
 
-A common example is when a cluster is configured in an on-prem environment and control-plane nodes are virtualized whith only one network interface, but the worker nodes are bare-metal nodes with multiple interfaces that can be bonded or VLAN devices with sub-interfaces and custom naming patterns. In such cases, the `bpfDataIfacePattern` setting may need to be adjusted to include the interface from the control-plane node and only necessary interface from the worker node.
-For example, it's common that sub-interface from a VLAN main device is used for Kubernetes networking. In such a case, only that sub-interface from the worker node should be matched by the regex command but not other interfaces on the node including its parent interface.
+A common example is when a cluster is configured in an on-prem environment and control-plane nodes are virtualized with only one network interface, but the worker nodes are bare-metal nodes with additional interfaces that could be VLAN devices with sub-interfaces and specific naming patterns. In such cases, the `bpfDataIfacePattern` setting may need to be adjusted to include the interface from the control-plane nodes as well as necessary interface from the worker nodes.
 
 :::
 


### PR DESCRIPTION
In some corner cases cluster nodes may have custom interface names which may not get matched by the `bpfDataIfacePattern` regex. Need to clarify what users need to change to have their nodes BPF dataplane ready.

Product Version(s):
CE v3.19+

Issue:
[DOCS-2385](https://tigera.atlassian.net/browse/DOCS-2385)

Link to docs preview:


SME review:
- [ ] An SME has approved this change. 

DOCS review:
- [ ] A member of the docs team has approved this change.

Additional information:
This needs to be added to all versions of Calico docs.

Merge checklist:
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


[DOCS-2385]: https://tigera.atlassian.net/browse/DOCS-2385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ