### PR TITLE
Calico OSS 3.26 docs is missing redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -41,10 +41,12 @@
 /calico-enterprise/3.14/ /calico-enterprise/3.14/about-calico-enterprise 301
 
 # For archived Docusaurus-native docs sets
+/calico/3.26/* https://archive-os-3-26.netlify.app/calico/3.26/:splat 301
 /calico/3.25/* https://archive-os-3-25.netlify.app/calico/3.25/:splat 301
 /calico/3.24/* https://archive-os-3-24.netlify.app/calico/3.24/:splat 301
-/calico-enterprise/3.14/* https://archive-ce-3-14.netlify.app/calico-enterprise/3.14/:splat 301
+/calico-enterprise/3.16/* https://archive-ce-3-16.netlify.app/calico-enterprise/3.16/:splat 301
 /calico-enterprise/3.15/* https://archive-ce-3-15.netlify.app/calico-enterprise/3.15/:splat 301
+/calico-enterprise/3.14/* https://archive-ce-3-14.netlify.app/calico-enterprise/3.14/:splat 301
 
 
 


### PR DESCRIPTION
N/A

Product Version(s):
Calico

Issue:
Calico OSS 3.26 is missing redirects

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->