### PR TITLE
[DE-2807] Update current docs

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.17/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
@@ -12,10 +12,6 @@ All upgrades in $[prodname] are free with a valid license.
 
 :::
 
-## Upgrades paths
-
-Upgrading to $[prodname] v3.13 and above, from Calico 3.22 and below is currently unsupported.
-
 ## Prepare your cluster for the upgrade
 
 Calico Enterprise creates default-deny policies for all Calico and Tigera namespaces, including calico-system. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.

--- a/calico-enterprise_versioned_docs/version-3.17/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
@@ -32,8 +32,9 @@ The following steps assume the Calico deployment is installed on `tigera-operato
 
    <CodeBlock language='bash'>
      {'$[version]' === 'master'
-       ? 'gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz'
-       : 'curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz'}
+       ? (`gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz`)
+       : (`curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz`)
+      }
    </CodeBlock>
 
 1. Install the $[prodname] custom resource definitions.
@@ -49,7 +50,7 @@ The following steps assume the Calico deployment is installed on `tigera-operato
 1. Run the Helm upgrade command for `tigera-operator`:
 
    <CodeBlock language='bash'>
-     {'${version}' === 'master'
+     {'$[version]' === 'master'
        ? (
          `helm upgrade calico tigera-operator-v0.0.tgz \\
    --set-file imagePullSecrets.tigera-pull-secret=<path/to/pull/secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path/to/pull/secret> \\

--- a/calico-enterprise_versioned_docs/version-3.17/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
@@ -49,7 +49,7 @@ The following steps assume the Calico deployment is installed on `tigera-operato
 1. Run the Helm upgrade command for `tigera-operator`:
 
    <CodeBlock language='bash'>
-     {'$[version]' === 'master'
+     {'${version}' === 'master'
        ? (
          `helm upgrade calico tigera-operator-v0.0.tgz \\
    --set-file imagePullSecrets.tigera-pull-secret=<path/to/pull/secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path/to/pull/secret> \\

--- a/calico-enterprise_versioned_docs/version-3.17/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
@@ -61,7 +61,7 @@ These steps differ based on your cluster type. If you are unsure of your cluster
 1. Get the Helm chart
 
    <CodeBlock language='bash'>
-     {'$[version]' === 'master'
+     {'${version}' === 'master'
        ? 'gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz'
        : 'curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz'}
    </CodeBlock>

--- a/calico-enterprise_versioned_docs/version-3.17/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
@@ -50,7 +50,7 @@ If your cluster has Windows nodes and uses custom TLS certificates for log stora
 
 $[prodname] creates a default-deny for the calico-system namespace. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.
 
-## Upgrade from 3.13 or later
+## Upgrade from 3.15 or later
 
 :::note
 
@@ -61,9 +61,10 @@ These steps differ based on your cluster type. If you are unsure of your cluster
 1. Get the Helm chart
 
    <CodeBlock language='bash'>
-     {'${version}' === 'master'
-       ? 'gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz'
-       : 'curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz'}
+     {'$[version]' === 'master'
+       ? (`gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz`)
+       : (`curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz`)
+      }
    </CodeBlock>
 
 1. Install the $[prodname] custom resource definitions.

--- a/calico-enterprise_versioned_docs/version-3.17/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
@@ -12,16 +12,6 @@ All upgrades in $[prodname] are free with a valid license.
 
 :::
 
-## Upgrades paths
-
-Upgrading to $[prodname] v3.14 from previous $[prodname] versions other than v3.13 is currently unsupported.
-
-:::note
-
-Always check the [Release Notes](../../../../release-notes/index.mdx) for exceptions; limitations can override the above pattern.
-
-:::
-
 ## Prerequisites
 
 - Verify that your Kubernetes cluster is using Helm

--- a/calico-enterprise_versioned_docs/version-3.17/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/operator.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/operator.mdx
@@ -16,9 +16,9 @@ All upgrades in $[prodname] are free with a valid license.
 
 ## Upgrades paths
 
-You can upgrade your cluster to a maximum of **two releases** from your existing version. For example, if you are on version 3.6, you can upgrade to 3.7, or you can upgrade directly to 3.8. However, you cannot upgrade beyond **two releases**; upgrading from 3.6 to 3.9 (three releases) is not supported.
+You can upgrade your cluster to a maximum of **two releases** from your existing version. For example, if you are on version 3.14, you can upgrade to 3.15, or you can upgrade directly to 3.16. However, you cannot upgrade beyond **two releases**; upgrading from 3.14 to 3.17 (three releases) is not supported.
 
-If you are several versions behind where you want to be, you must go through each group of two releases to get there. For example, if you are on version 3.6, and you want to get to 3.10, you can upgrade to 3.8, then upgrade from 3.8 directly to 3.10.
+If you are several versions behind where you want to be, you must go through each group of two releases to get there. For example, if you are on version 3.14, and you want to get to 3.17, you can upgrade to 3.16, then upgrade from 3.16 directly to 3.17.
 
 :::note
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
@@ -12,10 +12,6 @@ All upgrades in $[prodname] are free with a valid license.
 
 :::
 
-## Upgrades paths
-
-Upgrading to $[prodname] v3.13 and above, from Calico 3.22 and below is currently unsupported.
-
 ## Prepare your cluster for the upgrade
 
 Calico Enterprise creates default-deny policies for all Calico and Tigera namespaces, including calico-system. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.

--- a/calico-enterprise_versioned_docs/version-3.18-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
@@ -32,8 +32,9 @@ The following steps assume the Calico deployment is installed on `tigera-operato
 
    <CodeBlock language='bash'>
      {'$[version]' === 'master'
-       ? 'gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz'
-       : 'curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz'}
+       ? (`gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz`)
+       : (`curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz`)
+      }
    </CodeBlock>
 
 1. Install the $[prodname] custom resource definitions.

--- a/calico-enterprise_versioned_docs/version-3.18-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
@@ -50,7 +50,7 @@ If your cluster has Windows nodes and uses custom TLS certificates for log stora
 
 $[prodname] creates a default-deny for the calico-system namespace. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.
 
-## Upgrade from 3.13 or later
+## Upgrade from 3.16 or later
 
 :::note
 
@@ -62,8 +62,9 @@ These steps differ based on your cluster type. If you are unsure of your cluster
 
    <CodeBlock language='bash'>
      {'$[version]' === 'master'
-       ? 'gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz'
-       : 'curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz'}
+       ? (`gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz`)
+       : (`curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz`)
+      }
    </CodeBlock>
 
 1. Install the $[prodname] custom resource definitions.

--- a/calico-enterprise_versioned_docs/version-3.18-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
@@ -12,16 +12,6 @@ All upgrades in $[prodname] are free with a valid license.
 
 :::
 
-## Upgrades paths
-
-Upgrading to $[prodname] v3.14 from previous $[prodname] versions other than v3.13 is currently unsupported.
-
-:::note
-
-Always check the [Release Notes](../../../../release-notes/index.mdx) for exceptions; limitations can override the above pattern.
-
-:::
-
 ## Prerequisites
 
 - Verify that your Kubernetes cluster is using Helm

--- a/calico-enterprise_versioned_docs/version-3.18-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/operator.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/operator.mdx
@@ -16,9 +16,9 @@ All upgrades in $[prodname] are free with a valid license.
 
 ## Upgrades paths
 
-You can upgrade your cluster to a maximum of **two releases** from your existing version. For example, if you are on version 3.6, you can upgrade to 3.7, or you can upgrade directly to 3.8. However, you cannot upgrade beyond **two releases**; upgrading from 3.6 to 3.9 (three releases) is not supported.
+You can upgrade your cluster to a maximum of **two releases** from your existing version. For example, if you are on version 3.15, you can upgrade to 3.16, or you can upgrade directly to 3.17. However, you cannot upgrade beyond **two releases**; upgrading from 3.15 to 3.18 (three releases) is not supported.
 
-If you are several versions behind where you want to be, you must go through each group of two releases to get there. For example, if you are on version 3.6, and you want to get to 3.10, you can upgrade to 3.8, then upgrade from 3.8 directly to 3.10.
+If you are several versions behind where you want to be, you must go through each group of two releases to get there. For example, if you are on version 3.15, and you want to get to 3.18, you can upgrade to 3.17, then upgrade from 3.17 directly to 3.18.
 
 :::note
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
@@ -12,10 +12,6 @@ All upgrades in $[prodname] are free with a valid license.
 
 :::
 
-## Upgrades paths
-
-Upgrading to $[prodname] v3.13 and above, from Calico 3.22 and below is currently unsupported.
-
 ## Prepare your cluster for the upgrade
 
 Calico Enterprise creates default-deny policies for all Calico and Tigera namespaces, including calico-system. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
@@ -32,8 +32,9 @@ The following steps assume the Calico deployment is installed on `tigera-operato
 
    <CodeBlock language='bash'>
      {'$[version]' === 'master'
-       ? 'gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz'
-       : 'curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz'}
+       ? (`gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz`)
+       : (`curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz`)
+      }
    </CodeBlock>
 
 1. Install the $[prodname] custom resource definitions.

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
@@ -62,7 +62,7 @@ owned resources being garbage collected by Kubernetes.
 
 $[prodname] creates a default-deny for the calico-system namespace. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.
 
-## Upgrade from 3.13 or later
+## Upgrade from 3.17 or later
 
 :::note
 
@@ -74,8 +74,9 @@ These steps differ based on your cluster type. If you are unsure of your cluster
 
    <CodeBlock language='bash'>
      {'$[version]' === 'master'
-       ? 'gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz'
-       : 'curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz'}
+       ? (`gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz`)
+       : (`curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz`)
+      }
    </CodeBlock>
 
 1. Install the $[prodname] custom resource definitions.

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
@@ -12,16 +12,6 @@ All upgrades in $[prodname] are free with a valid license.
 
 :::
 
-## Upgrades paths
-
-Upgrading to $[prodname] v3.14 from previous $[prodname] versions other than v3.13 is currently unsupported.
-
-:::note
-
-Always check the [Release Notes](../../../../release-notes/index.mdx) for exceptions; limitations can override the above pattern.
-
-:::
-
 ## Prerequisites
 
 - Verify that your Kubernetes cluster is using Helm

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/operator.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/operator.mdx
@@ -16,9 +16,9 @@ All upgrades in $[prodname] are free with a valid license.
 
 ## Upgrades paths
 
-You can upgrade your cluster to a maximum of **two releases** from your existing version. For example, if you are on version 3.6, you can upgrade to 3.7, or you can upgrade directly to 3.8. However, you cannot upgrade beyond **two releases**; upgrading from 3.6 to 3.9 (three releases) is not supported.
+You can upgrade your cluster to a maximum of **two releases** from your existing version. For example, if you are on version 3.15, you can upgrade to 3.16, or you can upgrade directly to 3.17. However, you cannot upgrade beyond **two releases**; upgrading from 3.15 to 3.18 (three releases) is not supported.
 
-If you are several versions behind where you want to be, you must go through each group of two releases to get there. For example, if you are on version 3.6, and you want to get to 3.10, you can upgrade to 3.8, then upgrade from 3.8 directly to 3.10.
+If you are several versions behind where you want to be, you must go through each group of two releases to get there. For example, if you are on version 3.16, and you want to get to 3.19, you can upgrade to 3.18, then upgrade from 3.18 directly to 3.19.
 
 :::note
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
@@ -12,10 +12,6 @@ All upgrades in $[prodname] are free with a valid license.
 
 :::
 
-## Upgrades paths
-
-Upgrading to $[prodname] v3.13 and above, from Calico 3.22 and below is currently unsupported.
-
 ## Prepare your cluster for the upgrade
 
 Calico Enterprise creates default-deny policies for all Calico and Tigera namespaces, including calico-system. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.

--- a/calico-enterprise_versioned_docs/version-3.20-1/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
@@ -32,8 +32,9 @@ The following steps assume the Calico deployment is installed on `tigera-operato
 
    <CodeBlock language='bash'>
      {'$[version]' === 'master'
-       ? 'gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz'
-       : 'curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz'}
+       ? (`gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz`)
+       : (`curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz`)
+      }
    </CodeBlock>
 
 1. Install the $[prodname] custom resource definitions.

--- a/calico-enterprise_versioned_docs/version-3.20-1/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
@@ -12,16 +12,6 @@ All upgrades in $[prodname] are free with a valid license.
 
 :::
 
-## Upgrades paths
-
-Upgrading to $[prodname] v3.14 from previous $[prodname] versions other than v3.13 is currently unsupported.
-
-:::note
-
-Always check the [Release Notes](../../../../release-notes/index.mdx) for exceptions; limitations can override the above pattern.
-
-:::
-
 ## Prerequisites
 
 - Verify that your Kubernetes cluster is using Helm

--- a/calico-enterprise_versioned_docs/version-3.20-1/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
@@ -62,7 +62,7 @@ owned resources being garbage collected by Kubernetes.
 
 $[prodname] creates a default-deny for the calico-system namespace. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.
 
-## Upgrade from 3.13 or later
+## Upgrade from 3.18 or later
 
 :::note
 
@@ -74,8 +74,9 @@ These steps differ based on your cluster type. If you are unsure of your cluster
 
    <CodeBlock language='bash'>
      {'$[version]' === 'master'
-       ? 'gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz'
-       : 'curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz'}
+       ? (`gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz`)
+       : (`curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz`)
+      }
    </CodeBlock>
 
 1. Install the $[prodname] custom resource definitions.

--- a/calico-enterprise_versioned_docs/version-3.20-1/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/operator.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/operator.mdx
@@ -16,9 +16,9 @@ All upgrades in $[prodname] are free with a valid license.
 
 ## Upgrades paths
 
-You can upgrade your cluster to a maximum of **two releases** from your existing version. For example, if you are on version 3.6, you can upgrade to 3.7, or you can upgrade directly to 3.8. However, you cannot upgrade beyond **two releases**; upgrading from 3.6 to 3.9 (three releases) is not supported.
+You can upgrade your cluster to a maximum of **two releases** from your existing version. For example, if you are on version 3.16, you can upgrade to 3.17, or you can upgrade directly to 3.18. However, you cannot upgrade beyond **two releases**; upgrading from 3.16 to 3.19 (three releases) is not supported.
 
-If you are several versions behind where you want to be, you must go through each group of two releases to get there. For example, if you are on version 3.6, and you want to get to 3.10, you can upgrade to 3.8, then upgrade from 3.8 directly to 3.10.
+If you are several versions behind where you want to be, you must go through each group of two releases to get there. For example, if you are on version 3.16, and you want to get to 3.20, you can upgrade to 3.18, then upgrade from 3.18 directly to 3.20.
 
 :::note
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
@@ -12,10 +12,6 @@ All upgrades in $[prodname] are free with a valid license.
 
 :::
 
-## Upgrades paths
-
-Upgrading to $[prodname] v3.13 and above, from Calico 3.22 and below is currently unsupported.
-
 ## Prepare your cluster for the upgrade
 
 Calico Enterprise creates default-deny policies for all Calico and Tigera namespaces, including calico-system. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
@@ -32,8 +32,9 @@ The following steps assume the Calico deployment is installed on `tigera-operato
 
    <CodeBlock language='bash'>
      {'$[version]' === 'master'
-       ? 'gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz'
-       : 'curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz'}
+       ? (`gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz`)
+       : (`curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz`)
+      }
    </CodeBlock>
 
 1. Install the $[prodname] custom resource definitions.

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
@@ -12,16 +12,6 @@ All upgrades in $[prodname] are free with a valid license.
 
 :::
 
-## Upgrades paths
-
-Upgrading to $[prodname] v3.14 from previous $[prodname] versions other than v3.13 is currently unsupported.
-
-:::note
-
-Always check the [Release Notes](../../../../release-notes/index.mdx) for exceptions; limitations can override the above pattern.
-
-:::
-
 ## Prerequisites
 
 - Verify that your Kubernetes cluster is using Helm

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
@@ -62,7 +62,7 @@ owned resources being garbage collected by Kubernetes.
 
 $[prodname] creates a default-deny for the calico-system namespace. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.
 
-## Upgrade from 3.13 or later
+## Upgrade from 3.18 or later
 
 :::note
 
@@ -74,8 +74,9 @@ These steps differ based on your cluster type. If you are unsure of your cluster
 
    <CodeBlock language='bash'>
      {'$[version]' === 'master'
-       ? 'gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz'
-       : 'curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz'}
+       ? (`gsutil cp gs://tigera-helm-charts/tigera-operator-v0.0.tgz`)
+       : (`curl -O -L $[downloadsurl]/ee/charts/tigera-operator-$[chart_version_name].tgz`)
+      }
    </CodeBlock>
 
 1. Install the $[prodname] custom resource definitions.

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/operator.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/operator.mdx
@@ -16,9 +16,9 @@ All upgrades in $[prodname] are free with a valid license.
 
 ## Upgrades paths
 
-You can upgrade your cluster to a maximum of **two releases** from your existing version. For example, if you are on version 3.6, you can upgrade to 3.7, or you can upgrade directly to 3.8. However, you cannot upgrade beyond **two releases**; upgrading from 3.6 to 3.9 (three releases) is not supported.
+You can upgrade your cluster to a maximum of **two releases** from your existing version. For example, if you are on version 3.16, you can upgrade to 3.17, or you can upgrade directly to 3.18. However, you cannot upgrade beyond **two releases**; upgrading from 3.16 to 3.19 (three releases) is not supported.
 
-If you are several versions behind where you want to be, you must go through each group of two releases to get there. For example, if you are on version 3.6, and you want to get to 3.10, you can upgrade to 3.8, then upgrade from 3.8 directly to 3.10.
+If you are several versions behind where you want to be, you must go through each group of two releases to get there. For example, if you are on version 3.16, and you want to get to 3.20, you can upgrade to 3.18, then upgrade from 3.18 directly to 3.20.
 
 :::note
 


### PR DESCRIPTION
Product Version(s):
Calico Enterprise

Issue:
Updating certain section of the docs as they had mention of old versions

Removed some section of docs as they are no more valid. For example, upgrading to latest versions from 3.13 and above don't have to be mentioned in the latest docs as it is well past our support matrix.

Also the helm chart in current docs were returning wrong location for obtaining the charts.
Fixed the condition as the commands needed to be within (`...`)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->