### PR TITLE
Update EE v3.20-ep2 release notes to warn about default tier change

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.20-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/release-notes/index.mdx
@@ -140,9 +140,8 @@ $[prodname] 3.20 contains breaking changes for installations that use the Calico
   If you're using the Calico API server, you must restart any controllers, including `kube-controller-manager`, that manage these resources after the upgrade.
   This change addresses an issue where duplicate UIDs on different API resources could disrupt Kubernetes garbage collection.
 
-* ***Important change:*** In Calico Enterprise 3.20.0-2.0, the order of the default tier is changed to 1,000,000. This changes tiers evaluation if there is another tier with higher order value.
-  It's important to verify the existence of tiers with higher order numbers before upgrading to Calico Enterprise 3.20.0-2.0 or newer releases.
-  In case such a tier exists, the order number must be changed to a lower value than 1,000,000 to guarantee its evaluation before the default tier.
+* ***Breaking change:*** Previously, the default tier had no order and was always evaluated last. Starting with Calico Enterprise 3.20.0-2.0,
+    the default tier now has an order of 1,000,000. When upgrading, you must ensure that existing tiers have a lower order or else policy decisions may be affected.
 
 ## Release details
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/release-notes/index.mdx
@@ -140,6 +140,10 @@ $[prodname] 3.20 contains breaking changes for installations that use the Calico
   If you're using the Calico API server, you must restart any controllers, including `kube-controller-manager`, that manage these resources after the upgrade.
   This change addresses an issue where duplicate UIDs on different API resources could disrupt Kubernetes garbage collection.
 
+* ***Important change:*** In Calico Enterprise 3.20.0-2.0, the order of the default tier is changed to 1,000,000. This changes tiers evaluation if there is another tier with higher order value.
+  It's important to verify the existence of tiers with higher order numbers before upgrading to Calico Enterprise 3.20.0-2.0 or newer releases.
+  In case such a tier exists, the order number must be changed to a lower value than 1,000,000 to guarantee its evaluation before the default tier.
+
 ## Release details
 
 ### Calico Enterprise 3.20.0-1.0 (early preview)


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Update Calico Enterprise v3.20-ep2 to warn users about the default tier change, i.e. order value changed from nil to 1M.

Product Version(s): Calico Enterprise v3.20-ep2
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->