### PR TITLE
EV-5318 create federation secrets in calico-system namespace instead …

### DIFF
--- a/calico-cloud/multicluster/kubeconfig.mdx
+++ b/calico-cloud/multicluster/kubeconfig.mdx
@@ -129,20 +129,20 @@ Create a kubeconfig file, for each cluster, that will be used by other clusters 
    type: kubernetes.io/service-account-token
    metadata:
      name: tigera-federation-remote-cluster
-     namespace: kube-system
+     namespace: calico-system
      annotations:
        kubernetes.io/service-account.name: "tigera-federation-remote-cluster"
    EOF
    ```
    - Retrieve the ServiceAccount token value and replace `<YOUR-SERVICE-ACCOUNT-TOKEN>` with it's value:
    ```bash
-   kubectl describe secret tigera-federation-remote-cluster -n kube-system
+   kubectl describe secret tigera-federation-remote-cluster -n calico-system
    ```
 
    #### If using Kubernetes < 1.24
    - Retrieve the ServiceAccount token value and replace `<YOUR-SERVICE-ACCOUNT-TOKEN>` with it's value:
    ```bash
-   kubectl describe secret -n kube-system $(kubectl get serviceaccounts tigera-federation-remote-cluster -n kube-system -o jsonpath='{.secrets[0].name}')
+   kubectl describe secret -n calico-system $(kubectl get serviceaccounts tigera-federation-remote-cluster -n calico-system -o jsonpath='{.secrets[0].name}')
    ```
 
 1. Retrieve and save the certificate authority and server data:

--- a/calico-enterprise/multicluster/federation/kubeconfig.mdx
+++ b/calico-enterprise/multicluster/federation/kubeconfig.mdx
@@ -430,10 +430,10 @@ calicoq eval "all()"
 If all remote clusters are accessible, calicoq returns something like the following. Note the remote cluster prefixes: there should be endpoints prefixed with the name of each RemoteClusterConfiguration in the local cluster.
 ```
 Endpoints matching selector all():
-  Workload endpoint remote-cluster-1/host-1/k8s/calico-system.kube-dns-5fbcb4d67b-h6686/eth0
-  Workload endpoint remote-cluster-1/host-2/k8s/calico-system.cnx-manager-66c4dbc5b7-6d9xv/eth0
-  Workload endpoint host-a/k8s/calico-system.kube-dns-5fbcb4d67b-7wbhv/eth0
-  Workload endpoint host-b/k8s/calico-system.cnx-manager-66c4dbc5b7-6ghsm/eth0
+  Workload endpoint remote-cluster-1/host-1/k8s/kube-system.kube-dns-5fbcb4d67b-h6686/eth0
+  Workload endpoint remote-cluster-1/host-2/k8s/kube-system.cnx-manager-66c4dbc5b7-6d9xv/eth0
+  Workload endpoint host-a/k8s/kube-system.kube-dns-5fbcb4d67b-7wbhv/eth0
+  Workload endpoint host-b/k8s/kube-system.cnx-manager-66c4dbc5b7-6ghsm/eth0
 ```
 
 If this command fails, the error messages returned by the command may provide insight into where issues are occurring.

--- a/calico-enterprise/multicluster/federation/kubeconfig.mdx
+++ b/calico-enterprise/multicluster/federation/kubeconfig.mdx
@@ -127,20 +127,20 @@ Create a kubeconfig file, for each cluster, that will be used by other clusters 
    type: kubernetes.io/service-account-token
    metadata:
      name: tigera-federation-remote-cluster
-     namespace: kube-system
+     namespace: calico-system
      annotations:
        kubernetes.io/service-account.name: "tigera-federation-remote-cluster"
    EOF
    ```
    - Retrieve the ServiceAccount token value and replace `<YOUR-SERVICE-ACCOUNT-TOKEN>` with it's value:
    ```bash
-   kubectl describe secret tigera-federation-remote-cluster -n kube-system
+   kubectl describe secret tigera-federation-remote-cluster -n calico-system
    ```
 
    #### If using Kubernetes < 1.24
    - Retrieve the ServiceAccount token value and replace `<YOUR-SERVICE-ACCOUNT-TOKEN>` with it's value:
    ```bash
-   kubectl describe secret -n kube-system $(kubectl get serviceaccounts tigera-federation-remote-cluster -n kube-system -o jsonpath='{.secrets[0].name}')
+   kubectl describe secret -n calico-system $(kubectl get serviceaccounts tigera-federation-remote-cluster -n calico-system -o jsonpath='{.secrets[0].name}')
    ```
 
 1. Retrieve and save the certificate authority and server data:
@@ -430,10 +430,10 @@ calicoq eval "all()"
 If all remote clusters are accessible, calicoq returns something like the following. Note the remote cluster prefixes: there should be endpoints prefixed with the name of each RemoteClusterConfiguration in the local cluster.
 ```
 Endpoints matching selector all():
-  Workload endpoint remote-cluster-1/host-1/k8s/kube-system.kube-dns-5fbcb4d67b-h6686/eth0
-  Workload endpoint remote-cluster-1/host-2/k8s/kube-system.cnx-manager-66c4dbc5b7-6d9xv/eth0
-  Workload endpoint host-a/k8s/kube-system.kube-dns-5fbcb4d67b-7wbhv/eth0
-  Workload endpoint host-b/k8s/kube-system.cnx-manager-66c4dbc5b7-6ghsm/eth0
+  Workload endpoint remote-cluster-1/host-1/k8s/calico-system.kube-dns-5fbcb4d67b-h6686/eth0
+  Workload endpoint remote-cluster-1/host-2/k8s/calico-system.cnx-manager-66c4dbc5b7-6d9xv/eth0
+  Workload endpoint host-a/k8s/calico-system.kube-dns-5fbcb4d67b-7wbhv/eth0
+  Workload endpoint host-b/k8s/calico-system.cnx-manager-66c4dbc5b7-6ghsm/eth0
 ```
 
 If this command fails, the error messages returned by the command may provide insight into where issues are occurring.


### PR DESCRIPTION
…of kube-system

https://tigera.atlassian.net/browse/EV-5318

Creating the federation resources/secerts inside the calico-system namespace instead of user's kube-system namespace.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->