### PR TITLE
Remove section on built-in retention

### DIFF
--- a/calico-enterprise/visibility/elastic/retention.mdx
+++ b/calico-enterprise/visibility/elastic/retention.mdx
@@ -12,12 +12,6 @@ Configure how long to retain logs and compliance reports.
 
 Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#operator.tigera.io/v1.Retention) and determine the appropriate values for your deployment.
 
-:::note
-
-LogStorage has built-in retention thresholds of 80% for total storage, and 70% for logs (flow and DNS). If either of these are exceeded, the oldest records and logs are removed.
-
-:::
-
 ## How to
 
 ### Configure data retention

--- a/calico-enterprise_versioned_docs/version-3.17/visibility/elastic/retention.mdx
+++ b/calico-enterprise_versioned_docs/version-3.17/visibility/elastic/retention.mdx
@@ -12,12 +12,6 @@ Configure how long to retain logs and compliance reports.
 
 Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#operator.tigera.io/v1.Retention) and determine the appropriate values for your deployment.
 
-:::note
-
-LogStorage has built-in retention thresholds of 80% for total storage, and 70% for logs (flow and DNS). If either of these are exceeded, the oldest records and logs are removed.
-
-:::
-
 ## How to
 
 ### Configure data retention

--- a/calico-enterprise_versioned_docs/version-3.18-2/visibility/elastic/retention.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/visibility/elastic/retention.mdx
@@ -12,12 +12,6 @@ Configure how long to retain logs and compliance reports.
 
 Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#operator.tigera.io/v1.Retention) and determine the appropriate values for your deployment.
 
-:::note
-
-LogStorage has built-in retention thresholds of 80% for total storage, and 70% for logs (flow and DNS). If either of these are exceeded, the oldest records and logs are removed.
-
-:::
-
 ## How to
 
 ### Configure data retention

--- a/calico-enterprise_versioned_docs/version-3.19-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/release-notes/index.mdx
@@ -163,6 +163,8 @@ This release is supported for use in production.
 #### Updates
 
 * License usage data is now collected and stored locally in the cluster
+* Curator was removed from Calico Enterprise due to its limited reliability. To ensure that your Elasticsearch does not
+run out of space, please consult our documentation on [Data retention](../visibility/elastic/retention.mdx) and [Prometheus alerts for Elasticsearch](operations/monitor/metrics/elasticsearch-and-fluentd-metrics#create-prometheus-alerts-for-elasticsearch.mdx).
 
 #### Bug fixes
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/release-notes/index.mdx
@@ -164,7 +164,7 @@ This release is supported for use in production.
 
 * License usage data is now collected and stored locally in the cluster
 * Curator was removed from Calico Enterprise due to its limited reliability. To ensure that your Elasticsearch does not
-run out of space, please consult our documentation on [Data retention](../visibility/elastic/retention.mdx) and [Prometheus alerts for Elasticsearch](operations/monitor/metrics/elasticsearch-and-fluentd-metrics#create-prometheus-alerts-for-elasticsearch.mdx).
+run out of space, please consult our documentation on [Data retention](../visibility/elastic/retention.mdx) and [Prometheus alerts for Elasticsearch](../operations/monitor/metrics/elasticsearch-and-fluentd-metrics#create-prometheus-alerts-for-elasticsearch.mdx).
 
 #### Bug fixes
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/visibility/elastic/retention.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/visibility/elastic/retention.mdx
@@ -12,12 +12,6 @@ Configure how long to retain logs and compliance reports.
 
 Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#operator.tigera.io/v1.Retention) and determine the appropriate values for your deployment.
 
-:::note
-
-LogStorage has built-in retention thresholds of 80% for total storage, and 70% for logs (flow and DNS). If either of these are exceeded, the oldest records and logs are removed.
-
-:::
-
 ## How to
 
 ### Configure data retention

--- a/calico-enterprise_versioned_docs/version-3.20-1/visibility/elastic/retention.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/visibility/elastic/retention.mdx
@@ -12,12 +12,6 @@ Configure how long to retain logs and compliance reports.
 
 Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#operator.tigera.io/v1.Retention) and determine the appropriate values for your deployment.
 
-:::note
-
-LogStorage has built-in retention thresholds of 80% for total storage, and 70% for logs (flow and DNS). If either of these are exceeded, the oldest records and logs are removed.
-
-:::
-
 ## How to
 
 ### Configure data retention

--- a/calico-enterprise_versioned_docs/version-3.20-2/visibility/elastic/retention.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/visibility/elastic/retention.mdx
@@ -12,12 +12,6 @@ Configure how long to retain logs and compliance reports.
 
 Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#operator.tigera.io/v1.Retention) and determine the appropriate values for your deployment.
 
-:::note
-
-LogStorage has built-in retention thresholds of 80% for total storage, and 70% for logs (flow and DNS). If either of these are exceeded, the oldest records and logs are removed.
-
-:::
-
 ## How to
 
 ### Configure data retention


### PR DESCRIPTION
Remove section on built-in retention even on docs where curator was not yet removed from the product.

This is because we have reports that curator does not work and we want to keep users from relying on it.