### PR TITLE
Removing create service step for Felix metrics

### DIFF
--- a/calico-cloud/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-cloud/operations/monitor/prometheus/byo-prometheus.mdx
@@ -272,24 +272,6 @@ For all Prometheus Felix configuration values, see [Felix Prometheus](../../../r
 
 **Create a service to expose Felix metrics**
 
-```bash
-kubectl apply -f - <<EOF
-apiVersion: v1
-kind: Service
-metadata:
-  name: felix-metrics-svc
-  namespace: calico-system
-  labels:
-    k8s-app: felix-metrics
-spec:
-  selector:
-    k8s-app: calico-node
-  ports:
-  - port: 9091
-    targetPort: 9091
-EOF
-```
-
 If running $[prodnameWindows], also create a service for Windows nodes:
 
 ```bash

--- a/calico-cloud/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-cloud/operations/monitor/prometheus/byo-prometheus.mdx
@@ -270,9 +270,9 @@ For all Felix configuration values, see [Felix configuration](../../../reference
 
 For all Prometheus Felix configuration values, see [Felix Prometheus](../../../reference/component-resources/node/felix/prometheus.mdx).
 
-**Create a service to expose Felix metrics**
+**For Windows nodes, create a service to expose Felix metrics**
 
-If running $[prodnameWindows], also create a service for Windows nodes:
+If you're running $[prodnameWindows], you must create a service to expose Felix metrics for Windows nodes:
 
 ```bash
 kubectl apply -f - <<EOF

--- a/calico-enterprise/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-enterprise/operations/monitor/prometheus/byo-prometheus.mdx
@@ -272,24 +272,6 @@ For all Prometheus Felix configuration values, see [Felix Prometheus](../../../r
 
 **Create a service to expose Felix metrics**
 
-```bash
-kubectl apply -f - <<EOF
-apiVersion: v1
-kind: Service
-metadata:
-  name: felix-metrics-svc
-  namespace: calico-system
-  labels:
-    k8s-app: felix-metrics
-spec:
-  selector:
-    k8s-app: calico-node
-  ports:
-  - port: 9091
-    targetPort: 9091
-EOF
-```
-
 If running $[prodnameWindows], also create a service for Windows nodes:
 
 ```bash

--- a/calico-enterprise/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-enterprise/operations/monitor/prometheus/byo-prometheus.mdx
@@ -270,9 +270,9 @@ For all Felix configuration values, see [Felix configuration](../../../reference
 
 For all Prometheus Felix configuration values, see [Felix Prometheus](../../../reference/component-resources/node/felix/prometheus.mdx).
 
-**Create a service to expose Felix metrics**
+**For Windows nodes, create a service to expose Felix metrics**
 
-If running $[prodnameWindows], also create a service for Windows nodes:
+If you're running $[prodnameWindows], you must create a service to expose Felix metrics for Windows nodes:
 
 ```bash
 kubectl apply -f - <<EOF


### PR DESCRIPTION
Removing create service step for Felix metrics as this step is automated through code.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
https://tigera.atlassian.net/browse/EV-5305
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->