### PR TITLE
Update minikube.mdx

### DIFF
--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/minikube.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/minikube.mdx
@@ -39,7 +39,7 @@ Enabling preinstalled $[prodname] might be the quickest way for testing. However
 :::
 
 ```bash
-minikube start --network-plugin=cni --cni=calico
+minikube start --cni="calico"
 ```
 
 </TabItem>


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
- The `--network-plugin` flag in Minikube is deprecated and has been replaced by the `--cni` flag. 

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->