### PR TITLE
DOCS-2428: [EV-4811] Upgrade elasticsearch and kibana to version 8

### DIFF
--- a/calico-enterprise/releases.json
+++ b/calico-enterprise/releases.json
@@ -76,14 +76,14 @@
         "version": "master"
       },
       "eck-kibana": {
-        "version": "7.17.9"
+        "version": "8.16.1"
       },
       "kibana": {
         "image": "tigera/kibana",
         "version": "master"
       },
       "eck-elasticsearch": {
-        "version": "7.17.9"
+        "version": "8.16.1"
       },
       "elasticsearch": {
         "image": "tigera/elasticsearch",


### PR DESCRIPTION
https://tigera.atlassian.net/browse/EV-4811

Upgrading elasticsearch and kibana to version 8 in 3.21 ep 1 for enterprise.
We have no cloud changes, since elastic is maintained by the our cloud team.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->