### PR TITLE
Fix : namespace name in quickstart.mdx

### DIFF
--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/quickstart.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/quickstart.mdx
@@ -116,14 +116,14 @@ The geeky details of what you get:
 1. Confirm that all of the pods are running with the following command.
 
    ```
-   watch kubectl get pods -n calico-system
+   watch kubectl get pods -n tigera-operator
    ```
 
    Wait until each pod has the `STATUS` of `Running`.
 
    :::note
 
-   The Tigera operator installs resources in the `calico-system` namespace. Other install methods may use
+   The Tigera operator installs resources in the `tigera-operator` namespace. Other install methods may use
    the `kube-system` namespace instead.
 
    :::


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Updated namespace name to match actual deployment.

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Calico Open Source 3.29

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://docs.tigera.io/calico/latest/getting-started/kubernetes/quickstart

SME review:
- [❌] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [❌] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Here is the actual results when applying the documentation. The kubernetes cluster was just created with kubeadm. No customizations used.

```bash
# kubectl get ns
NAME               STATUS   AGE
calico-apiserver   Active   15m
default            Active   20m
kube-node-lease    Active   20m
kube-public        Active   20m
kube-system        Active   20m
tigera-operator    Active   16m
```

```bash
# kubectl get all -n tigera-operator
NAME                                   READY   STATUS    RESTARTS   AGE
pod/tigera-operator-7d68577dc5-9nt2h   1/1     Running   0          16m

NAME                              READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/tigera-operator   1/1     1            1           16m

NAME                                         DESIRED   CURRENT   READY   AGE
replicaset.apps/tigera-operator-7d68577dc5   1         1         1       16m
```

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 

<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->