### PR TITLE
Set correct maxBlocksPerHost default

### DIFF
--- a/calico-cloud/reference/resources/ipamconfig.mdx
+++ b/calico-cloud/reference/resources/ipamconfig.mdx
@@ -33,7 +33,7 @@ The resource is a singleton which must have the name `default`.
 | Field            | Description                                                         | Accepted Values | Schema | Default   |
 | ---------------- | ------------------------------------------------------------------- | --------------- | ------ | --------- |
 | strictAffinity   | When StrictAffinity is true, borrowing IP addresses is not allowed. | true, false     | bool   | false     |
-| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | unlimited |
+| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | 20        |
 
 ## Supported operations
 

--- a/calico-cloud_versioned_docs/version-20-2/reference/resources/ipamconfig.mdx
+++ b/calico-cloud_versioned_docs/version-20-2/reference/resources/ipamconfig.mdx
@@ -33,7 +33,7 @@ The resource is a singleton which must have the name `default`.
 | Field            | Description                                                         | Accepted Values | Schema | Default   |
 | ---------------- | ------------------------------------------------------------------- | --------------- | ------ | --------- |
 | strictAffinity   | When StrictAffinity is true, borrowing IP addresses is not allowed. | true, false     | bool   | false     |
-| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | unlimited |
+| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | 20        |
 
 ## Supported operations
 

--- a/calico-enterprise/reference/resources/ipamconfig.mdx
+++ b/calico-enterprise/reference/resources/ipamconfig.mdx
@@ -33,7 +33,7 @@ The resource is a singleton which must have the name `default`.
 | Field            | Description                                                         | Accepted Values | Schema | Default   |
 | ---------------- | ------------------------------------------------------------------- | --------------- | ------ | --------- |
 | strictAffinity   | When StrictAffinity is true, borrowing IP addresses is not allowed. | true, false     | bool   | false     |
-| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | unlimited |
+| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | 20        |
 
 ## Supported operations
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/reference/resources/ipamconfig.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/reference/resources/ipamconfig.mdx
@@ -33,7 +33,7 @@ The resource is a singleton which must have the name `default`.
 | Field            | Description                                                         | Accepted Values | Schema | Default   |
 | ---------------- | ------------------------------------------------------------------- | --------------- | ------ | --------- |
 | strictAffinity   | When StrictAffinity is true, borrowing IP addresses is not allowed. | true, false     | bool   | false     |
-| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | unlimited |
+| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | 20        |
 
 ## Supported operations
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/reference/resources/ipamconfig.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/reference/resources/ipamconfig.mdx
@@ -33,7 +33,7 @@ The resource is a singleton which must have the name `default`.
 | Field            | Description                                                         | Accepted Values | Schema | Default   |
 | ---------------- | ------------------------------------------------------------------- | --------------- | ------ | --------- |
 | strictAffinity   | When StrictAffinity is true, borrowing IP addresses is not allowed. | true, false     | bool   | false     |
-| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | unlimited |
+| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | 20        |
 
 ## Supported operations
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/resources/ipamconfig.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/resources/ipamconfig.mdx
@@ -33,7 +33,7 @@ The resource is a singleton which must have the name `default`.
 | Field            | Description                                                         | Accepted Values | Schema | Default   |
 | ---------------- | ------------------------------------------------------------------- | --------------- | ------ | --------- |
 | strictAffinity   | When StrictAffinity is true, borrowing IP addresses is not allowed. | true, false     | bool   | false     |
-| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | unlimited |
+| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | 20        |
 
 ## Supported operations
 

--- a/calico/reference/resources/ipamconfig.mdx
+++ b/calico/reference/resources/ipamconfig.mdx
@@ -33,7 +33,7 @@ The resource is a singleton which must have the name `default`.
 | Field            | Description                                                         | Accepted Values | Schema | Default   |
 | ---------------- | ------------------------------------------------------------------- | --------------- | ------ | --------- |
 | strictAffinity   | When StrictAffinity is true, borrowing IP addresses is not allowed. | true, false     | bool   | false     |
-| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | unlimited |
+| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | 20        |
 
 ## Supported operations
 

--- a/calico_versioned_docs/version-3.27/reference/resources/ipamconfig.mdx
+++ b/calico_versioned_docs/version-3.27/reference/resources/ipamconfig.mdx
@@ -33,7 +33,7 @@ The resource is a singleton which must have the name `default`.
 | Field            | Description                                                         | Accepted Values | Schema | Default   |
 | ---------------- | ------------------------------------------------------------------- | --------------- | ------ | --------- |
 | strictAffinity   | When StrictAffinity is true, borrowing IP addresses is not allowed. | true, false     | bool   | false     |
-| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | unlimited |
+| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | 20        |
 
 ## Supported operations
 

--- a/calico_versioned_docs/version-3.29/reference/resources/ipamconfig.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/ipamconfig.mdx
@@ -33,7 +33,7 @@ The resource is a singleton which must have the name `default`.
 | Field            | Description                                                         | Accepted Values | Schema | Default   |
 | ---------------- | ------------------------------------------------------------------- | --------------- | ------ | --------- |
 | strictAffinity   | When StrictAffinity is true, borrowing IP addresses is not allowed. | true, false     | bool   | false     |
-| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | unlimited |
+| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | 20        |
 
 ## Supported operations
 


### PR DESCRIPTION
Fixes https://github.com/projectcalico/calico/issues/9462

While the API structure itself defaults to 0, the code interprets 0 to
mean "20" . . .


<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->