### PR TITLE
Add required steps for installing enterprise on Openshift v4.16+ on AWS

### DIFF
--- a/calico-enterprise/_includes/components/InstallOpenShift.js
+++ b/calico-enterprise/_includes/components/InstallOpenShift.js
@@ -80,6 +80,27 @@ export default function InstallOpenShift(props) {
       </Heading>
       <p>Now generate the Kubernetes manifests using your configuration file:</p>
       <CodeBlock language='bash'>openshift-install create manifests</CodeBlock>
+        <Admonition type={'note'}>
+            <p>For OpenShift <b>v4.16 or newer</b> on <b>AWS</b>, configure AWS security groups to allow BGP, typha and IP-in-IP encapsulation traffic by editing the OpenShift cluster-api manifests.</p>
+            <p>Edit <code>spec.network.cni.cniIngressRules</code> in the <code>cluster-api/02_infra-cluster.yaml</code> file to add </p>
+            <CodeBlock language='bash'>
+        {`cniIngressRules:
+(...)
+- description: BGP (calico enterprise)
+  fromPort: 179
+  protocol: tcp
+  toPort: 179
+- description: IP-in-IP (calico enterprise)
+  fromPort: -1
+  protocol: "4"
+  toPort: -1
+- description: Typha (calico enterprise)
+  fromPort: 5473
+  protocol: tcp
+  toPort: 5473
+`}
+            </CodeBlock>
+        </Admonition>
 
       <InstallOpenShiftManifests />
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/_includes/components/InstallOpenShift.js
+++ b/calico-enterprise_versioned_docs/version-3.20-1/_includes/components/InstallOpenShift.js
@@ -80,6 +80,27 @@ export default function InstallOpenShift(props) {
       </Heading>
       <p>Now generate the Kubernetes manifests using your configuration file:</p>
       <CodeBlock language='bash'>openshift-install create manifests</CodeBlock>
+        <Admonition type={'note'}>
+            <p>For OpenShift **v4.16 or newer** on **AWS**, configure AWS security groups to allow BGP, typha and IP-in-IP encapsulation traffic by editing the OpenShift cluster-api manifests.</p>
+            <p>Edit `spec.network.cni.cniIngressRules` in the `cluster-api/02_infra-cluster.yaml` file to add </p>
+            <CodeBlock language='bash'>
+                {`cniIngressRules:
+(...)
+- description: BGP (calico enterprise)
+  fromPort: 179
+  protocol: tcp
+  toPort: 179
+- description: IP-in-IP (calico enterprise)
+  fromPort: -1
+  protocol: "4"
+  toPort: -1
+- description: Typha (calico enterprise)
+  fromPort: 5473
+  protocol: tcp
+  toPort: 5473
+`}
+            </CodeBlock>
+        </Admonition>
 
       <InstallOpenShiftManifests />
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/InstallOpenShift.js
+++ b/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/InstallOpenShift.js
@@ -80,7 +80,27 @@ export default function InstallOpenShift(props) {
       </Heading>
       <p>Now generate the Kubernetes manifests using your configuration file:</p>
       <CodeBlock language='bash'>openshift-install create manifests</CodeBlock>
-
+        <Admonition type={'note'}>
+            <p>For OpenShift **v4.16 or newer** on **AWS**, configure AWS security groups to allow BGP, typha and IP-in-IP encapsulation traffic by editing the OpenShift cluster-api manifests.</p>
+            <p>Edit `spec.network.cni.cniIngressRules` in the `cluster-api/02_infra-cluster.yaml` file to add </p>
+            <CodeBlock language='bash'>
+                {`cniIngressRules:
+(...)
+- description: BGP (calico enterprise)
+  fromPort: 179
+  protocol: tcp
+  toPort: 179
+- description: IP-in-IP (calico enterprise)
+  fromPort: -1
+  protocol: "4"
+  toPort: -1
+- description: Typha (calico enterprise)
+  fromPort: 5473
+  protocol: tcp
+  toPort: 5473
+`}
+            </CodeBlock>
+        </Admonition>
       <InstallOpenShiftManifests />
 
       {/* For IPI hybrid clusters (Linux + Windows) we need to enable VXLAN and disable BGP */}


### PR DESCRIPTION
Updating enterprise doc similar to this OSS change -  https://github.com/tigera/docs/pull/1820 

![image](https://github.com/user-attachments/assets/d0d04101-ce56-41ef-b930-681e0b3b6883)

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->