### PR TITLE
DOCS-2240: Removes supported operations table from resources.

### DIFF
--- a/calico/reference/resources/bgpconfig.mdx
+++ b/calico/reference/resources/bgpconfig.mdx
@@ -78,10 +78,3 @@ spec:
 | ----------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
 | cidr        | CIDR for which properties should be advertised. | `cidr: XXX.XXX.XXX.XXX/XX`                                                                                                                                                                                                                                                                                                                                                                                                                               | string         |
 | communities | BGP communities to be advertised.               | Communities can be list of either community names already defined in [communities](#communities) or community value of format `aa:nn` or `aa:nn:mm`. <br/>For standard community, value should be in `aa:nn` format, where both `aa` and `nn` are 16 bit integers.<br/> For large community, value should be `aa:nn:mm` format, where `aa`, `nn` and `mm` are all 32 bit integers. <br/>Where `aa` is an AS Number, `nn` and `mm` are per-AS identifier. | List of string |
-
-## Supported operations
-
-| Datastore type        | Create | Delete | Delete (Global `default`) | Update | Get/List | Notes |
-| --------------------- | ------ | ------ | ------------------------- | ------ | -------- | ----- |
-| etcdv3                | Yes    | Yes    | No                        | Yes    | Yes      |
-| Kubernetes API server | Yes    | Yes    | No                        | Yes    | Yes      |

--- a/calico/reference/resources/bgpfilter.mdx
+++ b/calico/reference/resources/bgpfilter.mdx
@@ -100,9 +100,3 @@ spec:
 | ------ | --------------------------------------------- | ------------------------------------------------------------------- | ------ | ------- |
 | min    | Smallest matched mask size (0 by default)     | Valid integers between 0 and ipv4/6 max (32, 128)                   | int    |         |
 | max    | Largest matched mask size (32/128 by default) | Valid integers between 1 and ipv4/6 max (32, 128)                   | int    |         |
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| Kubernetes API server | Yes           | Yes    | Yes      |       |

--- a/calico/reference/resources/bgppeer.mdx
+++ b/calico/reference/resources/bgppeer.mdx
@@ -106,13 +106,6 @@ A BGP peer can also be node-specific. When the `node` field is included, only th
 will peer with it. When the `nodeSelector` field is included, the nodes with labels that match that selector
 will peer with it.
 
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | Yes           | Yes    | Yes      |
-
 ## Selectors
 
 <Selectors />

--- a/calico/reference/resources/blockaffinity.mdx
+++ b/calico/reference/resources/blockaffinity.mdx
@@ -22,10 +22,3 @@ A block affinity resource (`BlockAffinity`) represents the affinity for an IPAM 
 | node    | The node that this affinity is assigned to.                                | The hostname of the node            | string  |         |
 | cidr    | The CIDR range this block affinity references.                             | A valid IPv4 or IPv6 CIDR.          | string  |         |
 | deleted | When set to true, clients should treat this block as if it does not exist. | true, false                         | boolean | `false` |
-
-## Supported operations
-
-| Datastore type        | Create | Delete | Update | Get/List | Watch |
-| --------------------- | ------ | ------ | ------ | -------- | ----- |
-| etcdv3                | No     | No     | No     | Yes      | Yes   |
-| Kubernetes API server | No     | No     | No     | Yes      | Yes   |

--- a/calico/reference/resources/felixconfig.mdx
+++ b/calico/reference/resources/felixconfig.mdx
@@ -290,10 +290,3 @@ Setting `awsSrcDstCheck` to `Disable` will automatically disable source-destinat
 If there are no policies attached to node roles containing the above statement, attach a new policy. For example, if a node role is `test-cluster-nodeinstance-role`, click on the IAM role in AWS console. In the `Permission policies` list, add a new inline policy with the above statement to the new policy JSON definition. For detailed information, see [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create.html?icmpid=docs_iam_console).
 
 For an EKS cluster, the necessary IAM role and policy is available by default. No further actions are needed.
-
-## Supported operations
-
-| Datastore type        | Create | Delete | Delete (Global `default`) | Update | Get/List | Notes |
-| --------------------- | ------ | ------ | ------------------------- | ------ | -------- | ----- |
-| etcdv3                | Yes    | Yes    | No                        | Yes    | Yes      |       |
-| Kubernetes API server | Yes    | Yes    | No                        | Yes    | Yes      |       |

--- a/calico/reference/resources/globalnetworkpolicy.mdx
+++ b/calico/reference/resources/globalnetworkpolicy.mdx
@@ -171,10 +171,3 @@ Application layer policy match criteria are supported with the following restric
 ### HTTPMatch
 
 <Httpmatch />
-
-## Supported operations
-
-| Datastore type           | Create/Delete | Update | Get/List | Notes |
-| ------------------------ | ------------- | ------ | -------- | ----- |
-| etcdv3                   | Yes           | Yes    | Yes      |
-| Kubernetes API datastore | Yes           | Yes    | Yes      |

--- a/calico/reference/resources/hostendpoint.mdx
+++ b/calico/reference/resources/hostendpoint.mdx
@@ -107,10 +107,3 @@ spec:
 ### EndpointPort
 
 <Endpointport />
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | Yes           | Yes    | Yes      |

--- a/calico/reference/resources/ipamconfig.mdx
+++ b/calico/reference/resources/ipamconfig.mdx
@@ -34,10 +34,3 @@ The resource is a singleton which must have the name `default`.
 | ---------------- | ------------------------------------------------------------------- | --------------- | ------ | --------- |
 | strictAffinity   | When StrictAffinity is true, borrowing IP addresses is not allowed. | true, false     | bool   | false     |
 | maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | 20        |
-
-## Supported operations
-
-| Datastore type        | Create | Delete | Update | Get/List |
-| --------------------- | ------ | ------ | ------ | -------- |
-| etcdv3                | Yes    | Yes    | Yes    | Yes      |
-| Kubernetes API server | Yes    | Yes    | Yes    | Yes      |

--- a/calico/reference/resources/ippool.mdx
+++ b/calico/reference/resources/ippool.mdx
@@ -133,13 +133,6 @@ used for manual assignments.
 
 <Selectors />
 
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | Yes           | Yes    | Yes      |
-
 ## See also
 
 The [`IPReservation` resource](ipreservation.mdx) allows for small parts of an IP pool to be reserved so that they will

--- a/calico/reference/resources/kubecontrollersconfig.mdx
+++ b/calico/reference/resources/kubecontrollersconfig.mdx
@@ -117,11 +117,4 @@ $[prodname] datastore.
 | ---------------- | ---------------------------------------------------------------- | --------------------------------- | ------- |
 | reconcilerPeriod | Period to perform reconciliation with the $[prodname] datastore | [Duration string][parse-duration] | 5m      |
 
-## Supported operations
-
-| Datastore type        | Create | Delete (Global `default`) | Update | Get/List | Notes |
-| --------------------- | ------ | ------------------------- | ------ | -------- | ----- |
-| etcdv3                | Yes    | Yes                       | Yes    | Yes      |
-| Kubernetes API server | Yes    | Yes                       | Yes    | Yes      |
-
 [parse-duration]: https://golang.org/pkg/time/#ParseDuration

--- a/calico/reference/resources/networkpolicy.mdx
+++ b/calico/reference/resources/networkpolicy.mdx
@@ -155,10 +155,3 @@ Application layer policy match criteria are supported with the following restric
 ### HTTPMatch
 
 <Httpmatch />
-
-## Supported operations
-
-| Datastore type           | Create/Delete | Update | Get/List | Notes |
-| ------------------------ | ------------- | ------ | -------- | ----- |
-| etcdv3                   | Yes           | Yes    | Yes      |
-| Kubernetes API datastore | Yes           | Yes    | Yes      |

--- a/calico/reference/resources/node.mdx
+++ b/calico/reference/resources/node.mdx
@@ -72,10 +72,3 @@ spec:
 | -------------------- | ----------------------------------------------------------------------------------------- | --------------- | ------ | ------- |
 | interfaceIPv4Address | The IP address and subnet for the IPv4 WireGuard interface created by Felix on this node. | Optional        | string |
 | interfaceIPv6Address | The IP address and subnet for the IPv6 WireGuard interface created by Felix on this node. | Optional        | string |
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes                                                              |
-| --------------------- | ------------- | ------ | -------- | ------------------------------------------------------------------ |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | No            | Yes    | Yes      | `$[nodecontainer]` data is directly tied to the Kubernetes nodes. |

--- a/calico/reference/resources/profile.mdx
+++ b/calico/reference/resources/profile.mdx
@@ -44,10 +44,3 @@ spec:
 
 For `Rule` details please see the [NetworkPolicy](networkpolicy.mdx) or
 [GlobalNetworkPolicy](globalnetworkpolicy.mdx) resource.
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes                                                                          |
-| --------------------- | ------------- | ------ | -------- | ------------------------------------------------------------------------------ |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | No            | No     | Yes      | $[prodname] profiles are pre-assigned for each Namespace and Service Account. |

--- a/calico/reference/resources/workloadendpoint.mdx
+++ b/calico/reference/resources/workloadendpoint.mdx
@@ -121,10 +121,3 @@ The hostPort and hostIP fields are read-only and determined from Kubernetes host
 These fields are used only when host ports are enabled in Calico.
 
 :::
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes                                                    |
-| --------------------- | ------------- | ------ | -------- | -------------------------------------------------------- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | No            | Yes    | Yes      | WorkloadEndpoints are directly tied to a Kubernetes pod. |

--- a/calico_versioned_docs/version-3.26/reference/resources/bgpconfig.mdx
+++ b/calico_versioned_docs/version-3.26/reference/resources/bgpconfig.mdx
@@ -78,10 +78,3 @@ spec:
 | ----------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
 | cidr        | CIDR for which properties should be advertised. | `cidr: XXX.XXX.XXX.XXX/XX`                                                                                                                                                                                                                                                                                                                                                                                                                               | string         |
 | communities | BGP communities to be advertised.               | Communities can be list of either community names already defined in [communities](#communities) or community value of format `aa:nn` or `aa:nn:mm`. <br/>For standard community, value should be in `aa:nn` format, where both `aa` and `nn` are 16 bit integers.<br/> For large community, value should be `aa:nn:mm` format, where `aa`, `nn` and `mm` are all 32 bit integers. <br/>Where `aa` is an AS Number, `nn` and `mm` are per-AS identifier. | List of string |
-
-## Supported operations
-
-| Datastore type        | Create | Delete | Delete (Global `default`) | Update | Get/List | Notes |
-| --------------------- | ------ | ------ | ------------------------- | ------ | -------- | ----- |
-| etcdv3                | Yes    | Yes    | No                        | Yes    | Yes      |
-| Kubernetes API server | Yes    | Yes    | No                        | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.26/reference/resources/bgppeer.mdx
+++ b/calico_versioned_docs/version-3.26/reference/resources/bgppeer.mdx
@@ -106,13 +106,6 @@ A BGP peer can also be node-specific. When the `node` field is included, only th
 will peer with it. When the `nodeSelector` field is included, the nodes with labels that match that selector
 will peer with it.
 
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | Yes           | Yes    | Yes      |
-
 ## Selectors
 
 <Selectors />

--- a/calico_versioned_docs/version-3.26/reference/resources/felixconfig.mdx
+++ b/calico_versioned_docs/version-3.26/reference/resources/felixconfig.mdx
@@ -256,10 +256,3 @@ Setting `awsSrcDstCheck` to `Disable` will automatically disable source-destinat
 If there are no policies attached to node roles containing the above statement, attach a new policy. For example, if a node role is `test-cluster-nodeinstance-role`, click on the IAM role in AWS console. In the `Permission policies` list, add a new inline policy with the above statement to the new policy JSON definition. For detailed information, see [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create.html?icmpid=docs_iam_console).
 
 For an EKS cluster, the necessary IAM role and policy is available by default. No further actions are needed.
-
-## Supported operations
-
-| Datastore type        | Create | Delete | Delete (Global `default`) | Update | Get/List | Notes |
-| --------------------- | ------ | ------ | ------------------------- | ------ | -------- | ----- |
-| etcdv3                | Yes    | Yes    | No                        | Yes    | Yes      |       |
-| Kubernetes API server | Yes    | Yes    | No                        | Yes    | Yes      |       |

--- a/calico_versioned_docs/version-3.26/reference/resources/globalnetworkpolicy.mdx
+++ b/calico_versioned_docs/version-3.26/reference/resources/globalnetworkpolicy.mdx
@@ -158,10 +158,3 @@ Application layer policy match criteria are supported with the following restric
 ### HTTPMatch
 
 <Httpmatch />
-
-## Supported operations
-
-| Datastore type           | Create/Delete | Update | Get/List | Notes |
-| ------------------------ | ------------- | ------ | -------- | ----- |
-| etcdv3                   | Yes           | Yes    | Yes      |
-| Kubernetes API datastore | Yes           | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.26/reference/resources/hostendpoint.mdx
+++ b/calico_versioned_docs/version-3.26/reference/resources/hostendpoint.mdx
@@ -107,10 +107,3 @@ spec:
 ### EndpointPort
 
 <Endpointport />
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | Yes           | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.26/reference/resources/ippool.mdx
+++ b/calico_versioned_docs/version-3.26/reference/resources/ippool.mdx
@@ -133,13 +133,6 @@ used for manual assignments.
 
 <Selectors />
 
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | Yes           | Yes    | Yes      |
-
 ## See also
 
 The [`IPReservation` resource](ipreservation.mdx) allows for small parts of an IP pool to be reserved so that they will

--- a/calico_versioned_docs/version-3.26/reference/resources/kubecontrollersconfig.mdx
+++ b/calico_versioned_docs/version-3.26/reference/resources/kubecontrollersconfig.mdx
@@ -117,11 +117,4 @@ $[prodname] datastore.
 | ---------------- | ---------------------------------------------------------------- | --------------------------------- | ------- |
 | reconcilerPeriod | Period to perform reconciliation with the $[prodname] datastore | [Duration string][parse-duration] | 5m      |
 
-## Supported operations
-
-| Datastore type        | Create | Delete (Global `default`) | Update | Get/List | Notes |
-| --------------------- | ------ | ------------------------- | ------ | -------- | ----- |
-| etcdv3                | Yes    | Yes                       | Yes    | Yes      |
-| Kubernetes API server | Yes    | Yes                       | Yes    | Yes      |
-
 [parse-duration]: https://golang.org/pkg/time/#ParseDuration

--- a/calico_versioned_docs/version-3.26/reference/resources/networkpolicy.mdx
+++ b/calico_versioned_docs/version-3.26/reference/resources/networkpolicy.mdx
@@ -142,10 +142,3 @@ Application layer policy match criteria are supported with the following restric
 ### HTTPMatch
 
 <Httpmatch />
-
-## Supported operations
-
-| Datastore type           | Create/Delete | Update | Get/List | Notes |
-| ------------------------ | ------------- | ------ | -------- | ----- |
-| etcdv3                   | Yes           | Yes    | Yes      |
-| Kubernetes API datastore | Yes           | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.26/reference/resources/node.mdx
+++ b/calico_versioned_docs/version-3.26/reference/resources/node.mdx
@@ -72,10 +72,3 @@ spec:
 | -------------------- | ----------------------------------------------------------------------------------------- | --------------- | ------ | ------- |
 | interfaceIPv4Address | The IP address and subnet for the IPv4 WireGuard interface created by Felix on this node. | Optional        | string |
 | interfaceIPv6Address | The IP address and subnet for the IPv6 WireGuard interface created by Felix on this node. | Optional        | string |
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes                                                              |
-| --------------------- | ------------- | ------ | -------- | ------------------------------------------------------------------ |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | No            | Yes    | Yes      | `$[nodecontainer]` data is directly tied to the Kubernetes nodes. |

--- a/calico_versioned_docs/version-3.26/reference/resources/profile.mdx
+++ b/calico_versioned_docs/version-3.26/reference/resources/profile.mdx
@@ -44,10 +44,3 @@ spec:
 
 For `Rule` details please see the [NetworkPolicy](networkpolicy.mdx) or
 [GlobalNetworkPolicy](globalnetworkpolicy.mdx) resource.
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes                                                                          |
-| --------------------- | ------------- | ------ | -------- | ------------------------------------------------------------------------------ |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | No            | No     | Yes      | $[prodname] profiles are pre-assigned for each Namespace and Service Account. |

--- a/calico_versioned_docs/version-3.26/reference/resources/workloadendpoint.mdx
+++ b/calico_versioned_docs/version-3.26/reference/resources/workloadendpoint.mdx
@@ -121,10 +121,3 @@ The hostPort and hostIP fields are read-only and determined from Kubernetes host
 These fields are used only when host ports are enabled in Calico.
 
 :::
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes                                                    |
-| --------------------- | ------------- | ------ | -------- | -------------------------------------------------------- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | No            | Yes    | Yes      | WorkloadEndpoints are directly tied to a Kubernetes pod. |

--- a/calico_versioned_docs/version-3.27/reference/resources/bgpconfig.mdx
+++ b/calico_versioned_docs/version-3.27/reference/resources/bgpconfig.mdx
@@ -78,10 +78,3 @@ spec:
 | ----------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
 | cidr        | CIDR for which properties should be advertised. | `cidr: XXX.XXX.XXX.XXX/XX`                                                                                                                                                                                                                                                                                                                                                                                                                               | string         |
 | communities | BGP communities to be advertised.               | Communities can be list of either community names already defined in [communities](#communities) or community value of format `aa:nn` or `aa:nn:mm`. <br/>For standard community, value should be in `aa:nn` format, where both `aa` and `nn` are 16 bit integers.<br/> For large community, value should be `aa:nn:mm` format, where `aa`, `nn` and `mm` are all 32 bit integers. <br/>Where `aa` is an AS Number, `nn` and `mm` are per-AS identifier. | List of string |
-
-## Supported operations
-
-| Datastore type        | Create | Delete | Delete (Global `default`) | Update | Get/List | Notes |
-| --------------------- | ------ | ------ | ------------------------- | ------ | -------- | ----- |
-| etcdv3                | Yes    | Yes    | No                        | Yes    | Yes      |
-| Kubernetes API server | Yes    | Yes    | No                        | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.27/reference/resources/bgpfilter.mdx
+++ b/calico_versioned_docs/version-3.27/reference/resources/bgpfilter.mdx
@@ -86,9 +86,3 @@ spec:
 | source        | Indicator of the source of route          | `RemotePeers` means any route learned from other BGP peers          | string |         |
 | interface     | String to match interface names           | A valid pattern to match interfaces. "*" can be used as a wildcard. | string |         |
 | action        | Action to be taken for this rule          | `Accept` or `Reject`                                                | string |         |
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| Kubernetes API server | Yes           | Yes    | Yes      |       |

--- a/calico_versioned_docs/version-3.27/reference/resources/bgppeer.mdx
+++ b/calico_versioned_docs/version-3.27/reference/resources/bgppeer.mdx
@@ -105,14 +105,6 @@ the cluster will attempt to establish BGP connections with it
 A BGP peer can also be node-specific. When the `node` field is included, only the specified node
 will peer with it. When the `nodeSelector` field is included, the nodes with labels that match that selector
 will peer with it.
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | Yes           | Yes    | Yes      |
-
 ## Selectors
 
 <Selectors />

--- a/calico_versioned_docs/version-3.27/reference/resources/blockaffinity.mdx
+++ b/calico_versioned_docs/version-3.27/reference/resources/blockaffinity.mdx
@@ -22,10 +22,3 @@ A block affinity resource (`BlockAffinity`) represents the affinity for an IPAM 
 | node    | The node that this affinity is assigned to.                                | The hostname of the node            | string  |         |
 | cidr    | The CIDR range this block affinity references.                             | A valid IPv4 or IPv6 CIDR.          | string  |         |
 | deleted | When set to true, clients should treat this block as if it does not exist. | true, false                         | boolean | `false` |
-
-## Supported operations
-
-| Datastore type        | Create | Delete | Update | Get/List | Watch |
-| --------------------- | ------ | ------ | ------ | -------- | ----- |
-| etcdv3                | No     | No     | No     | Yes      | Yes   |
-| Kubernetes API server | No     | No     | No     | Yes      | Yes   |

--- a/calico_versioned_docs/version-3.27/reference/resources/felixconfig.mdx
+++ b/calico_versioned_docs/version-3.27/reference/resources/felixconfig.mdx
@@ -261,10 +261,3 @@ Setting `awsSrcDstCheck` to `Disable` will automatically disable source-destinat
 If there are no policies attached to node roles containing the above statement, attach a new policy. For example, if a node role is `test-cluster-nodeinstance-role`, click on the IAM role in AWS console. In the `Permission policies` list, add a new inline policy with the above statement to the new policy JSON definition. For detailed information, see [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create.html?icmpid=docs_iam_console).
 
 For an EKS cluster, the necessary IAM role and policy is available by default. No further actions are needed.
-
-## Supported operations
-
-| Datastore type        | Create | Delete | Delete (Global `default`) | Update | Get/List | Notes |
-| --------------------- | ------ | ------ | ------------------------- | ------ | -------- | ----- |
-| etcdv3                | Yes    | Yes    | No                        | Yes    | Yes      |       |
-| Kubernetes API server | Yes    | Yes    | No                        | Yes    | Yes      |       |

--- a/calico_versioned_docs/version-3.27/reference/resources/globalnetworkpolicy.mdx
+++ b/calico_versioned_docs/version-3.27/reference/resources/globalnetworkpolicy.mdx
@@ -171,10 +171,3 @@ Application layer policy match criteria are supported with the following restric
 ### HTTPMatch
 
 <Httpmatch />
-
-## Supported operations
-
-| Datastore type           | Create/Delete | Update | Get/List | Notes |
-| ------------------------ | ------------- | ------ | -------- | ----- |
-| etcdv3                   | Yes           | Yes    | Yes      |
-| Kubernetes API datastore | Yes           | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.27/reference/resources/hostendpoint.mdx
+++ b/calico_versioned_docs/version-3.27/reference/resources/hostendpoint.mdx
@@ -107,10 +107,3 @@ spec:
 ### EndpointPort
 
 <Endpointport />
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | Yes           | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.27/reference/resources/ipamconfig.mdx
+++ b/calico_versioned_docs/version-3.27/reference/resources/ipamconfig.mdx
@@ -34,10 +34,3 @@ The resource is a singleton which must have the name `default`.
 | ---------------- | ------------------------------------------------------------------- | --------------- | ------ | --------- |
 | strictAffinity   | When StrictAffinity is true, borrowing IP addresses is not allowed. | true, false     | bool   | false     |
 | maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | 20        |
-
-## Supported operations
-
-| Datastore type        | Create | Delete | Update | Get/List |
-| --------------------- | ------ | ------ | ------ | -------- |
-| etcdv3                | Yes    | Yes    | Yes    | Yes      |
-| Kubernetes API server | Yes    | Yes    | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.27/reference/resources/ippool.mdx
+++ b/calico_versioned_docs/version-3.27/reference/resources/ippool.mdx
@@ -133,13 +133,6 @@ used for manual assignments.
 
 <Selectors />
 
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | Yes           | Yes    | Yes      |
-
 ## See also
 
 The [`IPReservation` resource](ipreservation.mdx) allows for small parts of an IP pool to be reserved so that they will

--- a/calico_versioned_docs/version-3.27/reference/resources/kubecontrollersconfig.mdx
+++ b/calico_versioned_docs/version-3.27/reference/resources/kubecontrollersconfig.mdx
@@ -117,11 +117,4 @@ $[prodname] datastore.
 | ---------------- | ---------------------------------------------------------------- | --------------------------------- | ------- |
 | reconcilerPeriod | Period to perform reconciliation with the $[prodname] datastore | [Duration string][parse-duration] | 5m      |
 
-## Supported operations
-
-| Datastore type        | Create | Delete (Global `default`) | Update | Get/List | Notes |
-| --------------------- | ------ | ------------------------- | ------ | -------- | ----- |
-| etcdv3                | Yes    | Yes                       | Yes    | Yes      |
-| Kubernetes API server | Yes    | Yes                       | Yes    | Yes      |
-
 [parse-duration]: https://golang.org/pkg/time/#ParseDuration

--- a/calico_versioned_docs/version-3.27/reference/resources/networkpolicy.mdx
+++ b/calico_versioned_docs/version-3.27/reference/resources/networkpolicy.mdx
@@ -155,10 +155,3 @@ Application layer policy match criteria are supported with the following restric
 ### HTTPMatch
 
 <Httpmatch />
-
-## Supported operations
-
-| Datastore type           | Create/Delete | Update | Get/List | Notes |
-| ------------------------ | ------------- | ------ | -------- | ----- |
-| etcdv3                   | Yes           | Yes    | Yes      |
-| Kubernetes API datastore | Yes           | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.27/reference/resources/node.mdx
+++ b/calico_versioned_docs/version-3.27/reference/resources/node.mdx
@@ -72,10 +72,3 @@ spec:
 | -------------------- | ----------------------------------------------------------------------------------------- | --------------- | ------ | ------- |
 | interfaceIPv4Address | The IP address and subnet for the IPv4 WireGuard interface created by Felix on this node. | Optional        | string |
 | interfaceIPv6Address | The IP address and subnet for the IPv6 WireGuard interface created by Felix on this node. | Optional        | string |
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes                                                              |
-| --------------------- | ------------- | ------ | -------- | ------------------------------------------------------------------ |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | No            | Yes    | Yes      | `$[nodecontainer]` data is directly tied to the Kubernetes nodes. |

--- a/calico_versioned_docs/version-3.27/reference/resources/profile.mdx
+++ b/calico_versioned_docs/version-3.27/reference/resources/profile.mdx
@@ -44,10 +44,3 @@ spec:
 
 For `Rule` details please see the [NetworkPolicy](networkpolicy.mdx) or
 [GlobalNetworkPolicy](globalnetworkpolicy.mdx) resource.
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes                                                                          |
-| --------------------- | ------------- | ------ | -------- | ------------------------------------------------------------------------------ |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | No            | No     | Yes      | $[prodname] profiles are pre-assigned for each Namespace and Service Account. |

--- a/calico_versioned_docs/version-3.27/reference/resources/workloadendpoint.mdx
+++ b/calico_versioned_docs/version-3.27/reference/resources/workloadendpoint.mdx
@@ -121,10 +121,3 @@ The hostPort and hostIP fields are read-only and determined from Kubernetes host
 These fields are used only when host ports are enabled in Calico.
 
 :::
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes                                                    |
-| --------------------- | ------------- | ------ | -------- | -------------------------------------------------------- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | No            | Yes    | Yes      | WorkloadEndpoints are directly tied to a Kubernetes pod. |

--- a/calico_versioned_docs/version-3.28/reference/resources/bgpconfig.mdx
+++ b/calico_versioned_docs/version-3.28/reference/resources/bgpconfig.mdx
@@ -78,10 +78,3 @@ spec:
 | ----------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
 | cidr        | CIDR for which properties should be advertised. | `cidr: XXX.XXX.XXX.XXX/XX`                                                                                                                                                                                                                                                                                                                                                                                                                               | string         |
 | communities | BGP communities to be advertised.               | Communities can be list of either community names already defined in [communities](#communities) or community value of format `aa:nn` or `aa:nn:mm`. <br/>For standard community, value should be in `aa:nn` format, where both `aa` and `nn` are 16 bit integers.<br/> For large community, value should be `aa:nn:mm` format, where `aa`, `nn` and `mm` are all 32 bit integers. <br/>Where `aa` is an AS Number, `nn` and `mm` are per-AS identifier. | List of string |
-
-## Supported operations
-
-| Datastore type        | Create | Delete | Delete (Global `default`) | Update | Get/List | Notes |
-| --------------------- | ------ | ------ | ------------------------- | ------ | -------- | ----- |
-| etcdv3                | Yes    | Yes    | No                        | Yes    | Yes      |
-| Kubernetes API server | Yes    | Yes    | No                        | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.28/reference/resources/bgpfilter.mdx
+++ b/calico_versioned_docs/version-3.28/reference/resources/bgpfilter.mdx
@@ -86,9 +86,3 @@ spec:
 | source        | Indicator of the source of route          | `RemotePeers` means any route learned from other BGP peers          | string |         |
 | interface     | String to match interface names           | A valid pattern to match interfaces. "*" can be used as a wildcard. | string |         |
 | action        | Action to be taken for this rule          | `Accept` or `Reject`                                                | string |         |
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| Kubernetes API server | Yes           | Yes    | Yes      |       |

--- a/calico_versioned_docs/version-3.28/reference/resources/bgppeer.mdx
+++ b/calico_versioned_docs/version-3.28/reference/resources/bgppeer.mdx
@@ -106,13 +106,6 @@ A BGP peer can also be node-specific. When the `node` field is included, only th
 will peer with it. When the `nodeSelector` field is included, the nodes with labels that match that selector
 will peer with it.
 
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | Yes           | Yes    | Yes      |
-
 ## Selectors
 
 <Selectors />

--- a/calico_versioned_docs/version-3.28/reference/resources/blockaffinity.mdx
+++ b/calico_versioned_docs/version-3.28/reference/resources/blockaffinity.mdx
@@ -22,10 +22,3 @@ A block affinity resource (`BlockAffinity`) represents the affinity for an IPAM 
 | node    | The node that this affinity is assigned to.                                | The hostname of the node            | string  |         |
 | cidr    | The CIDR range this block affinity references.                             | A valid IPv4 or IPv6 CIDR.          | string  |         |
 | deleted | When set to true, clients should treat this block as if it does not exist. | true, false                         | boolean | `false` |
-
-## Supported operations
-
-| Datastore type        | Create | Delete | Update | Get/List | Watch |
-| --------------------- | ------ | ------ | ------ | -------- | ----- |
-| etcdv3                | No     | No     | No     | Yes      | Yes   |
-| Kubernetes API server | No     | No     | No     | Yes      | Yes   |

--- a/calico_versioned_docs/version-3.28/reference/resources/felixconfig.mdx
+++ b/calico_versioned_docs/version-3.28/reference/resources/felixconfig.mdx
@@ -262,10 +262,3 @@ Setting `awsSrcDstCheck` to `Disable` will automatically disable source-destinat
 If there are no policies attached to node roles containing the above statement, attach a new policy. For example, if a node role is `test-cluster-nodeinstance-role`, click on the IAM role in AWS console. In the `Permission policies` list, add a new inline policy with the above statement to the new policy JSON definition. For detailed information, see [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create.html?icmpid=docs_iam_console).
 
 For an EKS cluster, the necessary IAM role and policy is available by default. No further actions are needed.
-
-## Supported operations
-
-| Datastore type        | Create | Delete | Delete (Global `default`) | Update | Get/List | Notes |
-| --------------------- | ------ | ------ | ------------------------- | ------ | -------- | ----- |
-| etcdv3                | Yes    | Yes    | No                        | Yes    | Yes      |       |
-| Kubernetes API server | Yes    | Yes    | No                        | Yes    | Yes      |       |

--- a/calico_versioned_docs/version-3.28/reference/resources/globalnetworkpolicy.mdx
+++ b/calico_versioned_docs/version-3.28/reference/resources/globalnetworkpolicy.mdx
@@ -171,10 +171,3 @@ Application layer policy match criteria are supported with the following restric
 ### HTTPMatch
 
 <Httpmatch />
-
-## Supported operations
-
-| Datastore type           | Create/Delete | Update | Get/List | Notes |
-| ------------------------ | ------------- | ------ | -------- | ----- |
-| etcdv3                   | Yes           | Yes    | Yes      |
-| Kubernetes API datastore | Yes           | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.28/reference/resources/hostendpoint.mdx
+++ b/calico_versioned_docs/version-3.28/reference/resources/hostendpoint.mdx
@@ -107,10 +107,3 @@ spec:
 ### EndpointPort
 
 <Endpointport />
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | Yes           | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.28/reference/resources/ipamconfig.mdx
+++ b/calico_versioned_docs/version-3.28/reference/resources/ipamconfig.mdx
@@ -34,10 +34,3 @@ The resource is a singleton which must have the name `default`.
 | ---------------- | ------------------------------------------------------------------- | --------------- | ------ | --------- |
 | strictAffinity   | When StrictAffinity is true, borrowing IP addresses is not allowed. | true, false     | bool   | false     |
 | maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | 20        |
-
-## Supported operations
-
-| Datastore type        | Create | Delete | Update | Get/List |
-| --------------------- | ------ | ------ | ------ | -------- |
-| etcdv3                | Yes    | Yes    | Yes    | Yes      |
-| Kubernetes API server | Yes    | Yes    | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.28/reference/resources/ippool.mdx
+++ b/calico_versioned_docs/version-3.28/reference/resources/ippool.mdx
@@ -133,13 +133,6 @@ used for manual assignments.
 
 <Selectors />
 
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | Yes           | Yes    | Yes      |
-
 ## See also
 
 The [`IPReservation` resource](ipreservation.mdx) allows for small parts of an IP pool to be reserved so that they will

--- a/calico_versioned_docs/version-3.28/reference/resources/kubecontrollersconfig.mdx
+++ b/calico_versioned_docs/version-3.28/reference/resources/kubecontrollersconfig.mdx
@@ -117,11 +117,4 @@ $[prodname] datastore.
 | ---------------- | ---------------------------------------------------------------- | --------------------------------- | ------- |
 | reconcilerPeriod | Period to perform reconciliation with the $[prodname] datastore | [Duration string][parse-duration] | 5m      |
 
-## Supported operations
-
-| Datastore type        | Create | Delete (Global `default`) | Update | Get/List | Notes |
-| --------------------- | ------ | ------------------------- | ------ | -------- | ----- |
-| etcdv3                | Yes    | Yes                       | Yes    | Yes      |
-| Kubernetes API server | Yes    | Yes                       | Yes    | Yes      |
-
 [parse-duration]: https://golang.org/pkg/time/#ParseDuration

--- a/calico_versioned_docs/version-3.28/reference/resources/networkpolicy.mdx
+++ b/calico_versioned_docs/version-3.28/reference/resources/networkpolicy.mdx
@@ -155,10 +155,3 @@ Application layer policy match criteria are supported with the following restric
 ### HTTPMatch
 
 <Httpmatch />
-
-## Supported operations
-
-| Datastore type           | Create/Delete | Update | Get/List | Notes |
-| ------------------------ | ------------- | ------ | -------- | ----- |
-| etcdv3                   | Yes           | Yes    | Yes      |
-| Kubernetes API datastore | Yes           | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.28/reference/resources/node.mdx
+++ b/calico_versioned_docs/version-3.28/reference/resources/node.mdx
@@ -72,10 +72,3 @@ spec:
 | -------------------- | ----------------------------------------------------------------------------------------- | --------------- | ------ | ------- |
 | interfaceIPv4Address | The IP address and subnet for the IPv4 WireGuard interface created by Felix on this node. | Optional        | string |
 | interfaceIPv6Address | The IP address and subnet for the IPv6 WireGuard interface created by Felix on this node. | Optional        | string |
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes                                                              |
-| --------------------- | ------------- | ------ | -------- | ------------------------------------------------------------------ |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | No            | Yes    | Yes      | `$[nodecontainer]` data is directly tied to the Kubernetes nodes. |

--- a/calico_versioned_docs/version-3.28/reference/resources/profile.mdx
+++ b/calico_versioned_docs/version-3.28/reference/resources/profile.mdx
@@ -44,10 +44,3 @@ spec:
 
 For `Rule` details please see the [NetworkPolicy](networkpolicy.mdx) or
 [GlobalNetworkPolicy](globalnetworkpolicy.mdx) resource.
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes                                                                          |
-| --------------------- | ------------- | ------ | -------- | ------------------------------------------------------------------------------ |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | No            | No     | Yes      | $[prodname] profiles are pre-assigned for each Namespace and Service Account. |

--- a/calico_versioned_docs/version-3.28/reference/resources/workloadendpoint.mdx
+++ b/calico_versioned_docs/version-3.28/reference/resources/workloadendpoint.mdx
@@ -121,10 +121,3 @@ The hostPort and hostIP fields are read-only and determined from Kubernetes host
 These fields are used only when host ports are enabled in Calico.
 
 :::
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes                                                    |
-| --------------------- | ------------- | ------ | -------- | -------------------------------------------------------- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | No            | Yes    | Yes      | WorkloadEndpoints are directly tied to a Kubernetes pod. |

--- a/calico_versioned_docs/version-3.29/reference/resources/bgpconfig.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/bgpconfig.mdx
@@ -78,10 +78,3 @@ spec:
 | ----------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
 | cidr        | CIDR for which properties should be advertised. | `cidr: XXX.XXX.XXX.XXX/XX`                                                                                                                                                                                                                                                                                                                                                                                                                               | string         |
 | communities | BGP communities to be advertised.               | Communities can be list of either community names already defined in [communities](#communities) or community value of format `aa:nn` or `aa:nn:mm`. <br/>For standard community, value should be in `aa:nn` format, where both `aa` and `nn` are 16 bit integers.<br/> For large community, value should be `aa:nn:mm` format, where `aa`, `nn` and `mm` are all 32 bit integers. <br/>Where `aa` is an AS Number, `nn` and `mm` are per-AS identifier. | List of string |
-
-## Supported operations
-
-| Datastore type        | Create | Delete | Delete (Global `default`) | Update | Get/List | Notes |
-| --------------------- | ------ | ------ | ------------------------- | ------ | -------- | ----- |
-| etcdv3                | Yes    | Yes    | No                        | Yes    | Yes      |
-| Kubernetes API server | Yes    | Yes    | No                        | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.29/reference/resources/bgpfilter.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/bgpfilter.mdx
@@ -100,9 +100,3 @@ spec:
 | ------ | --------------------------------------------- | ------------------------------------------------------------------- | ------ | ------- |
 | min    | Smallest matched mask size (0 by default)     | Valid integers between 0 and ipv4/6 max (32, 128)                   | int    |         |
 | max    | Largest matched mask size (32/128 by default) | Valid integers between 1 and ipv4/6 max (32, 128)                   | int    |         |
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| Kubernetes API server | Yes           | Yes    | Yes      |       |

--- a/calico_versioned_docs/version-3.29/reference/resources/bgppeer.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/bgppeer.mdx
@@ -106,13 +106,6 @@ A BGP peer can also be node-specific. When the `node` field is included, only th
 will peer with it. When the `nodeSelector` field is included, the nodes with labels that match that selector
 will peer with it.
 
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | Yes           | Yes    | Yes      |
-
 ## Selectors
 
 <Selectors />

--- a/calico_versioned_docs/version-3.29/reference/resources/blockaffinity.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/blockaffinity.mdx
@@ -22,10 +22,3 @@ A block affinity resource (`BlockAffinity`) represents the affinity for an IPAM 
 | node    | The node that this affinity is assigned to.                                | The hostname of the node            | string  |         |
 | cidr    | The CIDR range this block affinity references.                             | A valid IPv4 or IPv6 CIDR.          | string  |         |
 | deleted | When set to true, clients should treat this block as if it does not exist. | true, false                         | boolean | `false` |
-
-## Supported operations
-
-| Datastore type        | Create | Delete | Update | Get/List | Watch |
-| --------------------- | ------ | ------ | ------ | -------- | ----- |
-| etcdv3                | No     | No     | No     | Yes      | Yes   |
-| Kubernetes API server | No     | No     | No     | Yes      | Yes   |

--- a/calico_versioned_docs/version-3.29/reference/resources/felixconfig.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/felixconfig.mdx
@@ -290,10 +290,3 @@ Setting `awsSrcDstCheck` to `Disable` will automatically disable source-destinat
 If there are no policies attached to node roles containing the above statement, attach a new policy. For example, if a node role is `test-cluster-nodeinstance-role`, click on the IAM role in AWS console. In the `Permission policies` list, add a new inline policy with the above statement to the new policy JSON definition. For detailed information, see [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create.html?icmpid=docs_iam_console).
 
 For an EKS cluster, the necessary IAM role and policy is available by default. No further actions are needed.
-
-## Supported operations
-
-| Datastore type        | Create | Delete | Delete (Global `default`) | Update | Get/List | Notes |
-| --------------------- | ------ | ------ | ------------------------- | ------ | -------- | ----- |
-| etcdv3                | Yes    | Yes    | No                        | Yes    | Yes      |       |
-| Kubernetes API server | Yes    | Yes    | No                        | Yes    | Yes      |       |

--- a/calico_versioned_docs/version-3.29/reference/resources/globalnetworkpolicy.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/globalnetworkpolicy.mdx
@@ -171,10 +171,3 @@ Application layer policy match criteria are supported with the following restric
 ### HTTPMatch
 
 <Httpmatch />
-
-## Supported operations
-
-| Datastore type           | Create/Delete | Update | Get/List | Notes |
-| ------------------------ | ------------- | ------ | -------- | ----- |
-| etcdv3                   | Yes           | Yes    | Yes      |
-| Kubernetes API datastore | Yes           | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.29/reference/resources/hostendpoint.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/hostendpoint.mdx
@@ -107,10 +107,3 @@ spec:
 ### EndpointPort
 
 <Endpointport />
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | Yes           | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.29/reference/resources/ipamconfig.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/ipamconfig.mdx
@@ -34,10 +34,3 @@ The resource is a singleton which must have the name `default`.
 | ---------------- | ------------------------------------------------------------------- | --------------- | ------ | --------- |
 | strictAffinity   | When StrictAffinity is true, borrowing IP addresses is not allowed. | true, false     | bool   | false     |
 | maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | 20        |
-
-## Supported operations
-
-| Datastore type        | Create | Delete | Update | Get/List |
-| --------------------- | ------ | ------ | ------ | -------- |
-| etcdv3                | Yes    | Yes    | Yes    | Yes      |
-| Kubernetes API server | Yes    | Yes    | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.29/reference/resources/ippool.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/ippool.mdx
@@ -133,13 +133,6 @@ used for manual assignments.
 
 <Selectors />
 
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes |
-| --------------------- | ------------- | ------ | -------- | ----- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | Yes           | Yes    | Yes      |
-
 ## See also
 
 The [`IPReservation` resource](ipreservation.mdx) allows for small parts of an IP pool to be reserved so that they will

--- a/calico_versioned_docs/version-3.29/reference/resources/kubecontrollersconfig.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/kubecontrollersconfig.mdx
@@ -117,11 +117,4 @@ $[prodname] datastore.
 | ---------------- | ---------------------------------------------------------------- | --------------------------------- | ------- |
 | reconcilerPeriod | Period to perform reconciliation with the $[prodname] datastore | [Duration string][parse-duration] | 5m      |
 
-## Supported operations
-
-| Datastore type        | Create | Delete (Global `default`) | Update | Get/List | Notes |
-| --------------------- | ------ | ------------------------- | ------ | -------- | ----- |
-| etcdv3                | Yes    | Yes                       | Yes    | Yes      |
-| Kubernetes API server | Yes    | Yes                       | Yes    | Yes      |
-
 [parse-duration]: https://golang.org/pkg/time/#ParseDuration

--- a/calico_versioned_docs/version-3.29/reference/resources/networkpolicy.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/networkpolicy.mdx
@@ -155,10 +155,3 @@ Application layer policy match criteria are supported with the following restric
 ### HTTPMatch
 
 <Httpmatch />
-
-## Supported operations
-
-| Datastore type           | Create/Delete | Update | Get/List | Notes |
-| ------------------------ | ------------- | ------ | -------- | ----- |
-| etcdv3                   | Yes           | Yes    | Yes      |
-| Kubernetes API datastore | Yes           | Yes    | Yes      |

--- a/calico_versioned_docs/version-3.29/reference/resources/node.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/node.mdx
@@ -72,10 +72,3 @@ spec:
 | -------------------- | ----------------------------------------------------------------------------------------- | --------------- | ------ | ------- |
 | interfaceIPv4Address | The IP address and subnet for the IPv4 WireGuard interface created by Felix on this node. | Optional        | string |
 | interfaceIPv6Address | The IP address and subnet for the IPv6 WireGuard interface created by Felix on this node. | Optional        | string |
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes                                                              |
-| --------------------- | ------------- | ------ | -------- | ------------------------------------------------------------------ |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | No            | Yes    | Yes      | `$[nodecontainer]` data is directly tied to the Kubernetes nodes. |

--- a/calico_versioned_docs/version-3.29/reference/resources/profile.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/profile.mdx
@@ -44,10 +44,3 @@ spec:
 
 For `Rule` details please see the [NetworkPolicy](networkpolicy.mdx) or
 [GlobalNetworkPolicy](globalnetworkpolicy.mdx) resource.
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes                                                                          |
-| --------------------- | ------------- | ------ | -------- | ------------------------------------------------------------------------------ |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | No            | No     | Yes      | $[prodname] profiles are pre-assigned for each Namespace and Service Account. |

--- a/calico_versioned_docs/version-3.29/reference/resources/workloadendpoint.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/workloadendpoint.mdx
@@ -121,10 +121,3 @@ The hostPort and hostIP fields are read-only and determined from Kubernetes host
 These fields are used only when host ports are enabled in Calico.
 
 :::
-
-## Supported operations
-
-| Datastore type        | Create/Delete | Update | Get/List | Notes                                                    |
-| --------------------- | ------------- | ------ | -------- | -------------------------------------------------------- |
-| etcdv3                | Yes           | Yes    | Yes      |
-| Kubernetes API server | No            | Yes    | Yes      | WorkloadEndpoints are directly tied to a Kubernetes pod. |


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Previously, we included a section, **Supported operations**, that explained the different operations you could perform on resources, depending on whether you had etcd or kdd datastores.
This was needed because we didn't yet have feature parity between the two datastore types.

But now that we do have feature parity, the table is no longer needed.

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://deploy-preview-1832--tigera.netlify.app/calico/latest/reference/resources/

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->
