### PR TITLE
Apply operator-crds.yaml before creating custom resources

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/docker-enterprise.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/docker-enterprise.mdx
@@ -86,9 +86,10 @@ The geeky details of what you get:
 
 1. Install any extra [$[prodname] resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resource definitions and custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
 
    ```bash
+   kubectl create -f $[filesUrl]/manifests/operator-crds.yaml
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml
    ```
 

--- a/calico-enterprise/getting-started/install-on-clusters/kubernetes/quickstart.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/kubernetes/quickstart.mdx
@@ -121,9 +121,10 @@ A Linux host that meets the following requirements.
    curl -O -L $[filesUrl]/manifests/custom-resources.yaml
    ```
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+1. Install the Tigera custom resource definitions and custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
 
    ```bash
+   kubectl create -f $[filesUrl]/manifests/operator-crds.yaml
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml
    ```
 

--- a/calico-enterprise/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/rancher.mdx
@@ -85,9 +85,10 @@ The geeky details of what you get:
 
 1. Install any extra [$[prodname] resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resource definitions and custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
 
    ```bash
+   kubectl create -f $[filesUrl]/manifests/operator-crds.yaml
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml
    ```
 

--- a/calico-enterprise/getting-started/install-on-clusters/windows-calico/rancher.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/windows-calico/rancher.mdx
@@ -87,9 +87,10 @@ The following steps will outline the installation of $[prodname] networking on t
 
    :::
 
-1. Apply the updated custom resources:
+1. Apply the Tigera custom resource definitions and updated custom resources:
 
    ```bash
+   kubectl create -f $[filesUrl]/manifests/operator-crds.yaml
    kubectl create -f custom-resources.yaml
    ```
 

--- a/calico-enterprise/getting-started/manifest-archive.mdx
+++ b/calico-enterprise/getting-started/manifest-archive.mdx
@@ -50,9 +50,10 @@ In the patch release archive, navigate to the `manifests` folder.
       kubectl create -f <your-local-directory-archive>/manifests/tigera-prometheus-operator.yaml
       ```
 
-   3. Install Tigera custom resources.
+   3. Install Tigera custom resource definitions and custom resources.
 
       ```bash
+      kubectl create -f <your-local-directory-archive>/manifests/operator-crds.yaml
       kubectl create -f <your-local-directory-archive>/manifests/custom-resources.yaml
       ```
 

--- a/calico-enterprise/multicluster/change-cluster-type.mdx
+++ b/calico-enterprise/multicluster/change-cluster-type.mdx
@@ -171,9 +171,10 @@ If you wish to retain LogStorage data for your managed cluster, verify that the 
    kubectl delete managedcluster <managed-cluster-name>
    ```
 
-1. Install the Tigera custom resources.
+1. Install the Tigera custom resource definitions and custom resources.
    For more information, see [the installation reference](../reference/installation/api.mdx).
    ```bash
+   kubectl apply -f $[filesUrl]/manifests/operator-crds.yaml
    kubectl apply -f $[filesUrl]/manifests/custom-resources.yaml
    ```
 1. Monitor the progress with the following command:

--- a/calico-enterprise/operations/ebpf/install.mdx
+++ b/calico-enterprise/operations/ebpf/install.mdx
@@ -317,9 +317,10 @@ spec:
   variant: TigeraSecureEnterprise
   ```
 
-Then apply the edited file:
+Then apply the Tigera custom resource definitions and the edited file:
 
 ```bash
+kubectl create -f $[filesUrl]/manifests/operator-crds.yaml
 kubectl create -f custom-resources.yaml
 ```
 

--- a/calico/getting-started/kubernetes/k3s/multi-node-install.mdx
+++ b/calico/getting-started/kubernetes/k3s/multi-node-install.mdx
@@ -106,9 +106,10 @@ Due to the large size of the CRD bundle, `kubectl apply` might exceed request li
 
 :::
 
-Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+Install $[prodname] by creating the necessary custom resource definitions and custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
 
 ```bash
+kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
 kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml
 ```
 

--- a/calico/getting-started/kubernetes/k3s/quickstart.mdx
+++ b/calico/getting-started/kubernetes/k3s/quickstart.mdx
@@ -77,9 +77,10 @@ Due to the large size of the CRD bundle, `kubectl apply` might exceed request li
 
 :::
 
-2. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+2. Install $[prodname] by creating the necessary custom resource definitions and custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
 
 ```bash
+kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
 kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml
 ```
 

--- a/calico/getting-started/kubernetes/kind.mdx
+++ b/calico/getting-started/kubernetes/kind.mdx
@@ -84,7 +84,7 @@ dev-worker2         NotReady    <none>          4m     v1.25.0   172.18.0.3    <
 kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
 ```
 
-2. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+2. Install $[prodname] by creating the necessary custom resource definitions and custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
 
 :::note
 
@@ -94,6 +94,7 @@ if you have replaced `pod-network-cidr` you must change it in this file as well.
 :::
 
 ```bash
+kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
 kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml
 ```
 

--- a/calico/getting-started/kubernetes/minikube.mdx
+++ b/calico/getting-started/kubernetes/minikube.mdx
@@ -69,7 +69,7 @@ minikube start --cni=calico
 
    :::
 
-3. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+3. Install $[prodname] by creating the necessary custom resource definitions and custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
 
    :::note
 
@@ -79,6 +79,7 @@ minikube start --cni=calico
    :::
 
    ```bash
+   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
    kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml
    ```
 

--- a/calico/getting-started/kubernetes/nftables.mdx
+++ b/calico/getting-started/kubernetes/nftables.mdx
@@ -104,7 +104,7 @@ Installing $[prodname] in nftables mode provides a networking and network policy
 
    :::
 
-1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install $[prodname] by creating the necessary custom resource definitions and custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
 
    ```bash
    cat > custom-resources.yaml <<EOF
@@ -132,6 +132,7 @@ Installing $[prodname] in nftables mode provides a networking and network policy
    ```
 
    ```bash
+   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
    kubectl create -f custom-resources.yaml
    ```
 

--- a/calico/getting-started/kubernetes/quickstart.mdx
+++ b/calico/getting-started/kubernetes/quickstart.mdx
@@ -100,9 +100,10 @@ The geeky details of what you get:
 
    :::
 
-1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install $[prodname] by creating the necessary custom resource definitions and custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
 
    ```
+   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
    kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml
    ```
 

--- a/calico/getting-started/kubernetes/rancher.mdx
+++ b/calico/getting-started/kubernetes/rancher.mdx
@@ -54,9 +54,10 @@ The geeky details of what you get:
 
    :::
 
-1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install $[prodname] by creating the necessary custom resource definitions and custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
 
    ```
+   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
    kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml
    ```
 

--- a/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
+++ b/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
@@ -54,9 +54,10 @@ $[prodname] can also be installed using raw manifests as an alternative to the o
 
    If you wish to customize the $[prodname] install, customize the downloaded custom-resources.yaml manifest locally.
 
-1. Create the manifest to install $[prodname].
+1. Create the custom resource definitions and the manifest to install $[prodname].
 
    ```
+   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
    kubectl create -f custom-resources.yaml
    ```
 

--- a/calico/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
+++ b/calico/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
@@ -201,9 +201,10 @@ worker-2     NotReady   <none>   5s      v1.17.2
   curl $[manifestsUrl]/manifests/custom-resources.yaml -O
   ```
 
-3. If you wish to customize the $[prodname] install, customize the downloaded custom-resources.yaml manifest. Then create the manifest to install $[prodname].
+3. If you wish to customize the $[prodname] install, customize the downloaded custom-resources.yaml manifest. Then create the custem resource definitions and downloaded manifest to install $[prodname].
 
   ```bash
+  kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
   kubectl create -f custom-resources.yaml
   ```
 

--- a/calico/getting-started/kubernetes/windows-calico/rancher.mdx
+++ b/calico/getting-started/kubernetes/windows-calico/rancher.mdx
@@ -99,9 +99,10 @@ The following steps will outline the installation of $[prodname] networking on t
 
    :::
 
-1. Apply the updated custom resources:
+1. Apply the custom resource definitions and the updated custom resources:
 
    ```bash
+   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
    kubectl create -f custom-resources.yaml
    ```
 

--- a/calico/operations/ebpf/install.mdx
+++ b/calico/operations/ebpf/install.mdx
@@ -345,9 +345,10 @@ metadata:
 spec: {}  
 ```
 
-Then apply the edited file:
+Then apply the custom resource definitions and the edited file:
 
 ```bash
+kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
 kubectl create -f custom-resources.yaml
 ```
 


### PR DESCRIPTION
Add command to create/apply operator-crds.yaml before custom-resources.yaml (installation, etc) to ensure CRDs are present.

With the recent changes to the operator to manage CRDs, they are no longer included in the tigera-operator.yaml manifest, so there might be timing issues where the installation and other custom resources are attempted to be created before their definitions are present in the cluster.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->