### PR TITLE
Add example for Role, RoleBinding and Secret to configure BGP passwords

### DIFF
--- a/calico/reference/resources/bgppeer.mdx
+++ b/calico/reference/resources/bgppeer.mdx
@@ -91,7 +91,7 @@ secret must be in the same namespace as the $[nodecontainer] pod.
 
 :::warning
 
-Calico must be able to read the referenced secret!
+$[prodname] must be able to read the referenced secret!
 
 This means that the `calico-node` ServiceAccount must have permissions to `list, get, watch` the secret referenced in the KeyRef.
 
@@ -105,7 +105,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: bgp-passwords-reader
-  namespace: kube-system
+  namespace: $NAMESPACE_IN_WHICH_CALICO_IS_RUNNING
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -117,7 +117,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: calico-read-bgp-passwords
-  namespace: kube-system
+  namespace: $NAMESPACE_IN_WHICH_CALICO_IS_RUNNING
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -131,7 +131,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "bgp-passwords"
-  namespace: kube-system
+  namespace: $NAMESPACE_IN_WHICH_CALICO_IS_RUNNING
 data:
   peer_a_pw: "base64-encoded Password for Peer A"
   peer_b_pw: "base64-encoded Password for Peer B"

--- a/calico/reference/resources/bgppeer.mdx
+++ b/calico/reference/resources/bgppeer.mdx
@@ -89,6 +89,78 @@ secret must be in the same namespace as the $[nodecontainer] pod.
 | name  | The name of the secret    | string |
 | key   | The key within the secret | string |
 
+:::warning
+
+Calico must be able to read the referenced secret!
+
+This means that the `calico-node` ServiceAccount must have permissions to `list, get, watch` the secret referenced in the KeyRef.
+
+In practice, this can be done by creating a Role (which allows to `list, get, watch` the secret) and a RoleBinding (which grants the Role's permission to the `calico-node` ServiceAccount).
+
+Example:
+
+```yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: bgp-passwords-reader
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["bgp-passwords"]
+    verbs: ["list", "watch", "get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: calico-read-bgp-passwords
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: bgp-passwords-reader
+subjects:
+  - kind: ServiceAccount
+    name: calico-node
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "bgp-passwords"
+  namespace: kube-system
+data:
+  peer_a_pw: "base64-encoded Password for Peer A"
+  peer_b_pw: "base64-encoded Password for Peer B"
+
+---
+apiVersion: crd.projectcalico.org/v1
+kind: BGPPeer
+metadata:
+  name: "peer-a"
+spec:
+  password:
+    secretKeyRef:
+      name: "bgp-passwords"
+      key: "peer_a_pw"
+
+---
+apiVersion: crd.projectcalico.org/v1
+kind: BGPPeer
+metadata:
+  name: "peer-b"
+spec:
+  password:
+    secretKeyRef:
+      name: "bgp-passwords"
+      key: "peer_b_pw"
+```
+
+:::
+
 ## Peer scopes
 
 BGP Peers can exist at either global or node-specific scope. A peer's scope

--- a/calico/reference/resources/bgppeer.mdx
+++ b/calico/reference/resources/bgppeer.mdx
@@ -91,7 +91,7 @@ secret must be in the same namespace as the $[nodecontainer] pod.
 
 :::warning
 
-$[prodname] must be able to read the referenced secret!
+$[prodname] must be able to read the referenced secret.
 
 This means that the `calico-node` ServiceAccount must have permissions to `list, get, watch` the secret referenced in the KeyRef.
 

--- a/calico/reference/resources/bgppeer.mdx
+++ b/calico/reference/resources/bgppeer.mdx
@@ -105,7 +105,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: bgp-passwords-reader
-  namespace: $NAMESPACE_IN_WHICH_CALICO_IS_RUNNING
+  namespace: calico-system # Or kube-system if installed using manifests.
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -117,7 +117,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: calico-read-bgp-passwords
-  namespace: $NAMESPACE_IN_WHICH_CALICO_IS_RUNNING
+  namespace: calico-system # Or kube-system if installed using manifests.
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -131,7 +131,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "bgp-passwords"
-  namespace: $NAMESPACE_IN_WHICH_CALICO_IS_RUNNING
+  namespace: calico-system # Or kube-system if installed using manifests.
 data:
   peer_a_pw: "base64-encoded Password for Peer A"
   peer_b_pw: "base64-encoded Password for Peer B"


### PR DESCRIPTION
Product Version(s):
Calico

Issue:
fixes projectcalico/calico#6893

Link to docs preview:
[CLICK](https://deploy-preview-1837--calico-docs-preview-next.netlify.app/calico/next/reference/resources/bgppeer#keyref)

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:

The Docs (in the reource definition for BGP peers) show that BGP Passwords must be stored in a Secret and then be referenced via the `KeyRef` (name of the secret and the key within that secret).

BUT it does not mention that this requires additional privileges for the `calico-node` ServiceAccount to access this secret.

It obviously makes sense if you think about it, but IMO it would make a lot of sense to mention that somewhere - see also @caseydavenport comments in projectcalico/calico#6893

I _think_ the included example might be a bit over the top, maybe there is a way to make it show only partially by default and expand on click or something?

I am not exactly familiar with mdx unfortunately.

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 