### PR TITLE
update supported k8s version for 3.20-EP2

### DIFF
--- a/calico-enterprise/getting-started/compatibility.mdx
+++ b/calico-enterprise/getting-started/compatibility.mdx
@@ -53,7 +53,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | $[prodname] version | kOps and Kubernetes versions | $[prodname] support                                                                   |
 | -------------------- | ---------------------------- | -------------------------------------------------------------------------------------- |
-| 3.20                 | 1.28 - 1.30                  | - $[prodname] CNI with network policy<br />- AWS CNI with $[prodname] network policy |
+| 3.20                 | 1.29 - 1.30                  | - $[prodname] CNI with network policy<br />- AWS CNI with $[prodname] network policy |
 | 3.19                 | 1.28 - 1.29                  | - $[prodname] CNI with network policy<br />- AWS CNI with $[prodname] network policy |
 | 3.18                 | 1.26 - 1.28                  | - $[prodname] CNI with network policy<br />- AWS CNI with $[prodname] network policy |
 
@@ -61,7 +61,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | $[prodname] version | Kubernetes/kubeadm versions | $[prodname] support                 |
 | -------------------- | --------------------------- | ------------------------------------ |
-| 3.20                 | 1.28 - 1.30                 | $[prodname] CNI with network policy |
+| 3.20                 | 1.29 - 1.31                 | $[prodname] CNI with network policy |
 | 3.19                 | 1.28 - 1.30                 | $[prodname] CNI with network policy |
 | 3.18                 | 1.26 - 1.28                 | $[prodname] CNI with network policy |
 
@@ -85,7 +85,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | $[prodname] version | RKE version | $[prodname] support                 | Kubernetes versions |
 | -------------------- | ----------- | ------------------------------------ | ------------------- |
-| 3.20                 | 1.5         | $[prodname] CNI with network policy | 1.28                |
+| 3.20                 | 1.5         | $[prodname] CNI with network policy | 1.29                |
 | 3.19                 | 1.5         | $[prodname] CNI with network policy | 1.28                |
 | 3.18                 | 1.4         | $[prodname] CNI with network policy | 1.26                |
 
@@ -93,7 +93,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | $[prodname] version | $[prodname] support                 | Kubernetes versions |
 | -------------------- | ------------------------------------ | ------------------- |
-| 3.20                 | $[prodname] CNI with network policy | 1.28 - 1.30         |
+| 3.20                 | $[prodname] CNI with network policy | 1.29 - 1.30         |
 | 3.19                 | $[prodname] CNI with network policy | 1.28 - 1.30         |
 | 3.18                 | $[prodname] CNI with network policy | 1.26 - 1.28         |
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/compatibility.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/compatibility.mdx
@@ -53,7 +53,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | $[prodname] version | kOps and Kubernetes versions | $[prodname] support                                                                   |
 | -------------------- | ---------------------------- | -------------------------------------------------------------------------------------- |
-| 3.20                 | 1.28 - 1.30                  | - $[prodname] CNI with network policy<br />- AWS CNI with $[prodname] network policy |
+| 3.20                 | 1.29 - 1.30                  | - $[prodname] CNI with network policy<br />- AWS CNI with $[prodname] network policy |
 | 3.19                 | 1.28 - 1.29                  | - $[prodname] CNI with network policy<br />- AWS CNI with $[prodname] network policy |
 | 3.18                 | 1.26 - 1.28                  | - $[prodname] CNI with network policy<br />- AWS CNI with $[prodname] network policy |
 
@@ -61,7 +61,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | $[prodname] version | Kubernetes/kubeadm versions | $[prodname] support                 |
 | -------------------- | --------------------------- | ------------------------------------ |
-| 3.20                 | 1.28 - 1.30                 | $[prodname] CNI with network policy |
+| 3.20                 | 1.29 - 1.31                 | $[prodname] CNI with network policy |
 | 3.19                 | 1.28 - 1.30                 | $[prodname] CNI with network policy |
 | 3.18                 | 1.26 - 1.28                 | $[prodname] CNI with network policy |
 
@@ -85,7 +85,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | $[prodname] version | RKE version | $[prodname] support                 | Kubernetes versions |
 | -------------------- | ----------- | ------------------------------------ | ------------------- |
-| 3.20                 | 1.5         | $[prodname] CNI with network policy | 1.28                |
+| 3.20                 | 1.5         | $[prodname] CNI with network policy | 1.29                |
 | 3.19                 | 1.5         | $[prodname] CNI with network policy | 1.28                |
 | 3.18                 | 1.4         | $[prodname] CNI with network policy | 1.26                |
 
@@ -93,7 +93,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | $[prodname] version | $[prodname] support                 | Kubernetes versions |
 | -------------------- | ------------------------------------ | ------------------- |
-| 3.20                 | $[prodname] CNI with network policy | 1.28 - 1.30         |
+| 3.20                 | $[prodname] CNI with network policy | 1.29 - 1.30         |
 | 3.19                 | $[prodname] CNI with network policy | 1.28 - 1.30         |
 | 3.18                 | $[prodname] CNI with network policy | 1.26 - 1.28         |
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->
Calico Enterprise 3.20-EP2.

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->
The current supported k8s versions for CE 3.20-EP2 is not accurate. This change updates it to depict k8s 1.31 support.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->