### PR TITLE
RS-2231 Remove steps to manually manage policy sync path 

### DIFF
--- a/calico-cloud/threat/web-application-firewall.mdx
+++ b/calico-cloud/threat/web-application-firewall.mdx
@@ -97,15 +97,7 @@ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/microserv
 
 #### Enable WAF using the CLI
 
-##### Enable the Policy Sync API in Felix
-To enable WAF using the CLI, you must enable the Policy Sync API in Felix. To do this cluster-wide,
-modify the `default` FelixConfiguration to set the field `policySyncPathPrefix` to `/var/run/nodeagent`:
-
-```bash
-kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"policySyncPathPrefix":"/var/run/nodeagent"}}'
-```
-
-##### Enable WAF using kubectl
+##### Using kubectl
 
 In the ApplicationLayer custom resource, named `tigera-secure`, set the `webApplicationFirewall` field to `Enabled`.
 

--- a/calico-cloud/visibility/elastic/l7/configure.mdx
+++ b/calico-cloud/visibility/elastic/l7/configure.mdx
@@ -50,14 +50,6 @@ Note removed for CC
 
 ### Configure Felix for log data collection
 
-1. Enable the Policy Sync API in Felix.
-
-   For cluster-wide enablement, modify the `default` FelixConfiguration and set the field `policySyncPathPrefix` to `/var/run/nodeagent`.
-
-   ```bash
-   kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"policySyncPathPrefix":"/var/run/nodeagent"}}'
-   ```
-
 1. Configure L7 log aggregation, retention, and reporting.
 
    For help, see [Felix Configuration documentation](../../../reference/component-resources/node/felix/configuration.mdx#calico-enterprise-specific-configuration).

--- a/calico-cloud_versioned_docs/version-20-2/threat/web-application-firewall.mdx
+++ b/calico-cloud_versioned_docs/version-20-2/threat/web-application-firewall.mdx
@@ -97,15 +97,7 @@ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/microserv
 
 #### Enable WAF using the CLI
 
-##### Enable the Policy Sync API in Felix
-To enable WAF using the CLI, you must enable the Policy Sync API in Felix. To do this cluster-wide,
-modify the `default` FelixConfiguration to set the field `policySyncPathPrefix` to `/var/run/nodeagent`:
-
-```bash
-kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"policySyncPathPrefix":"/var/run/nodeagent"}}'
-```
-
-##### Enable WAF using kubectl
+##### Using kubectl
 
 In the ApplicationLayer custom resource, named `tigera-secure`, set the `webApplicationFirewall` field to `Enabled`.
 

--- a/calico-cloud_versioned_docs/version-20-2/visibility/elastic/l7/configure.mdx
+++ b/calico-cloud_versioned_docs/version-20-2/visibility/elastic/l7/configure.mdx
@@ -50,14 +50,6 @@ Note removed for CC
 
 ### Configure Felix for log data collection
 
-1. Enable the Policy Sync API in Felix.
-
-   For cluster-wide enablement, modify the `default` FelixConfiguration and set the field `policySyncPathPrefix` to `/var/run/nodeagent`.
-
-   ```bash
-   kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"policySyncPathPrefix":"/var/run/nodeagent"}}'
-   ```
-
 1. Configure L7 log aggregation, retention, and reporting.
 
    For help, see [Felix Configuration documentation](../../../reference/component-resources/node/felix/configuration.mdx#calico-enterprise-specific-configuration).

--- a/calico-enterprise/threat/web-application-firewall.mdx
+++ b/calico-enterprise/threat/web-application-firewall.mdx
@@ -64,16 +64,7 @@ If you enable WAF for deployments that are part of the Kubernetes system itself,
 
 ### Enable WAF using the CLI
 
-#### Enable the Policy Sync API in Felix
-
-To enable WAF using the CLI, you must enable the Policy Sync API in Felix. To do this cluster-wide,
-modify the `default` FelixConfiguration to set the field `policySyncPathPrefix` to `/var/run/nodeagent`:
-
-```bash
-kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"policySyncPathPrefix":"/var/run/nodeagent"}}'
-```
-
-#### Enable WAF using kubectl
+#### Using kubectl
 
 Create an (or edit an existing) ApplicationLayer resource named `tigera-secure`, set the `sidecarInjection` field to `Enabled`.
 

--- a/calico-enterprise/visibility/elastic/l7/configure.mdx
+++ b/calico-enterprise/visibility/elastic/l7/configure.mdx
@@ -51,14 +51,6 @@ L7 logs require a minimum of 1 additional GB of log storage per node, per one-da
 
 ## Configure Felix for log data collection
 
-1. Enable the Policy Sync API in Felix.
-
-   For cluster-wide enablement, modify the `default` FelixConfiguration and set the field `policySyncPathPrefix` to `/var/run/nodeagent`.
-
-   ```bash
-   kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"policySyncPathPrefix":"/var/run/nodeagent"}}'
-   ```
-
 1. Configure L7 log aggregation, retention, and reporting.
 
    For help, see [Felix Configuration documentation](../../../reference/component-resources/node/felix/configuration.mdx#calico-enterprise-specific-configuration).

--- a/calico-enterprise_versioned_docs/version-3.19-2/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/threat/web-application-firewall.mdx
@@ -96,15 +96,7 @@ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/microserv
 
 #### Enable WAF using the CLI
 
-##### Enable the Policy Sync API in Felix
-To enable WAF using the CLI, you must enable the Policy Sync API in Felix. To do this cluster-wide,
-modify the `default` FelixConfiguration to set the field `policySyncPathPrefix` to `/var/run/nodeagent`:
-
-```bash
-kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"policySyncPathPrefix":"/var/run/nodeagent"}}'
-```
-
-##### Enable WAF using kubectl
+##### Using kubectl
 
 In the ApplicationLayer custom resource, named `tigera-secure`, set the `webApplicationFirewall` field to `Enabled`.
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/visibility/elastic/l7/configure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/visibility/elastic/l7/configure.mdx
@@ -53,14 +53,6 @@ L7 logs require a minimum of 1 additional GB of log storage per node, per one-da
 
 ### Configure Felix for log data collection
 
-1. Enable the Policy Sync API in Felix.
-
-   For cluster-wide enablement, modify the `default` FelixConfiguration and set the field `policySyncPathPrefix` to `/var/run/nodeagent`.
-
-   ```bash
-   kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"policySyncPathPrefix":"/var/run/nodeagent"}}'
-   ```
-
 1. Configure L7 log aggregation, retention, and reporting.
 
    For help, see [Felix Configuration documentation](../../../reference/component-resources/node/felix/configuration.mdx#calico-enterprise-specific-configuration).

--- a/calico-enterprise_versioned_docs/version-3.20-1/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/threat/web-application-firewall.mdx
@@ -96,15 +96,7 @@ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/microserv
 
 #### Enable WAF using the CLI
 
-##### Enable the Policy Sync API in Felix
-To enable WAF using the CLI, you must enable the Policy Sync API in Felix. To do this cluster-wide,
-modify the `default` FelixConfiguration to set the field `policySyncPathPrefix` to `/var/run/nodeagent`:
-
-```bash
-kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"policySyncPathPrefix":"/var/run/nodeagent"}}'
-```
-
-##### Enable WAF using kubectl
+##### Using kubectl
 
 In the ApplicationLayer custom resource, named `tigera-secure`, set the `webApplicationFirewall` field to `Enabled`.
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/visibility/elastic/l7/configure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/visibility/elastic/l7/configure.mdx
@@ -51,15 +51,7 @@ L7 logs require a minimum of 1 additional GB of log storage per node, per one-da
 - [Configure L7 logs](#configure-l7-logs)
 - [View L7 logs in Manager UI](#view-l7-logs-in-manager-ui)
 
-### Configure Felix for log data collection
-
-1. Enable the Policy Sync API in Felix.
-
-   For cluster-wide enablement, modify the `default` FelixConfiguration and set the field `policySyncPathPrefix` to `/var/run/nodeagent`.
-
-   ```bash
-   kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"policySyncPathPrefix":"/var/run/nodeagent"}}'
-   ```
+### Configure Felix for log data logCollection
 
 1. Configure L7 log aggregation, retention, and reporting.
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/threat/web-application-firewall.mdx
@@ -65,16 +65,7 @@ If you enable WAF for deployments that are part of the Kubernetes system itself,
 
 ### Enable WAF using the CLI
 
-#### Enable the Policy Sync API in Felix
-
-To enable WAF using the CLI, you must enable the Policy Sync API in Felix. To do this cluster-wide,
-modify the `default` FelixConfiguration to set the field `policySyncPathPrefix` to `/var/run/nodeagent`:
-
-```bash
-kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"policySyncPathPrefix":"/var/run/nodeagent"}}'
-```
-
-#### Enable WAF using kubectl
+#### Using kubectl
 
 In the ApplicationLayer custom resource, named `tigera-secure`, set the `sidecarInjection` field to `Enabled`.
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/visibility/elastic/l7/configure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/visibility/elastic/l7/configure.mdx
@@ -51,14 +51,6 @@ L7 logs require a minimum of 1 additional GB of log storage per node, per one-da
 
 ## Configure Felix for log data collection
 
-1. Enable the Policy Sync API in Felix.
-
-   For cluster-wide enablement, modify the `default` FelixConfiguration and set the field `policySyncPathPrefix` to `/var/run/nodeagent`.
-
-   ```bash
-   kubectl patch felixconfiguration default --type='merge' -p '{"spec":{"policySyncPathPrefix":"/var/run/nodeagent"}}'
-   ```
-
 1. Configure L7 log aggregation, retention, and reporting.
 
    For help, see [Felix Configuration documentation](../../../reference/component-resources/node/felix/configuration.mdx#calico-enterprise-specific-configuration).


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Since CE 3.19, Tigera Operator already manages this setting for the user. 3.18 and below requires manually setting this path.


Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->