### PR TITLE
Fix mistaken repetition on component versions pages

### DIFF
--- a/calico-enterprise/_includes/components/ComponentVersions.js
+++ b/calico-enterprise/_includes/components/ComponentVersions.js
@@ -17,9 +17,6 @@ export default function ComponentVersions() {
     <>
       {releases.map((release) => (
         <div key={release.title}>
-          <p>
-            This page lists the specific component versions that go into {variables.prodname} patch releases.
-          </p>
           <Heading
             as='h2'
             id={`component-versions-${toKebab(release.title)}`}

--- a/calico-enterprise/reference/component-versions.mdx
+++ b/calico-enterprise/reference/component-versions.mdx
@@ -6,8 +6,6 @@ import ComponentVersions from '@site/calico-enterprise/_includes/components/Comp
 
 # Component versions
 
-<p>
-  This page lists the specific component versions that go into each {variables.prodname} release.
-</p>
+This page lists the specific component versions that go into each {{prodname}} release.
 
 <ComponentVersions />

--- a/calico-enterprise/reference/component-versions.mdx
+++ b/calico-enterprise/reference/component-versions.mdx
@@ -6,6 +6,6 @@ import ComponentVersions from '@site/calico-enterprise/_includes/components/Comp
 
 # Component versions
 
-This page lists the specific component versions that go into each {{prodname}} release.
+This page lists the specific component versions that go into each release of $[prodname].
 
 <ComponentVersions />

--- a/calico-enterprise/reference/component-versions.mdx
+++ b/calico-enterprise/reference/component-versions.mdx
@@ -6,4 +6,8 @@ import ComponentVersions from '@site/calico-enterprise/_includes/components/Comp
 
 # Component versions
 
+<p>
+  This page lists the specific component versions that go into each {variables.prodname} release.
+</p>
+
 <ComponentVersions />

--- a/calico-enterprise_versioned_docs/version-3.18-2/_includes/components/ComponentVersions.js
+++ b/calico-enterprise_versioned_docs/version-3.18-2/_includes/components/ComponentVersions.js
@@ -17,9 +17,6 @@ export default function ComponentVersions() {
     <>
       {releases.map((release) => (
         <div key={release.title}>
-          <p>
-            This page lists the specific component versions that go into {variables.prodname} patch releases.
-          </p>
           <Heading
             as='h2'
             id={`component-versions-${toKebab(release.title)}`}

--- a/calico-enterprise_versioned_docs/version-3.18-2/reference/component-versions.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/reference/component-versions.mdx
@@ -6,4 +6,6 @@ import ComponentVersions from '@site/calico-enterprise_versioned_docs/version-3.
 
 # Component versions
 
+This page lists the specific component versions that go into each release of $[prodname].
+
 <ComponentVersions />

--- a/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/ComponentVersions.js
+++ b/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/ComponentVersions.js
@@ -17,9 +17,6 @@ export default function ComponentVersions() {
     <>
       {releases.map((release) => (
         <div key={release.title}>
-          <p>
-            This page lists the specific component versions that go into {variables.prodname} patch releases.
-          </p>
           <Heading
             as='h2'
             id={`component-versions-${toKebab(release.title)}`}

--- a/calico-enterprise_versioned_docs/version-3.19-2/reference/component-versions.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/reference/component-versions.mdx
@@ -6,4 +6,6 @@ import ComponentVersions from '@site/calico-enterprise_versioned_docs/version-3.
 
 # Component versions
 
+This page lists the specific component versions that go into each release of $[prodname].
+
 <ComponentVersions />

--- a/calico-enterprise_versioned_docs/version-3.20-1/_includes/components/ComponentVersions.js
+++ b/calico-enterprise_versioned_docs/version-3.20-1/_includes/components/ComponentVersions.js
@@ -17,9 +17,6 @@ export default function ComponentVersions() {
     <>
       {releases.map((release) => (
         <div key={release.title}>
-          <p>
-            This page lists the specific component versions that go into {variables.prodname} patch releases.
-          </p>
           <Heading
             as='h2'
             id={`component-versions-${toKebab(release.title)}`}

--- a/calico-enterprise_versioned_docs/version-3.20-1/reference/component-versions.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/reference/component-versions.mdx
@@ -6,4 +6,6 @@ import ComponentVersions from '@site/calico-enterprise_versioned_docs/version-3.
 
 # Component versions
 
+This page lists the specific component versions that go into each release of $[prodname].
+
 <ComponentVersions />

--- a/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/ComponentVersions.js
+++ b/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/ComponentVersions.js
@@ -17,9 +17,6 @@ export default function ComponentVersions() {
     <>
       {releases.map((release) => (
         <div key={release.title}>
-          <p>
-            This page lists the specific component versions that go into {variables.prodname} patch releases.
-          </p>
           <Heading
             as='h2'
             id={`component-versions-${toKebab(release.title)}`}

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/component-versions.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/component-versions.mdx
@@ -6,4 +6,6 @@ import ComponentVersions from '@site/calico-enterprise_versioned_docs/version-3.
 
 # Component versions
 
+This page lists the specific component versions that go into each release of $[prodname].
+
 <ComponentVersions />

--- a/calico/_includes/components/ComponentVersions.js
+++ b/calico/_includes/components/ComponentVersions.js
@@ -17,9 +17,6 @@ export default function ComponentVersions() {
     <>
       {releases.map((release) => (
         <div key={release.title}>
-          <p>
-            This page lists the specific component versions that go into {variables.prodname} patch releases.
-          </p>
           <Heading
             as='h2'
             id={`component-versions-${toKebab(release.title)}`}

--- a/calico/reference/component-versions.mdx
+++ b/calico/reference/component-versions.mdx
@@ -6,6 +6,6 @@ import ComponentVersions from '@site/calico/_includes/components/ComponentVersio
 
 # Component versions
 
-This page lists the specific component versions that go into each {{prodname}} release.
+This page lists the specific component versions that go into each release of $[prodname].
 
 <ComponentVersions />

--- a/calico/reference/component-versions.mdx
+++ b/calico/reference/component-versions.mdx
@@ -6,8 +6,6 @@ import ComponentVersions from '@site/calico/_includes/components/ComponentVersio
 
 # Component versions
 
-<p>
-  This page lists the specific component versions that go into each {variables.prodname} release.
-</p>
+This page lists the specific component versions that go into each {{prodname}} release.
 
 <ComponentVersions />

--- a/calico/reference/component-versions.mdx
+++ b/calico/reference/component-versions.mdx
@@ -6,4 +6,8 @@ import ComponentVersions from '@site/calico/_includes/components/ComponentVersio
 
 # Component versions
 
+<p>
+  This page lists the specific component versions that go into each {variables.prodname} release.
+</p>
+
 <ComponentVersions />

--- a/calico_versioned_docs/version-3.27/_includes/components/ComponentVersions.js
+++ b/calico_versioned_docs/version-3.27/_includes/components/ComponentVersions.js
@@ -17,9 +17,6 @@ export default function ComponentVersions() {
     <>
       {releases.map((release) => (
         <div key={release.title}>
-          <p>
-            This page lists the specific component versions that go into {variables.prodname} patch releases.
-          </p>
           <Heading
             as='h2'
             id={`component-versions-${toKebab(release.title)}`}

--- a/calico_versioned_docs/version-3.27/reference/component-versions.mdx
+++ b/calico_versioned_docs/version-3.27/reference/component-versions.mdx
@@ -6,4 +6,6 @@ import ComponentVersions from '@site/calico_versioned_docs/version-3.27/_include
 
 # Component versions
 
+This page lists the specific component versions that go into each release of $[prodname].
+
 <ComponentVersions />

--- a/calico_versioned_docs/version-3.28/_includes/components/ComponentVersions.js
+++ b/calico_versioned_docs/version-3.28/_includes/components/ComponentVersions.js
@@ -17,9 +17,6 @@ export default function ComponentVersions() {
     <>
       {releases.map((release) => (
         <div key={release.title}>
-          <p>
-            This page lists the specific component versions that go into {variables.prodname} patch releases.
-          </p>
           <Heading
             as='h2'
             id={`component-versions-${toKebab(release.title)}`}

--- a/calico_versioned_docs/version-3.28/reference/component-versions.mdx
+++ b/calico_versioned_docs/version-3.28/reference/component-versions.mdx
@@ -6,4 +6,6 @@ import ComponentVersions from '@site/calico_versioned_docs/version-3.28/_include
 
 # Component versions
 
+This page lists the specific component versions that go into each release of $[prodname].
+
 <ComponentVersions />

--- a/calico_versioned_docs/version-3.29/_includes/components/ComponentVersions.js
+++ b/calico_versioned_docs/version-3.29/_includes/components/ComponentVersions.js
@@ -17,9 +17,6 @@ export default function ComponentVersions() {
     <>
       {releases.map((release) => (
         <div key={release.title}>
-          <p>
-            This page lists the specific component versions that go into {variables.prodname} patch releases.
-          </p>
           <Heading
             as='h2'
             id={`component-versions-${toKebab(release.title)}`}

--- a/calico_versioned_docs/version-3.29/reference/component-versions.mdx
+++ b/calico_versioned_docs/version-3.29/reference/component-versions.mdx
@@ -6,4 +6,6 @@ import ComponentVersions from '@site/calico_versioned_docs/version-3.29/_include
 
 # Component versions
 
+This page lists the specific component versions that go into each release of $[prodname].
+
 <ComponentVersions />


### PR DESCRIPTION
And also a slight wording improvement.

Product Version(s):
Calico, Calico Enterprise