### PR TITLE
CRDs installation for OCP is handled by Operator

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/openshift/hostedcontrolplanes.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/openshift/hostedcontrolplanes.mdx
@@ -161,8 +161,6 @@ Apply the install manifests paying attention to the required order:
 
 ```
 cd calico/
-ls *crd*.yaml | xargs -n1 oc apply -f
-ls operator.tigera*.yaml | xargs -n1 oc apply -f
 ls 00*.yaml | xargs -n1 oc apply -f
 ls 01*.yaml | xargs -n1 oc apply -f
 ls 02*.yaml | xargs -n1 oc apply -f

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/openshift/hostedcontrolplanes.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/openshift/hostedcontrolplanes.mdx
@@ -161,8 +161,6 @@ Apply the install manifests paying attention to the required order:
 
 ```
 cd calico/
-ls *crd*.yaml | xargs -n1 oc apply -f
-ls operator.tigera*.yaml | xargs -n1 oc apply -f
 ls 00*.yaml | xargs -n1 oc apply -f
 ls 01*.yaml | xargs -n1 oc apply -f
 ls 02*.yaml | xargs -n1 oc apply -f


### PR DESCRIPTION
Change docs accordingly

N/A

Product Version(s):
Calico Enterprise

Issue:
CRDs installation is handled by Operator

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->