### PR TITLE
Updates list of excluded namespaces from global network policy example

### DIFF
--- a/calico-cloud/network-policy/beginners/kubernetes-default-deny.mdx
+++ b/calico-cloud/network-policy/beginners/kubernetes-default-deny.mdx
@@ -96,7 +96,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: deny-app-policy
 spec:
-  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system", "tigera-system"}
+  namespaceSelector: kubernetes.io/metadata.name not in {"calico-system", "kube-public", "kube-system", "tigera-operator", "tigera-system"}
   types:
   - Ingress
   - Egress
@@ -120,7 +120,9 @@ Note the following:
 
 - Even though we call this policy "global default deny", the above policy is not explicitly denying traffic. By selecting the traffic with the `namespaceSelector` but not specifying an allow, the traffic is denied after all other policy is evaluated. This design also makes it unnecessary to ensure any specific order (priority) for the default-deny policy.
 - Allowing access to `kube-dns` simplifies per-pod policies because you don't need to duplicate the DNS rules in every policy
-- The policy deliberately excludes the `kube-system`, `calico-system`, and `tigera-system` namespaces by using a negative `namespaceSelector` to avoid impacting any control plane components
+- This policy uses a negative selector for the `spec.namespaceselector` field to exclude control plane namespaces.
+  In this example, those namespaces include the `calico-system`, `kube-public`, `kube-system`, `tigera-operator`, and `tigera-system` namespaces.
+  Because your installation may have different components, make sure to check what you have installed before implementing a similar policy.
 
 In a staging environment, verify that the policy does not block any necessary traffic before enforcing it.
 

--- a/calico-cloud_versioned_docs/version-20-2/network-policy/beginners/kubernetes-default-deny.mdx
+++ b/calico-cloud_versioned_docs/version-20-2/network-policy/beginners/kubernetes-default-deny.mdx
@@ -96,7 +96,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: deny-app-policy
 spec:
-  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system", "tigera-system"}
+  namespaceSelector: kubernetes.io/metadata.name not in {"calico-system", "kube-public", "kube-system", "tigera-operator", "tigera-system"}
   types:
   - Ingress
   - Egress
@@ -120,7 +120,9 @@ Note the following:
 
 - Even though we call this policy "global default deny", the above policy is not explicitly denying traffic. By selecting the traffic with the `namespaceSelector` but not specifying an allow, the traffic is denied after all other policy is evaluated. This design also makes it unnecessary to ensure any specific order (priority) for the default-deny policy.
 - Allowing access to `kube-dns` simplifies per-pod policies because you don't need to duplicate the DNS rules in every policy
-- The policy deliberately excludes the `kube-system`, `calico-system`, and `tigera-system` namespaces by using a negative `namespaceSelector` to avoid impacting any control plane components
+- This policy uses a negative selector for the `spec.namespaceselector` field to exclude control plane namespaces.
+  In this example, those namespaces include the `calico-system`, `kube-public`, `kube-system`, `tigera-operator`, and `tigera-system` namespaces.
+  Because your installation may have different components, make sure to check what you have installed before implementing a similar policy.
 
 In a staging environment, verify that the policy does not block any necessary traffic before enforcing it.
 

--- a/calico-enterprise/network-policy/beginners/kubernetes-default-deny.mdx
+++ b/calico-enterprise/network-policy/beginners/kubernetes-default-deny.mdx
@@ -96,7 +96,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: deny-app-policy
 spec:
-  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system", "tigera-system"}
+  namespaceSelector: kubernetes.io/metadata.name not in {"calico-system", "kube-public", "kube-system", "tigera-operator", "tigera-system"}
   types:
   - Ingress
   - Egress
@@ -120,7 +120,9 @@ Note the following:
 
 - Even though we call this policy "global default deny", the above policy is not explicitly denying traffic. By selecting the traffic with the `namespaceSelector` but not specifying an allow, the traffic is denied after all other policy is evaluated. This design also makes it unnecessary to ensure any specific order (priority) for the default-deny policy.
 - Allowing access to `kube-dns` simplifies per-pod policies because you don't need to duplicate the DNS rules in every policy
-- The policy deliberately excludes the `kube-system`, `calico-system`, and `tigera-system` namespaces by using a negative `namespaceSelector` to avoid impacting any control plane components
+- This policy uses a negative selector for the `spec.namespaceselector` field to exclude control plane namespaces.
+  In this example, those namespaces include the `calico-system`, `kube-public`, `kube-system`, `tigera-operator`, and `tigera-system` namespaces.
+  Because your installation may have different components, make sure to check what you have installed before implementing a similar policy.
 
 In a staging environment, verify that the policy does not block any necessary traffic before enforcing it.
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/network-policy/beginners/kubernetes-default-deny.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/network-policy/beginners/kubernetes-default-deny.mdx
@@ -96,7 +96,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: deny-app-policy
 spec:
-  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system", "tigera-system"}
+  namespaceSelector: kubernetes.io/metadata.name not in {"calico-system", "kube-public", "kube-system", "tigera-operator", "tigera-system"}
   types:
   - Ingress
   - Egress
@@ -120,7 +120,9 @@ Note the following:
 
 - Even though we call this policy "global default deny", the above policy is not explicitly denying traffic. By selecting the traffic with the `namespaceSelector` but not specifying an allow, the traffic is denied after all other policy is evaluated. This design also makes it unnecessary to ensure any specific order (priority) for the default-deny policy.
 - Allowing access to `kube-dns` simplifies per-pod policies because you don't need to duplicate the DNS rules in every policy
-- The policy deliberately excludes the `kube-system`, `calico-system`, and `tigera-system` namespaces by using a negative `namespaceSelector` to avoid impacting any control plane components
+- This policy uses a negative selector for the `spec.namespaceselector` field to exclude control plane namespaces.
+  In this example, those namespaces include the `calico-system`, `kube-public`, `kube-system`, `tigera-operator`, and `tigera-system` namespaces.
+  Because your installation may have different components, make sure to check what you have installed before implementing a similar policy.
 
 In a staging environment, verify that the policy does not block any necessary traffic before enforcing it.
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/network-policy/beginners/kubernetes-default-deny.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/network-policy/beginners/kubernetes-default-deny.mdx
@@ -96,7 +96,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: deny-app-policy
 spec:
-  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system", "tigera-system"}
+  namespaceSelector: kubernetes.io/metadata.name not in {"calico-system", "kube-public", "kube-system", "tigera-operator", "tigera-system"}
   types:
   - Ingress
   - Egress
@@ -120,7 +120,9 @@ Note the following:
 
 - Even though we call this policy "global default deny", the above policy is not explicitly denying traffic. By selecting the traffic with the `namespaceSelector` but not specifying an allow, the traffic is denied after all other policy is evaluated. This design also makes it unnecessary to ensure any specific order (priority) for the default-deny policy.
 - Allowing access to `kube-dns` simplifies per-pod policies because you don't need to duplicate the DNS rules in every policy
-- The policy deliberately excludes the `kube-system`, `calico-system`, and `tigera-system` namespaces by using a negative `namespaceSelector` to avoid impacting any control plane components
+- This policy uses a negative selector for the `spec.namespaceselector` field to exclude control plane namespaces.
+  In this example, those namespaces include the `calico-system`, `kube-public`, `kube-system`, `tigera-operator`, and `tigera-system` namespaces.
+  Because your installation may have different components, make sure to check what you have installed before implementing a similar policy.
 
 In a staging environment, verify that the policy does not block any necessary traffic before enforcing it.
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/network-policy/beginners/kubernetes-default-deny.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/network-policy/beginners/kubernetes-default-deny.mdx
@@ -96,7 +96,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: deny-app-policy
 spec:
-  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system", "tigera-system"}
+  namespaceSelector: kubernetes.io/metadata.name not in {"calico-system", "kube-public", "kube-system", "tigera-operator", "tigera-system"}
   types:
   - Ingress
   - Egress
@@ -120,7 +120,9 @@ Note the following:
 
 - Even though we call this policy "global default deny", the above policy is not explicitly denying traffic. By selecting the traffic with the `namespaceSelector` but not specifying an allow, the traffic is denied after all other policy is evaluated. This design also makes it unnecessary to ensure any specific order (priority) for the default-deny policy.
 - Allowing access to `kube-dns` simplifies per-pod policies because you don't need to duplicate the DNS rules in every policy
-- The policy deliberately excludes the `kube-system`, `calico-system`, and `tigera-system` namespaces by using a negative `namespaceSelector` to avoid impacting any control plane components
+- This policy uses a negative selector for the `spec.namespaceselector` field to exclude control plane namespaces.
+  In this example, those namespaces include the `calico-system`, `kube-public`, `kube-system`, `tigera-operator`, and `tigera-system` namespaces.
+  Because your installation may have different components, make sure to check what you have installed before implementing a similar policy.
 
 In a staging environment, verify that the policy does not block any necessary traffic before enforcing it.
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/network-policy/beginners/kubernetes-default-deny.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/network-policy/beginners/kubernetes-default-deny.mdx
@@ -96,7 +96,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: deny-app-policy
 spec:
-  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system", "tigera-system"}
+  namespaceSelector: kubernetes.io/metadata.name not in {"calico-system", "kube-public", "kube-system", "tigera-operator", "tigera-system"}
   types:
   - Ingress
   - Egress
@@ -120,7 +120,9 @@ Note the following:
 
 - Even though we call this policy "global default deny", the above policy is not explicitly denying traffic. By selecting the traffic with the `namespaceSelector` but not specifying an allow, the traffic is denied after all other policy is evaluated. This design also makes it unnecessary to ensure any specific order (priority) for the default-deny policy.
 - Allowing access to `kube-dns` simplifies per-pod policies because you don't need to duplicate the DNS rules in every policy
-- The policy deliberately excludes the `kube-system`, `calico-system`, and `tigera-system` namespaces by using a negative `namespaceSelector` to avoid impacting any control plane components
+- This policy uses a negative selector for the `spec.namespaceselector` field to exclude control plane namespaces.
+  In this example, those namespaces include the `calico-system`, `kube-public`, `kube-system`, `tigera-operator`, and `tigera-system` namespaces.
+  Because your installation may have different components, make sure to check what you have installed before implementing a similar policy.
 
 In a staging environment, verify that the policy does not block any necessary traffic before enforcing it.
 

--- a/calico-enterprise_versioned_docs/version-3.21-1/network-policy/beginners/kubernetes-default-deny.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-1/network-policy/beginners/kubernetes-default-deny.mdx
@@ -96,7 +96,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: deny-app-policy
 spec:
-  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system", "tigera-system"}
+  namespaceSelector: kubernetes.io/metadata.name not in {"calico-system", "kube-public", "kube-system", "tigera-operator", "tigera-system"}
   types:
   - Ingress
   - Egress
@@ -120,7 +120,9 @@ Note the following:
 
 - Even though we call this policy "global default deny", the above policy is not explicitly denying traffic. By selecting the traffic with the `namespaceSelector` but not specifying an allow, the traffic is denied after all other policy is evaluated. This design also makes it unnecessary to ensure any specific order (priority) for the default-deny policy.
 - Allowing access to `kube-dns` simplifies per-pod policies because you don't need to duplicate the DNS rules in every policy
-- The policy deliberately excludes the `kube-system`, `calico-system`, and `tigera-system` namespaces by using a negative `namespaceSelector` to avoid impacting any control plane components
+- This policy uses a negative selector for the `spec.namespaceselector` field to exclude control plane namespaces.
+  In this example, those namespaces include the `calico-system`, `kube-public`, `kube-system`, `tigera-operator`, and `tigera-system` namespaces.
+  Because your installation may have different components, make sure to check what you have installed before implementing a similar policy.
 
 In a staging environment, verify that the policy does not block any necessary traffic before enforcing it.
 

--- a/calico/network-policy/get-started/kubernetes-default-deny.mdx
+++ b/calico/network-policy/get-started/kubernetes-default-deny.mdx
@@ -100,7 +100,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: deny-app-policy
 spec:
-  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system", "tigera-system"}
+  namespaceSelector: kubernetes.io/metadata.name not in {"calico-system", "kube-public", "kube-system", "tigera-operator"}
   types:
   - Ingress
   - Egress
@@ -124,7 +124,9 @@ Note the following:
 
 - Even though we call this policy "global default deny", the above policy is not explicitly denying traffic. By selecting the traffic with the `namespaceSelector` but not specifying an allow, the traffic is denied after all other policy is evaluated. This design also makes it unnecessary to ensure any specific order (priority) for the default-deny policy.
 - Allowing access to `kube-dns` simplifies per-pod policies because you don't need to duplicate the DNS rules in every policy
-- The policy deliberately excludes the `kube-system`, `calico-system`, and `tigera-system` namespaces by using a negative `namespaceSelector` to avoid impacting any control plane components
+- This policy uses a negative selector for the `spec.namespaceselector` field to exclude control plane namespaces.
+  In this example, those namespaces include the `calico-system`, `kube-public`, `kube-system`, and `tigera-operator` namespaces.
+  Because your installation may have different components, make sure to check what you have installed before implementing a similar policy.
 
 In a staging environment, verify that the policy does not block any necessary traffic before enforcing it.
 

--- a/calico_versioned_docs/version-3.27/network-policy/get-started/kubernetes-default-deny.mdx
+++ b/calico_versioned_docs/version-3.27/network-policy/get-started/kubernetes-default-deny.mdx
@@ -100,7 +100,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: deny-app-policy
 spec:
-  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system", "tigera-system"}
+  namespaceSelector: kubernetes.io/metadata.name not in {"calico-system", "kube-public", "kube-system", "tigera-operator"}
   types:
   - Ingress
   - Egress
@@ -124,7 +124,9 @@ Note the following:
 
 - Even though we call this policy "global default deny", the above policy is not explicitly denying traffic. By selecting the traffic with the `namespaceSelector` but not specifying an allow, the traffic is denied after all other policy is evaluated. This design also makes it unnecessary to ensure any specific order (priority) for the default-deny policy.
 - Allowing access to `kube-dns` simplifies per-pod policies because you don't need to duplicate the DNS rules in every policy
-- The policy deliberately excludes the `kube-system`, `calico-system`, and `tigera-system` namespaces by using a negative `namespaceSelector` to avoid impacting any control plane components
+- This policy uses a negative selector for the `spec.namespaceselector` field to exclude control plane namespaces.
+  In this example, those namespaces include the `calico-system`, `kube-public`, `kube-system`, and `tigera-operator` namespaces.
+  Because your installation may have different components, make sure to check what you have installed before implementing a similar policy.
 
 In a staging environment, verify that the policy does not block any necessary traffic before enforcing it.
 

--- a/calico_versioned_docs/version-3.28/network-policy/get-started/kubernetes-default-deny.mdx
+++ b/calico_versioned_docs/version-3.28/network-policy/get-started/kubernetes-default-deny.mdx
@@ -100,7 +100,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: deny-app-policy
 spec:
-  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system", "tigera-system"}
+  namespaceSelector: kubernetes.io/metadata.name not in {"calico-system", "kube-public", "kube-system", "tigera-operator"}
   types:
   - Ingress
   - Egress
@@ -124,7 +124,9 @@ Note the following:
 
 - Even though we call this policy "global default deny", the above policy is not explicitly denying traffic. By selecting the traffic with the `namespaceSelector` but not specifying an allow, the traffic is denied after all other policy is evaluated. This design also makes it unnecessary to ensure any specific order (priority) for the default-deny policy.
 - Allowing access to `kube-dns` simplifies per-pod policies because you don't need to duplicate the DNS rules in every policy
-- The policy deliberately excludes the `kube-system`, `calico-system`, and `tigera-system` namespaces by using a negative `namespaceSelector` to avoid impacting any control plane components
+- This policy uses a negative selector for the `spec.namespaceselector` field to exclude control plane namespaces.
+  In this example, those namespaces include the `calico-system`, `kube-public`, `kube-system`, and `tigera-operator` namespaces.
+  Because your installation may have different components, make sure to check what you have installed before implementing a similar policy.
 
 In a staging environment, verify that the policy does not block any necessary traffic before enforcing it.
 

--- a/calico_versioned_docs/version-3.29/network-policy/get-started/kubernetes-default-deny.mdx
+++ b/calico_versioned_docs/version-3.29/network-policy/get-started/kubernetes-default-deny.mdx
@@ -100,7 +100,7 @@ kind: GlobalNetworkPolicy
 metadata:
   name: deny-app-policy
 spec:
-  namespaceSelector: has(projectcalico.org/name) && projectcalico.org/name not in {"kube-system", "calico-system", "tigera-system"}
+  namespaceSelector: kubernetes.io/metadata.name not in {"calico-system", "kube-public", "kube-system", "tigera-operator"}
   types:
   - Ingress
   - Egress
@@ -124,7 +124,9 @@ Note the following:
 
 - Even though we call this policy "global default deny", the above policy is not explicitly denying traffic. By selecting the traffic with the `namespaceSelector` but not specifying an allow, the traffic is denied after all other policy is evaluated. This design also makes it unnecessary to ensure any specific order (priority) for the default-deny policy.
 - Allowing access to `kube-dns` simplifies per-pod policies because you don't need to duplicate the DNS rules in every policy
-- The policy deliberately excludes the `kube-system`, `calico-system`, and `tigera-system` namespaces by using a negative `namespaceSelector` to avoid impacting any control plane components
+- This policy uses a negative selector for the `spec.namespaceselector` field to exclude control plane namespaces.
+  In this example, those namespaces include the `calico-system`, `kube-public`, `kube-system`, and `tigera-operator` namespaces.
+  Because your installation may have different components, make sure to check what you have installed before implementing a similar policy.
 
 In a staging environment, verify that the policy does not block any necessary traffic before enforcing it.
 


### PR DESCRIPTION


<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://deploy-preview-1879--calico-docs-preview-next.netlify.app/calico/next/network-policy/get-started/kubernetes-default-deny#best-practice-2-keep-the-scope-to-non-system-pods

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->