### PR TITLE
[RS-2320] Doc for new support of Neutron QoS fields

### DIFF
--- a/calico/networking/openstack/configuration.mdx
+++ b/calico/networking/openstack/configuration.mdx
@@ -24,8 +24,7 @@ configure the Neutron service.
 
 | Setting              | Value     | Meaning                                  |
 | -------------------- | --------- | ---------------------------------------- |
-| core_plugin          | calico    | Use the $[prodname] core plugin         |
-| -------------------- | --------- | ---------------------------------------- |
+| core_plugin          | calico    | Use the $[prodname] core plugin          |
 
 $[prodname] can operate either as a core plugin or as an ML2 mechanism driver. The
 function is the same both ways, except that floating IPs are only supported
@@ -37,7 +36,6 @@ you can, instead, set
 | Setting              | Value                                  | Meaning                |
 | -------------------- | -------------------------------------- | ---------------------- |
 | core_plugin          | neutron.plugins.ml2.plugin.ML2Plugin   | Use ML2 plugin         |
-| -------------------- | -------------------------------------- | ---------------------- |
 
 and then the further ML2-specific configuration as covered below.
 
@@ -68,7 +66,7 @@ node belongs to.
 
 | Setting            | Default Value | Meaning                                                                      |
 | ------------------ | ------------- | ---------------------------------------------------------------------------- |
-| `openstack_region` | none          | The name of the region that the local compute of controller node belongs to. |
+| openstack_region   | none          | The name of the region that the local compute of controller node belongs to. |
 
 When specified, the value of `openstack_region` must be a string of lower case alphanumeric
 characters or '-', starting and ending with an alphanumeric character, and must match the value of
@@ -82,6 +80,6 @@ settings to configure the ML2 plugin.
 
 | Setting              | Value       | Meaning                           |
 | -------------------- | ----------- | --------------------------------- |
-| mechanism_drivers    | calico      | Use $[prodname]                  |
+| mechanism_drivers    | calico      | Use $[prodname]                   |
 | type_drivers         | local, flat | Allow 'local' and 'flat' networks |
 | tenant_network_types | local, flat | Allow 'local' and 'flat' networks |

--- a/calico/networking/openstack/neutron-api.mdx
+++ b/calico/networking/openstack/neutron-api.mdx
@@ -139,6 +139,22 @@ model. See [Detailed semantics](semantics.mdx) for a
 fuller explanation. Where isolation of a particular Neutron network is
 desired, we recommend expressing that through security group rules.
 
+## QoS
+
+Calico for OpenStack implements some Neutron QoS policy fields: the `max_kbps`
+and `max_burst_kbps` fields of bandwidth limit rules, and the `max_kpps` field
+of packet rate limit rules.  Calico also honours the `direction` field of these
+rules, so these limits can be set independently for both ingress and egress
+directions.
+
+There are also new Calico Neutron driver settings (cluster-wide):
+
+- `[calico] max_ingress_connections_per_port` for imposing a maximum number of
+  ingress connections per Neutron port, and
+
+- `[calico] max_egress_connections_per_port` for imposing a maximum number of
+  egress connections per Neutron port.
+
 ## Load Balancer as a Service
 
 Load Balancer as a Service (LBaaS) does not function in a $[prodname] network. Any


### PR DESCRIPTION
Also:
- remove extraneous final dashed lines, in some tables
- remove inconsistent double-quoting of `openstack-region`
