### PR TITLE
Fix install sequence for CE 3.21

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -92,7 +92,7 @@ To install a standard $[prodname] cluster with Helm:
         }
     </CodeBlock>
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -121,7 +121,7 @@ To install a $[prodname] [managed](../standard-install/create-a-managed-cluster#
         key: $MANAGED_CLUSTER_KEY" >> values.yaml
   ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -136,7 +136,7 @@ To install a $[prodname] [management](create-a-management-cluster-helm#value) cl
       certificate: $MANAGED_CLUSTER_CERTIFICATE" >> values.yaml
   ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'
@@ -224,7 +224,7 @@ For example, if you are using EKS, you must meet the requirements defined in [cr
         value: "internet-facing"
   ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -80,7 +80,7 @@ To install a standard $[prodname] cluster with Helm:
 
 1. [Configure a storage class for Calico Enterprise](../../../operations/logstorage/create-storage).
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/windows-calico/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/windows-calico/rancher.mdx
@@ -27,7 +27,7 @@ Install $[prodnameWindows] on Rancher Kubernetes Engine (RKE).
 
 The following steps will outline the installation of $[prodname] networking on the RKE cluster, then the installation of $[prodnameWindows] on the Windows nodes.
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/tigera-operator.yaml

--- a/calico-enterprise_versioned_docs/version-3.18-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -122,7 +122,7 @@ To install a $[prodname] [managed](../standard-install/create-a-managed-cluster#
         key: $MANAGED_CLUSTER_KEY" >> values.yaml
   ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico-enterprise_versioned_docs/version-3.18-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -137,7 +137,7 @@ To install a $[prodname] [management](create-a-management-cluster-helm#value) cl
       certificate: $MANAGED_CLUSTER_CERTIFICATE" >> values.yaml
   ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'
@@ -225,7 +225,7 @@ For example, if you are using EKS, you must meet the requirements defined in [cr
         value: "internet-facing"
   ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -79,7 +79,7 @@ To install a standard $[prodname] cluster with Helm:
 
 1. [Configure a storage class for Calico Enterprise](../../../operations/logstorage/create-storage).
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/windows-calico/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/windows-calico/rancher.mdx
@@ -27,7 +27,7 @@ Install $[prodnameWindows] on Rancher Kubernetes Engine (RKE).
 
 The following steps will outline the installation of $[prodname] networking on the RKE cluster, then the installation of $[prodnameWindows] on the Windows nodes.
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/tigera-operator.yaml

--- a/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -121,7 +121,7 @@ To install a $[prodname] [managed](../standard-install/create-a-managed-cluster#
         key: $MANAGED_CLUSTER_KEY" >> values.yaml
   ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -136,7 +136,7 @@ To install a $[prodname] [management](create-a-management-cluster-helm#value) cl
       certificate: $MANAGED_CLUSTER_CERTIFICATE" >> values.yaml
   ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'
@@ -224,7 +224,7 @@ For example, if you are using EKS, you must meet the requirements defined in [cr
         value: "internet-facing"
   ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico-enterprise_versioned_docs/version-3.20-1/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -92,7 +92,7 @@ To install a standard $[prodname] cluster with Helm:
         }
     </CodeBlock>
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico-enterprise_versioned_docs/version-3.20-1/getting-started/install-on-clusters/windows-calico/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/getting-started/install-on-clusters/windows-calico/rancher.mdx
@@ -27,7 +27,7 @@ Install $[prodnameWindows] on Rancher Kubernetes Engine (RKE).
 
 The following steps will outline the installation of $[prodname] networking on the RKE cluster, then the installation of $[prodnameWindows] on the Windows nodes.
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/tigera-operator.yaml

--- a/calico-enterprise_versioned_docs/version-3.20-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -121,7 +121,7 @@ To install a $[prodname] [managed](../standard-install/create-a-managed-cluster#
         key: $MANAGED_CLUSTER_KEY" >> values.yaml
   ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico-enterprise_versioned_docs/version-3.20-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -136,7 +136,7 @@ To install a $[prodname] [management](create-a-management-cluster-helm#value) cl
       certificate: $MANAGED_CLUSTER_CERTIFICATE" >> values.yaml
   ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'
@@ -224,7 +224,7 @@ For example, if you are using EKS, you must meet the requirements defined in [cr
         value: "internet-facing"
   ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -92,7 +92,7 @@ To install a standard $[prodname] cluster with Helm:
         }
     </CodeBlock>
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/windows-calico/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/windows-calico/rancher.mdx
@@ -27,7 +27,7 @@ Install $[prodnameWindows] on Rancher Kubernetes Engine (RKE).
 
 The following steps will outline the installation of $[prodname] networking on the RKE cluster, then the installation of $[prodnameWindows] on the Windows nodes.
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/tigera-operator.yaml

--- a/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -121,7 +121,7 @@ To install a $[prodname] [managed](../standard-install/create-a-managed-cluster#
         key: $MANAGED_CLUSTER_KEY" >> values.yaml
   ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -136,7 +136,7 @@ To install a $[prodname] [management](create-a-management-cluster-helm#value) cl
       certificate: $MANAGED_CLUSTER_CERTIFICATE" >> values.yaml
   ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'
@@ -224,7 +224,7 @@ For example, if you are using EKS, you must meet the requirements defined in [cr
         value: "internet-facing"
   ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico-enterprise_versioned_docs/version-3.21-1/_includes/components/InstallAKS.js
+++ b/calico-enterprise_versioned_docs/version-3.21-1/_includes/components/InstallAKS.js
@@ -20,7 +20,6 @@ export default function InstallAKS(props) {
       <ol>
         <li>
           <p>Install the Tigera operator and custom resource definitions.</p>
-          <CodeBlock>kubectl create -f {filesUrl}/manifests/operator-crds.yaml</CodeBlock>
           <CodeBlock>kubectl create -f {filesUrl}/manifests/tigera-operator.yaml</CodeBlock>
         </li>
         <li>
@@ -131,7 +130,6 @@ spec:
         </li>
         <li>
           <p>Install the Tigera operator and custom resource definitions.</p>
-          <CodeBlock>kubectl create -f {filesUrl}/manifests/operator-crds.yaml</CodeBlock>
           <CodeBlock>kubectl create -f {filesUrl}/manifests/tigera-operator.yaml</CodeBlock>
         </li>
         <li>

--- a/calico-enterprise_versioned_docs/version-3.21-1/_includes/components/InstallEKS.js
+++ b/calico-enterprise_versioned_docs/version-3.21-1/_includes/components/InstallEKS.js
@@ -22,7 +22,6 @@ export default function InstallEKS(props) {
       <ol>
         <li>
           <p>Install the Tigera operator and custom resource definitions.</p>
-          <CodeBlock>kubectl create -f {filesUrl}/manifests/operator-crds.yaml</CodeBlock>
           <CodeBlock>kubectl create -f {filesUrl}/manifests/tigera-operator.yaml</CodeBlock>
         </li>
         <li>
@@ -182,7 +181,6 @@ spec:
         </li>
         <li>
           <p>Install the Tigera operator and custom resource definitions.</p>
-          <CodeBlock>kubectl create -f {filesUrl}/manifests/operator-crds.yaml</CodeBlock>
           <CodeBlock>kubectl create -f {filesUrl}/manifests/tigera-operator.yaml</CodeBlock>
         </li>
         <li>

--- a/calico-enterprise_versioned_docs/version-3.21-1/_includes/components/InstallGKE.js
+++ b/calico-enterprise_versioned_docs/version-3.21-1/_includes/components/InstallGKE.js
@@ -21,7 +21,6 @@ export default function InstallGKE(props) {
       <ol>
         <li>
           <p>Install the Tigera operator and custom resource definitions.</p>
-          <CodeBlock>kubectl create -f {filesUrl}/manifests/operator-crds.yaml</CodeBlock>
           <CodeBlock>kubectl create -f {filesUrl}/manifests/tigera-operator.yaml</CodeBlock>
         </li>
         <li>

--- a/calico-enterprise_versioned_docs/version-3.21-1/_includes/components/InstallGeneric.js
+++ b/calico-enterprise_versioned_docs/version-3.21-1/_includes/components/InstallGeneric.js
@@ -26,7 +26,6 @@ export default function InstallGeneric(props) {
       <ol>
         <li>
           <p>Install the Tigera operator and custom resource definitions.</p>
-          <CodeBlock>kubectl create -f {filesUrl}/manifests/operator-crds.yaml</CodeBlock>
           <CodeBlock>kubectl create -f {filesUrl}/manifests/tigera-operator.yaml</CodeBlock>
         </li>
         <li>
@@ -60,9 +59,7 @@ export default function InstallGeneric(props) {
         </li>
         <li>
           <p>
-            (Optional) Compliance and packet capture features are optional. To enable these features during
-            installation, download and review the custom-resources.yaml file. Uncomment the necessary CRs and use this
-            custom-resources.yaml for installation.
+            (Optional) Compliance and packet capture features are optional. To enable these features during installation, download and review the custom-resources.yaml file. Uncomment the necessary CRs and use this custom-resources.yaml for installation.
           </p>
           <p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/custom-resources.yaml</CodeBlock>

--- a/calico-enterprise_versioned_docs/version-3.21-1/getting-started/install-on-clusters/docker-enterprise.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-1/getting-started/install-on-clusters/docker-enterprise.mdx
@@ -59,7 +59,6 @@ The geeky details of what you get:
 1. Install the Tigera operator and custom resource definitions.
 
    ```bash
-   kubectl create -f $[filesUrl]/manifests/operator-crds.yaml
    kubectl create -f $[filesUrl]/manifests/tigera-operator.yaml
    ```
 

--- a/calico-enterprise_versioned_docs/version-3.21-1/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-1/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -92,7 +92,7 @@ To install a standard $[prodname] cluster with Helm:
         }
     </CodeBlock>
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico-enterprise_versioned_docs/version-3.21-1/getting-started/install-on-clusters/kubernetes/quickstart.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-1/getting-started/install-on-clusters/kubernetes/quickstart.mdx
@@ -90,7 +90,6 @@ A Linux host that meets the following requirements.
 1. Install the Tigera operator and custom resource definitions.
 
    ```bash
-   kubectl create -f $[filesUrl]/manifests/operator-crds.yaml
    kubectl create -f $[filesUrl]/manifests/tigera-operator.yaml
    ```
 

--- a/calico-enterprise_versioned_docs/version-3.21-1/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-1/getting-started/install-on-clusters/rancher.mdx
@@ -58,7 +58,6 @@ The geeky details of what you get:
 1. Install the Tigera operator and custom resource definitions.
 
    ```bash
-   kubectl create -f $[filesUrl]/manifests/operator-crds.yaml
    kubectl create -f $[filesUrl]/manifests/tigera-operator.yaml
    ```
 

--- a/calico-enterprise_versioned_docs/version-3.21-1/getting-started/install-on-clusters/rke2.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-1/getting-started/install-on-clusters/rke2.mdx
@@ -55,7 +55,6 @@ The geeky details of what you get:
 1. Install the Tigera operator and custom resource definitions.
 
    ```bash
-   kubectl create -f $[filesUrl]/manifests/operator-crds.yaml
    kubectl create -f $[filesUrl]/manifests/tigera-operator.yaml
    ```
 

--- a/calico-enterprise_versioned_docs/version-3.21-1/getting-started/install-on-clusters/windows-calico/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-1/getting-started/install-on-clusters/windows-calico/rancher.mdx
@@ -27,10 +27,9 @@ Install $[prodnameWindows] on Rancher Kubernetes Engine (RKE).
 
 The following steps will outline the installation of $[prodname] networking on the RKE cluster, then the installation of $[prodnameWindows] on the Windows nodes.
 
-1. Install the Tigera operator and custom resource definitions.
+1. Install the Tigera $[prodname] operator and custom resource definitions.
 
    ```bash
-   kubectl create -f $[filesUrl]/manifests/operator-crds.yaml
    kubectl create -f $[filesUrl]/manifests/tigera-operator.yaml
    ```
 

--- a/calico-enterprise_versioned_docs/version-3.21-1/getting-started/install-on-clusters/windows-calico/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-1/getting-started/install-on-clusters/windows-calico/rancher.mdx
@@ -27,7 +27,7 @@ Install $[prodnameWindows] on Rancher Kubernetes Engine (RKE).
 
 The following steps will outline the installation of $[prodname] networking on the RKE cluster, then the installation of $[prodnameWindows] on the Windows nodes.
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/tigera-operator.yaml

--- a/calico-enterprise_versioned_docs/version-3.21-1/getting-started/manifest-archive.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-1/getting-started/manifest-archive.mdx
@@ -41,7 +41,6 @@ In the patch release archive, navigate to the `manifests` folder.
    1. Install Tigera operator and custom resource definitions.
 
       ```bash
-      kubectl create -f <your-local-directory-archive>/manifests/operator-crds.yaml
       kubectl create -f <your-local-directory-archive>/manifests/tigera-operator.yaml
       ```
 

--- a/calico-enterprise_versioned_docs/version-3.21-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -121,7 +121,7 @@ To install a $[prodname] [managed](../standard-install/create-a-managed-cluster#
         key: $MANAGED_CLUSTER_KEY" >> values.yaml
   ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico-enterprise_versioned_docs/version-3.21-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -136,7 +136,7 @@ To install a $[prodname] [management](create-a-management-cluster-helm#value) cl
       certificate: $MANAGED_CLUSTER_CERTIFICATE" >> values.yaml
   ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'
@@ -224,7 +224,7 @@ For example, if you are using EKS, you must meet the requirements defined in [cr
         value: "internet-facing"
   ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart:
+1. Install the Tigera operator and custom resource definitions using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico/getting-started/kubernetes/helm.mdx
+++ b/calico/getting-started/kubernetes/helm.mdx
@@ -31,7 +31,7 @@ Helm charts are a way to package up an application for Kubernetes (similar to `a
 
 ### Operator based installation
 
-In this guide, you install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart. The Tigera operator provides lifecycle management for $[prodname] exposed via the Kubernetes API defined as a custom resource definition.
+In this guide, you install the Tigera operator and custom resource definitions using the Helm 3 chart. The Tigera operator provides lifecycle management for $[prodname] exposed via the Kubernetes API defined as a custom resource definition.
 
 ## How to
 
@@ -79,7 +79,7 @@ For more information about configurable options via `values.yaml` please see [He
    kubectl create namespace tigera-operator
    ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm chart:
+1. Install the Tigera operator and custom resource definitions using the Helm chart:
 
    ```bash
    helm install $[prodnamedash] projectcalico/tigera-operator --version $[releaseTitle] --namespace tigera-operator

--- a/calico/getting-started/kubernetes/minikube.mdx
+++ b/calico/getting-started/kubernetes/minikube.mdx
@@ -58,7 +58,7 @@ minikube start --cni=calico
    minikube start --cni=false --network-plugin=cni --extra-config=kubeadm.pod-network-cidr=192.168.0.0/16 --subnet=172.16.0.0/24
    ```
 
-2. Install the Tigera $[prodname] operator and custom resource definitions.
+2. Install the Tigera operator and custom resource definitions.
 
    ```bash
    kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml

--- a/calico/getting-started/kubernetes/quickstart.mdx
+++ b/calico/getting-started/kubernetes/quickstart.mdx
@@ -89,7 +89,7 @@ The geeky details of what you get:
 
 ### Install $[prodname]
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml

--- a/calico/network-policy/non-privileged.mdx
+++ b/calico/network-policy/non-privileged.mdx
@@ -43,7 +43,7 @@ Support for features added after Calico v3.21 is not guaranteed.
 
 ## How to
 
-1. Follow the Tigera $[prodname] operator [installation instructions](../getting-started/kubernetes/quickstart.mdx).
+1. Follow the Tigera operator [installation instructions](../getting-started/kubernetes/quickstart.mdx).
    If you have already installed the operator, skip to the next step.
 
 1. Edit the $[prodname] installation to set the `nonPrivileged` field to `Enabled`.

--- a/calico_versioned_docs/version-3.27/getting-started/kubernetes/helm.mdx
+++ b/calico_versioned_docs/version-3.27/getting-started/kubernetes/helm.mdx
@@ -30,7 +30,7 @@ Helm charts are a way to package up an application for Kubernetes (similar to `a
 
 ### Operator based installation
 
-In this guide, you install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart. The Tigera operator provides lifecycle management for $[prodname] exposed via the Kubernetes API defined as a custom resource definition.
+In this guide, you install the Tigera operator and custom resource definitions using the Helm 3 chart. The Tigera operator provides lifecycle management for $[prodname] exposed via the Kubernetes API defined as a custom resource definition.
 
 ## How to
 
@@ -84,7 +84,7 @@ If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubern
    kubectl create namespace tigera-operator
    ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm chart:
+1. Install the Tigera operator and custom resource definitions using the Helm chart:
 
    ```bash
    helm install $[prodnamedash] projectcalico/tigera-operator --version $[releaseTitle] --namespace tigera-operator

--- a/calico_versioned_docs/version-3.27/getting-started/kubernetes/minikube.mdx
+++ b/calico_versioned_docs/version-3.27/getting-started/kubernetes/minikube.mdx
@@ -57,7 +57,7 @@ minikube start --cni=calico
    minikube start --cni=false --network-plugin=cni --extra-config=kubeadm.pod-network-cidr=192.168.0.0/16 --subnet=172.16.0.0/24
    ```
 
-2. Install the Tigera $[prodname] operator and custom resource definitions.
+2. Install the Tigera operator and custom resource definitions.
 
    ```bash
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml

--- a/calico_versioned_docs/version-3.27/getting-started/kubernetes/quickstart.mdx
+++ b/calico_versioned_docs/version-3.27/getting-started/kubernetes/quickstart.mdx
@@ -88,7 +88,7 @@ The geeky details of what you get:
 
 ### Install $[prodname]
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml

--- a/calico_versioned_docs/version-3.27/getting-started/kubernetes/rancher.mdx
+++ b/calico_versioned_docs/version-3.27/getting-started/kubernetes/rancher.mdx
@@ -42,7 +42,7 @@ The geeky details of what you get:
 
 ### Install $[prodname]
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml

--- a/calico_versioned_docs/version-3.27/getting-started/kubernetes/windows-calico/rancher.mdx
+++ b/calico_versioned_docs/version-3.27/getting-started/kubernetes/windows-calico/rancher.mdx
@@ -33,7 +33,7 @@ Run Linux and Windows workloads on a RKE cluster with $[prodname].
 
 The following steps will outline the installation of $[prodname] networking on the RKE cluster, then the installation of $[prodnameWindows] on the Windows nodes.
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml

--- a/calico_versioned_docs/version-3.27/network-policy/non-privileged.mdx
+++ b/calico_versioned_docs/version-3.27/network-policy/non-privileged.mdx
@@ -43,7 +43,7 @@ Support for features added after Calico v3.21 is not guaranteed.
 
 ## How to
 
-1. Follow the Tigera $[prodname] operator [installation instructions](../getting-started/kubernetes/quickstart.mdx).
+1. Follow the Tigera operator [installation instructions](../getting-started/kubernetes/quickstart.mdx).
    If you have already installed the operator, skip to the next step.
 
 1. Edit the $[prodname] installation to set the `nonPrivileged` field to `Enabled`.

--- a/calico_versioned_docs/version-3.27/operations/operator-migration.mdx
+++ b/calico_versioned_docs/version-3.27/operations/operator-migration.mdx
@@ -54,7 +54,7 @@ Do not edit or delete any resources in the `kube-system` Namespace during the fo
 
 :::
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```bash
    kubectl apply --server-side --force-conflicts -f $[manifestsUrl]/manifests/tigera-operator.yaml

--- a/calico_versioned_docs/version-3.28/getting-started/kubernetes/helm.mdx
+++ b/calico_versioned_docs/version-3.28/getting-started/kubernetes/helm.mdx
@@ -30,7 +30,7 @@ Helm charts are a way to package up an application for Kubernetes (similar to `a
 
 ### Operator based installation
 
-In this guide, you install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart. The Tigera operator provides lifecycle management for $[prodname] exposed via the Kubernetes API defined as a custom resource definition.
+In this guide, you install the Tigera operator and custom resource definitions using the Helm 3 chart. The Tigera operator provides lifecycle management for $[prodname] exposed via the Kubernetes API defined as a custom resource definition.
 
 ## How to
 
@@ -78,7 +78,7 @@ For more information about configurable options via `values.yaml` please see [He
    kubectl create namespace tigera-operator
    ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm chart:
+1. Install the Tigera operator and custom resource definitions using the Helm chart:
 
    ```bash
    helm install $[prodnamedash] projectcalico/tigera-operator --version $[releaseTitle] --namespace tigera-operator

--- a/calico_versioned_docs/version-3.28/getting-started/kubernetes/minikube.mdx
+++ b/calico_versioned_docs/version-3.28/getting-started/kubernetes/minikube.mdx
@@ -57,7 +57,7 @@ minikube start --cni=calico
    minikube start --cni=false --network-plugin=cni --extra-config=kubeadm.pod-network-cidr=192.168.0.0/16 --subnet=172.16.0.0/24
    ```
 
-2. Install the Tigera $[prodname] operator and custom resource definitions.
+2. Install the Tigera operator and custom resource definitions.
 
    ```bash
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml

--- a/calico_versioned_docs/version-3.28/getting-started/kubernetes/quickstart.mdx
+++ b/calico_versioned_docs/version-3.28/getting-started/kubernetes/quickstart.mdx
@@ -88,7 +88,7 @@ The geeky details of what you get:
 
 ### Install $[prodname]
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml

--- a/calico_versioned_docs/version-3.28/getting-started/kubernetes/rancher.mdx
+++ b/calico_versioned_docs/version-3.28/getting-started/kubernetes/rancher.mdx
@@ -42,7 +42,7 @@ The geeky details of what you get:
 
 ### Install $[prodname]
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml

--- a/calico_versioned_docs/version-3.28/getting-started/kubernetes/windows-calico/rancher.mdx
+++ b/calico_versioned_docs/version-3.28/getting-started/kubernetes/windows-calico/rancher.mdx
@@ -33,7 +33,7 @@ Run Linux and Windows workloads on a RKE cluster with $[prodname].
 
 The following steps will outline the installation of $[prodname] networking on the RKE cluster, then the installation of $[prodnameWindows] on the Windows nodes.
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml

--- a/calico_versioned_docs/version-3.28/network-policy/non-privileged.mdx
+++ b/calico_versioned_docs/version-3.28/network-policy/non-privileged.mdx
@@ -43,7 +43,7 @@ Support for features added after Calico v3.21 is not guaranteed.
 
 ## How to
 
-1. Follow the Tigera $[prodname] operator [installation instructions](../getting-started/kubernetes/quickstart.mdx).
+1. Follow the Tigera operator [installation instructions](../getting-started/kubernetes/quickstart.mdx).
    If you have already installed the operator, skip to the next step.
 
 1. Edit the $[prodname] installation to set the `nonPrivileged` field to `Enabled`.

--- a/calico_versioned_docs/version-3.28/operations/operator-migration.mdx
+++ b/calico_versioned_docs/version-3.28/operations/operator-migration.mdx
@@ -54,7 +54,7 @@ Do not edit or delete any resources in the `kube-system` Namespace during the fo
 
 :::
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```bash
    kubectl apply --server-side --force-conflicts -f $[manifestsUrl]/manifests/tigera-operator.yaml

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/helm.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/helm.mdx
@@ -31,7 +31,7 @@ Helm charts are a way to package up an application for Kubernetes (similar to `a
 
 ### Operator based installation
 
-In this guide, you install the Tigera $[prodname] operator and custom resource definitions using the Helm 3 chart. The Tigera operator provides lifecycle management for $[prodname] exposed via the Kubernetes API defined as a custom resource definition.
+In this guide, you install the Tigera operator and custom resource definitions using the Helm 3 chart. The Tigera operator provides lifecycle management for $[prodname] exposed via the Kubernetes API defined as a custom resource definition.
 
 ## How to
 
@@ -79,7 +79,7 @@ For more information about configurable options via `values.yaml` please see [He
    kubectl create namespace tigera-operator
    ```
 
-1. Install the Tigera $[prodname] operator and custom resource definitions using the Helm chart:
+1. Install the Tigera operator and custom resource definitions using the Helm chart:
 
    ```bash
    helm install $[prodnamedash] projectcalico/tigera-operator --version $[releaseTitle] --namespace tigera-operator

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/minikube.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/minikube.mdx
@@ -58,7 +58,7 @@ minikube start --cni=calico
    minikube start --cni=false --network-plugin=cni --extra-config=kubeadm.pod-network-cidr=192.168.0.0/16 --subnet=172.16.0.0/24
    ```
 
-2. Install the Tigera $[prodname] operator and custom resource definitions.
+2. Install the Tigera operator and custom resource definitions.
 
    ```bash
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/nftables.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/nftables.mdx
@@ -95,7 +95,7 @@ Installing $[prodname] in nftables mode provides a networking and network policy
 
 ### Install $[prodname] in nftables data plane mode
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```bash
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/quickstart.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/quickstart.mdx
@@ -89,7 +89,7 @@ The geeky details of what you get:
 
 ### Install $[prodname]
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/rancher.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/rancher.mdx
@@ -43,7 +43,7 @@ The geeky details of what you get:
 
 ### Install $[prodname]
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/windows-calico/rancher.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/windows-calico/rancher.mdx
@@ -33,7 +33,7 @@ Run Linux and Windows workloads on a RKE cluster with $[prodname].
 
 The following steps will outline the installation of $[prodname] networking on the RKE cluster, then the installation of $[prodnameWindows] on the Windows nodes.
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml

--- a/calico_versioned_docs/version-3.29/network-policy/non-privileged.mdx
+++ b/calico_versioned_docs/version-3.29/network-policy/non-privileged.mdx
@@ -43,7 +43,7 @@ Support for features added after Calico v3.21 is not guaranteed.
 
 ## How to
 
-1. Follow the Tigera $[prodname] operator [installation instructions](../getting-started/kubernetes/quickstart.mdx).
+1. Follow the Tigera operator [installation instructions](../getting-started/kubernetes/quickstart.mdx).
    If you have already installed the operator, skip to the next step.
 
 1. Edit the $[prodname] installation to set the `nonPrivileged` field to `Enabled`.

--- a/calico_versioned_docs/version-3.29/operations/operator-migration.mdx
+++ b/calico_versioned_docs/version-3.29/operations/operator-migration.mdx
@@ -54,7 +54,7 @@ Do not edit or delete any resources in the `kube-system` Namespace during the fo
 
 :::
 
-1. Install the Tigera $[prodname] operator and custom resource definitions.
+1. Install the Tigera operator and custom resource definitions.
 
    ```bash
    kubectl apply --server-side --force-conflicts -f $[manifestsUrl]/manifests/tigera-operator.yaml


### PR DESCRIPTION
A change to the installation sequence was incorrectly made to
CE 3.21 EP1. The change should have applied only from CE 3.21 EP2
and later. This commit reverts the changes for this version.

Original PR: https://github.com/tigera/docs/pull/1840

Closes https://tigera.atlassian.net/browse/DOCS-2490.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->