### PR TITLE
GH#1906: Update storage provisioners

### DIFF
--- a/calico-enterprise/operations/logstorage/create-storage.mdx
+++ b/calico-enterprise/operations/logstorage/create-storage.mdx
@@ -98,7 +98,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: tigera-elasticsearch
-provisioner: kubernetes.io/aws-ebs
+provisioner: ebs.csi.aws.com
 parameters:
   type: gp2
   fsType: ext4
@@ -124,7 +124,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: tigera-elasticsearch
-provisioner: kubernetes.io/azure-disk
+provisioner: disk.cni.azure.com
 parameters:
   cachingmode: ReadOnly
   kind: Managed
@@ -149,7 +149,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: tigera-elasticsearch
-provisioner: kubernetes.io/gce-pd
+provisioner: pd.csi.storage.gke.io
 parameters:
   type: pd-ssd
   replication-type: none

--- a/calico-enterprise_versioned_docs/version-3.18-2/operations/logstorage/create-storage.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/operations/logstorage/create-storage.mdx
@@ -98,7 +98,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: tigera-elasticsearch
-provisioner: kubernetes.io/aws-ebs
+provisioner: ebs.csi.aws.com
 parameters:
   type: gp2
   fsType: ext4
@@ -124,7 +124,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: tigera-elasticsearch
-provisioner: kubernetes.io/azure-disk
+provisioner: disk.cni.azure.com
 parameters:
   cachingmode: ReadOnly
   kind: Managed
@@ -149,7 +149,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: tigera-elasticsearch
-provisioner: kubernetes.io/gce-pd
+provisioner: pd.csi.storage.gke.io
 parameters:
   type: pd-ssd
   replication-type: none

--- a/calico-enterprise_versioned_docs/version-3.19-2/operations/logstorage/create-storage.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/operations/logstorage/create-storage.mdx
@@ -98,7 +98,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: tigera-elasticsearch
-provisioner: kubernetes.io/aws-ebs
+provisioner: ebs.csi.aws.com
 parameters:
   type: gp2
   fsType: ext4
@@ -124,7 +124,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: tigera-elasticsearch
-provisioner: kubernetes.io/azure-disk
+provisioner: disk.cni.azure.com
 parameters:
   cachingmode: ReadOnly
   kind: Managed
@@ -149,7 +149,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: tigera-elasticsearch
-provisioner: kubernetes.io/gce-pd
+provisioner: pd.csi.storage.gke.io
 parameters:
   type: pd-ssd
   replication-type: none

--- a/calico-enterprise_versioned_docs/version-3.20-1/operations/logstorage/create-storage.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/operations/logstorage/create-storage.mdx
@@ -98,7 +98,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: tigera-elasticsearch
-provisioner: kubernetes.io/aws-ebs
+provisioner: ebs.csi.aws.com
 parameters:
   type: gp2
   fsType: ext4
@@ -124,7 +124,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: tigera-elasticsearch
-provisioner: kubernetes.io/azure-disk
+provisioner: disk.cni.azure.com
 parameters:
   cachingmode: ReadOnly
   kind: Managed
@@ -149,7 +149,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: tigera-elasticsearch
-provisioner: kubernetes.io/gce-pd
+provisioner: pd.csi.storage.gke.io
 parameters:
   type: pd-ssd
   replication-type: none

--- a/calico-enterprise_versioned_docs/version-3.20-2/operations/logstorage/create-storage.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/operations/logstorage/create-storage.mdx
@@ -98,7 +98,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: tigera-elasticsearch
-provisioner: kubernetes.io/aws-ebs
+provisioner: ebs.csi.aws.com
 parameters:
   type: gp2
   fsType: ext4
@@ -124,7 +124,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: tigera-elasticsearch
-provisioner: kubernetes.io/azure-disk
+provisioner: disk.cni.azure.com
 parameters:
   cachingmode: ReadOnly
   kind: Managed
@@ -149,7 +149,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: tigera-elasticsearch
-provisioner: kubernetes.io/gce-pd
+provisioner: pd.csi.storage.gke.io
 parameters:
   type: pd-ssd
   replication-type: none

--- a/calico-enterprise_versioned_docs/version-3.21-1/operations/logstorage/create-storage.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-1/operations/logstorage/create-storage.mdx
@@ -98,7 +98,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: tigera-elasticsearch
-provisioner: kubernetes.io/aws-ebs
+provisioner: ebs.csi.aws.com
 parameters:
   type: gp2
   fsType: ext4
@@ -124,7 +124,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: tigera-elasticsearch
-provisioner: kubernetes.io/azure-disk
+provisioner: disk.cni.azure.com
 parameters:
   cachingmode: ReadOnly
   kind: Managed
@@ -149,7 +149,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: tigera-elasticsearch
-provisioner: kubernetes.io/gce-pd
+provisioner: pd.csi.storage.gke.io
 parameters:
   type: pd-ssd
   replication-type: none


### PR DESCRIPTION
The in-tree provisioners were migrated to external providers. They are
now all deprecated or removed.

This commit replaces the old in-tree values with their external
counterparts.

Resolves #1906

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->