### PR TITLE
 Allow CE 3.21 in robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -40,3 +40,6 @@ Disallow: /calico-enterprise/
 Allow: /calico/latest/
 Allow: /calico-enterprise/latest/
 
+# TEST: Allowing /calico-enterprise/3.21 to test indexing issue
+Allow: /calico-enterprise/3.21/
+


### PR DESCRIPTION
Google is indexing versioned pages, which we don't want. One theory
is that, by blocking crawlers to those pages with robots.txt, we've
prevented Google from even viewing the no-index rule in the HTTP
header. This change allows crawls for CE 3.21 to see if that affects
the indexing pattern.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->
https://tigera.atlassian.net/browse/DOCS-2470

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->