### PR TITLE
Add sitemap ignore patterns

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -63,6 +63,9 @@ export default async function createAsyncConfig() {
             path: 'default',
             sidebarPath: false,
           },
+          sitemap: {
+            ignorePatterns: ['/calico/[0-9]*.[0-9]*/**', '/calico-enterprise/[0-9]*.[0-9]*/**'],
+          },
           googleTagManager: {
             containerId: 'GTM-KCHDXB2',
           },


### PR DESCRIPTION
This is part of an effort to have Google stop indexing non-latest
documentation.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->
https://tigera.atlassian.net/browse/DOCS-2470

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://deploy-preview-1921--tigera.netlify.app/sitemap.xml

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->