### PR TITLE
Correct indentation of registry and imagePath fields in code samples for private registry installs

### DIFF
--- a/calico-enterprise/_includes/components/PrivateRegistryImagePath.js
+++ b/calico-enterprise/_includes/components/PrivateRegistryImagePath.js
@@ -141,10 +141,10 @@ spec:
   variant: TigeraSecureEnterprise
   imagePullSecrets:
     - name: tigera-pull-secret
-    // highlight-next-line
-      registry: myregistry.com
-    // highlight-next-line
-      imagePath: my-image-path`}
+  // highlight-next-line
+  registry: myregistry.com
+  // highlight-next-line
+  imagePath: my-image-path`}
             </CodeBlock>
         </>
     );

--- a/calico-enterprise/_includes/components/PrivateRegistryRegular.js
+++ b/calico-enterprise/_includes/components/PrivateRegistryRegular.js
@@ -125,8 +125,8 @@ spec:
   variant: TigeraSecureEnterprise
   imagePullSecrets:
     - name: tigera-pull-secret
-    // highlight-next-line
-      registry: myregistry.com`}</CodeBlock>
+  // highlight-next-line
+  registry: myregistry.com`}</CodeBlock>
         </>
     );
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/_includes/components/PrivateRegistryImagePath.js
+++ b/calico-enterprise_versioned_docs/version-3.18-2/_includes/components/PrivateRegistryImagePath.js
@@ -141,10 +141,10 @@ spec:
   variant: TigeraSecureEnterprise
   imagePullSecrets:
     - name: tigera-pull-secret
-    // highlight-next-line
-      registry: myregistry.com
-    // highlight-next-line
-      imagePath: my-image-path`}
+  // highlight-next-line
+  registry: myregistry.com
+  // highlight-next-linedd
+  imagePath: my-image-path`}
             </CodeBlock>
         </>
     );

--- a/calico-enterprise_versioned_docs/version-3.18-2/_includes/components/PrivateRegistryRegular.js
+++ b/calico-enterprise_versioned_docs/version-3.18-2/_includes/components/PrivateRegistryRegular.js
@@ -125,8 +125,8 @@ spec:
   variant: TigeraSecureEnterprise
   imagePullSecrets:
     - name: tigera-pull-secret
-    // highlight-next-line
-      registry: myregistry.com`}</CodeBlock>
+  // highlight-next-line
+  registry: myregistry.com`}</CodeBlock>
         </>
     );
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/PrivateRegistryImagePath.js
+++ b/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/PrivateRegistryImagePath.js
@@ -141,10 +141,10 @@ spec:
   variant: TigeraSecureEnterprise
   imagePullSecrets:
     - name: tigera-pull-secret
-    // highlight-next-line
-      registry: myregistry.com
-    // highlight-next-line
-      imagePath: my-image-path`}
+  // highlight-next-line
+  registry: myregistry.com
+  // highlight-next-line
+  imagePath: my-image-path`}
             </CodeBlock>
         </>
     );

--- a/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/PrivateRegistryRegular.js
+++ b/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/PrivateRegistryRegular.js
@@ -125,8 +125,8 @@ spec:
   variant: TigeraSecureEnterprise
   imagePullSecrets:
     - name: tigera-pull-secret
-    // highlight-next-line
-      registry: myregistry.com`}</CodeBlock>
+  // highlight-next-line
+  registry: myregistry.com`}</CodeBlock>
         </>
     );
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/_includes/components/PrivateRegistryImagePath.js
+++ b/calico-enterprise_versioned_docs/version-3.20-1/_includes/components/PrivateRegistryImagePath.js
@@ -141,10 +141,10 @@ spec:
   variant: TigeraSecureEnterprise
   imagePullSecrets:
     - name: tigera-pull-secret
-    // highlight-next-line
-      registry: myregistry.com
-    // highlight-next-line
-      imagePath: my-image-path`}
+  // highlight-next-line
+  registry: myregistry.com
+  // highlight-next-line
+  imagePath: my-image-path`}
             </CodeBlock>
         </>
     );

--- a/calico-enterprise_versioned_docs/version-3.20-1/_includes/components/PrivateRegistryRegular.js
+++ b/calico-enterprise_versioned_docs/version-3.20-1/_includes/components/PrivateRegistryRegular.js
@@ -125,8 +125,8 @@ spec:
   variant: TigeraSecureEnterprise
   imagePullSecrets:
     - name: tigera-pull-secret
-    // highlight-next-line
-      registry: myregistry.com`}</CodeBlock>
+  // highlight-next-line
+  registry: myregistry.com`}</CodeBlock>
         </>
     );
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/PrivateRegistryImagePath.js
+++ b/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/PrivateRegistryImagePath.js
@@ -141,10 +141,10 @@ spec:
   variant: TigeraSecureEnterprise
   imagePullSecrets:
     - name: tigera-pull-secret
-    // highlight-next-line
-      registry: myregistry.com
-    // highlight-next-line
-      imagePath: my-image-path`}
+  // highlight-next-line
+  registry: myregistry.com
+  // highlight-next-line
+  imagePath: my-image-path`}
             </CodeBlock>
         </>
     );

--- a/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/PrivateRegistryRegular.js
+++ b/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/PrivateRegistryRegular.js
@@ -125,8 +125,8 @@ spec:
   variant: TigeraSecureEnterprise
   imagePullSecrets:
     - name: tigera-pull-secret
-    // highlight-next-line
-      registry: myregistry.com`}</CodeBlock>
+  // highlight-next-line
+  registry: myregistry.com`}</CodeBlock>
         </>
     );
 

--- a/calico-enterprise_versioned_docs/version-3.21-1/_includes/components/PrivateRegistryImagePath.js
+++ b/calico-enterprise_versioned_docs/version-3.21-1/_includes/components/PrivateRegistryImagePath.js
@@ -141,10 +141,10 @@ spec:
   variant: TigeraSecureEnterprise
   imagePullSecrets:
     - name: tigera-pull-secret
-    // highlight-next-line
-      registry: myregistry.com
-    // highlight-next-line
-      imagePath: my-image-path`}
+  // highlight-next-line
+  registry: myregistry.com
+  // highlight-next-line
+  imagePath: my-image-path`}
             </CodeBlock>
         </>
     );

--- a/calico-enterprise_versioned_docs/version-3.21-1/_includes/components/PrivateRegistryRegular.js
+++ b/calico-enterprise_versioned_docs/version-3.21-1/_includes/components/PrivateRegistryRegular.js
@@ -125,8 +125,8 @@ spec:
   variant: TigeraSecureEnterprise
   imagePullSecrets:
     - name: tigera-pull-secret
-    // highlight-next-line
-      registry: myregistry.com`}</CodeBlock>
+  // highlight-next-line
+  registry: myregistry.com`}</CodeBlock>
         </>
     );
 


### PR DESCRIPTION
This was fixed in OSS docs in 2023 but never ported across.  The imagePath and registry fields need to be in the top level of the spec: if they're placed inside the imagePullSecrets as they were they will all be ignored.


Product Version(s):
Calico Enterprise


SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->