### PR TITLE
Add a wildcard redirect for all OSS manifests

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -4,7 +4,7 @@
 # Manifest redirects to help out some 3.15 stragglers.
 /v3.15/manifests/* https://downloads.tigera.io/ee/v3.15.1/manifests/:splat 301!
 
-/calico/latest/manifests/calico.yaml  https://raw.githubusercontent.com/projectcalico/calico/v3.29.2/manifests/calico.yaml 301
+/calico/latest/manifests/*  https://raw.githubusercontent.com/projectcalico/calico/v3.29.2/manifests/:splat 302
 
 # Redirect version Next to calico-docs-preview-next.netlify.app
 /calico/next/* https://calico-docs-preview-next.netlify.app/calico/next/:splat


### PR DESCRIPTION
**Product Version(s):** Calico OSS

**Issue:** N/A

**DOCS review:**
- [ ] A member of the docs team has approved this change.

**Additional information:**

Instead of only redirecting `calico.yaml`, provide a wildcard redirect for any manifests. This was asked for by @frozenprocess for documentation/examples/boilerplate purposes.

An example case can be found in [this k3d PR](https://github.com/k3d-io/k3d/pull/1523/files#diff-0521f8d52677a9d6b72ddc804fd4dd256b20722754d796f9d6cd01d79a18ec04R32).

Also, we change the redirect to a 302 because it's a temporary redirect and will change with each patch release.

**Merge checklist:**
<!--- Mandatory for docs team members before merging code --->
- [X] Deploy preview inspected wherever changes were made 
- [X] Build completed successfully
- [X] Test have passed 
