### PR TITLE
Revert change to lower k8s version support

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/compatibility.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/compatibility.mdx
@@ -53,7 +53,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | $[prodname] version | kOps and Kubernetes versions | $[prodname] support                                                                  |
 | ------------------- | ---------------------------- | ------------------------------------------------------------------------------------ |
-| 3.19                | 1.28 - 1.30                  | - $[prodname] CNI with network policy<br />- AWS CNI with $[prodname] network policy |
+| 3.19                | 1.27 - 1.30                  | - $[prodname] CNI with network policy<br />- AWS CNI with $[prodname] network policy |
 | 3.18                | 1.26 - 1.28                  | - $[prodname] CNI with network policy<br />- AWS CNI with $[prodname] network policy |
 | 3.17                | 1.25 - 1.26                  | - $[prodname] CNI with network policy<br />- AWS CNI with $[prodname] network policy |
 


### PR DESCRIPTION
An change to the kOps and Kubernetes version for 3.19 was merged by
mistake as part of the CE 3.19.5 release. This commit reverts the change
to the lower end, version 1.27.

See https://github.com/tigera/docs/commit/388dcafdfb2ed0fb3a4263624faf286c5af6967a

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->