### PR TITLE
Update documentation for non-cluster host Typha scaling

### DIFF
--- a/calico-enterprise/getting-started/bare-metal/about.mdx
+++ b/calico-enterprise/getting-started/bare-metal/about.mdx
@@ -105,21 +105,13 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
 
 ### Set up your non-cluster host or VM
 
-1. Configure the Calico RHEL yum/dnf repositories
+1. Configure the Calico Enterprise repository.
 
-   - If your non-cluster host or VM has RHEL 8 installed, then run the following command:
+    ```bash
+    curl -sfL https://downloads.tigera.io/ee/rpms/v3.21/calico-enterprise.repo -o /etc/yum.repos.d/calico-enterprise.repo
+    ```
 
-      ```bash
-      curl https://downloads.tigera.io/ee/rpms/v3.21/calico_rhel8.repo -o /etc/yum.repos.d/calico_rhel8.repo
-      ```
-
-   - If your non-cluster host or VM has RHEL 9 installed, then run the following command:
-
-      ```bash
-      curl https://downloads.tigera.io/ee/rpms/v3.21/calico_rhel9.repo -o /etc/yum.repos.d/calico_rhel9.repo
-      ```
-
-     Only Red Hat Enterprise Linux 8 and 9 x86-64 operating systems are supported in this version of $[prodname].
+    Only Red Hat Enterprise Linux 8 and 9 x86-64 operating systems are supported in this version of $[prodname].
 
 1. Install Calico node and fluent-bit log forwarder packages.
 

--- a/calico-enterprise/getting-started/bare-metal/about.mdx
+++ b/calico-enterprise/getting-started/bare-metal/about.mdx
@@ -40,7 +40,7 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
 
 ## How to
 
-### Set up your Kubernetes cluster to work with Accepted Values non-cluster host or VM
+### Set up your Kubernetes cluster to work with a non-cluster host or VM
 
 1. Create a `NonClusterHost` custom resource.
 
@@ -73,12 +73,6 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
 
 3. Create a `kubeconfig` file for your non-cluster host or VM similar to the following:
 
-    - Cluster:
-      - `server`: The URL of the Kubernetes API server.
-      - `certificate-authority-data`: Base64 encoded CA certificate to verify the Kubernetes API server's certificate.
-    - User:
-      - `token`: A bearer token associated with the `tigera-noncluster-host` service account obtained in the previous step.
-
     ```yaml
     apiVersion: v1
     kind: Config
@@ -86,8 +80,8 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
     preferences: {}
     clusters:
     - cluster:
-        certificate-authority-data: <ca-cert-to-verify-Kubernetes-api-server>
-        server: <URL-of-the-Kubernetes-api-server>
+        certificate-authority-data: <certificate-authority-data>
+        server: <server>
       name: noncluster-hosts
     contexts:
     - context:
@@ -97,8 +91,15 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
     users:
     - name: tigera-noncluster-host
       user:
-        token: <token-for-tigera-noncluster-host>
+        token: <token>
     ```
+
+    Replace the following:
+    - Cluster:
+      - `<server>`: The URL of the Kubernetes API server.
+      - `<certificate-authority-data>`: Base64 encoded CA certificate to verify the Kubernetes API server's certificate.
+    - User:
+      - `<token>`: A bearer token associated with the `tigera-noncluster-host` service account obtained in the previous step.
 
 4. Create a [`HostEndpoint` resource](../../reference/host-endpoints/overview.mdx) for each non-cluster host or VM. The `node` and `expectedIPs` fields are required to match the hostname and the expected interface IP addresses.
 

--- a/calico-enterprise/getting-started/bare-metal/about.mdx
+++ b/calico-enterprise/getting-started/bare-metal/about.mdx
@@ -40,57 +40,71 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
 
 ## How to
 
-### Set up your Kubernetes cluster to work with a non-cluster host or VM
+### Set up your Kubernetes cluster to work with Accepted Valuesa non-cluster host or VM
 
-1. Apply the `NonClusterHost` custom resource. The `endpoint` field is required. It defines the remote endpoint for the non-cluster host log forwarder.
+1. Apply the `NonClusterHost` custom resource. This resource enables the cluster-side ingestion endpoint to receive logs from non-cluster hosts. Additionally, it provides a dedicated Typha deployment for managing communication between the non-cluster host agent and Typha.
 
-   ```bash
-   kubectl create -f - <<EOF
-   apiVersion: operator.tigera.io/v1
-   kind: NonClusterHost
-   metadata:
-     name: tigera-secure
-   spec:
-     endpoint: <endpoint for non-cluster host log forwarder>
-   EOF
-   ```
+    To ensure a secure connection, non-cluster host agents will establish an mTLS connection via the `typhaEndpoint` endpoint. As a result, the external ingress or load balancer must be configured to pass through TCP Layer 4 traffic.
 
-   Wait until the manager shows a status of Available, then proceed to the next step.
+    :::note
 
-1. Obtain the token for `tigera-noncluster-host` service account.
+    Starting from Calico Enterprise version v3.21.0 Early Preview 2, the `typhaEndpoint` field is required for non-cluster host agents to function correctly. Ensure this filed is properly configured to maintain seamless connectivity.
 
-   ```bash
-   kubectl get secret -n calico-system tigera-noncluster-host -o jsonpath='{.data.token}' | base64 --decode
-   ```
+    :::
 
-1. Use a text editor to create a kubeconfig file for non-cluster host or VM.
+    | Field         | Description                                                          | Accepted Values                                                          | Schema |
+    | ------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------ |
+    | endpoint      | Location of the log ingestion point for non-cluster hosts. Required. | Any HTTPS URL with a domain name and a port number                       | string |
+    | typhaEndpoint | Location of the Typha endpoint for non-cluster host agent and Typha communication. Required. | Any IP address or domain name with a port number | string |
 
-   ```yaml
-   apiVersion: v1
-   kind: Config
-   current-context: noncluster-hosts
-   preferences: {}
-   clusters:
-   - cluster:
-       certificate-authority-data: <your cluster certificate>
-       server: <your cluster server>
-     name: noncluster-hosts
-   contexts:
-   - context:
-       cluster: noncluster-hosts
-       user: tigera-noncluster-host
-     name: noncluster-hosts
-   users:
-   - name: tigera-noncluster-host
-     user:
-       token: <token from previous step>
-   ```
+    ```bash
+    kubectl create -f - <<EOF
+    apiVersion: operator.tigera.io/v1
+    kind: NonClusterHost
+    metadata:
+      name: tigera-secure
+    spec:
+      endpoint: https://ingress-or-load-balancer.example.com:443
+      typhaEndpoint: 5.6.7.8:5473
+    EOF
+    ```
 
-   Take the cluster information from an already existing kubeconfig.
+    Wait until the Tigera Manager and non-cluster Typha deployments reach the Available status before proceeding to the next step.
 
-1. Create a [`HostEndpoint` resource](../../reference/host-endpoints/overview.mdx) for each non-cluster host or VM. The `node` and `expectedIPs` fields are required to match the hostname and the expected interface IP addresses.
+2. Obtain the token for `tigera-noncluster-host` service account.
 
-1. Follow [Configure access to the $[prodname] web console](../../operations/cnx/access-the-manager.mdx) page to configure the $[prodname] web console access.
+    ```bash
+    kubectl get secret -n calico-system tigera-noncluster-host -o jsonpath='{.data.token}' | base64 --decode
+    ```
+
+3. Use a text editor to create a kubeconfig file for non-cluster host or VM.
+
+    ```yaml
+    apiVersion: v1
+    kind: Config
+    current-context: noncluster-hosts
+    preferences: {}
+    clusters:
+    - cluster:
+        certificate-authority-data: <your cluster certificate>
+        server: <your cluster server>
+      name: noncluster-hosts
+    contexts:
+    - context:
+        cluster: noncluster-hosts
+        user: tigera-noncluster-host
+      name: noncluster-hosts
+    users:
+    - name: tigera-noncluster-host
+      user:
+        token: <token from previous step>
+    ```
+
+    Take the cluster information from the administrator kubeconfig.
+
+4. Create a [`HostEndpoint` resource](../../reference/host-endpoints/overview.mdx) for each non-cluster host or VM. The `node` and `expectedIPs` fields are required to match the hostname and the expected interface IP addresses.
+
+5. Follow [Configure access to the $[prodname] web console](../../operations/cnx/access-the-manager.mdx) page to configure the $[prodname] web console access.
 
 ### Set up your non-cluster host or VM
 
@@ -98,15 +112,15 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
 
    - If your non-cluster host or VM has RHEL 8 installed, then run the following command:
 
-     ```bash
-     curl https://downloads.tigera.io/ee/rpms/v3.20/calico_rhel8.repo -o /etc/yum.repos.d/calico_rhel8.repo
-     ```
+      ```bash
+      curl https://downloads.tigera.io/ee/rpms/v3.21/calico_rhel8.repo -o /etc/yum.repos.d/calico_rhel8.repo
+      ```
 
    - If your non-cluster host or VM has RHEL 9 installed, then run the following command:
 
-     ```bash
-     curl https://downloads.tigera.io/ee/rpms/v3.20/calico_rhel9.repo -o /etc/yum.repos.d/calico_rhel9.repo
-     ```
+      ```bash
+      curl https://downloads.tigera.io/ee/rpms/v3.21/calico_rhel9.repo -o /etc/yum.repos.d/calico_rhel9.repo
+      ```
 
      Only Red Hat Enterprise Linux 8 and 9 x86-64 operating systems are supported in this version of $[prodname].
 
@@ -114,20 +128,20 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
 
     - Use `dnf` to install the `calico-node` and `calico-fluent-bit` packages:
 
-    ```bash
-    dnf install calico-node calico-fluent-bit
-    ```
+      ```bash
+      dnf install calico-node calico-fluent-bit
+      ```
 
 1. Copy the kubeconfig created in cluster setup step 3 to host folder `/etc/calico/kubeconfig` and change ownership to `calico:calico`.
 
 1. Start Calico node and log forwarder.
 
-   ```bash
-   systemctl enable --now calico-node.service
-   systemctl enable --now calico-fluent-bit.service
-   ```
+    ```bash
+    systemctl enable --now calico-node.service
+    systemctl enable --now calico-fluent-bit.service
+    ```
 
-   You can configure the Calico node by tuning the environment variables defined in the `/etc/calico/calico-node/calico-node.env` file. For more information, see the [Felix configuration reference](../../reference/resources/felixconfig.mdx).
+    You can configure the Calico node by tuning the environment variables defined in the `/etc/calico/calico-node/calico-node.env` file. For more information, see the [Felix configuration reference](../../reference/resources/felixconfig.mdx).
 
 ### Configure hosts to communicate with your Kubernetes cluster
 

--- a/calico-enterprise/getting-started/bare-metal/about.mdx
+++ b/calico-enterprise/getting-started/bare-metal/about.mdx
@@ -40,22 +40,16 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
 
 ## How to
 
-### Set up your Kubernetes cluster to work with Accepted Valuesa non-cluster host or VM
+### Set up your Kubernetes cluster to work with Accepted Values non-cluster host or VM
 
-1. Apply the `NonClusterHost` custom resource. This resource enables the cluster-side ingestion endpoint to receive logs from non-cluster hosts. Additionally, it provides a dedicated Typha deployment for managing communication between the non-cluster host agent and Typha.
+1. Create a `NonClusterHost` custom resource.
 
-    To ensure a secure connection, non-cluster host agents will establish an mTLS connection via the `typhaEndpoint` endpoint. As a result, the external ingress or load balancer must be configured to pass through TCP Layer 4 traffic.
-
-    :::note
-
-    Starting from Calico Enterprise version v3.21.0 Early Preview 2, the `typhaEndpoint` field is required for non-cluster host agents to function correctly. Ensure this filed is properly configured to maintain seamless connectivity.
-
-    :::
+    This resource enables the cluster-side ingestion endpoint to receive logs from non-cluster hosts. Additionally, it provides a dedicated Typha deployment for managing communication between the non-cluster host agent and Typha.
 
     | Field         | Description                                                          | Accepted Values                                                          | Schema |
     | ------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------ |
-    | endpoint      | Location of the log ingestion point for non-cluster hosts. Required. | Any HTTPS URL with a domain name and a port number                       | string |
-    | typhaEndpoint | Location of the Typha endpoint for non-cluster host agent and Typha communication. Required. | Any IP address or domain name with a port number | string |
+    | endpoint      | Required. Location of the log ingestion point for non-cluster hosts. | Any HTTPS URL with a domain name and a port number                       | string |
+    | typhaEndpoint | Required. Location of the Typha endpoint for non-cluster host agent and Typha communication. | Any IP address or domain name with a port number | string |
 
     ```bash
     kubectl create -f - <<EOF
@@ -64,8 +58,8 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
     metadata:
       name: tigera-secure
     spec:
-      endpoint: https://ingress-or-load-balancer.example.com:443
-      typhaEndpoint: 5.6.7.8:5473
+      endpoint: <https://domain-or-ip-address:port>
+      typhaEndpoint: <domain-or-ip-address:port>
     EOF
     ```
 
@@ -77,7 +71,13 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
     kubectl get secret -n calico-system tigera-noncluster-host -o jsonpath='{.data.token}' | base64 --decode
     ```
 
-3. Use a text editor to create a kubeconfig file for non-cluster host or VM.
+3. Create a `kubeconfig` file for your non-cluster host or VM similar to the following:
+
+    - Cluster:
+      - `server`: The URL of the Kubernetes API server.
+      - `certificate-authority-data`: Base64 encoded CA certificate to verify the Kubernetes API server's certificate.
+    - User:
+      - `token`: A bearer token associated with the `tigera-noncluster-host` service account obtained in the previous step.
 
     ```yaml
     apiVersion: v1
@@ -86,8 +86,8 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
     preferences: {}
     clusters:
     - cluster:
-        certificate-authority-data: <your cluster certificate>
-        server: <your cluster server>
+        certificate-authority-data: <ca-cert-to-verify-Kubernetes-api-server>
+        server: <URL-of-the-Kubernetes-api-server>
       name: noncluster-hosts
     contexts:
     - context:
@@ -97,14 +97,10 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
     users:
     - name: tigera-noncluster-host
       user:
-        token: <token from previous step>
+        token: <token-for-tigera-noncluster-host>
     ```
 
-    Take the cluster information from the administrator kubeconfig.
-
 4. Create a [`HostEndpoint` resource](../../reference/host-endpoints/overview.mdx) for each non-cluster host or VM. The `node` and `expectedIPs` fields are required to match the hostname and the expected interface IP addresses.
-
-5. Follow [Configure access to the $[prodname] web console](../../operations/cnx/access-the-manager.mdx) page to configure the $[prodname] web console access.
 
 ### Set up your non-cluster host or VM
 
@@ -145,18 +141,20 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
 
 ### Configure hosts to communicate with your Kubernetes cluster
 
-Using $[prodname] network policy-only mode (i.e. with other CNIs), you must ensure that the non-cluster host or VM can directly communicate with your Kubernetes cluster. Here are some vendor tips:
+You must ensure that the non-cluster hosts or VMs can communicate with your Kubernetes cluster. If you are using an ingress controller or an external load balancer, ensure it is configured to allow TCP Layer 4 passthrough. This is required for non-cluster host agent to establish a mutual TLS (mTLS) connection to the cluster via the `typhaEndpoint` endpoint.
+
+Below are some vendor-specific considerations:
 
 #### AWS
 
-- For hosts to communicate with your Kubernetes cluster, the node must be in the same VPC as nodes in your Kubernetes cluster, and must use the AWS VPC CNI plugin (used by default in EKS).
-- The Kubernetes cluster security group needs to allow traffic from your host endpoint. Make sure that an inbound rule is set so that traffic from your host endpoint node is allowed.
-- For a non-cluster host to communicate with an EKS cluster, the correct IAM roles must be configured.
-- You also need to provide authentication to your Kubernetes cluster using [aws-iam-authenticator](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html) and the [aws cli](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
+- The node must reside in the same VPC as the nodes in your Kubernetes cluster, and utilize the AWS VPC CNI plugin (the default for Amazon EKS).
+- Ensure that the Kubernetes cluster's security group permits inbound traffic from the host. You may need to add a rule allowing traffic from the hosts or VMs.
+- For successful communication with an EKS cluster, the appropriate IAM roles must be configured.
+- The host or VM must also be authenticated to access the cluster using tools such as [aws-iam-authenticator](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html) and the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
 
 #### GKE
 
-For hosts to communicate with your Kubernetes cluster directly, you must make the host directly reachable/routable; this is not set up by default with the VPC native network routing.
+- To enable communication with your Kubernetes cluster from a non-cluster host, the host must be directly reachable or routable. This configuration is not enabled by default when using GKE’s VPC-native network routing.
 
 ## Additional resources
 


### PR DESCRIPTION
This change updates the non-cluster host installation documentation to support Typha scaling introduced in CE v3.21 EP2. It also clarifies the purpose of the NonClusterHost custom resource and endpoints defined in the spec.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):

Calico Enterprise v3.21 EP2.

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->