### PR TITLE
fix outdated links for rancher page

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/rancher.mdx
@@ -29,7 +29,7 @@ The geeky details of what you get:
 
 - Configure your cluster for $[prodname] CNI
 
-  - Create a [Cluster Config File](https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/#cluster-config-file). In the config file under `network`, set the [network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) to `plugin: none`.
+  - Create a [Cluster Config File](https://rancher.com/docs/rancher/en/cluster-provisioning/rke-clusters/options/#cluster-config-file). In the config file under `network`, set the [network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) to `plugin: none`.
 
   :::note
 
@@ -42,7 +42,7 @@ The geeky details of what you get:
 - A [Tigera license key and credentials](calico-enterprise.mdx).
 
 - A `kubectl` environment with access to your cluster
-  - Use [Rancher kubectl Shell](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/cluster-access/kubectl/) for access
+  - Use [Rancher kubectl Shell](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters/use-kubectl-and-kubeconfig#accessing-clusters-with-kubectl-shell-in-the-rancher-ui) for access
   - Ensure you have the [Kubeconfig file that was generated when you created the cluster](https://rancher.com/docs/rke/latest/en/installation/#save-your-files).
 - If using a Kubeconfig file locally, [install and set up the Kubectl CLI tool](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 

--- a/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.18-2/getting-started/install-on-clusters/rancher.mdx
@@ -29,7 +29,7 @@ The geeky details of what you get:
 
 - Configure your cluster for $[prodname] CNI
 
-  - Create a [Cluster Config File](https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/#cluster-config-file). In the config file under `network`, set the [network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) to `plugin: none`.
+  - Create a [Cluster Config File](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#rke-cluster-config-file-reference). In the config file under `network`, set the [network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) to `plugin: none`.
 
   :::note
 
@@ -42,7 +42,7 @@ The geeky details of what you get:
 - A [Tigera license key and credentials](calico-enterprise.mdx).
 
 - A `kubectl` environment with access to your cluster
-  - Use [Rancher kubectl Shell](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/cluster-access/kubectl/) for access
+  - Use [Rancher kubectl Shell](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters/use-kubectl-and-kubeconfig#accessing-clusters-with-kubectl-shell-in-the-rancher-ui) for access
   - Ensure you have the [Kubeconfig file that was generated when you created the cluster](https://rancher.com/docs/rke/latest/en/installation/#save-your-files).
 - If using a Kubeconfig file locally, [install and set up the Kubectl CLI tool](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/rancher.mdx
@@ -29,7 +29,7 @@ The geeky details of what you get:
 
 - Configure your cluster for $[prodname] CNI
 
-  - Create a [Cluster Config File](https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/#cluster-config-file). In the config file under `network`, set the [network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) to `plugin: none`.
+  - Create a [Cluster Config File](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#rke-cluster-config-file-reference). In the config file under `network`, set the [network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) to `plugin: none`.
 
   :::note
 
@@ -42,7 +42,7 @@ The geeky details of what you get:
 - A [Tigera license key and credentials](calico-enterprise.mdx).
 
 - A `kubectl` environment with access to your cluster
-  - Use [Rancher kubectl Shell](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/cluster-access/kubectl/) for access
+  - Use [Rancher kubectl Shell](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters/use-kubectl-and-kubeconfig#accessing-clusters-with-kubectl-shell-in-the-rancher-ui) for access
   - Ensure you have the [Kubeconfig file that was generated when you created the cluster](https://rancher.com/docs/rke/latest/en/installation/#save-your-files).
 - If using a Kubeconfig file locally, [install and set up the Kubectl CLI tool](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/getting-started/install-on-clusters/rancher.mdx
@@ -29,7 +29,7 @@ The geeky details of what you get:
 
 - Configure your cluster for $[prodname] CNI
 
-  - Create a [Cluster Config File](https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/#cluster-config-file). In the config file under `network`, set the [network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) to `plugin: none`.
+  - Create a [Cluster Config File](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#rke-cluster-config-file-reference). In the config file under `network`, set the [network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) to `plugin: none`.
 
   :::note
 
@@ -42,7 +42,7 @@ The geeky details of what you get:
 - A [Tigera license key and credentials](calico-enterprise.mdx).
 
 - A `kubectl` environment with access to your cluster
-  - Use [Rancher kubectl Shell](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/cluster-access/kubectl/) for access
+  - Use [Rancher kubectl Shell](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters/use-kubectl-and-kubeconfig#accessing-clusters-with-kubectl-shell-in-the-rancher-ui) for access
   - Ensure you have the [Kubeconfig file that was generated when you created the cluster](https://rancher.com/docs/rke/latest/en/installation/#save-your-files).
 - If using a Kubeconfig file locally, [install and set up the Kubectl CLI tool](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/rancher.mdx
@@ -29,7 +29,7 @@ The geeky details of what you get:
 
 - Configure your cluster for $[prodname] CNI
 
-  - Create a [Cluster Config File](https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/#cluster-config-file). In the config file under `network`, set the [network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) to `plugin: none`.
+  - Create a [Cluster Config File](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#rke-cluster-config-file-reference). In the config file under `network`, set the [network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) to `plugin: none`.
 
   :::note
 
@@ -42,7 +42,7 @@ The geeky details of what you get:
 - A [Tigera license key and credentials](calico-enterprise.mdx).
 
 - A `kubectl` environment with access to your cluster
-  - Use [Rancher kubectl Shell](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/cluster-access/kubectl/) for access
+  - Use [Rancher kubectl Shell](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters/use-kubectl-and-kubeconfig#accessing-clusters-with-kubectl-shell-in-the-rancher-ui) for access
   - Ensure you have the [Kubeconfig file that was generated when you created the cluster](https://rancher.com/docs/rke/latest/en/installation/#save-your-files).
 - If using a Kubeconfig file locally, [install and set up the Kubectl CLI tool](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 

--- a/calico-enterprise_versioned_docs/version-3.21-1/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-1/getting-started/install-on-clusters/rancher.mdx
@@ -29,7 +29,7 @@ The geeky details of what you get:
 
 - Configure your cluster for $[prodname] CNI
 
-  - Create a [Cluster Config File](https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/#cluster-config-file). In the config file under `network`, set the [network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) to `plugin: none`.
+  - Create a [Cluster Config File](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#rke-cluster-config-file-reference). In the config file under `network`, set the [network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) to `plugin: none`.
 
   :::note
 
@@ -42,7 +42,7 @@ The geeky details of what you get:
 - A [Tigera license key and credentials](calico-enterprise.mdx).
 
 - A `kubectl` environment with access to your cluster
-  - Use [Rancher kubectl Shell](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/cluster-access/kubectl/) for access
+  - Use [Rancher kubectl Shell](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters/use-kubectl-and-kubeconfig#accessing-clusters-with-kubectl-shell-in-the-rancher-ui) for access
   - Ensure you have the [Kubeconfig file that was generated when you created the cluster](https://rancher.com/docs/rke/latest/en/installation/#save-your-files).
 - If using a Kubeconfig file locally, [install and set up the Kubectl CLI tool](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 

--- a/calico/getting-started/kubernetes/rancher.mdx
+++ b/calico/getting-started/kubernetes/rancher.mdx
@@ -26,13 +26,13 @@ The geeky details of what you get:
 
 - A compatible [Rancher Kubernetes Engine cluster](https://rancher.com/docs/rke/latest/en/) with version 1.3
 
-  - Configure your cluster with a [Cluster Config File](https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/#cluster-config-file) and specify [no network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) by setting `plugin: none` under `network` in your configuration file.
+  - Configure your cluster with a [Cluster Config File](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#rke-cluster-config-file-reference) and specify [no network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) by setting `plugin: none` under `network` in your configuration file.
 
 - RKE cluster meets the [$[prodname] requirements](requirements.mdx)
 
 - A `kubectl` environment with access to your cluster
 
-  - Use [Rancher kubectl Shell](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/cluster-access/kubectl/) for access
+  - Use [Rancher kubectl Shell](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters/use-kubectl-and-kubeconfig#accessing-clusters-with-kubectl-shell-in-the-rancher-ui) for access
   - Ensure you have the [Kubeconfig file that was generated when you created the cluster](https://rancher.com/docs/rke/latest/en/installation/#save-your-files).
 
 - If using a Kubeconfig file locally, [install and set up the Kubectl CLI tool](https://kubernetes.io/docs/tasks/tools/install-kubectl/).

--- a/calico_versioned_docs/version-3.27/getting-started/kubernetes/rancher.mdx
+++ b/calico_versioned_docs/version-3.27/getting-started/kubernetes/rancher.mdx
@@ -25,13 +25,13 @@ The geeky details of what you get:
 
 - A compatible [Rancher Kubernetes Engine cluster](https://rancher.com/docs/rke/latest/en/) with version 1.3
 
-  - Configure your cluster with a [Cluster Config File](https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/#cluster-config-file) and specify [no network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) by setting `plugin: none` under `network` in your configuration file.
+  - Configure your cluster with a [Cluster Config File](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#rke-cluster-config-file-reference) and specify [no network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) by setting `plugin: none` under `network` in your configuration file.
 
 - RKE cluster meets the [$[prodname] requirements](requirements.mdx)
 
 - A `kubectl` environment with access to your cluster
 
-  - Use [Rancher kubectl Shell](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/cluster-access/kubectl/) for access
+  - Use [Rancher kubectl Shell](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters/use-kubectl-and-kubeconfig#accessing-clusters-with-kubectl-shell-in-the-rancher-ui) for access
   - Ensure you have the [Kubeconfig file that was generated when you created the cluster](https://rancher.com/docs/rke/latest/en/installation/#save-your-files).
 
 - If using a Kubeconfig file locally, [install and set up the Kubectl CLI tool](https://kubernetes.io/docs/tasks/tools/install-kubectl/).

--- a/calico_versioned_docs/version-3.28/getting-started/kubernetes/rancher.mdx
+++ b/calico_versioned_docs/version-3.28/getting-started/kubernetes/rancher.mdx
@@ -25,13 +25,13 @@ The geeky details of what you get:
 
 - A compatible [Rancher Kubernetes Engine cluster](https://rancher.com/docs/rke/latest/en/) with version 1.3
 
-  - Configure your cluster with a [Cluster Config File](https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/#cluster-config-file) and specify [no network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) by setting `plugin: none` under `network` in your configuration file.
+  - Configure your cluster with a [Cluster Config File](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#rke-cluster-config-file-reference) and specify [no network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) by setting `plugin: none` under `network` in your configuration file.
 
 - RKE cluster meets the [$[prodname] requirements](requirements.mdx)
 
 - A `kubectl` environment with access to your cluster
 
-  - Use [Rancher kubectl Shell](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/cluster-access/kubectl/) for access
+  - Use [Rancher kubectl Shell](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters/use-kubectl-and-kubeconfig#accessing-clusters-with-kubectl-shell-in-the-rancher-ui) for access
   - Ensure you have the [Kubeconfig file that was generated when you created the cluster](https://rancher.com/docs/rke/latest/en/installation/#save-your-files).
 
 - If using a Kubeconfig file locally, [install and set up the Kubectl CLI tool](https://kubernetes.io/docs/tasks/tools/install-kubectl/).

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/rancher.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/rancher.mdx
@@ -26,13 +26,13 @@ The geeky details of what you get:
 
 - A compatible [Rancher Kubernetes Engine cluster](https://rancher.com/docs/rke/latest/en/) with version 1.3
 
-  - Configure your cluster with a [Cluster Config File](https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/#cluster-config-file) and specify [no network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) by setting `plugin: none` under `network` in your configuration file.
+  - Configure your cluster with a [Cluster Config File](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#rke-cluster-config-file-reference) and specify [no network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) by setting `plugin: none` under `network` in your configuration file.
 
 - RKE cluster meets the [$[prodname] requirements](requirements.mdx)
 
 - A `kubectl` environment with access to your cluster
 
-  - Use [Rancher kubectl Shell](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/cluster-access/kubectl/) for access
+  - Use [Rancher kubectl Shell](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters/use-kubectl-and-kubeconfig#accessing-clusters-with-kubectl-shell-in-the-rancher-ui) for access
   - Ensure you have the [Kubeconfig file that was generated when you created the cluster](https://rancher.com/docs/rke/latest/en/installation/#save-your-files).
 
 - If using a Kubeconfig file locally, [install and set up the Kubectl CLI tool](https://kubernetes.io/docs/tasks/tools/install-kubectl/).


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
N/A

Issue:
Links on **Rancher Kubernetes Engine** page return `Page Not Found`

Link to docs preview:

SME review:
- [ ] An SME has approved this change. 

DOCS review:
- [ ] A member of the docs team has approved this change.

Additional information:

Merge checklist:
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 
