### PR TITLE
[CORE-11251] Update OpenShift HCP docs

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/openshift/hostedcontrolplanes.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/openshift/hostedcontrolplanes.mdx
@@ -78,7 +78,7 @@ You can find them in [https://amd64.ocp.releases.ci.openshift.org], for example 
 :::
 
 :::note
-There is currently an [issue](https://github.com/openshift/hypershift/issues/3927) with the HyperShift middleware that will result in the hosted cluster installation not progressing due to a missing `OVNSbDb` service. Patch the hosted cluster resource in order to add it:
+If you face an [issue](https://github.com/openshift/hypershift/issues/3927) with the HyperShift middleware that results in the hosted cluster installation not progressing due to a missing `OVNSbDb` service, patch the hosted cluster resource in order to add it:
 ```
 HOSTED_CLUSTER_NAME=my-os-hosted-cluster
 CLUSTER_NS="clusters"
@@ -157,14 +157,22 @@ check the output of the init-container with `oc logs -n tigera-operator -l k8s-a
 
 ### Apply the $[prodname] install manifests
 
-Apply the install manifests paying attention to the required order:
+Apply the install manifests paying attention to the required order. First apply all necessary manifests to install the Tigera operator:
 
 ```
 cd calico/
-ls 00*.yaml | xargs -n1 oc apply -f
-ls 01*.yaml | xargs -n1 oc apply -f
-ls 02*.yaml | xargs -n1 oc apply -f
+ls 00* | xargs -n1 oc apply -f
+ls 01* | xargs -n1 oc apply -f
+ls 02* | xargs -n1 oc apply -f
 ```
+
+Then wait until the Tigera operator creates the necessary CustomResourceDefinitions (CRDs) before applying the CustomResources to install $[prodname] on your cluster:
+
+```
+timeout --foreground 600 bash -c "while ! kubectl get crd installations.operator.tigera.io; do sleep 5; done" # wait until CRDs are created by the operator
+ls 03* | xargs -n1 oc apply -f
+```
+
 ### Install the $[prodname] license
 
 In order to use $[prodname], you must install the license provided to you by Tigera support representative. Before applying the license, wait until the Tigera API server is ready with the following command:

--- a/calico-enterprise_versioned_docs/version-3.20-1/getting-started/install-on-clusters/openshift/hostedcontrolplanes.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/getting-started/install-on-clusters/openshift/hostedcontrolplanes.mdx
@@ -78,7 +78,7 @@ You can find them in [https://amd64.ocp.releases.ci.openshift.org], for example 
 :::
 
 :::note
-There is currently an [issue](https://github.com/openshift/hypershift/issues/3927) with the HyperShift middleware that will result in the hosted cluster installation not progressing due to a missing `OVNSbDb` service. Patch the hosted cluster resource in order to add it:
+If you face an [issue](https://github.com/openshift/hypershift/issues/3927) with the HyperShift middleware that results in the hosted cluster installation not progressing due to a missing `OVNSbDb` service, patch the hosted cluster resource in order to add it:
 ```
 HOSTED_CLUSTER_NAME=my-os-hosted-cluster
 CLUSTER_NS="clusters"
@@ -157,16 +157,22 @@ check the output of the init-container with `oc logs -n tigera-operator -l k8s-a
 
 ### Apply the $[prodname] install manifests
 
-Apply the install manifests paying attention to the required order:
+Apply the install manifests paying attention to the required order. First apply all necessary manifests to install the Tigera operator:
 
 ```
 cd calico/
-ls *crd*.yaml | xargs -n1 oc apply -f
-ls operator.tigera*.yaml | xargs -n1 oc apply -f
-ls 00*.yaml | xargs -n1 oc apply -f
-ls 01*.yaml | xargs -n1 oc apply -f
-ls 02*.yaml | xargs -n1 oc apply -f
+ls 00* | xargs -n1 oc apply -f
+ls 01* | xargs -n1 oc apply -f
+ls 02* | xargs -n1 oc apply -f
 ```
+
+Then wait until the Tigera operator creates the necessary CustomResourceDefinitions (CRDs) before applying the CustomResources to install $[prodname] on your cluster:
+
+```
+timeout --foreground 600 bash -c "while ! kubectl get crd installations.operator.tigera.io; do sleep 5; done" # wait until CRDs are created by the operator
+ls 03* | xargs -n1 oc apply -f
+```
+
 ### Install the $[prodname] license
 
 In order to use $[prodname], you must install the license provided to you by Tigera support representative. Before applying the license, wait until the Tigera API server is ready with the following command:

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/openshift/hostedcontrolplanes.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/openshift/hostedcontrolplanes.mdx
@@ -78,7 +78,7 @@ You can find them in [https://amd64.ocp.releases.ci.openshift.org], for example 
 :::
 
 :::note
-There is currently an [issue](https://github.com/openshift/hypershift/issues/3927) with the HyperShift middleware that will result in the hosted cluster installation not progressing due to a missing `OVNSbDb` service. Patch the hosted cluster resource in order to add it:
+If you face an [issue](https://github.com/openshift/hypershift/issues/3927) with the HyperShift middleware that results in the hosted cluster installation not progressing due to a missing `OVNSbDb` service, patch the hosted cluster resource in order to add it:
 ```
 HOSTED_CLUSTER_NAME=my-os-hosted-cluster
 CLUSTER_NS="clusters"
@@ -157,14 +157,22 @@ check the output of the init-container with `oc logs -n tigera-operator -l k8s-a
 
 ### Apply the $[prodname] install manifests
 
-Apply the install manifests paying attention to the required order:
+Apply the install manifests paying attention to the required order. First apply all necessary manifests to install the Tigera operator:
 
 ```
 cd calico/
-ls 00*.yaml | xargs -n1 oc apply -f
-ls 01*.yaml | xargs -n1 oc apply -f
-ls 02*.yaml | xargs -n1 oc apply -f
+ls 00* | xargs -n1 oc apply -f
+ls 01* | xargs -n1 oc apply -f
+ls 02* | xargs -n1 oc apply -f
 ```
+
+Then wait until the Tigera operator creates the necessary CustomResourceDefinitions (CRDs) before applying the CustomResources to install $[prodname] on your cluster:
+
+```
+timeout --foreground 600 bash -c "while ! kubectl get crd installations.operator.tigera.io; do sleep 5; done" # wait until CRDs are created by the operator
+ls 03* | xargs -n1 oc apply -f
+```
+
 ### Install the $[prodname] license
 
 In order to use $[prodname], you must install the license provided to you by Tigera support representative. Before applying the license, wait until the Tigera API server is ready with the following command:

--- a/calico-enterprise_versioned_docs/version-3.21-1/getting-started/install-on-clusters/openshift/hostedcontrolplanes.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-1/getting-started/install-on-clusters/openshift/hostedcontrolplanes.mdx
@@ -78,7 +78,7 @@ You can find them in [https://amd64.ocp.releases.ci.openshift.org], for example 
 :::
 
 :::note
-There is currently an [issue](https://github.com/openshift/hypershift/issues/3927) with the HyperShift middleware that will result in the hosted cluster installation not progressing due to a missing `OVNSbDb` service. Patch the hosted cluster resource in order to add it:
+If you face an [issue](https://github.com/openshift/hypershift/issues/3927) with the HyperShift middleware that results in the hosted cluster installation not progressing due to a missing `OVNSbDb` service, patch the hosted cluster resource in order to add it:
 ```
 HOSTED_CLUSTER_NAME=my-os-hosted-cluster
 CLUSTER_NS="clusters"
@@ -157,14 +157,22 @@ check the output of the init-container with `oc logs -n tigera-operator -l k8s-a
 
 ### Apply the $[prodname] install manifests
 
-Apply the install manifests paying attention to the required order:
+Apply the install manifests paying attention to the required order. First apply all necessary manifests to install the Tigera operator:
 
 ```
 cd calico/
-ls 00*.yaml | xargs -n1 oc apply -f
-ls 01*.yaml | xargs -n1 oc apply -f
-ls 02*.yaml | xargs -n1 oc apply -f
+ls 00* | xargs -n1 oc apply -f
+ls 01* | xargs -n1 oc apply -f
+ls 02* | xargs -n1 oc apply -f
 ```
+
+Then wait until the Tigera operator creates the necessary CustomResourceDefinitions (CRDs) before applying the CustomResources to install $[prodname] on your cluster:
+
+```
+timeout --foreground 600 bash -c "while ! kubectl get crd installations.operator.tigera.io; do sleep 5; done" # wait until CRDs are created by the operator
+ls 03* | xargs -n1 oc apply -f
+```
+
 ### Install the $[prodname] license
 
 In order to use $[prodname], you must install the license provided to you by Tigera support representative. Before applying the license, wait until the Tigera API server is ready with the following command:

--- a/calico/getting-started/kubernetes/openshift/hostedcontrolplanes.mdx
+++ b/calico/getting-started/kubernetes/openshift/hostedcontrolplanes.mdx
@@ -77,7 +77,7 @@ You can find them in [https://amd64.ocp.releases.ci.openshift.org], for example 
 :::
 
 :::note
-There is currently an [issue](https://github.com/openshift/hypershift/issues/3927) with the HyperShift middleware that will result in the hosted cluster installation not progressing due to a missing `OVNSbDb` service. Patch the hosted cluster resource in order to add it:
+If you face an [issue](https://github.com/openshift/hypershift/issues/3927) with the HyperShift middleware that results in the hosted cluster installation not progressing due to a missing `OVNSbDb` service, patch the hosted cluster resource in order to add it:
 ```
 HOSTED_CLUSTER_NAME=my-os-hosted-cluster
 CLUSTER_NS="clusters"
@@ -140,14 +140,20 @@ check the output of the init-container with `oc logs -n tigera-operator -l k8s-a
 
 ### Apply the $[prodname] install manifests
 
-Apply the install manifests paying attention to the required order:
+Apply the install manifests paying attention to the required order. First apply all necessary manifests to install the Tigera operator:
 
 ```
 cd calico/
-ls *crd*.yaml | xargs -n1 oc apply -f
 ls 00* | xargs -n1 oc apply -f
 ls 01* | xargs -n1 oc apply -f
 ls 02* | xargs -n1 oc apply -f
+```
+
+Then wait until the Tigera operator creates the necessary CustomResourceDefinitions (CRDs) before applying the CustomResources to install $[prodname] on your cluster:
+
+```
+timeout --foreground 600 bash -c "while ! kubectl get crd installations.operator.tigera.io; do sleep 5; done" # wait until CRDs are created by the operator
+ls 03* | xargs -n1 oc apply -f
 ```
 
 Once the above commands are complete, you can verify $[prodname] is installed by verifying the components are available with the following command.

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/openshift/hostedcontrolplanes.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/openshift/hostedcontrolplanes.mdx
@@ -77,7 +77,7 @@ You can find them in [https://amd64.ocp.releases.ci.openshift.org], for example 
 :::
 
 :::note
-There is currently an [issue](https://github.com/openshift/hypershift/issues/3927) with the HyperShift middleware that will result in the hosted cluster installation not progressing due to a missing `OVNSbDb` service. Patch the hosted cluster resource in order to add it:
+If you face an [issue](https://github.com/openshift/hypershift/issues/3927) with the HyperShift middleware that results in the hosted cluster installation not progressing due to a missing `OVNSbDb` service, patch the hosted cluster resource in order to add it:
 ```
 HOSTED_CLUSTER_NAME=my-os-hosted-cluster
 CLUSTER_NS="clusters"
@@ -142,14 +142,20 @@ check the output of the init-container with `oc logs -n tigera-operator -l k8s-a
 
 ### Apply the $[prodname] install manifests
 
-Apply the install manifests paying attention to the required order:
+Apply the install manifests paying attention to the required order. First apply all necessary manifests to install the Tigera operator:
 
 ```
 cd calico/
-ls *crd*.yaml | xargs -n1 oc apply -f
 ls 00* | xargs -n1 oc apply -f
 ls 01* | xargs -n1 oc apply -f
 ls 02* | xargs -n1 oc apply -f
+```
+
+Then wait until the Tigera operator creates the necessary CustomResourceDefinitions (CRDs) before applying the CustomResources to install $[prodname] on your cluster:
+
+```
+timeout --foreground 600 bash -c "while ! kubectl get crd installations.operator.tigera.io; do sleep 5; done" # wait until CRDs are created by the operator
+ls 03* | xargs -n1 oc apply -f
 ```
 
 Once the above commands are complete, you can verify $[prodname] is installed by verifying the components are available with the following command.


### PR DESCRIPTION
Update OpenShift HCP docs to properly account for CRDs being created by the operator, and a pause for them to be present in the cluster before creating CRs (installation, apiserver, and goldmane and whisker where applicable).

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->