### PR TITLE
Add staged policy page to OSS docs

### DIFF
--- a/calico/network-policy/staged-network-policies.mdx
+++ b/calico/network-policy/staged-network-policies.mdx
@@ -4,4 +4,138 @@ description: Stage and preview policies to observe traffic implications before e
 
 # Stage, preview impacts, and enforce policy
 
-{/* This is a placeholder file. */}
+## Big picture
+
+Stage and preview impacts on traffic before enforcing policy.
+
+## Value
+
+$[prodname] staged network policy resources lets you test the traffic impact of the policy as if it were enforced, but without changing traffic flow. You can also preview the impacts of a staged policy on existing traffic. By verifying that correct flows are allowed and denied before enforcement, you can minimize misconfiguration and potential network disruption.
+
+## Concepts
+
+### About staged policies
+
+The following staged policy resources have the same structure (i.e. the resource spec has the same fields) as their “enforced” counterpart.
+
+- Staged global network policy
+- Staged network policy
+- Staged Kubernetes network policy
+
+## How to
+
+- [Stage a policy](#stage-a-policy)
+- [Preview policy impact](#preview-policy-impact)
+- [Enforce a staged policy](#enforce-a-staged-policy)
+
+### Stage a policy
+
+Stage a policy to test it in a near replica of a production environment. A best practice is to stage a policy before enforcing it to avoid unintentionally exposing or blocking other network traffic.
+You can use custom resources to stage Kubernetes and $[prodname] policies, and apply them using `kubectl`. Here are sample YAML files.
+
+**Example: StagedGlobalNetworkPolicy**
+
+```yaml
+apiVersion: projectcalico.org/v3
+kind: StagedGlobalNetworkPolicy
+metadata:
+  name: default.allow-tcp-6379
+spec:
+  tier: default
+  selector: role == 'database'
+  types:
+    - Ingress
+    - Egress
+  ingress:
+    - action: Allow
+      protocol: TCP
+      source:
+        selector: role == 'frontend'
+      destination:
+        ports:
+          - 6379
+  egress:
+    - action: Allow
+```
+
+**Example: StagedNetworkPolicy**
+
+```yaml
+apiVersion: projectcalico.org/v3
+kind: StagedNetworkPolicy
+metadata:
+  name: default.allow-tcp-6379
+  namespace: default
+spec:
+  tier: default
+  selector: role == 'database'
+  types:
+    - Ingress
+    - Egress
+  ingress:
+    - action: Allow
+      protocol: TCP
+      source:
+        selector: role == 'frontend'
+      destination:
+        ports:
+          - 6379
+  egress:
+    - action: Allow
+```
+
+**Example: StagedKubernetesNetworkPolicy**
+
+```yaml
+apiVersion: projectcalico.org/v3
+kind: StagedKubernetesNetworkPolicy
+metadata:
+  name: test-network-policy
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      role: db
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 172.17.0.0/16
+            except:
+              - 172.17.1.0/24
+        - namespaceSelector:
+            matchLabels:
+              project: myproject
+        - podSelector:
+            matchLabels:
+              role: frontend
+      ports:
+        - protocol: TCP
+          port: 6379
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/24
+      ports:
+        - protocol: TCP
+          port: 5978
+```
+
+### Preview policy impact
+
+The impact of staged policies are reflected in the _enforced_ field of the generated [flow logs] (link to flow logs details) in Whisker. This field show what would happen to traffic if a staged policy is enforced.
+
+### Enforce a staged policy
+
+When the result of a staged policy is satisfactory, create an identical policy and apply it.
+
+## Additional resources
+
+- [Staged global network policy](../reference/resources/stagedglobalnetworkpolicy.mdx)
+- [Staged network policy](../reference/resources/stagednetworkpolicy.mdx)
+- [Staged Kubernetes network policy](../reference/resources/stagedkubernetesnetworkpolicy.mdx)
+- For details on how to configure RBAC for staged policy resources, see [Configuring RBAC for tiered policy](policy-tiers/rbac-tiered-policies.mdx)
+- For details on staged policy metrics, see
+  - [Flow logs](link to flowlogs)


### PR DESCRIPTION
This is to move https://docs.tigera.io/calico-enterprise/latest/network-policy/staged-network-policies
to open source documentation.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->