### PR TITLE
Add training resources to additional section for OS observability page

### DIFF
--- a/calico/observability/flow-logs-api.mdx
+++ b/calico/observability/flow-logs-api.mdx
@@ -14,3 +14,8 @@ The flow logs API (also known as Goldmane) is a gRPC API that powers the Calico 
 You can use this API to retrieve aggregated network traffic data, which includes policy enforcement details and statistics like packet and byte counts.
 
 For a complete description of the API, including its available endpoints and function definitions, please refer to the specifications outlined in this PROTO file: https://github.com/projectcalico/calico/blob/master/goldmane/proto/api.proto.
+
+## Additional resources
+* Exploring the [Goldmane API for custom Kubernetes Network Observability blog](https://www.tigera.io/blog/calico-open-source-3-30-exploring-the-goldmane-api-for-custom-kubernetes-network-observability/).
+* Click here to try [Goldmane integration in your browser right now!](https://play.instruqt.com/tigera/invite/wlzsrwx2qlus)
+* Watch [this video presentation to learn about Calico APIs and how to integrate with Goldmane](https://youtu.be/OA20R5JQnw8?list=PLoWxE_5hnZUZHemmSMnu_oUzF_xWi69zj&t=419).

--- a/calico/observability/view-flow-logs.mdx
+++ b/calico/observability/view-flow-logs.mdx
@@ -107,3 +107,6 @@ By default, Whisker does not automatically expose an endpoint.
 
 * To use flow logs in your own scripts or applications, see [Flow logs API](../observability/flow-logs-api.mdx).
 * For more free observability tools, try [Calico Cloud Free](/calico-cloud/free/overview).
+* How to [get started with Calico Observability features blog](https://www.tigera.io/blog/how-to-get-started-with-calico-observability-features/).
+* Click here to [try Kubernetes observability in your browser right now](https://play.instruqt.com/tigera/invite/fjk58ue5b49n).
+* Learn [everything about Calico Whisker from this video presentation](https://youtu.be/gtgUiDsHjYM?si=ETmCeU6LJrFU_Yhe). 

--- a/calico_versioned_docs/version-3.30/observability/flow-logs-api.mdx
+++ b/calico_versioned_docs/version-3.30/observability/flow-logs-api.mdx
@@ -13,4 +13,9 @@ This feature is tech preview. Tech preview features may be subject to significan
 The flow logs API (also known as Goldmane) is a gRPC API that powers the Calico Whisker web console.
 You can use this API to retrieve aggregated network traffic data, which includes policy enforcement details and statistics like packet and byte counts.
 
-For a complete description of the API, including its available endpoints and function definitions, please refer to the specifications outlined in the Protocol Buffers file: https://github.com/projectcalico/calico/blob/master/goldmane/proto/api.proto.
+For a complete description of the API, including its available endpoints and function definitions, please refer to the specifications outlined in this PROTO file: https://github.com/projectcalico/calico/blob/master/goldmane/proto/api.proto.
+
+## Additional resources
+* Exploring the [Goldmane API for custom Kubernetes Network Observability blog](https://www.tigera.io/blog/calico-open-source-3-30-exploring-the-goldmane-api-for-custom-kubernetes-network-observability/).
+* Click here to try [Goldmane integration in your browser right now!](https://play.instruqt.com/tigera/invite/wlzsrwx2qlus)
+* Watch [this video presentation to learn about Calico APIs and how to integrate with Goldmane](https://youtu.be/OA20R5JQnw8?list=PLoWxE_5hnZUZHemmSMnu_oUzF_xWi69zj&t=419).

--- a/calico_versioned_docs/version-3.30/observability/view-flow-logs.mdx
+++ b/calico_versioned_docs/version-3.30/observability/view-flow-logs.mdx
@@ -107,3 +107,6 @@ By default, Whisker does not automatically expose an endpoint.
 
 * To use flow logs in your own scripts or applications, see [Flow logs API](../observability/flow-logs-api.mdx).
 * For more free observability tools, try [Calico Cloud Free](/calico-cloud/free/overview).
+* How to [get started with Calico Observability features blog](https://www.tigera.io/blog/how-to-get-started-with-calico-observability-features/).
+* Click here to [try Kubernetes observability in your browser right now](https://play.instruqt.com/tigera/invite/fjk58ue5b49n).
+* Learn [everything about Calico Whisker from this video presentation](https://youtu.be/gtgUiDsHjYM?si=ETmCeU6LJrFU_Yhe). 


### PR DESCRIPTION
This PR adds our blogs and other tutorial resources to the observability and Goldmane page.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->