### PR TITLE
[CORE-11189] Pin v3.30 grafana dashboard to more recent version

### DIFF
--- a/calico_versioned_docs/version-3.30/operations/monitor/monitor-component-visual.mdx
+++ b/calico_versioned_docs/version-3.30/operations/monitor/monitor-component-visual.mdx
@@ -109,7 +109,7 @@ EOF
 Here you will create a configmap with Felix and Typha dashboards.
 
 ```bash
-kubectl apply -f $[manifestsUrl]/manifests/grafana-dashboards.yaml
+kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/refs/heads/release-v3.30/manifests/grafana-dashboards.yaml
 ```
 
 #### **3. Creating Grafana pod**


### PR DESCRIPTION
I updated the Felix Grafana Dashboard for v3.30 but the change missed the release tagging.  Temporarily pin the link to the new manifest for the v3.30 docs only.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->
Calico OS v3.30

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->
CORE-11189

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://deploy-preview-2040--tigera.netlify.app/calico/latest/operations/monitor/monitor-component-visual

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->