### PR TITLE
DOCS-2568: Clarify local kubectl access

### DIFF
--- a/calico/observability/view-flow-logs.mdx
+++ b/calico/observability/view-flow-logs.mdx
@@ -82,7 +82,7 @@ By default, Whisker does not automatically expose an endpoint.
 
 ***Prerequisites***
 
-* You have `kubectl` access to a Kubernetes cluster with Calico installed.
+* You have local `kubectl` access to a Kubernetes cluster with Calico installed.
 * Calico Whisker and the flow logs API are enabled on your cluster.
   For new installations, they're both enabled by default.
   If you upgraded from Calico Open Source 3.29 or earlier, [you need to enable them manually](enable-whisker.mdx).

--- a/calico_versioned_docs/version-3.30/observability/view-flow-logs.mdx
+++ b/calico_versioned_docs/version-3.30/observability/view-flow-logs.mdx
@@ -82,7 +82,7 @@ By default, Whisker does not automatically expose an endpoint.
 
 ***Prerequisites***
 
-* You have `kubectl` access to a Kubernetes cluster with Calico installed.
+* You have local `kubectl` access to a Kubernetes cluster with Calico installed.
 * Calico Whisker and the flow logs API are enabled on your cluster.
   For new installations, they're both enabled by default.
   If you upgraded from Calico Open Source 3.29 or earlier, [you need to enable them manually](enable-whisker.mdx).


### PR DESCRIPTION
Viewing Whisker with port forwarding requires local kubectl access.

DOCS-2568

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->