### PR TITLE
DOCS-2582: Add step to Helm upgrade

### DIFF
--- a/calico_versioned_docs/version-3.30/operations/upgrading/kubernetes-upgrade.mdx
+++ b/calico_versioned_docs/version-3.30/operations/upgrading/kubernetes-upgrade.mdx
@@ -42,14 +42,14 @@ owned resources being garbage collected by Kubernetes.
 1. Perform the upgrade normally.
 1. Add new OwnerReferences to your resources referencing the new UID.
 
-## Upgrading an installation that was installed using helm
+## Upgrading an installation that was installed using Helm
 
-Prior to release v3.23, the $[prodname] helm chart itself deployed the `tigera-operator` namespace and required that the helm release was
+Prior to release v3.23, the $[prodname]Helm chart itself deployed the `tigera-operator` namespace and required that the Helm release was
 installed in the `default` namespace. Newer releases properly defer creation of the `tigera-operator` namespace to the user and allow installation
 of the chart into the `tigera-operator` namespace.
 
 When upgrading from a version of $[prodname] v3.22 or lower to a version of $[prodname] v3.23 or greater, you must complete the following steps to migrate
-ownership of the helm resources to the new chart location.
+ownership of the Helm resources to the new chart location.
 
 ### Upgrade from Calico versions prior to v3.23.0
 
@@ -71,7 +71,7 @@ ownership of the helm resources to the new chart location.
    kubectl apply --server-side --force-conflicts -f $[manifestsUrl]/manifests/operator-crds.yaml
    ```
 
-1. Install the helm chart in the `tigera-operator` namespace.
+1. Install the Helm chart in the `tigera-operator` namespace.
 
    ```
    helm install $[prodnamedash] projectcalico/tigera-operator --version $[releaseTitle] --namespace tigera-operator
@@ -92,13 +92,19 @@ the output and then re-running the command without --dry-run to commit to the ch
 
 ### All other upgrades
 
+1. Update the Helm chart to the latest version:
+
+   ```bash
+   helm repo update projectcalico
+   ```
+
 1. Apply the $[version] CRDs:
 
    ```bash
    kubectl apply --server-side --force-conflicts -f $[manifestsUrl]/manifests/operator-crds.yaml
    ```
 
-1. Run the helm upgrade:
+1. Run the Helm upgrade:
 
    ```bash
    helm upgrade $[prodnamedash] projectcalico/tigera-operator


### PR DESCRIPTION
This adds a step to make sure you update the helm chart before upgrading.

DOCS-2582

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->