### PR TITLE
[CORE-11399] Update EE v3.19 OpenShift versions in the suppport matrix

### DIFF
--- a/calico-enterprise/getting-started/compatibility.mdx
+++ b/calico-enterprise/getting-started/compatibility.mdx
@@ -79,7 +79,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | -------------------- | --------------------------------- | ------------------------------------ |
 | 3.21                 | 4.16 - 4.17                       | $[prodname] CNI with network policy |
 | 3.20                 | 4.15 - 4.17                       | $[prodname] CNI with network policy |
-| 3.19                 | 4.14 - 4.15                       | $[prodname] CNI with network policy |
+| 3.19                 | 4.14 - 4.16                       | $[prodname] CNI with network policy |
 
 ## RKE
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/compatibility.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/compatibility.mdx
@@ -77,7 +77,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | $[prodname] version | OpenShift versions for Kubernetes | $[prodname] support                 |
 | ------------------- | --------------------------------- | ----------------------------------- |
-| 3.19                | 4.14 - 4.15                       | $[prodname] CNI with network policy |
+| 3.19                | 4.14 - 4.16                       | $[prodname] CNI with network policy |
 | 3.18                | 4.12 - 4.14                       | $[prodname] CNI with network policy |
 | 3.17                | 4.12 - 4.13                       | $[prodname] CNI with network policy |
 

--- a/calico-enterprise_versioned_docs/version-3.20-1/getting-started/compatibility.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-1/getting-started/compatibility.mdx
@@ -77,8 +77,8 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | $[prodname] version | OpenShift versions for Kubernetes | $[prodname] support                 |
 | -------------------- | --------------------------------- | ------------------------------------ |
-| 3.20                 | 4.14 - 4.15                       | $[prodname] CNI with network policy |
-| 3.19                 | 4.14 - 4.15                       | $[prodname] CNI with network policy |
+| 3.20                 | 4.15 - 4.17                       | $[prodname] CNI with network policy |
+| 3.19                 | 4.14 - 4.16                       | $[prodname] CNI with network policy |
 | 3.18                 | 4.12 - 4.14                       | $[prodname] CNI with network policy |
 
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/compatibility.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/compatibility.mdx
@@ -78,7 +78,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | $[prodname] version | OpenShift versions for Kubernetes | $[prodname] support                 |
 | -------------------- | --------------------------------- | ------------------------------------ |
 | 3.20                 | 4.15 - 4.17                       | $[prodname] CNI with network policy |
-| 3.19                 | 4.14 - 4.15                       | $[prodname] CNI with network policy |
+| 3.19                 | 4.14 - 4.16                       | $[prodname] CNI with network policy |
 | 3.18                 | 4.12 - 4.14                       | $[prodname] CNI with network policy |
 
 ## RKE

--- a/calico-enterprise_versioned_docs/version-3.21-1/getting-started/compatibility.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-1/getting-started/compatibility.mdx
@@ -79,7 +79,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | -------------------- | --------------------------------- | ------------------------------------ |
 | 3.21                 | 4.16 - 4.17                       | $[prodname] CNI with network policy |
 | 3.20                 | 4.15 - 4.17                       | $[prodname] CNI with network policy |
-| 3.19                 | 4.14 - 4.15                       | $[prodname] CNI with network policy |
+| 3.19                 | 4.14 - 4.16                       | $[prodname] CNI with network policy |
 
 ## RKE
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/compatibility.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/compatibility.mdx
@@ -79,7 +79,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | -------------------- | --------------------------------- | ------------------------------------ |
 | 3.21                 | 4.16 - 4.17                       | $[prodname] CNI with network policy |
 | 3.20                 | 4.15 - 4.17                       | $[prodname] CNI with network policy |
-| 3.19                 | 4.14 - 4.15                       | $[prodname] CNI with network policy |
+| 3.19                 | 4.14 - 4.16                       | $[prodname] CNI with network policy |
 
 ## RKE
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

With the changes from https://github.com/tigera/calico-private/pull/9111 and https://github.com/tigera/docs/pull/2046, Calico Enterprise v3.19 now supports OpenShift versions up to v4.16. Update the support matrix accordingly.

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->