### PR TITLE
VPP: rename downloaded openshift manifests

### DIFF
--- a/calico/getting-started/kubernetes/vpp/openshift.mdx
+++ b/calico/getting-started/kubernetes/vpp/openshift.mdx
@@ -83,11 +83,11 @@ Download the Calico VPP manifests for OpenShift and add them to the generated ma
 mkdir vpp
 cd vpp
 curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/00-namespace-calico-vpp-dataplane.yaml"
-curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/01-cr-installation.yaml"
-curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-configmap-calico-vpp-resources.yaml"
-curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-role-calico-vpp-dataplane.yaml"
-curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-rolebinding-calico-vpp-dataplane.yaml"
-curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-serviceaccount-calico-vpp-dataplane.yaml"
+curl -o 03-cr-installation.yaml "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/01-cr-installation.yaml"
+curl -o 02-configmap-calico-vpp-resources.yaml "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-configmap-calico-vpp-resources.yaml"
+curl -o 02-role-calico-vpp-dataplane.yaml "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-role-calico-vpp-dataplane.yaml"
+curl -o 02-rolebinding-calico-vpp-dataplane.yaml "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-rolebinding-calico-vpp-dataplane.yaml"
+curl -o 02-serviceaccount-calico-vpp-dataplane.yaml "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-serviceaccount-calico-vpp-dataplane.yaml"
 curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/04-calico-vpp-nohuge.yaml"
 cd ..
 cp vpp/* manifests/

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/vpp/openshift.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/vpp/openshift.mdx
@@ -83,11 +83,11 @@ Download the Calico VPP manifests for OpenShift and add them to the generated ma
 mkdir vpp
 cd vpp
 curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/00-namespace-calico-vpp-dataplane.yaml"
-curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/01-cr-installation.yaml"
-curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-configmap-calico-vpp-resources.yaml"
-curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-role-calico-vpp-dataplane.yaml"
-curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-rolebinding-calico-vpp-dataplane.yaml"
-curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-serviceaccount-calico-vpp-dataplane.yaml"
+curl -o 03-cr-installation.yaml "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/01-cr-installation.yaml"
+curl -o 02-configmap-calico-vpp-resources.yaml "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-configmap-calico-vpp-resources.yaml"
+curl -o 02-role-calico-vpp-dataplane.yaml "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-role-calico-vpp-dataplane.yaml"
+curl -o 02-rolebinding-calico-vpp-dataplane.yaml "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-rolebinding-calico-vpp-dataplane.yaml"
+curl -o 02-serviceaccount-calico-vpp-dataplane.yaml "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-serviceaccount-calico-vpp-dataplane.yaml"
 curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/04-calico-vpp-nohuge.yaml"
 cd ..
 cp vpp/* manifests/

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/vpp/openshift.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/vpp/openshift.mdx
@@ -83,11 +83,11 @@ Download the Calico VPP manifests for OpenShift and add them to the generated ma
 mkdir vpp
 cd vpp
 curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/00-namespace-calico-vpp-dataplane.yaml"
-curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/01-cr-installation.yaml"
-curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-configmap-calico-vpp-resources.yaml"
-curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-role-calico-vpp-dataplane.yaml"
-curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-rolebinding-calico-vpp-dataplane.yaml"
-curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-serviceaccount-calico-vpp-dataplane.yaml"
+curl -o 03-cr-installation.yaml "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/01-cr-installation.yaml"
+curl -o 02-configmap-calico-vpp-resources.yaml "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-configmap-calico-vpp-resources.yaml"
+curl -o 02-role-calico-vpp-dataplane.yaml "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-role-calico-vpp-dataplane.yaml"
+curl -o 02-rolebinding-calico-vpp-dataplane.yaml "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-rolebinding-calico-vpp-dataplane.yaml"
+curl -o 02-serviceaccount-calico-vpp-dataplane.yaml "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/03-serviceaccount-calico-vpp-dataplane.yaml"
 curl -O "https://raw.githubusercontent.com/projectcalico/vpp-dataplane/$[vppbranch]/yaml/platforms/openshift/04-calico-vpp-nohuge.yaml"
 cd ..
 cp vpp/* manifests/


### PR DESCRIPTION
Rename some downloaded VPP openshift manifests to make them compatible with the changes introduced in
https://github.com/projectcalico/calico/pull/10246

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->