### PR TITLE
DOCS-2624: Add K8s compatibility for old CC versions

### DIFF
--- a/calico-cloud/get-started/system-requirements.mdx
+++ b/calico-cloud/get-started/system-requirements.mdx
@@ -37,10 +37,34 @@ The Calico Cloud installer may be able to successfully connect
 
 ## Kubernetes versions
 
-Your Kubernetes distribution must be based on one of the following Kubernetes versions:
+To install Calico Cloud $[cloudUserVersion], your Kubernetes distribution must be based on one of the following Kubernetes versions:
 * Kubernetes 1.33
 * Kubernetes 1.32
 * Kubernetes 1.31
+
+<details>
+  <summary>Kubernetes compatibility for older versions of Calico Cloud</summary>
+
+  | Calico Cloud version | Kubernetes versions |
+  |-----------------------|---------------------|
+  | 21.3.0               | 1.31-1.33          |
+  | 21.2.0               | 1.30-1.32          |
+  | 21.1.0               | 1.30-1.32          |
+  | 21.0.0               | 1.30-1.32          |
+  | 20.4.0               | 1.29-1.31          |
+  | 20.3.1               | 1.29-1.31          |
+  | 20.2.0               | 1.28-1.30          |
+  | 20.1.0               | 1.28-1.30          |
+  | 20.0.1               | 1.28-1.30          |
+  | 20.0.0               | 1.28-1.30          |
+  | 19.4.1               | 1.27-1.29          |
+  | 19.4.0               | 1.27-1.29          |
+  | 19.3.0               | 1.27-1.29          |
+  | 19.2.0               | 1.26-1.28          |
+  | 19.1.0               | 1.26-1.28          |
+  | 19.0.0               | 1.26-1.28          |
+
+</details>
 
 :::tip
 

--- a/calico-cloud_versioned_docs/version-21-2/get-started/system-requirements.mdx
+++ b/calico-cloud_versioned_docs/version-21-2/get-started/system-requirements.mdx
@@ -37,10 +37,34 @@ The Calico Cloud installer may be able to successfully connect
 
 ## Kubernetes versions
 
-Your Kubernetes distribution must be based on one of the following Kubernetes versions:
+To install Calico Cloud $[cloudUserVersion], your Kubernetes distribution must be based on one of the following Kubernetes versions:
 * Kubernetes 1.33
 * Kubernetes 1.32
 * Kubernetes 1.31
+
+<details>
+  <summary>Kubernetes compatibility for older versions of Calico Cloud</summary>
+
+  | Calico Cloud version | Kubernetes versions |
+  |-----------------------|---------------------|
+  | 21.3.0               | 1.31-1.33          |
+  | 21.2.0               | 1.30-1.32          |
+  | 21.1.0               | 1.30-1.32          |
+  | 21.0.0               | 1.30-1.32          |
+  | 20.4.0               | 1.29-1.31          |
+  | 20.3.1               | 1.29-1.31          |
+  | 20.2.0               | 1.28-1.30          |
+  | 20.1.0               | 1.28-1.30          |
+  | 20.0.1               | 1.28-1.30          |
+  | 20.0.0               | 1.28-1.30          |
+  | 19.4.1               | 1.27-1.29          |
+  | 19.4.0               | 1.27-1.29          |
+  | 19.3.0               | 1.27-1.29          |
+  | 19.2.0               | 1.26-1.28          |
+  | 19.1.0               | 1.26-1.28          |
+  | 19.0.0               | 1.26-1.28          |
+
+</details>
 
 :::tip
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -554,3 +554,8 @@ pre {
   margin-left: 8px;
   font-family: inherit;
 }
+
+details table th,
+details table td {
+  background-color: white;
+}


### PR DESCRIPTION
This adds historical k8s compatibility data for active CC versions.

DOCS-2624
