### PR TITLE
DOCS-2624: Add dark mode styling for details table

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -555,7 +555,17 @@ pre {
   font-family: inherit;
 }
 
+/* Overrides for details tables */
+
 details table th,
 details table td {
   background-color: white;
+}
+
+html[data-theme='dark'] {
+  details table th,
+  details table td {
+    background-color: #444;
+    color: white;
+  }
 }


### PR DESCRIPTION
- **Add styling for dark mode details table**

### Before
<img width="800" alt="image" src="https://github.com/user-attachments/assets/7dc59b76-c8c6-4bab-9327-641375843a01" />

### After
<img width="737" alt="image" src="https://github.com/user-attachments/assets/0dcd4824-637d-492e-ae3e-061042ba7622" />

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->