### PR TITLE
[DE-3561] Add Red Hat Openshift on AWS (ROSA) install steps to docs.

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/openshift/rosa.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/openshift/rosa.mdx
@@ -1,0 +1,174 @@
+---
+description: Install Calico Enterprise on a Red Hat Openshift on AWS (ROSA) cluster.
+---
+
+# Install Calico Enterprise on a Red Hat Openshift on AWS (ROSA) cluster
+
+import DownloadOpenShiftManifests from '@site/calico-enterprise/_includes/components/DownloadOpenShiftManifests.js';
+import InstallOpenShiftHCPResources from '@site/calico-enterprise/_includes/components/InstallOpenShiftHCPResources.js';
+
+## Big picture
+
+Install $[prodname] on a Red Hat Openshift on AWS (ROSA) cluster. Classic ROSA does not support installations with custom CNI plugin. ROSA with HCP clusters allows installing $[prodname]. 
+
+## Value
+
+Provides steps to install $[prodname] in [Red Hat Openshift on AWS (ROSA)](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/index) with HCP clusters.
+
+## Before you begin
+
+- Ensure that your environment meets the $[prodname] [system requirements](requirements.mdx).
+
+- Ensure that you have a [RedHat account](https://cloud.redhat.com/). A RedHat account is required to get the pull secret necessary to provision a ROSA cluster. 
+
+- Ensure that you have:
+
+    - Configured an AWS account appropriate for OpenShift 4
+    - [Set up your AWS credentials](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html)
+    - Enabled ROSA with HCP and HCP classic on AWS.
+    - Ensured you have met the resource quota requirements for ROSA on AWS.
+    - Linked AWS and Red Hat accounts.
+    - Generated a local SSH private key and added it to your ssh-agent
+
+- Install the ROSA CLI and fulfill all the other [prerequisites from the ROSA documentation](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/prepare_your_environment/index)
+
+- Create a [Virtual Private Cloud (VPC) for your ROSA cluster](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-sts-creating-a-cluster-quickly#rosa-hcp-creating-vpc) following the documentation.
+
+## How to
+
+### Create roles, policies
+
+- Create the account wide STS roles and policies needed to create a ROSA with HCP cluster by following the [Red Hat documentation](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-cluster-no-cli#rosa-hcp-sts-creating-a-cluster-cli_rosa-hcp-cluster-no-cni-no-cni).
+
+- Create the [OpenID Connect (OIDC) configuration](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-cluster-no-cli#rosa-sts-byo-oidc_rosa-hcp-cluster-no-cni) prior to creating the ROSA with HCP cluster.
+
+- Create [Operator IAM roles and policies](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-cluster-no-cli#rosa-operator-config_rosa-hcp-cluster-no-cni) needed for ROSA with HCP clusters.
+
+### Create ROSA cluster with HCP and no CNI plugin
+
+Follow the steps from the Red Hat Openshift on AWS documentation to [create a ROSA cluster with HCP and no CNI plugin](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-cluster-no-cli#rosa-hcp-sts-creating-a-cluster-cli_rosa-hcp-cluster-no-cni-no-cni).
+
+### Create a storage class
+
+$[prodname] requires storage for logs and reports. Before finishing the installation, you must [create a StorageClass for $[prodname]](../../../operations/logstorage/create-storage).
+
+### Download the $[prodname] install manifests
+
+:::note
+
+For OpenShift **v4.16 or newer** on **AWS**, configure AWS security groups to allow BGP, typha and IP-in-IP encapsulation traffic.
+
+```
+    Custom TCP traffic
+    Port: 179
+    Description: BGP (Calico)
+    
+    Custom TCP traffic
+    Port: 5473
+    Description: Typha (Calico)
+    
+    Custom protocol
+    Protocol: 4
+    Description: IP-in-IP (Calico)
+```
+
+:::
+
+Now download and apply the $[prodname] manifests.
+
+<DownloadOpenShiftManifests />
+
+### Add an image pull secret
+
+Update the contents of the secret with the image pull secret provided to you by a Tigera support representative.
+
+For example, if the secret is located at ~/.docker/config.json, run the following commands.
+
+```
+SECRET=$(cat ~/.docker/config.json | tr -d '\n\r\t ' | base64 -w 0)
+sed -i "s/SECRET/${SECRET}/" calico/02-pull-secret.yaml
+```
+
+### Optionally provide additional configuration
+
+You may want to provide $[prodname] with additional configuration at install-time. For example, BGP configuration or peers.
+You can use a Kubernetes ConfigMap with your desired Calico resources to set configuration as part of the installation.
+If you do not need to provide additional configuration, you can skip this section.
+
+To include [Calico resources](../../../reference/resources/index.mdx) during installation, edit `calico/02-configmap-calico-resources.yaml` to add your own configuration.
+
+:::note
+If you have a directory with the Calico resources, you can create the file with the command:
+
+```
+oc create configmap -n tigera-operator calico-resources \
+--from-file=<resource-directory> --dry-run -o yaml \
+calico/02-configmap-calico-resources.yaml
+```
+
+With recent versions of oc it is necessary to have a kubeconfig configured or add `--server='127.0.0.1:443'`
+even though it is not used.
+:::
+
+:::note
+If you have provided a `calico-resources` configmap and the tigera-operator pod fails to come up with `Init:CrashLoopBackOff`,
+check the output of the init-container with `oc logs -n tigera-operator -l k8s-app=tigera-operator -c create-initial-resources`.
+:::
+
+### Apply the $[prodname] install manifests
+
+Apply the install manifests paying attention to the required order. First apply all necessary manifests to install the Tigera Operator:
+
+```
+cd calico/
+ls 00* | xargs -n1 oc apply -f
+ls 01* | xargs -n1 oc apply -f
+ls 02* | xargs -n1 oc apply -f
+```
+
+Then wait until the Tigera Operator creates the necessary CustomResourceDefinitions (CRDs) before applying the CustomResources to install $[prodname] on your cluster:
+
+```
+timeout --foreground 600 bash -c "while ! kubectl get crd installations.operator.tigera.io; do sleep 5; done" # wait until CRDs are created by the operator
+ls 03* | xargs -n1 oc apply -f
+```
+
+:::note
+You can safely ignore any `ls: cannot access '0X*': No such file or directory` errors if there's no yaml files with that prefix to be applied.
+:::
+
+### Install the $[prodname] license
+
+In order to use $[prodname], you must install the license provided to you by Tigera support representative. Before applying the license, wait until the Tigera API server is ready with the following command:
+
+```
+watch oc get tigerastatus
+```
+
+Wait until the `apiserver` shows a status of `Available`.
+
+After the Tigera API server is ready, apply the license:
+
+```
+oc create -f </path/to/license.yaml>
+```
+
+### Install $[prodname] resources
+
+<InstallOpenShiftHCPResources />
+
+## Next steps
+
+**Recommended**
+
+- [Configure access to the $[prodname] web console](../../../operations/cnx/access-the-manager.mdx)
+- [Authentication quickstart](../../../operations/cnx/authentication-quickstart.mdx)
+- [Configure your own identity provider](../../../operations/cnx/configure-identity-provider.mdx)
+
+**Recommended - Networking**
+
+- The default networking uses IP in IP encapsulation with BGP routing. For all networking options, see [Determine best networking option](../../../networking/determine-best-networking.mdx).
+
+**Recommended - Security**
+
+- [Get started with $[prodname] tiered network policy](../../../network-policy/policy-tiers/tiered-policy.mdx)

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/openshift/rosa.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/openshift/rosa.mdx
@@ -1,0 +1,174 @@
+---
+description: Install Calico Enterprise on a Red Hat Openshift on AWS (ROSA) cluster.
+---
+
+# Install Calico Enterprise on a Red Hat Openshift on AWS (ROSA) cluster
+
+import DownloadOpenShiftManifests from '@site/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/DownloadOpenShiftManifests.js';
+import InstallOpenShiftHCPResources from '@site/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallOpenShiftHCPResources.js';
+
+## Big picture
+
+Install $[prodname] on a Red Hat Openshift on AWS (ROSA) cluster. Classic ROSA does not support installations with custom CNI plugin. ROSA with HCP clusters allows installing $[prodname]. 
+
+## Value
+
+Provides steps to install $[prodname] in [Red Hat Openshift on AWS (ROSA)](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/index) with HCP clusters.
+
+## Before you begin
+
+- Ensure that your environment meets the $[prodname] [system requirements](requirements.mdx).
+
+- Ensure that you have a [RedHat account](https://cloud.redhat.com/). A RedHat account is required to get the pull secret necessary to provision a ROSA cluster. 
+
+- Ensure that you have:
+
+    - Configured an AWS account appropriate for OpenShift 4
+    - [Set up your AWS credentials](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html)
+    - Enabled ROSA with HCP and HCP classic on AWS.
+    - Ensured you have met the resource quota requirements for ROSA on AWS.
+    - Linked AWS and Red Hat accounts.
+    - Generated a local SSH private key and added it to your ssh-agent
+
+- Install the ROSA CLI and fulfill all the other [prerequisites from the ROSA documentation](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/prepare_your_environment/index)
+
+- Create a [Virtual Private Cloud (VPC) for your ROSA cluster](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-sts-creating-a-cluster-quickly#rosa-hcp-creating-vpc) following the documentation.
+
+## How to
+
+### Create roles, policies
+
+- Create the account wide STS roles and policies needed to create a ROSA with HCP cluster by following the [Red Hat documentation](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-cluster-no-cli#rosa-hcp-sts-creating-a-cluster-cli_rosa-hcp-cluster-no-cni-no-cni).
+
+- Create the [OpenID Connect (OIDC) configuration](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-cluster-no-cli#rosa-sts-byo-oidc_rosa-hcp-cluster-no-cni) prior to creating the ROSA with HCP cluster.
+
+- Create [Operator IAM roles and policies](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-cluster-no-cli#rosa-operator-config_rosa-hcp-cluster-no-cni) needed for ROSA with HCP clusters.
+
+### Create ROSA cluster with HCP and no CNI plugin
+
+Follow the steps from the Red Hat Openshift on AWS documentation to [create a ROSA cluster with HCP and no CNI plugin](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-cluster-no-cli#rosa-hcp-sts-creating-a-cluster-cli_rosa-hcp-cluster-no-cni-no-cni).
+
+### Create a storage class
+
+$[prodname] requires storage for logs and reports. Before finishing the installation, you must [create a StorageClass for $[prodname]](../../../operations/logstorage/create-storage).
+
+### Download the $[prodname] install manifests
+
+:::note
+
+For OpenShift **v4.16 or newer** on **AWS**, configure AWS security groups to allow BGP, typha and IP-in-IP encapsulation traffic.
+
+```
+    Custom TCP traffic
+    Port: 179
+    Description: BGP (Calico)
+    
+    Custom TCP traffic
+    Port: 5473
+    Description: Typha (Calico)
+    
+    Custom protocol
+    Protocol: 4
+    Description: IP-in-IP (Calico)
+```
+
+:::
+
+Now download and apply the $[prodname] manifests.
+
+<DownloadOpenShiftManifests />
+
+### Add an image pull secret
+
+Update the contents of the secret with the image pull secret provided to you by a Tigera support representative.
+
+For example, if the secret is located at ~/.docker/config.json, run the following commands.
+
+```
+SECRET=$(cat ~/.docker/config.json | tr -d '\n\r\t ' | base64 -w 0)
+sed -i "s/SECRET/${SECRET}/" calico/02-pull-secret.yaml
+```
+
+### Optionally provide additional configuration
+
+You may want to provide $[prodname] with additional configuration at install-time. For example, BGP configuration or peers.
+You can use a Kubernetes ConfigMap with your desired Calico resources to set configuration as part of the installation.
+If you do not need to provide additional configuration, you can skip this section.
+
+To include [Calico resources](../../../reference/resources/index.mdx) during installation, edit `calico/02-configmap-calico-resources.yaml` to add your own configuration.
+
+:::note
+If you have a directory with the Calico resources, you can create the file with the command:
+
+```
+oc create configmap -n tigera-operator calico-resources \
+--from-file=<resource-directory> --dry-run -o yaml \
+calico/02-configmap-calico-resources.yaml
+```
+
+With recent versions of oc it is necessary to have a kubeconfig configured or add `--server='127.0.0.1:443'`
+even though it is not used.
+:::
+
+:::note
+If you have provided a `calico-resources` configmap and the tigera-operator pod fails to come up with `Init:CrashLoopBackOff`,
+check the output of the init-container with `oc logs -n tigera-operator -l k8s-app=tigera-operator -c create-initial-resources`.
+:::
+
+### Apply the $[prodname] install manifests
+
+Apply the install manifests paying attention to the required order. First apply all necessary manifests to install the Tigera Operator:
+
+```
+cd calico/
+ls 00* | xargs -n1 oc apply -f
+ls 01* | xargs -n1 oc apply -f
+ls 02* | xargs -n1 oc apply -f
+```
+
+Then wait until the Tigera Operator creates the necessary CustomResourceDefinitions (CRDs) before applying the CustomResources to install $[prodname] on your cluster:
+
+```
+timeout --foreground 600 bash -c "while ! kubectl get crd installations.operator.tigera.io; do sleep 5; done" # wait until CRDs are created by the operator
+ls 03* | xargs -n1 oc apply -f
+```
+
+:::note
+You can safely ignore any `ls: cannot access '0X*': No such file or directory` errors if there's no yaml files with that prefix to be applied.
+:::
+
+### Install the $[prodname] license
+
+In order to use $[prodname], you must install the license provided to you by Tigera support representative. Before applying the license, wait until the Tigera API server is ready with the following command:
+
+```
+watch oc get tigerastatus
+```
+
+Wait until the `apiserver` shows a status of `Available`.
+
+After the Tigera API server is ready, apply the license:
+
+```
+oc create -f </path/to/license.yaml>
+```
+calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/openshift/rosa.mdx
+### Install $[prodname] resources
+
+<InstallOpenShiftHCPResources />
+
+## Next steps
+
+**Recommended**
+
+- [Configure access to the $[prodname] web console](../../../operations/cnx/access-the-manager.mdx)
+- [Authentication quickstart](../../../operations/cnx/authentication-quickstart.mdx)
+- [Configure your own identity provider](../../../operations/cnx/configure-identity-provider.mdx)
+
+**Recommended - Networking**
+
+- The default networking uses IP in IP encapsulation with BGP routing. For all networking options, see [Determine best networking option](../../../networking/determine-best-networking.mdx).
+
+**Recommended - Security**
+
+- [Get started with $[prodname] tiered network policy](../../../network-policy/policy-tiers/tiered-policy.mdx)


### PR DESCRIPTION
Adds installs docs for Red Hat Openshift on AWS (ROSA) for Calico Enterprise

Adds docs to 3.21-2 and vNext

Product Version(s):
Calico Enterprise v3.21.1 (GA) and above.

Issue:
N/A

Link to docs preview:


SME review:
- [ ] An SME has approved this change. 


DOCS review:
- [ ] A member of the docs team has approved this change.


Additional information:
N/A

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->