### PR TITLE
[CORE-11642] Add note about enabled ANNOTATE_POD_IP setting to EKS guide.

### DIFF
--- a/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -35,16 +35,31 @@ When using the Amazon VPC CNI plugin, $[prodname] does not support enforcement o
 
 :::
 
-***Prerequisites***
-
-* You [disabled network policy for the AWS VPC CNI](https://docs.aws.amazon.com/eks/latest/userguide/network-policy-disable.html). 
-* You [configured AWS VPC CNI to annotate Pods with their IPs](https://github.com/aws/amazon-vpc-cni-k8s?tab=readme-ov-file#annotate_pod_ip-v193).  Note the requirement to grant the "patch" permission to the `aws-node` daemon set.  Without this setting, pod IPs can propagate slowly when Kubernetes is under load resulting in slow policy application after pod creation.
 
 1. First, create an Amazon EKS cluster.
 
    ```bash
    eksctl create cluster --name  <my-calico-cluster>
    ```
+
+   Do **not** enable [network policy for the AWS VPC CNI](https://docs.aws.amazon.com/eks/latest/userguide/network-policy-disable.html); it conflicts with $[prodname].
+
+1. Configure AWS VPC CNI to [annotate Pods with their IPs](https://github.com/aws/amazon-vpc-cni-k8s?tab=readme-ov-file#annotate_pod_ip-v193).
+   Note the requirement to grant the "patch" permission to the `aws-node` daemon set to avoid permission errors.
+   This setting ensures that pod IPs propagate quickly from AWS VPC CNI to $[prodname].
+
+    ```bash
+    cat << EOF > append.yaml
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - patch
+    EOF
+    kubectl apply -f <(cat <(kubectl get clusterrole aws-node -o yaml) append.yaml)
+    kubectl set env  -n kube-system daemonset/aws-node ANNOTATE_POD_IP=true
+    ```
 
 1. Install the Tigera Operator and custom resource definitions.
 

--- a/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -38,6 +38,7 @@ When using the Amazon VPC CNI plugin, $[prodname] does not support enforcement o
 ***Prerequisites***
 
 * You [disabled network policy for the AWS VPC CNI](https://docs.aws.amazon.com/eks/latest/userguide/network-policy-disable.html). 
+* You [configured AWS VPC CNI to annotate Pods with their IPs](https://github.com/aws/amazon-vpc-cni-k8s?tab=readme-ov-file#annotate_pod_ip-v193).  Note the requirement to grant the "patch" permission to the `aws-node` daemon set.  Without this setting, pod IPs can propagate slowly when Kubernetes is under load resulting in slow policy application after pod creation.
 
 1. First, create an Amazon EKS cluster.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->
All

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->
https://tigera.atlassian.net/browse/CORE-11642

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://deploy-preview-2174--calico-docs-preview-next.netlify.app/calico/next/getting-started/kubernetes/managed-public-cloud/eks/

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->