### PR TITLE
Rename our API pages to Client library pages

### DIFF
--- a/calico-cloud/reference/api.mdx
+++ b/calico-cloud/reference/api.mdx
@@ -1,12 +1,12 @@
 ---
-description: Learn about the Tigera API and how to use it.
+description: Learn about the Tigera client library and how to use it.
 ---
 
-# Tigera API
+# Tigera Client library
 
-$[prodname] provides and consumes a public API in Go that allows
-developers to work with $[prodname] resources.
+$[prodname] provides and consumes a client library in Go that allows developers to work with $[prodname] resources. The
+client library can be used to get, list, watch, create, delete and update custom resources, such as network policies much
+like the [client-go project](https://github.com/kubernetes/client-go) does for native Kubernetes resources.
 
-To learn more about the Tigera API and how to use it, see the Tigera API project [README](https://github.com/tigera/api/blob/master/README.md) or
-the [github.com/tigera/api Go module page](https://pkg.go.dev/github.com/tigera/api)
-.
+To learn more about the Tigera client library and how to use it, see the Tigera API project [README](https://github.com/tigera/api/blob/master/README.md) or
+the [github.com/tigera/api Go module page](https://pkg.go.dev/github.com/tigera/api).

--- a/calico-cloud_versioned_docs/version-21-2/reference/api.mdx
+++ b/calico-cloud_versioned_docs/version-21-2/reference/api.mdx
@@ -1,12 +1,12 @@
 ---
-description: Learn about the Tigera API and how to use it.
+description: Learn about the Tigera client library and how to use it.
 ---
 
-# Tigera API
+# Tigera Client library
 
-$[prodname] provides and consumes a public API in Go that allows
-developers to work with $[prodname] resources.
+$[prodname] provides and consumes a client library in Go that allows developers to work with $[prodname] resources. The
+client library can be used to get, list, watch, create, delete and update custom resources, such as network policies much
+like the [client-go project](https://github.com/kubernetes/client-go) does for native Kubernetes resources.
 
-To learn more about the Tigera API and how to use it, see the Tigera API project [README](https://github.com/tigera/api/blob/master/README.md) or
-the [github.com/tigera/api Go module page](https://pkg.go.dev/github.com/tigera/api)
-.
+To learn more about the Tigera client library and how to use it, see the Tigera API project [README](https://github.com/tigera/api/blob/master/README.md) or
+the [github.com/tigera/api Go module page](https://pkg.go.dev/github.com/tigera/api).

--- a/calico-enterprise/reference/api.mdx
+++ b/calico-enterprise/reference/api.mdx
@@ -1,12 +1,12 @@
 ---
-description: Learn about the Tigera API and how to use it.
+description: Learn about the Tigera client library and how to use it.
 ---
 
-# Tigera API
+# Tigera Client library
 
-$[prodname] provides and consumes a public API in Go that allows
-developers to work with $[prodname] resources.
+$[prodname] provides and consumes a client library in Go that allows developers to work with $[prodname] resources. The
+client library can be used to get, list, watch, create, delete and update custom resources, such as network policies much
+like the [client-go project](https://github.com/kubernetes/client-go) does for native Kubernetes resources.
 
-To learn more about the Tigera API and how to use it, see the Tigera API project [README](https://github.com/tigera/api/blob/master/README.md) or
-the [github.com/tigera/api Go module page](https://pkg.go.dev/github.com/tigera/api)
-.
+To learn more about the Tigera client library and how to use it, see the Tigera API project [README](https://github.com/tigera/api/blob/master/README.md) or
+the [github.com/tigera/api Go module page](https://pkg.go.dev/github.com/tigera/api).

--- a/calico-enterprise_versioned_docs/version-3.19-2/reference/api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/reference/api.mdx
@@ -1,12 +1,12 @@
 ---
-description: Learn about the Tigera API and how to use it.
+description: Learn about the Tigera client library and how to use it.
 ---
 
-# Tigera API
+# Tigera Client library
 
-$[prodname] provides and consumes a public API in Go that allows
-developers to work with $[prodname] resources.
+$[prodname] provides and consumes a client library in Go that allows developers to work with $[prodname] resources. The
+client library can be used to get, list, watch, create, delete and update custom resources, such as network policies much
+like the [client-go project](https://github.com/kubernetes/client-go) does for native Kubernetes resources.
 
-To learn more about the Tigera API and how to use it, see the Tigera API project [README](https://github.com/tigera/api/blob/master/README.md) or
-the [github.com/tigera/api Go module page](https://pkg.go.dev/github.com/tigera/api)
-.
+To learn more about the Tigera client library and how to use it, see the Tigera API project [README](https://github.com/tigera/api/blob/master/README.md) or
+the [github.com/tigera/api Go module page](https://pkg.go.dev/github.com/tigera/api).

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/api.mdx
@@ -1,12 +1,12 @@
 ---
-description: Learn about the Tigera API and how to use it.
+description: Learn about the Tigera client library and how to use it.
 ---
 
-# Tigera API
+# Tigera Client library
 
-$[prodname] provides and consumes a public API in Go that allows
-developers to work with $[prodname] resources.
+$[prodname] provides and consumes a client library in Go that allows developers to work with $[prodname] resources. The
+client library can be used to get, list, watch, create, delete and update custom resources, such as network policies much
+like the [client-go project](https://github.com/kubernetes/client-go) does for native Kubernetes resources.
 
-To learn more about the Tigera API and how to use it, see the Tigera API project [README](https://github.com/tigera/api/blob/master/README.md) or
-the [github.com/tigera/api Go module page](https://pkg.go.dev/github.com/tigera/api)
-.
+To learn more about the Tigera client library and how to use it, see the Tigera API project [README](https://github.com/tigera/api/blob/master/README.md) or
+the [github.com/tigera/api Go module page](https://pkg.go.dev/github.com/tigera/api).

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/api.mdx
@@ -1,12 +1,12 @@
 ---
-description: Learn about the Tigera API and how to use it.
+description: Learn about the Tigera client library and how to use it.
 ---
 
-# Tigera API
+# Tigera Client library
 
-$[prodname] provides and consumes a public API in Go that allows
-developers to work with $[prodname] resources.
+$[prodname] provides and consumes a client library in Go that allows developers to work with $[prodname] resources. The
+client library can be used to get, list, watch, create, delete and update custom resources, such as network policies much
+like the [client-go project](https://github.com/kubernetes/client-go) does for native Kubernetes resources.
 
-To learn more about the Tigera API and how to use it, see the Tigera API project [README](https://github.com/tigera/api/blob/master/README.md) or
-the [github.com/tigera/api Go module page](https://pkg.go.dev/github.com/tigera/api)
-.
+To learn more about the Tigera client library and how to use it, see the Tigera API project [README](https://github.com/tigera/api/blob/master/README.md) or
+the [github.com/tigera/api Go module page](https://pkg.go.dev/github.com/tigera/api).

--- a/calico/reference/api.mdx
+++ b/calico/reference/api.mdx
@@ -1,12 +1,12 @@
 ---
-description: Learn about the Calico API and how to use it.
+description: Learn about the Calico client library and how to use it.
 ---
 
-# Calico API
+# Calico Client library
 
-$[prodname] provides and consumes a public API in Go that allows
-developers to work with $[prodname] resources.
+$[prodname] provides and consumes a client library in Go that allows developers to work with $[prodname] resources. The
+client library can be used to get, list, watch, create, delete and update custom resources, such as network policies much
+like the [client-go project](https://github.com/kubernetes/client-go) does for native Kubernetes resources.
 
-To learn more about the $[prodname] API and how to use it, see the Calico API project [README](https://github.com/projectcalico/api/blob/master/README.md) or
-the [github.com/projectcalico/api Go module page](https://pkg.go.dev/github.com/projectcalico/api)
-.
+To learn more about the Calico client library and how to use it, see the Calico API project [README](https://github.com/projectcalico/api/blob/master/README.md) or
+the [github.com/projectcalico/api Go module page](https://pkg.go.dev/github.com/projectcalico/api).

--- a/calico_versioned_docs/version-3.28/reference/api.mdx
+++ b/calico_versioned_docs/version-3.28/reference/api.mdx
@@ -1,12 +1,12 @@
 ---
-description: Learn about the Calico API and how to use it.
+description: Learn about the Calico client library and how to use it.
 ---
 
-# Calico API
+# Calico Client library
 
-$[prodname] provides and consumes a public API in Go that allows
-developers to work with $[prodname] resources.
+$[prodname] provides and consumes a client library in Go that allows developers to work with $[prodname] resources. The
+client library can be used to get, list, watch, create, delete and update custom resources, such as network policies much
+like the [client-go project](https://github.com/kubernetes/client-go) does for native Kubernetes resources.
 
-To learn more about the $[prodname] API and how to use it, see the Calico API project [README](https://github.com/projectcalico/api/blob/master/README.md) or
-the [github.com/projectcalico/api Go module page](https://pkg.go.dev/github.com/projectcalico/api)
-.
+To learn more about the Calico client library and how to use it, see the Calico API project [README](https://github.com/projectcalico/api/blob/master/README.md) or
+the [github.com/projectcalico/api Go module page](https://pkg.go.dev/github.com/projectcalico/api).

--- a/calico_versioned_docs/version-3.29/reference/api.mdx
+++ b/calico_versioned_docs/version-3.29/reference/api.mdx
@@ -1,12 +1,12 @@
 ---
-description: Learn about the Calico API and how to use it.
+description: Learn about the Calico client library and how to use it.
 ---
 
-# Calico API
+# Calico Client library
 
-$[prodname] provides and consumes a public API in Go that allows
-developers to work with $[prodname] resources.
+$[prodname] provides and consumes a client library in Go that allows developers to work with $[prodname] resources. The
+client library can be used to get, list, watch, create, delete and update custom resources, such as network policies much
+like the [client-go project](https://github.com/kubernetes/client-go) does for native Kubernetes resources.
 
-To learn more about the $[prodname] API and how to use it, see the Calico API project [README](https://github.com/projectcalico/api/blob/master/README.md) or
-the [github.com/projectcalico/api Go module page](https://pkg.go.dev/github.com/projectcalico/api)
-.
+To learn more about the Calico client library and how to use it, see the Calico API project [README](https://github.com/projectcalico/api/blob/master/README.md) or
+the [github.com/projectcalico/api Go module page](https://pkg.go.dev/github.com/projectcalico/api).

--- a/calico_versioned_docs/version-3.30/reference/api.mdx
+++ b/calico_versioned_docs/version-3.30/reference/api.mdx
@@ -1,12 +1,12 @@
 ---
-description: Learn about the Calico API and how to use it.
+description: Learn about the Calico client library and how to use it.
 ---
 
-# Calico API
+# Calico Client library
 
-$[prodname] provides and consumes a public API in Go that allows
-developers to work with $[prodname] resources.
+$[prodname] provides and consumes a client library in Go that allows developers to work with $[prodname] resources. The
+client library can be used to get, list, watch, create, delete and update custom resources, such as network policies much
+like the [client-go project](https://github.com/kubernetes/client-go) does for native Kubernetes resources.
 
-To learn more about the $[prodname] API and how to use it, see the Calico API project [README](https://github.com/projectcalico/api/blob/master/README.md) or
-the [github.com/projectcalico/api Go module page](https://pkg.go.dev/github.com/projectcalico/api)
-.
+To learn more about the Calico client library and how to use it, see the Calico API project [README](https://github.com/projectcalico/api/blob/master/README.md) or
+the [github.com/projectcalico/api Go module page](https://pkg.go.dev/github.com/projectcalico/api).


### PR DESCRIPTION
Rename our API pages to Client library pages

Tigera API and Calico API are a source of confusion to some users. By renaming the page and adding slightly more context, the user should have more context around the purpose and use cases for this page.