### PR TITLE
Fix that anchors would scroll behind top bar.

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -137,7 +137,7 @@ img {
   padding-left: 0.75rem;
 }
 
-.anchorWithStickyNavbar {
+.anchorWithStickyNavbar, article * {
   scroll-margin-top: calc(var(--ifm-navbar-height) + 0.5rem);
 }
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->
All

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->
When linking to an anchor deep in a page, it would scroll behind the top bar.

Current docs (bad): https://docs.tigera.io/calico/latest/reference/resources/felixconfig#goGCThreshold

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Example deep link:

Preview (fixed): https://deploy-preview-2196--tigera.netlify.app/calico/latest/reference/resources/felixconfig#goGCThreshold

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->