### PR TITLE
DOCS-2710: Update kcc with interfaceSelector

### DIFF
--- a/calico-cloud/reference/resources/kubecontrollersconfig.mdx
+++ b/calico-cloud/reference/resources/kubecontrollersconfig.mdx
@@ -31,6 +31,7 @@ spec:
           - generateName: custom-host-endpoint
             interfaceCIDRs:
               - 1.2.3.0/24
+            interfaceSelector: "eth0|eth1"
             nodeSelector: "has(my-label)"
             labels:
               key: value
@@ -91,6 +92,7 @@ The node controller automatically cleans up configuration for nodes that no long
 | generateName              | Unique name used as suffix for host endpoints created based on this template                                                        | Alphanumeric string | string                              |          |
 | nodeSelector              | Selects the nodes for which this template should create host endpoints                                                              |                     | [Selector](#selectors)              | all()    |
 | interfaceCIDRs            | This configuration defines which IP addresses from a node's specification (including standard, tunnel, and WireGuard IPs) are eligible for inclusion in the generated HostEndpoint. IP addresses must fall within the provided CIDR ranges to be considered. If no address on the node matches the specified CIDRs, the HostEndpoint creation is skipped. | List of valid CIDRs | List string                         |          |
+| interfaceSelector         | Regex to include matching interfaces and their IPs                                                                                  | string              | string                              |          |
 | labels                    | Labels to be added to generated host endpoints matching this template                                                               |                     | map of string key to string values  |          |
 
 ### Selectors

--- a/calico-enterprise/reference/resources/kubecontrollersconfig.mdx
+++ b/calico-enterprise/reference/resources/kubecontrollersconfig.mdx
@@ -31,6 +31,7 @@ spec:
           - generateName: custom-host-endpoint
             interfaceCIDRs:
               - 1.2.3.0/24
+            interfaceSelector: "eth0|eth1"
             nodeSelector: "has(my-label)"
             labels:
               key: value
@@ -90,6 +91,7 @@ The node controller automatically cleans up configuration for nodes that no long
 | generateName              | Unique name used as suffix for host endpoints created based on this template                                                        | Alphanumeric string | string                              |          |
 | nodeSelector              | Selects the nodes for which this template should create host endpoints                                                              |                     | [Selector](#selectors)              | all()    |
 | interfaceCIDRs            | This configuration defines which IP addresses from a node's specification (including standard, tunnel, and WireGuard IPs) are eligible for inclusion in the generated HostEndpoint. IP addresses must fall within the provided CIDR ranges to be considered. If no address on the node matches the specified CIDRs, the HostEndpoint creation is skipped. | List of valid CIDRs | List string                         |          |
+| interfaceSelector         | Regex to include matching interfaces and their IPs                                                                                  | string              | string                              |          |
 | labels                    | Labels to be added to generated host endpoints matching this template                                                               |                     | map of string key to string values  |          |
 
 ### Selectors

--- a/calico/reference/resources/kubecontrollersconfig.mdx
+++ b/calico/reference/resources/kubecontrollersconfig.mdx
@@ -32,6 +32,7 @@ spec:
           - generateName: custom-host-endpoint
             interfaceCIDRs:
               - 1.2.3.0/24
+            interfaceSelector: "eth0|eth1"
             nodeSelector: "has(my-label)"
             labels:
               key: value
@@ -103,6 +104,7 @@ The node controller automatically cleans up configuration for nodes that no long
 | generateName              | Unique name used as suffix for host endpoints created based on this template                                                        | Alphanumeric string | string                              |          |
 | nodeSelector              | Selects the nodes for which this template should create host endpoints                                                              |                     | [Selector](#selectors)              | all()    |
 | interfaceCIDRs            | This configuration defines which IP addresses from a node's specification (including standard, tunnel, and WireGuard IPs) are eligible for inclusion in the generated HostEndpoint. IP addresses must fall within the provided CIDR ranges to be considered. If no address on the node matches the specified CIDRs, the HostEndpoint creation is skipped. | List of valid CIDRs | List string                         |          |
+| interfaceSelector         | Regex to include matching interfaces and their IPs                                                                                  | string              | string                              |          |
 | labels                    | Labels to be added to generated host endpoints matching this template                                                               |                     | map of string key to string values  |          |
 
 ### Selectors


### PR DESCRIPTION
Update the kubecontrollersconfiguration to include new field interfaceSelector. This is used for AutoHep controller to create HostEndpoints according to the template spec. 

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->
Calico, Calico Enterprise, and Calico Cloud
Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->