### PR TITLE
remove mis-named config field and fix format

### DIFF
--- a/calico-enterprise/reference/resources/earlynetworkconfiguration.mdx
+++ b/calico-enterprise/reference/resources/earlynetworkconfiguration.mdx
@@ -53,8 +53,8 @@ spec:
       labels:
         rack: rb
   legacy:
-  nodeAddressIPDetection: false
-  unconditionalDefaultRouteProgramming: false
+    nodeIPFromDefaultRoute: false
+    unconditionalDefaultRouteProgramming: false
 ```
 
 ## Sample ConfigMap

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/resources/earlynetworkconfiguration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/resources/earlynetworkconfiguration.mdx
@@ -53,8 +53,8 @@ spec:
       labels:
         rack: rb
   legacy:
-  nodeAddressIPDetection: false
-  unconditionalDefaultRouteProgramming: false
+    nodeIPFromDefaultRoute: false
+    unconditionalDefaultRouteProgramming: false
 ```
 
 ## Sample ConfigMap

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/resources/earlynetworkconfiguration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/resources/earlynetworkconfiguration.mdx
@@ -53,8 +53,8 @@ spec:
       labels:
         rack: rb
   legacy:
-  nodeAddressIPDetection: false
-  unconditionalDefaultRouteProgramming: false
+    nodeIPFromDefaultRoute: false
+    unconditionalDefaultRouteProgramming: false
 ```
 
 ## Sample ConfigMap

--- a/calico-enterprise_versioned_docs/version-3.22-1/reference/resources/earlynetworkconfiguration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/reference/resources/earlynetworkconfiguration.mdx
@@ -53,8 +53,8 @@ spec:
       labels:
         rack: rb
   legacy:
-  nodeAddressIPDetection: false
-  unconditionalDefaultRouteProgramming: false
+    nodeIPFromDefaultRoute: false
+    unconditionalDefaultRouteProgramming: false
 ```
 
 ## Sample ConfigMap


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):

 - Latest,
 - calico-enterprise_versioned_docs/version-3.20-2,
 - calico-enterprise_versioned_docs/version-3.21-2,
 - calico-enterprise_versioned_docs/version-3.22-1.

Issue:
None

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
Noticed I used a config-option name which is no longer accurate.

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->