### PR TITLE
Remove "tech preview" notes for Gateway API

### DIFF
--- a/calico-cloud/networking/gateway-api.mdx
+++ b/calico-cloud/networking/gateway-api.mdx
@@ -8,12 +8,6 @@ description: Enable support for the Kubernetes Gateway API.
 
 Enable support for the Kubernetes Gateway API.
 
-:::note
-
-This feature is tech preview. Tech preview features may be subject to significant changes before they become GA.
-
-:::
-
 ## Value
 
 $[prodname] includes support for the Kubernetes Gateway API, which allows advanced routing to services in a cluster, including weighted or blue-green load balancing.

--- a/calico-enterprise/networking/gateway-api.mdx
+++ b/calico-enterprise/networking/gateway-api.mdx
@@ -8,12 +8,6 @@ description: Enable support for the Kubernetes Gateway API.
 
 Enable support for the Kubernetes Gateway API.
 
-:::note
-
-This feature is tech preview. Tech preview features may be subject to significant changes before they become GA.
-
-:::
-
 ## Value
 
 $[prodname] includes support for the Kubernetes Gateway API, which allows advanced routing to services in a cluster, including weighted or blue-green load balancing.

--- a/calico-enterprise_versioned_docs/version-3.22-1/networking/gateway-api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/networking/gateway-api.mdx
@@ -8,12 +8,6 @@ description: Enable support for the Kubernetes Gateway API.
 
 Enable support for the Kubernetes Gateway API.
 
-:::note
-
-This feature is tech preview. Tech preview features may be subject to significant changes before they become GA.
-
-:::
-
 ## Value
 
 $[prodname] includes support for the Kubernetes Gateway API, which allows advanced routing to services in a cluster, including weighted or blue-green load balancing.

--- a/calico/networking/gateway-api.mdx
+++ b/calico/networking/gateway-api.mdx
@@ -8,12 +8,6 @@ description: Enable support for the Kubernetes Gateway API.
 
 Enable support for the Kubernetes Gateway API.
 
-:::note
-
-This feature is tech preview. Tech preview features may be subject to significant changes before they become GA.
-
-:::
-
 ## Value
 
 $[prodname] includes support for the Kubernetes Gateway API, which allows advanced routing to services in a cluster, including weighted or blue-green load balancing.


### PR DESCRIPTION
As of Enterprise v3.22 EP1, we are saying that Gateway API is GA.