### PR TITLE
[DE-3586] For OSS - CE upgrades, add command to remove goldmane and whisker resources post upgrade

### DIFF
--- a/calico-enterprise/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
@@ -24,6 +24,16 @@ If your cluster already has $[prodname] installed, follow the [Upgrading $[prodn
 
 Calico Enterprise creates default-deny policies for all Calico and Tigera namespaces, including calico-system. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.
 
+### Deleting Goldmane and Whisker resources (for upgrades from Calico 3.30 or later)
+
+If you are upgrading from Calico 3.30 and have custom resources related to Goldmane and Whisker, you should delete these resources before the upgrade.
+
+```bash
+oc delete goldmanes,whiskers --all
+```
+
+If you receive error indicating the custom resource definitions or resource type does not exist, it means these resources were not present in your cluster. You can safely ignore the error and proceed.
+
 ## Upgrade Calico to $[prodname]
 
 ### Before you begin
@@ -92,12 +102,6 @@ Install the $[prodname] license provided to you by Tigera.
 
 ```
 oc create -f </path/to/license.yaml>
-```
-
-Delete Goldmane and Whisker resources as they are not needed for $[prodname].
-
-```
-oc delete goldmanes,whiskers --all
 ```
 
 <OpenShiftPrometheusOperator upgradeFrom='OpenSource' />

--- a/calico-enterprise/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
@@ -94,6 +94,12 @@ Install the $[prodname] license provided to you by Tigera.
 oc create -f </path/to/license.yaml>
 ```
 
+Delete Goldmane and Whisker resources as they are not needed for $[prodname].
+
+```
+oc delete goldmanes,whiskers --all
+```
+
 <OpenShiftPrometheusOperator upgradeFrom='OpenSource' />
 
 You can now monitor progress with the following command:

--- a/calico-enterprise/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
@@ -16,6 +16,16 @@ All upgrades in $[prodname] are free with a valid license.
 
 Calico Enterprise creates default-deny policies for all Calico and Tigera namespaces, including calico-system. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.
 
+### Deleting Goldmane and Whisker resources (for upgrades from Calico 3.30 or later)
+
+If you are upgrading from Calico 3.30 and have custom resources related to Goldmane and Whisker, you should delete these resources before the upgrade.
+
+```bash
+kubectl delete goldmanes,whiskers --all
+```
+
+If you receive error indicating the custom resource definitions or resource type does not exist, it means these resources were not present in your cluster. You can safely ignore the error and proceed.
+
 ## Upgrade from Calico to $[prodname]
 
 :::note
@@ -70,12 +80,6 @@ The following steps assume the Calico deployment is installed on `tigera-operato
 
    ```bash
    kubectl create -f </path/to/license.yaml>
-   ```
-
-1. Delete Goldmane and Whisker resources as they are not needed for $[prodname].
-
-   ```
-   kubectl delete goldmanes,whiskers --all
    ```
 
 1. Monitor progress, wait until all components show a status of `Available`, then proceed to the next step.

--- a/calico-enterprise/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
@@ -72,6 +72,12 @@ The following steps assume the Calico deployment is installed on `tigera-operato
    kubectl create -f </path/to/license.yaml>
    ```
 
+1. Delete Goldmane and Whisker resources as they are not needed for $[prodname].
+
+   ```
+   kubectl delete goldmanes,whiskers --all
+   ```
+
 1. Monitor progress, wait until all components show a status of `Available`, then proceed to the next step.
 
    ```bash

--- a/calico-enterprise/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/standard.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/standard.mdx
@@ -25,6 +25,16 @@ For hybrid Linux and Windows clusters, ensure that your Windows nodes have at le
 
 $[prodname] creates default-deny policies for all Calico and Tigera namespaces, including calico-system. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.
 
+### Deleting Goldmane and Whisker resources (for upgrades from Calico 3.30 or later)
+
+If you are upgrading from Calico 3.30 and have custom resources related to Goldmane and Whisker, you should delete these resources before the upgrade.
+
+```bash
+kubectl delete goldmanes,whiskers --all
+```
+
+If you receive error indicating the custom resource definitions or resource type does not exist, it means these resources were not present in your cluster. You can safely ignore the error and proceed.
+
 ## Upgrade Calico to $[prodname]
 
 :::note
@@ -87,12 +97,6 @@ To use $[prodname], you must install the license provided to you by Tigera.
 
 ```
 kubectl create -f </path/to/license.yaml>
-```
-
-Delete Goldmane and Whisker resources as they are not needed for $[prodname].
-
-```
-kubectl delete goldmanes,whiskers --all
 ```
 
 You can now monitor progress with the following command:

--- a/calico-enterprise/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/standard.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/standard.mdx
@@ -89,6 +89,12 @@ To use $[prodname], you must install the license provided to you by Tigera.
 kubectl create -f </path/to/license.yaml>
 ```
 
+Delete Goldmane and Whisker resources as they are not needed for $[prodname].
+
+```
+kubectl delete goldmanes,whiskers --all
+```
+
 You can now monitor progress with the following command:
 
 ```

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
@@ -96,6 +96,12 @@ oc create -f </path/to/license.yaml>
 
 <OpenShiftPrometheusOperator upgradeFrom='OpenSource' />
 
+Delete Goldmane and Whisker resources as they are not needed for $[prodname].
+
+```
+oc delete goldmanes,whiskers --all
+```
+
 You can now monitor progress with the following command:
 
 ```

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
@@ -24,6 +24,16 @@ If your cluster already has $[prodname] installed, follow the [Upgrading $[prodn
 
 Calico Enterprise creates default-deny policies for all Calico and Tigera namespaces, including calico-system. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.
 
+### Deleting Goldmane and Whisker resources (for upgrades from Calico 3.30 or later)
+
+If you are upgrading from Calico 3.30 and have custom resources related to Goldmane and Whisker, you should delete these resources before the upgrade.
+
+```bash
+oc delete goldmanes,whiskers --all
+```
+
+If you receive error indicating the custom resource definitions or resource type does not exist, it means these resources were not present in your cluster. You can safely ignore the error and proceed.
+
 ## Upgrade Calico to $[prodname]
 
 ### Before you begin
@@ -95,12 +105,6 @@ oc create -f </path/to/license.yaml>
 ```
 
 <OpenShiftPrometheusOperator upgradeFrom='OpenSource' />
-
-Delete Goldmane and Whisker resources as they are not needed for $[prodname].
-
-```
-oc delete goldmanes,whiskers --all
-```
 
 You can now monitor progress with the following command:
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
@@ -16,6 +16,16 @@ All upgrades in $[prodname] are free with a valid license.
 
 Calico Enterprise creates default-deny policies for all Calico and Tigera namespaces, including calico-system. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.
 
+### Deleting Goldmane and Whisker resources (for upgrades from Calico 3.30 or later)
+
+If you are upgrading from Calico 3.30 and have custom resources related to Goldmane and Whisker, you should delete these resources before the upgrade.
+
+```bash
+kubectl delete goldmanes,whiskers --all
+```
+
+If you receive error indicating the custom resource definitions or resource type does not exist, it means these resources were not present in your cluster. You can safely ignore the error and proceed.
+
 ## Upgrade from Calico to $[prodname]
 
 :::note
@@ -70,12 +80,6 @@ The following steps assume the Calico deployment is installed on `tigera-operato
 
    ```bash
    kubectl create -f </path/to/license.yaml>
-   ```
-
-1. Delete Goldmane and Whisker resources as they are not needed for $[prodname].
-
-   ```
-   kubectl delete goldmanes,whiskers --all
    ```
 
 1. Monitor progress, wait until all components show a status of `Available`, then proceed to the next step.

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
@@ -72,6 +72,12 @@ The following steps assume the Calico deployment is installed on `tigera-operato
    kubectl create -f </path/to/license.yaml>
    ```
 
+1. Delete Goldmane and Whisker resources as they are not needed for $[prodname].
+
+   ```
+   kubectl delete goldmanes,whiskers --all
+   ```
+
 1. Monitor progress, wait until all components show a status of `Available`, then proceed to the next step.
 
    ```bash

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/standard.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/standard.mdx
@@ -25,6 +25,16 @@ For hybrid Linux and Windows clusters, ensure that your Windows nodes have at le
 
 $[prodname] creates default-deny policies for all Calico and Tigera namespaces, including calico-system. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.
 
+### Deleting Goldmane and Whisker resources (for upgrades from Calico 3.30 or later)
+
+If you are upgrading from Calico 3.30 and have custom resources related to Goldmane and Whisker, you should delete these resources before the upgrade.
+
+```bash
+kubectl delete goldmanes,whiskers --all
+```
+
+If you receive error indicating the custom resource definitions or resource type does not exist, it means these resources were not present in your cluster. You can safely ignore the error and proceed.
+
 ## Upgrade Calico to $[prodname]
 
 :::note
@@ -87,12 +97,6 @@ To use $[prodname], you must install the license provided to you by Tigera.
 
 ```
 kubectl create -f </path/to/license.yaml>
-```
-
-Delete Goldmane and Whisker resources as they are not needed for $[prodname].
-
-```
-kubectl delete goldmanes,whiskers --all
 ```
 
 You can now monitor progress with the following command:

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/standard.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/standard.mdx
@@ -89,6 +89,12 @@ To use $[prodname], you must install the license provided to you by Tigera.
 kubectl create -f </path/to/license.yaml>
 ```
 
+Delete Goldmane and Whisker resources as they are not needed for $[prodname].
+
+```
+kubectl delete goldmanes,whiskers --all
+```
+
 You can now monitor progress with the following command:
 
 ```

--- a/calico-enterprise_versioned_docs/version-3.22-1/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
@@ -24,6 +24,16 @@ If your cluster already has $[prodname] installed, follow the [Upgrading $[prodn
 
 Calico Enterprise creates default-deny policies for all Calico and Tigera namespaces, including calico-system. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.
 
+### Deleting Goldmane and Whisker resources (for upgrades from Calico 3.30 or later)
+
+If you are upgrading from Calico 3.30 and have custom resources related to Goldmane and Whisker, you should delete these resources before the upgrade.
+
+```bash
+oc delete goldmanes,whiskers --all
+```
+
+If you receive error indicating the custom resource definitions or resource type does not exist, it means these resources were not present in your cluster. You can safely ignore the error and proceed.
+
 ## Upgrade Calico to $[prodname]
 
 ### Before you begin
@@ -92,12 +102,6 @@ Install the $[prodname] license provided to you by Tigera.
 
 ```
 oc create -f </path/to/license.yaml>
-```
-
-Delete Goldmane and Whisker resources as they are not needed for $[prodname].
-
-```
-oc delete goldmanes,whiskers --all
 ```
 
 <OpenShiftPrometheusOperator upgradeFrom='OpenSource' />

--- a/calico-enterprise_versioned_docs/version-3.22-1/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
@@ -94,6 +94,12 @@ Install the $[prodname] license provided to you by Tigera.
 oc create -f </path/to/license.yaml>
 ```
 
+Delete Goldmane and Whisker resources as they are not needed for $[prodname].
+
+```
+oc delete goldmanes,whiskers --all
+```
+
 <OpenShiftPrometheusOperator upgradeFrom='OpenSource' />
 
 You can now monitor progress with the following command:

--- a/calico-enterprise_versioned_docs/version-3.22-1/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
@@ -16,6 +16,16 @@ All upgrades in $[prodname] are free with a valid license.
 
 Calico Enterprise creates default-deny policies for all Calico and Tigera namespaces, including calico-system. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.
 
+### Deleting Goldmane and Whisker resources (for upgrades from Calico 3.30 or later)
+
+If you are upgrading from Calico 3.30 and have custom resources related to Goldmane and Whisker, you should delete these resources before the upgrade.
+
+```bash
+kubectl delete goldmanes,whiskers --all
+```
+
+If you receive error indicating the custom resource definitions or resource type does not exist, it means these resources were not present in your cluster. You can safely ignore the error and proceed.
+
 ## Upgrade from Calico to $[prodname]
 
 :::note
@@ -70,12 +80,6 @@ The following steps assume the Calico deployment is installed on `tigera-operato
 
    ```bash
    kubectl create -f </path/to/license.yaml>
-   ```
-
-1. Delete Goldmane and Whisker resources as they are not needed for $[prodname].
-
-   ```
-   kubectl delete goldmanes,whiskers --all
    ```
 
 1. Monitor progress, wait until all components show a status of `Available`, then proceed to the next step.

--- a/calico-enterprise_versioned_docs/version-3.22-1/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
@@ -72,6 +72,12 @@ The following steps assume the Calico deployment is installed on `tigera-operato
    kubectl create -f </path/to/license.yaml>
    ```
 
+1. Delete Goldmane and Whisker resources as they are not needed for $[prodname].
+
+   ```
+   kubectl delete goldmanes,whiskers --all
+   ```
+
 1. Monitor progress, wait until all components show a status of `Available`, then proceed to the next step.
 
    ```bash

--- a/calico-enterprise_versioned_docs/version-3.22-1/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/standard.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/standard.mdx
@@ -25,6 +25,16 @@ For hybrid Linux and Windows clusters, ensure that your Windows nodes have at le
 
 $[prodname] creates default-deny policies for all Calico and Tigera namespaces, including calico-system. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.
 
+### Deleting Goldmane and Whisker resources (for upgrades from Calico 3.30 or later)
+
+If you are upgrading from Calico 3.30 and have custom resources related to Goldmane and Whisker, you should delete these resources before the upgrade.
+
+```bash
+kubectl delete goldmanes,whiskers --all
+```
+
+If you receive error indicating the custom resource definitions or resource type does not exist, it means these resources were not present in your cluster. You can safely ignore the error and proceed.
+
 ## Upgrade Calico to $[prodname]
 
 :::note
@@ -87,12 +97,6 @@ To use $[prodname], you must install the license provided to you by Tigera.
 
 ```
 kubectl create -f </path/to/license.yaml>
-```
-
-Delete Goldmane and Whisker resources as they are not needed for $[prodname].
-
-```
-kubectl delete goldmanes,whiskers --all
 ```
 
 You can now monitor progress with the following command:

--- a/calico-enterprise_versioned_docs/version-3.22-1/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/standard.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/standard.mdx
@@ -89,6 +89,12 @@ To use $[prodname], you must install the license provided to you by Tigera.
 kubectl create -f </path/to/license.yaml>
 ```
 
+Delete Goldmane and Whisker resources as they are not needed for $[prodname].
+
+```
+kubectl delete goldmanes,whiskers --all
+```
+
 You can now monitor progress with the following command:
 
 ```


### PR DESCRIPTION
Add command to remove goldmane and whisker resources post upgrade

Product Version(s):
Calico Enterprise

Issue:
Delete goldmane and whisker resources post Open source to Enterprise upgrades

Link to docs preview:


SME review:
- [ ] An SME has approved this change. 

DOCS review:
- [ ] A member of the docs team has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->