### PR TITLE
fix version file generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,10 @@ run-update-cloud-image-list:
 
 VERSION_ALL_VERSIONS=$(foreach version,$(wildcard calico-enterprise_versioned_docs/*),version/autogen/$(version:calico-enterprise_versioned_docs/version-%=%))
 
-version/autogenall: $(VERSION_ALL_VERSIONS)
+# This target updates *the current versions* based on what is present in calico-private. It will
+# not (to my knowledge) add a new version which has not yet been added to the docs.
+version/updateall: $(VERSION_ALL_VERSIONS)
+	$(info [info] All current versions have been updated, but please check `git diff` to ensure the values are correct!)
 
 version/autogen/%:
 	$(info Building $@)

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,8 @@ ifdef LOCAL_BUILD
 else
 	docker run --rm --net=host \
 	-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
+	-e GOOS=$(shell go env GOOS) \
+	-e GOARCH=$(shell go env GOARCH) \
 	-v $(CURDIR):/go/src/$(PACKAGE_NAME):rw \
 	-v $(CURDIR)/.go-pkg-cache:/go/pkg:rw \
 	-w /go/src/$(PACKAGE_NAME) \

--- a/Makefile
+++ b/Makefile
@@ -213,11 +213,23 @@ run-update-cloud-image-list:
 # 	e.g. for new versions of v3.18.0-2, DOCS_VERSION_STREAM=3.18-2
 # If the version to updates is the latest version for the product, specify IS_LATEST=true
 # 	e.g. if 3,18,1 is the latest version, IS_LATEST=true
+
+VERSION_ALL_VERSIONS=$(foreach version,$(wildcard calico-enterprise_versioned_docs/*),version/autogen/$(version:calico-enterprise_versioned_docs/version-%=%))
+
+version/autogenall: $(VERSION_ALL_VERSIONS)
+
+version/autogen/%:
+	$(info Building $@)
+	@$(MAKE) --no-print-directory version/autogen \
+		PRODUCT=calico-enterprise \
+		DOCS_VERSION_STREAM=$* \
+		VERSION=$(shell jq -r '.[0].title' calico-enterprise_versioned_docs/version-$*/releases.json)
+
 version/autogen: scripts/versions/format-versions
 	$(if $(GITHUB_TOKEN),,$(error GITHUB_TOKEN is not set or empty, but is required))
 	$(if $(PRODUCT),,$(error PRODUCT is not set or empty, but is required))
 	$(if $(VERSION),,$(error VERSION is not set or empty, but is required))
-	./scripts/update-component-versions.sh
+	@./scripts/update-component-versions.sh
 
 # Call the github API. $(1) is the http method type for the https request, $(2) is the repo slug, and is $(3) is for json
 # data (if omitted then no data is set for the request). If GITHUB_API_EXIT_ON_FAILURE is set then the macro exits with 1

--- a/calico-cloud/reference/installation/_api.mdx
+++ b/calico-cloud/reference/installation/_api.mdx
@@ -146,7 +146,7 @@ APIServerDeployment
 <td>
 
 <p>
-APIServerDeployment configures the calico-apiserver Deployment. If
+APIServerDeployment configures the calico-apiserver (or tigera-apiserver in Enterprise) Deployment. If
 used in conjunction with ControlPlaneNodeSelector or ControlPlaneTolerations, then these overrides
 take precedence.
 </p>
@@ -4693,7 +4693,7 @@ APIServerDeployment
 <td>
 
 <p>
-APIServerDeployment configures the calico-apiserver Deployment. If
+APIServerDeployment configures the calico-apiserver (or tigera-apiserver in Enterprise) Deployment. If
 used in conjunction with ControlPlaneNodeSelector or ControlPlaneTolerations, then these overrides
 take precedence.
 </p>

--- a/calico-enterprise_versioned_docs/version-3.19-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.19-2/releases.json
@@ -2,8 +2,8 @@
   {
     "title": "v3.19.7",
     "tigera-operator": {
-      "image": "tigera/operator",
       "version": "v1.34.12",
+      "image": "tigera/operator",
       "registry": "quay.io"
     },
     "calico": {
@@ -11,171 +11,67 @@
       "archive_path": "archive"
     },
     "components": {
-      "cnx-manager": {
-        "image": "tigera/cnx-manager",
-        "version": "v3.19.7"
-      },
-      "voltron": {
-        "image": "tigera/voltron",
-        "version": "v3.19.7"
-      },
-      "guardian": {
-        "image": "tigera/guardian",
-        "version": "v3.19.7"
-      },
-      "cnx-apiserver": {
-        "image": "tigera/cnx-apiserver",
-        "version": "v3.19.7"
-      },
-      "cnx-queryserver": {
-        "image": "tigera/cnx-queryserver",
-        "version": "v3.19.7"
-      },
-      "cnx-kube-controllers": {
-        "image": "tigera/kube-controllers",
-        "version": "v3.19.7"
-      },
-      "calicoq": {
-        "image": "tigera/calicoq",
-        "version": "v3.19.7"
-      },
-      "typha": {
-        "image": "tigera/typha",
-        "version": "v3.19.7"
+      "alertmanager": {
+        "version": "v3.19.7",
+        "image": "tigera/alertmanager"
       },
       "calicoctl": {
-        "image": "tigera/calicoctl",
-        "version": "v3.19.7"
+        "version": "v3.19.7",
+        "image": "tigera/calicoctl"
+      },
+      "calicoq": {
+        "version": "v3.19.7",
+        "image": "tigera/calicoq"
+      },
+      "cnx-apiserver": {
+        "version": "v3.19.7",
+        "image": "tigera/cnx-apiserver"
+      },
+      "cnx-kube-controllers": {
+        "version": "v3.19.7",
+        "image": "tigera/kube-controllers"
+      },
+      "cnx-manager": {
+        "version": "v3.19.7",
+        "image": "tigera/cnx-manager"
       },
       "cnx-node": {
-        "image": "tigera/cnx-node",
-        "version": "v3.19.7"
+        "version": "v3.19.7",
+        "image": "tigera/cnx-node"
       },
       "cnx-node-windows": {
-        "image": "tigera/cnx-node-windows",
-        "version": "v3.19.7"
+        "version": "v3.19.7",
+        "image": "tigera/cnx-node-windows"
       },
-      "dikastes": {
-        "image": "tigera/dikastes",
-        "version": "v3.19.7"
-      },
-      "dex": {
-        "image": "tigera/dex",
-        "version": "v3.19.7"
-      },
-      "fluentd": {
-        "image": "tigera/fluentd",
-        "version": "v3.19.7"
-      },
-      "fluentd-windows": {
-        "image": "tigera/fluentd-windows",
-        "version": "v3.19.7"
-      },
-      "es-proxy": {
-        "image": "tigera/es-proxy",
-        "version": "v3.19.7"
-      },
-      "eck-kibana": {
-        "version": "7.17.28"
-      },
-      "kibana": {
-        "image": "tigera/kibana",
-        "version": "v3.19.7"
-      },
-      "eck-elasticsearch": {
-        "version": "7.17.28"
-      },
-      "elasticsearch": {
-        "image": "tigera/elasticsearch",
-        "version": "v3.19.7"
-      },
-      "elastic-tsee-installer": {
-        "image": "tigera/intrusion-detection-job-installer",
-        "version": "v3.19.7"
-      },
-      "intrusion-detection-controller": {
-        "image": "tigera/intrusion-detection-controller",
-        "version": "v3.19.7"
-      },
-      "compliance-controller": {
-        "image": "tigera/compliance-controller",
-        "version": "v3.19.7"
-      },
-      "compliance-reporter": {
-        "image": "tigera/compliance-reporter",
-        "version": "v3.19.7"
-      },
-      "compliance-snapshotter": {
-        "image": "tigera/compliance-snapshotter",
-        "version": "v3.19.7"
-      },
-      "compliance-server": {
-        "image": "tigera/compliance-server",
-        "version": "v3.19.7"
+      "cnx-queryserver": {
+        "version": "v3.19.7",
+        "image": "tigera/cnx-queryserver"
       },
       "compliance-benchmarker": {
-        "image": "tigera/compliance-benchmarker",
-        "version": "v3.19.7"
+        "version": "v3.19.7",
+        "image": "tigera/compliance-benchmarker"
       },
-      "ingress-collector": {
-        "image": "tigera/ingress-collector",
-        "version": "v3.19.7"
+      "compliance-controller": {
+        "version": "v3.19.7",
+        "image": "tigera/compliance-controller"
       },
-      "l7-collector": {
-        "image": "tigera/l7-collector",
-        "version": "v3.19.7"
+      "compliance-reporter": {
+        "version": "v3.19.7",
+        "image": "tigera/compliance-reporter"
       },
-      "license-agent": {
-        "image": "tigera/license-agent",
-        "version": "v3.19.7"
+      "compliance-server": {
+        "version": "v3.19.7",
+        "image": "tigera/compliance-server"
       },
-      "tigera-cni": {
-        "image": "tigera/cni",
-        "version": "v3.19.7"
+      "compliance-snapshotter": {
+        "version": "v3.19.7",
+        "image": "tigera/compliance-snapshotter"
       },
-      "tigera-cni-windows": {
-        "image": "tigera/cni-windows",
-        "version": "v3.19.7"
+      "coreos-alertmanager": {
+        "version": "v0.28.1"
       },
-      "firewall-integration": {
-        "image": "tigera/firewall-integration",
-        "version": "v3.19.7"
-      },
-      "egress-gateway": {
-        "image": "tigera/egress-gateway",
-        "version": "v3.19.7"
-      },
-      "honeypod": {
-        "image": "tigera/honeypod",
-        "version": "v3.19.7"
-      },
-      "honeypod-exp-service": {
-        "image": "tigera/honeypod-exp-service",
-        "version": "v3.19.7"
-      },
-      "honeypod-controller": {
-        "image": "tigera/honeypod-controller",
-        "version": "v3.19.7"
-      },
-      "key-cert-provisioner": {
-        "image": "tigera/key-cert-provisioner",
-        "version": "v3.19.7"
-      },
-      "elasticsearch-metrics": {
-        "image": "tigera/elasticsearch-metrics",
-        "version": "v3.19.7"
-      },
-      "packetcapture": {
-        "image": "tigera/packetcapture",
-        "version": "v3.19.7"
-      },
-      "policy-recommendation": {
-        "image": "tigera/policy-recommendation",
-        "version": "v3.19.7"
-      },
-      "prometheus": {
-        "image": "tigera/prometheus",
-        "version": "v3.19.7"
+      "coreos-config-reloader": {
+        "version": "v0.76.2"
       },
       "coreos-prometheus": {
         "version": "v2.55.1"
@@ -183,70 +79,174 @@
       "coreos-prometheus-operator": {
         "version": "v0.76.2"
       },
-      "coreos-config-reloader": {
-        "version": "v0.76.2"
+      "csi": {
+        "version": "v3.19.7",
+        "image": "tigera/csi"
       },
-      "prometheus-operator": {
-        "image": "tigera/prometheus-operator",
-        "version": "v3.19.7"
-      },
-      "prometheus-config-reloader": {
-        "image": "tigera/prometheus-config-reloader",
-        "version": "v3.19.7"
-      },
-      "tigera-prometheus-service": {
-        "image": "tigera/prometheus-service",
-        "version": "v3.19.7"
-      },
-      "es-gateway": {
-        "image": "tigera/es-gateway",
-        "version": "v3.19.7"
-      },
-      "linseed": {
-        "image": "tigera/linseed",
-        "version": "v3.19.7"
+      "csi-node-driver-registrar": {
+        "version": "v3.19.7",
+        "image": "tigera/node-driver-registrar"
       },
       "deep-packet-inspection": {
-        "image": "tigera/deep-packet-inspection",
-        "version": "v3.19.7"
+        "version": "v3.19.7",
+        "image": "tigera/deep-packet-inspection"
+      },
+      "dex": {
+        "version": "v3.19.7",
+        "image": "tigera/dex"
+      },
+      "dikastes": {
+        "version": "v3.19.7",
+        "image": "tigera/dikastes"
+      },
+      "eck-elasticsearch": {
+        "version": "7.17.28"
       },
       "eck-elasticsearch-operator": {
         "version": "2.16.1"
       },
+      "eck-kibana": {
+        "version": "7.17.28"
+      },
+      "egress-gateway": {
+        "version": "v3.19.7",
+        "image": "tigera/egress-gateway"
+      },
+      "elastic-tsee-installer": {
+        "version": "v3.19.7",
+        "image": "tigera/intrusion-detection-job-installer"
+      },
+      "elasticsearch": {
+        "version": "v3.19.7",
+        "image": "tigera/elasticsearch"
+      },
+      "elasticsearch-metrics": {
+        "version": "v3.19.7",
+        "image": "tigera/elasticsearch-metrics"
+      },
       "elasticsearch-operator": {
-        "image": "tigera/eck-operator",
-        "version": "v3.19.7"
-      },
-      "coreos-alertmanager": {
-        "version": "v0.28.1"
-      },
-      "alertmanager": {
-        "image": "tigera/alertmanager",
-        "version": "v3.19.7"
+        "version": "v3.19.7",
+        "image": "tigera/eck-operator"
       },
       "envoy": {
-        "image": "tigera/envoy",
-        "version": "v3.19.7"
+        "version": "v3.19.7",
+        "image": "tigera/envoy"
       },
       "envoy-init": {
-        "image": "tigera/envoy-init",
-        "version": "v3.19.7"
+        "version": "v3.19.7",
+        "image": "tigera/envoy-init"
       },
-      "webhooks-processor": {
-        "image": "tigera/webhooks-processor",
-        "version": "v3.19.7"
+      "es-gateway": {
+        "version": "v3.19.7",
+        "image": "tigera/es-gateway"
+      },
+      "es-proxy": {
+        "version": "v3.19.7",
+        "image": "tigera/es-proxy"
+      },
+      "firewall-integration": {
+        "version": "v3.19.7",
+        "image": "tigera/firewall-integration"
       },
       "flexvol": {
-        "image": "tigera/pod2daemon-flexvol",
-        "version": "v3.19.7"
+        "version": "v3.19.7",
+        "image": "tigera/pod2daemon-flexvol"
       },
-      "csi": {
-        "image": "tigera/csi",
-        "version": "v3.19.7"
+      "fluentd": {
+        "version": "v3.19.7",
+        "image": "tigera/fluentd"
       },
-      "csi-node-driver-registrar": {
-        "image": "tigera/node-driver-registrar",
-        "version": "v3.19.7"
+      "fluentd-windows": {
+        "version": "v3.19.7",
+        "image": "tigera/fluentd-windows"
+      },
+      "guardian": {
+        "version": "v3.19.7",
+        "image": "tigera/guardian"
+      },
+      "honeypod": {
+        "version": "v3.19.7",
+        "image": "tigera/honeypod"
+      },
+      "honeypod-controller": {
+        "version": "v3.19.7",
+        "image": "tigera/honeypod-controller"
+      },
+      "honeypod-exp-service": {
+        "version": "v3.19.7",
+        "image": "tigera/honeypod-exp-service"
+      },
+      "ingress-collector": {
+        "version": "v3.19.7",
+        "image": "tigera/ingress-collector"
+      },
+      "intrusion-detection-controller": {
+        "version": "v3.19.7",
+        "image": "tigera/intrusion-detection-controller"
+      },
+      "key-cert-provisioner": {
+        "version": "v3.19.7",
+        "image": "tigera/key-cert-provisioner"
+      },
+      "kibana": {
+        "version": "v3.19.7",
+        "image": "tigera/kibana"
+      },
+      "l7-collector": {
+        "version": "v3.19.7",
+        "image": "tigera/l7-collector"
+      },
+      "license-agent": {
+        "version": "v3.19.7",
+        "image": "tigera/license-agent"
+      },
+      "linseed": {
+        "version": "v3.19.7",
+        "image": "tigera/linseed"
+      },
+      "packetcapture": {
+        "version": "v3.19.7",
+        "image": "tigera/packetcapture"
+      },
+      "policy-recommendation": {
+        "version": "v3.19.7",
+        "image": "tigera/policy-recommendation"
+      },
+      "prometheus": {
+        "version": "v3.19.7",
+        "image": "tigera/prometheus"
+      },
+      "prometheus-config-reloader": {
+        "version": "v3.19.7",
+        "image": "tigera/prometheus-config-reloader"
+      },
+      "prometheus-operator": {
+        "version": "v3.19.7",
+        "image": "tigera/prometheus-operator"
+      },
+      "tigera-cni": {
+        "version": "v3.19.7",
+        "image": "tigera/cni"
+      },
+      "tigera-cni-windows": {
+        "version": "v3.19.7",
+        "image": "tigera/cni-windows"
+      },
+      "tigera-prometheus-service": {
+        "version": "v3.19.7",
+        "image": "tigera/prometheus-service"
+      },
+      "typha": {
+        "version": "v3.19.7",
+        "image": "tigera/typha"
+      },
+      "voltron": {
+        "version": "v3.19.7",
+        "image": "tigera/voltron"
+      },
+      "webhooks-processor": {
+        "version": "v3.19.7",
+        "image": "tigera/webhooks-processor"
       }
     }
   },

--- a/calico-enterprise_versioned_docs/version-3.19-2/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.19-2/variables.js
@@ -9,6 +9,7 @@ const variables = {
   openSourceVersion: releases[0].calico.minor_version.slice(1),
   baseUrl: '/calico-enterprise/3.19',
   filesUrl: 'https://downloads.tigera.io/ee/v3.19.7',
+  // No rpmsUrl for this release
   tutorialFilesURL: 'https://docs.tigera.io/files',
   tmpScriptsURL: 'https://docs.tigera.io/calico-enterprise/3.19',
   windowsScriptsURL: 'https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess',

--- a/calico-enterprise_versioned_docs/version-3.20-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.20-2/releases.json
@@ -71,7 +71,10 @@
         "version": "v0.28.1"
       },
       "coreos-config-reloader": {
-        "version": "v0.76.2"
+        "version": "v0.76.0"
+      },
+      "coreos-fluentd": {
+        "version": "1.18.0"
       },
       "coreos-prometheus": {
         "version": "v2.55.1"
@@ -234,9 +237,6 @@
       },
       "upstream-dex": {
         "version": "v2.41.1"
-      },
-      "upstream-fluentd": {
-        "version": "1.18.0"
       },
       "voltron": {
         "version": "v3.20.5",

--- a/calico-enterprise_versioned_docs/version-3.20-2/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.20-2/variables.js
@@ -7,7 +7,7 @@ const variables = {
   prodnamedash: 'calico-enterprise',
   version: 'v3.20',
   openSourceVersion: releases[0].calico.minor_version.slice(1),
-  baseUrl: '/calico-enterprise/latest',
+  baseUrl: '/calico-enterprise/3.20',
   filesUrl: 'https://downloads.tigera.io/ee/v3.20.5',
   rpmsUrl: 'https://downloads.tigera.io/ee/rpms/v3.20',
   tutorialFilesURL: 'https://docs.tigera.io/files',

--- a/calico-enterprise_versioned_docs/version-3.21-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.21-2/releases.json
@@ -1,5 +1,5 @@
 [
-    {
+  {
     "title": "v3.21.2",
     "tigera-operator": {
       "version": "v1.38.5",

--- a/calico-enterprise_versioned_docs/version-3.22-1/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.22-1/releases.json
@@ -35,6 +35,10 @@
         "version": "v3.22.0-1.0",
         "image": "tigera/cnx-manager"
       },
+      "cnx-manager-proxy": {
+        "version": "v3.22.0-1.0",
+        "image": "tigera/cnx-manager-proxy"
+      },
       "cnx-node": {
         "version": "v3.22.0-1.0",
         "image": "tigera/cnx-node"
@@ -68,7 +72,7 @@
         "image": "tigera/compliance-snapshotter"
       },
       "coreos-alertmanager": {
-        "version": "v0.28.1"
+        "version": "v0.28.0"
       },
       "coreos-config-reloader": {
         "version": "v0.84.0"
@@ -109,7 +113,7 @@
         "version": "8.18.4"
       },
       "eck-elasticsearch-operator": {
-        "version": "2.16.1"
+        "version": "2.16.0"
       },
       "eck-kibana": {
         "version": "8.18.4"
@@ -253,6 +257,10 @@
       "voltron": {
         "version": "v3.22.0-1.0",
         "image": "tigera/voltron"
+      },
+      "waf-http-filter": {
+        "version": "v3.22.0-1.0",
+        "image": "tigera/waf-http-filter"
       },
       "webhooks-processor": {
         "version": "v3.22.0-1.0",

--- a/calico-enterprise_versioned_docs/version-3.22-1/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.22-1/releases.json
@@ -72,7 +72,7 @@
         "image": "tigera/compliance-snapshotter"
       },
       "coreos-alertmanager": {
-        "version": "v0.28.0"
+        "version": "v0.28.1"
       },
       "coreos-config-reloader": {
         "version": "v0.84.0"
@@ -113,7 +113,7 @@
         "version": "8.18.4"
       },
       "eck-elasticsearch-operator": {
-        "version": "2.16.0"
+        "version": "2.16.1"
       },
       "eck-kibana": {
         "version": "8.18.4"

--- a/scripts/versions/.gitignore
+++ b/scripts/versions/.gitignore
@@ -1,0 +1,1 @@
+format-versions

--- a/scripts/versions/Makefile
+++ b/scripts/versions/Makefile
@@ -1,0 +1,4 @@
+.SILENT:
+
+all:
+	go build -v -o format-versions

--- a/scripts/versions/go.mod
+++ b/scripts/versions/go.mod
@@ -1,0 +1,5 @@
+module parseyaml/v2
+
+go 1.23.6
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/scripts/versions/go.sum
+++ b/scripts/versions/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/scripts/versions/main.go
+++ b/scripts/versions/main.go
@@ -1,0 +1,130 @@
+// Package main is small functionality to pre-process versions.yaml for docs.
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var imageNameMaps = map[string]string{
+	"cnx-kube-controllers":        "kube-controllers",
+	"csi-node-driver-registrar":   "node-driver-registrar",
+	"elastic-tsee-installer":      "intrusion-detection-job-installer",
+	"elasticsearch-operator":      "eck-operator",
+	"flexvol":                     "pod2daemon-flexvol",
+	"gateway-api-envoy-gateway":   "envoy-gateway",
+	"gateway-api-envoy-proxy":     "envoy-proxy",
+	"gateway-api-envoy-ratelimit": "envoy-ratelimit",
+	"tigera-cni-windows":          "cni-windows",
+	"tigera-cni":                  "cni",
+	"tigera-prometheus-service":   "prometheus-service",
+}
+
+var componentsToPrune = []string{
+	"calico-private",
+}
+
+var componentsToRename = map[string]string{
+	"upstream-fluentd": "coreos-fluentd",
+}
+
+// TigeraOperator represents the tigera-operator configuration
+type TigeraOperator struct {
+	Version  string `yaml:"version" json:"version"`
+	Image    string `yaml:"image" json:"image"`
+	Registry string `yaml:"registry" json:"registry"`
+}
+
+// Component represents a single component with version information
+type Component struct {
+	Version string `yaml:"version" json:"version"`
+	Image   string `yaml:"image,omitempty" json:"image"`
+}
+
+// Components represents all the components in the versions file
+type Components map[string]*Component
+
+// revalidate ensures that the appropriate keys are specified for each component
+func (c Components) revalidate() {
+
+	// Rename c[oldname] to c[newname] for cases where our keys don't match the docs keys
+	for oldName, newName := range componentsToRename {
+		entry, ok := c[oldName]
+		if ok {
+			c[newName] = entry
+			delete(c, oldName)
+		}
+	}
+
+	// Remove these components
+	for _, img := range componentsToPrune {
+		delete(c, img)
+	}
+
+	// Filter the remaining components to ensure their versions and image names are correct
+	for componentName, component := range c {
+		// We specify coreos and ECK components, even though they don't have images
+		// for those components. The actual images are listed under separate components.
+		if strings.HasPrefix(componentName, "coreos-") || strings.HasPrefix(componentName, "eck-") {
+			continue
+		}
+
+		// For each component, ensure that we set a default image path if one does not exist
+		if component.Image == "" {
+			val, ok := imageNameMaps[componentName]
+			if ok {
+				component.Image = fmt.Sprintf("tigera/%s", val)
+			} else {
+				component.Image = fmt.Sprintf("tigera/%s", componentName)
+			}
+		}
+	}
+}
+
+// Calico represents the calico configuration
+type Calico struct {
+	MinorVersion string `yaml:"minor_version" json:"minor_version"`
+	ArchivePath  string `yaml:"archive_path" json:"archive_path"`
+}
+
+// Versions represents the complete structure of the versions.yaml file
+type Versions struct {
+	Title          string         `yaml:"title" json:"title"`
+	ReleaseName    string         `yaml:"release_name" json:"release_name"`
+	Note           string         `yaml:"note" json:"note"`
+	FullHash       string         `yaml:"full_hash" json:"full_hash"`
+	TigeraOperator TigeraOperator `yaml:"tigera-operator" json:"tigera-operator"`
+	Components     Components     `yaml:"components" json:"components"`
+	HelmRelease    string         `yaml:"helmRelease" json:"helmRelease"`
+	Calico         Calico         `yaml:"calico" json:"calico"`
+}
+
+func main() {
+	// Read the YAML file
+	// yamlData, err := os.ReadFile("versions.yaml")
+	yamlData, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		log.Fatalf("Error reading YAML file from stdin: %v", err)
+	}
+
+	// Parse YAML into the Versions struct
+	var versions Versions
+	err = yaml.Unmarshal(yamlData, &versions)
+	if err != nil {
+		log.Fatalf("Error parsing YAML: %v", err)
+	}
+
+	versions.Components.revalidate()
+
+	newYamlData, err := yaml.Marshal(versions)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Print(string(newYamlData))
+
+}


### PR DESCRIPTION
This PR adds a small golang utility to filter the upstream versions file from Calico. It currently does the following:

1. Removes components which should not be present (based on what is currently in the docs list)
2. Renames components whose name differs between upstream and the docs list
3. Ignores (keeps but does not modify) components from `coreos-*` or `eck-*`
4. Adds an `image` field to each non-ignored component which does not have one, based either on a static mapping of `component name` -> `image name` if present, or assuming the image name and component name is identical otherwise.

The second commit shows the result of the new version filtering utility. A few notes on these results:
    
1. `cnx-manager-proxy` and `waf-http-filter` components are added; these components were not currently present in the docs `releases.json`, but do exist as images.
2. `coreos-alertmanager` and `eck-elasticsearch-operator` versions were downgraded in this PR; *THIS IS NOT CORRECT*; however, I wanted to commit this result anyway to show the unmodified results. This will be fixed upstream so that the generated file will be correct.
6. Some other filtering is done; `calico-private` as a component is removed, and the `fluentd` component is renamed, to match the component name used in docs already. Ideally, we should either fix these upstream or change them in docs so that we're being universally consistent.