### PR TITLE
fix: remove duplicate card link

### DIFF
--- a/calico_versioned_docs/version-3.30/getting-started/index.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/index.mdx
@@ -12,7 +12,6 @@ Quickstart tutorials and guides for installing Calico on Kubernetes, OpenStack, 
 
 <DocCardLinkLayout>
   <DocCardLink docId='getting-started/kubernetes/requirements' />
-  <DocCardLink docId='getting-started/kubernetes/community-tested' />
   <DocCardLink docId='getting-started/kubernetes/quickstart' />
   <DocCardLink docId='getting-started/kubernetes/community-tested' />
 </DocCardLinkLayout>


### PR DESCRIPTION
I noticed that the `Community-tested Kubernetes versions` card link was duplicated in the `Getting Started` section of the `Install Calico` page.  

This PR removes the duplicate link.