### PR TITLE
DOCS-2696: Add procedure for Maglev load balancing

### DIFF
--- a/calico/networking/configuring/add-maglev-load-balancing.mdx
+++ b/calico/networking/configuring/add-maglev-load-balancing.mdx
@@ -1,0 +1,41 @@
+---
+description: Add Maglev load balancing to a Kubernetes service.
+---
+
+# Add Maglev load balancing to a service
+
+This guide shows you how to enable Maglev-style load balancing to a service.
+Maglev's consistent-hashing load balancing algorithm minimizes the amount of dropped packets and improves performance.
+This is especially useful for maintaining sessions during a load balancer failover.
+
+## Prerequisites
+
+* Your cluster uses the eBPF data plane with [direct server return mode](https://docs.tigera.io/calico/latest/operations/ebpf/enabling-ebpf#try-out-direct-server-return-mode).
+* All your nodes are running on Linux.
+* You have the name and namespace of the service you want to use Maglev-style load balancing.
+
+## Enable consistent-hash load balancing for a service
+
+To enable consistent-hash load balancing for a service, annotate the service by running the following command:
+
+```bash
+kubectl -n <namespace> annotate service <service> 'lb.projectcalico.org/external-traffic-strategy: "maglev"'
+```
+
+Replace the following:
+* `<namespace>`: The namespace of the service.
+* `<service>`: The name of the service.
+
+To verify the configuration, check the logs for any `calico-node` pod for the string `Wrote Maglev` in reference to your service.
+
+```bash title='Example log query'
+kubectl -n calico-system logs calico-node-7kltn | grep --ignore-case 'Wrote Maglev'
+```
+
+```bash title='Example output'
+2025-10-28 15:30:53.091 [INFO][75] felix/syncer.go 893: Wrote Maglev service backends to NGINX service=default/svc:maglev-port
+```
+
+## Additional resources
+
+* [Enable the eBPF data plane](../../operations/ebpf/enabling-ebpf.mdx)

--- a/sidebars-calico.js
+++ b/sidebars-calico.js
@@ -272,6 +272,7 @@ module.exports = {
             'networking/configuring/pod-mac-address',
             'networking/configuring/node-local-dns-cache',
             'networking/configuring/qos-controls',
+            'networking/configuring/add-maglev-load-balancing',
           ],
         },
         {


### PR DESCRIPTION
This commit create a new docs page for enabling Maglev-style
load balancing for Kubernetes services.

DOCS-2696

<img width="1953" height="1025" alt="image" src="https://github.com/user-attachments/assets/d8f04ad2-b4be-4e83-a09d-aac046d38486" />

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->
* Calico 3.31
* CE 3.23.0-1.0?
* CC 23
* 
Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->
https://tigera.atlassian.net/browse/DOCS-2696

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://deploy-preview-2256--calico-docs-preview-next.netlify.app/calico/next/networking/configuring/add-maglev-load-balancing

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->