### PR TITLE
DOCS-2274: Clarify that licenses aren't needed for managed clusters

### DIFF
--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/standard-install/create-a-managed-cluster.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/standard-install/create-a-managed-cluster.mdx
@@ -29,7 +29,7 @@ policy resources across clusters, and lays the foundation for a “single pane o
 **Required**
 
 - A [Calico Enterprise management cluster](create-a-management-cluster.mdx)
-- A [$[prodname] license and pull secret](../../../getting-started/install-on-clusters/calico-enterprise.mdx)
+- A [$[prodname] pull secret](../../../getting-started/install-on-clusters/calico-enterprise.mdx)
 
 ## How to
 

--- a/calico-enterprise/reference/resources/licensekey.mdx
+++ b/calico-enterprise/reference/resources/licensekey.mdx
@@ -20,6 +20,8 @@ When you add $[prodname] to an existing Kubernetes cluster or create a
 new OpenShift cluster, you must apply your license key to complete the installation
 and gain access to the full set of $[prodname] features.
 
+In deployments that use multicluster management, a license key is required only on the management cluster.
+
 When your license key expires, you must update it to continue using $[prodname].
 
 To apply or update a license key use the following command, replacing `<customer-name>`

--- a/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-managed-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-managed-cluster.mdx
@@ -29,7 +29,7 @@ policy resources across clusters, and lays the foundation for a “single pane o
 **Required**
 
 - A [Calico Enterprise management cluster](create-a-management-cluster.mdx)
-- A [$[prodname] license and pull secret](../../../getting-started/install-on-clusters/calico-enterprise.mdx)
+- A [$[prodname] pull secret](../../../getting-started/install-on-clusters/calico-enterprise.mdx)
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/reference/resources/licensekey.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/reference/resources/licensekey.mdx
@@ -20,6 +20,8 @@ When you add $[prodname] to an existing Kubernetes cluster or create a
 new OpenShift cluster, you must apply your license key to complete the installation
 and gain access to the full set of $[prodname] features.
 
+In deployments that use multicluster management, a license key is required only on the management cluster.
+
 When your license key expires, you must update it to continue using $[prodname].
 
 To apply or update a license key use the following command, replacing `<customer-name>`

--- a/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-managed-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-managed-cluster.mdx
@@ -29,7 +29,7 @@ policy resources across clusters, and lays the foundation for a “single pane o
 **Required**
 
 - A [Calico Enterprise management cluster](create-a-management-cluster.mdx)
-- A [$[prodname] license and pull secret](../../../getting-started/install-on-clusters/calico-enterprise.mdx)
+- A [$[prodname] pull secret](../../../getting-started/install-on-clusters/calico-enterprise.mdx)
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/resources/licensekey.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/resources/licensekey.mdx
@@ -20,6 +20,8 @@ When you add $[prodname] to an existing Kubernetes cluster or create a
 new OpenShift cluster, you must apply your license key to complete the installation
 and gain access to the full set of $[prodname] features.
 
+In deployments that use multicluster management, a license key is required only on the management cluster.
+
 When your license key expires, you must update it to continue using $[prodname].
 
 To apply or update a license key use the following command, replacing `<customer-name>`

--- a/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-managed-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-managed-cluster.mdx
@@ -29,7 +29,7 @@ policy resources across clusters, and lays the foundation for a “single pane o
 **Required**
 
 - A [Calico Enterprise management cluster](create-a-management-cluster.mdx)
-- A [$[prodname] license and pull secret](../../../getting-started/install-on-clusters/calico-enterprise.mdx)
+- A [$[prodname] pull secret](../../../getting-started/install-on-clusters/calico-enterprise.mdx)
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/resources/licensekey.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/resources/licensekey.mdx
@@ -20,6 +20,8 @@ When you add $[prodname] to an existing Kubernetes cluster or create a
 new OpenShift cluster, you must apply your license key to complete the installation
 and gain access to the full set of $[prodname] features.
 
+In deployments that use multicluster management, a license key is required only on the management cluster.
+
 When your license key expires, you must update it to continue using $[prodname].
 
 To apply or update a license key use the following command, replacing `<customer-name>`

--- a/calico-enterprise_versioned_docs/version-3.22-1/multicluster/set-up-multi-cluster-management/standard-install/create-a-managed-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/multicluster/set-up-multi-cluster-management/standard-install/create-a-managed-cluster.mdx
@@ -29,7 +29,7 @@ policy resources across clusters, and lays the foundation for a “single pane o
 **Required**
 
 - A [Calico Enterprise management cluster](create-a-management-cluster.mdx)
-- A [$[prodname] license and pull secret](../../../getting-started/install-on-clusters/calico-enterprise.mdx)
+- A [$[prodname] pull secret](../../../getting-started/install-on-clusters/calico-enterprise.mdx)
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.22-1/reference/resources/licensekey.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/reference/resources/licensekey.mdx
@@ -20,6 +20,8 @@ When you add $[prodname] to an existing Kubernetes cluster or create a
 new OpenShift cluster, you must apply your license key to complete the installation
 and gain access to the full set of $[prodname] features.
 
+In deployments that use multicluster management, a license key is required only on the management cluster.
+
 When your license key expires, you must update it to continue using $[prodname].
 
 To apply or update a license key use the following command, replacing `<customer-name>`


### PR DESCRIPTION
License keys are not required to be installed on managed clusters
in a mulitcluster environment.

DOCS-2274

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->