### PR TITLE
Add kubeadm guide with ebpf default

### DIFF
--- a/calico/getting-started/kubernetes/install-kubeadm.mdx
+++ b/calico/getting-started/kubernetes/install-kubeadm.mdx
@@ -1,0 +1,88 @@
+---
+description: Install Calico on a self-managed kubeadm cluster.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Install Calico on a self-managed kubeadm cluster
+
+This guide describes how to install $[prodname] on a self-managed Kubernetes cluster that is deployed with the `kubeadm` tool.
+
+{/*
+## System requirements
+
+## Prerequisites
+
+## Pre-installation steps
+
+1. Check this.
+1. Do that.
+*/}
+
+## Before you begin
+
+* You have a self-managed Kubernetes cluster that was created with the `kubeadm` tool.
+* Your cluster meets the [system requirements](requirements.mdx). {/*TODO: Bring requirements to this doc */}
+
+# Install Calico Open Source
+
+1. Install the Tigera Operator and custom resource definitions.
+
+   ```shell
+   kubectl create -f https://2025-09-12-master-clubbing.docs.eng.tigera.net/manifests/operator-crds.yaml
+   kubectl create -f https://2025-09-12-master-clubbing.docs.eng.tigera.net/manifests/tigera-operator.yaml
+   ```
+
+1. Download the custom resources necessary to configure $[prodname].
+   :::note
+   Data plane, etc. Briefly explain what the choice is here.
+   :::
+   <Tabs groupId="data-plane" defaultValue="eBPF">
+   <TabItem label="eBPF" value = "eBPF">
+   ```shell
+   curl -O https://2025-09-12-master-clubbing.docs.eng.tigera.net/manifests/custom-resources-ebpf.yaml
+   ```
+   </TabItem>
+   <TabItem label="iptables" value = "iptables">
+   ```shell
+   curl -O https://2025-09-12-master-clubbing.docs.eng.tigera.net/manifests/custom-resources.yaml
+   ```
+   </TabItem>
+   </Tabs>
+   If you wish to customize the $[prodname] install, customize the downloaded custom-resources.yaml manifest locally.
+
+1. Create the manifest to install $[prodname].
+    <Tabs groupId="data-plane" defaultValue="eBPF">
+   <TabItem label="eBPF" value = "eBPF">
+   ```shell
+   kubectl create -f custom-resources-ebpf.yaml
+   ```
+   </TabItem>
+   <TabItem label="iptables" value = "iptables">
+   ```shell
+   kubectl create -f custom-resources.yaml
+   ```
+   </TabItem>
+   </Tabs>
+
+3. Monitor the deployment by running the following command:
+
+   ```shell
+   watch kubectl get tigerastatus
+   ```
+
+   After a few minutes, all the Calico components display `True` in the `AVAILABLE` column.
+
+   ```bash title="Expected output"
+   NAME                            AVAILABLE   PROGRESSING   DEGRADED   SINCE
+   apiserver                       True        False         False      4m9s
+   calico                          True        False         False      3m29s
+   goldmane                        True        False         False      3m39s
+   ippools                         True        False         False      6m4s
+   whisker                         True        False         False      3m19s
+   ```
+
+## Troubleshooting
+
+## Next steps

--- a/calico/operations/ebpf/enabling-ebpf.mdx
+++ b/calico/operations/ebpf/enabling-ebpf.mdx
@@ -13,6 +13,10 @@ import TabItem from '@theme/TabItem';
 
 Enable the eBPF data plane on an existing cluster.
 
+## Before you begin
+<details>
+  <summary>Learn more about eBPF: Concepts, Supported platforms, Performance, etc.</summary>
+
 ## Value
 
 <EbpfValue />
@@ -80,26 +84,6 @@ To enable IPv6 in eBPF mode, see [Configure dual stack or IPv6 only](../../netwo
   For more information, see [Debugging Connectivity in Calico eBPF](https://www.tigera.io/blog/deep-dive/debugging-connectivity-in-calico-ebpf-the-mysterious-bpfdataifaceregexp-co/).
   :::
 
-### Performance
-
-For best pod-to-pod performance, we recommend using an underlying network that doesn't require Calico to use an overlay. For example:
-
-- A cluster within a single AWS subnet.
-- A cluster using a compatible cloud provider's CNI (such as the AWS VPC CNI plugin).
-- An on-prem cluster with BGP peering configured.
-
-If you must use an overlay, we recommend that you use VXLAN, not IPIP. VXLAN has much better performance than IPIP in
-eBPF mode due to various kernel optimisations.
-
-## How to
-
-- [Verify that your cluster is ready for eBPF mode](#verify-that-your-cluster-is-ready-for-ebpf-mode)
-- [Configure $[prodname] to talk directly to the API server](#configure-calico-to-talk-directly-to-the-api-server)
-- [Configure kube-proxy](#configure-kube-proxy)
-- [Enable eBPF mode](#enable-ebpf-mode)
-- [Try out DSR mode](#try-out-direct-server-return-mode)
-- [Reversing the process](#reversing-the-process)
-
 ### Verify that your cluster is ready for eBPF mode
 
 This section explains how to make sure your cluster is suitable for eBPF mode.
@@ -126,7 +110,63 @@ On Red Hat-derived distributions, you may see something like this:
 
 Since the Red Hat kernel is v4.18 with at least build number 193, this kernel is suitable.
 
-### Configure $[prodname] to talk directly to the API server
+### Performance
+
+For best pod-to-pod performance, we recommend using an underlying network that doesn't require Calico to use an overlay. For example:
+
+- A cluster within a single AWS subnet.
+- A cluster using a compatible cloud provider's CNI (such as the AWS VPC CNI plugin).
+- An on-prem cluster with BGP peering configured.
+
+If you must use an overlay, we recommend that you use VXLAN, not IPIP. VXLAN has much better performance than IPIP in
+eBPF mode due to various kernel optimisations.
+
+</details>
+
+## Enable eBPF
+
+There are two ways to enable eBPF: Auto and Manual configuration.
+
+<Tabs>
+<TabItem id="test" label="Auto config" value="Auto-0">
+
+### Auto config
+#### Pre-requisites
+
+You can choose the automatic eBPF configuration if your cluster meets the following requisites:
+ - Installation with Operator.
+ - Your cluster has `kube-proxy` running in the `kube-system` namespace.
+ - `kube-proxy` is not managed by an automated tool, such as Helm or ArgoCD.
+ - Operator can access `kubernetes` service and endpoints.
+
+#### Configuring Installation CR
+
+To enable eBPF mode with the auto configuration, set the `spec.calicoNetwork.bpfNetworkBootstrap` and `spec.calicoNetwork.kubeProxyManagement` parameters in the operator's `Installation`
+  resource to "Enabled", and the `spec.calicoNetwork.linuxDataplane` parameter to "BPF".
+
+```bash
+  kubectl patch installation.operator.tigera.io default --type merge -p '{"spec":{"calicoNetwork":{"linuxDataplane":"BPF", "bpfNetworkBootstrap":"Enabled", "kubeProxyManagement":"Enabled"}}}'
+```
+
+:::note
+
+The operator rolls out the change with a rolling update (non-disruptive) and then swiftly transitions all nodes to eBPF mode. However, it's inevitable that some nodes will enter eBPF mode before others. This can disrupt the flow of traffic through node ports.
+
+:::
+
+After this change, the operator will configure the API Server addresses and disable `kube-proxy`.
+
+</TabItem>
+
+<TabItem label="Manual config" value="<Manual-1">
+
+### Manual config
+
+- [Configure $[prodname] to talk directly to the API server](#configure-calico-to-talk-directly-to-the-api-server)
+- [Configure kube-proxy](#configure-kube-proxy)
+- [Enable eBPF mode](#enable-ebpf-mode)
+
+#### Configure $[prodname] to talk directly to the API server
 
 In eBPF mode, $[prodname] implements Kubernetes service networking directly (rather than relying on `kube-proxy`).
 Of course, this makes it highly desirable to disable `kube-proxy` when running in eBPF mode to save resources
@@ -259,12 +299,12 @@ You should see the following log, with the correct `KUBERNETES_SERVICE_...` valu
 </TabItem>
 </Tabs>
 
-### Configure kube-proxy
+#### Configure kube-proxy
 
 In eBPF mode $[prodname] replaces `kube-proxy` so it wastes resources (and reduces performance) to run both.  
 This section explains how to disable `kube-proxy` in some common environments.
 
-#### Clusters that run `kube-proxy` with a `DaemonSet` (such as `kubeadm`)
+##### Clusters that run `kube-proxy` with a `DaemonSet` (such as `kubeadm`)
 
 For a cluster that runs `kube-proxy` in a `DaemonSet` (such as a `kubeadm`-created cluster), you can disable `kube-proxy` reversibly by adding a node selector to `kube-proxy`'s `DaemonSet` that matches no nodes, for example:
 
@@ -282,7 +322,7 @@ below.
 
 :::
 
-#### OpenShift
+##### OpenShift
 
 If you are running OpenShift, you can disable `kube-proxy` as follows:
 
@@ -296,7 +336,7 @@ To re-enable it:
 kubectl patch networks.operator.openshift.io cluster --type merge -p '{"spec":{"deployKubeProxy": true}}'
 ```
 
-#### MKE
+##### MKE
 
 If you are running MKE, you can disable `kube-proxy` as follows:
 
@@ -309,7 +349,7 @@ If you are running kube-proxy in IPVS mode, switch to iptables mode before disab
 
 :::
 
-### Avoiding conflicts with kube-proxy
+#### Avoiding conflicts with kube-proxy
 
 If you cannot disable `kube-proxy` (for example, because it is managed by your Kubernetes distribution), then you _must_ change Felix configuration parameter `BPFKubeProxyIptablesCleanupEnabled` to `false`. This can be done with `kubectl` as follows:
 
@@ -319,7 +359,7 @@ kubectl patch felixconfiguration default --patch='{"spec": {"bpfKubeProxyIptable
 
 If both `kube-proxy` and `BPFKubeProxyIptablesCleanupEnabled` is enabled then `kube-proxy` will write its iptables rules and Felix will try to clean them up resulting in iptables flapping between the two.
 
-### Enable eBPF mode
+#### Enable eBPF mode
 
 **The next step depends on whether you installed $[prodname] using the operator, or a manifest:**
 
@@ -327,7 +367,7 @@ If both `kube-proxy` and `BPFKubeProxyIptablesCleanupEnabled` is enabled then `k
 <TabItem label="Operator" value="Operator-2">
 
 To enable eBPF mode, change the `spec.calicoNetwork.linuxDataplane` parameter in the operator's `Installation`
-  resource to `"BPF".
+  resource to "BPF".
 
 ```bash
   kubectl patch installation.operator.tigera.io default --type merge -p '{"spec":{"calicoNetwork":{"linuxDataplane":"BPF"}}}'
@@ -355,7 +395,10 @@ calicoctl patch felixconfiguration default --patch='{"spec": {"bpfEnabled": true
 When enabling eBPF mode, preexisting connections continue to use the non-BPF datapath; such connections should
 not be disrupted, but they do not benefit from eBPF mode’s advantages.
 
-### Try out direct server return mode
+</TabItem>
+</Tabs>
+
+## Try out direct server return mode
 
 Direct server return (DSR) mode skips a hop through the network for traffic to services (such as node ports) from outside the cluster.
 This reduces latency and CPU overhead but it requires the underlying network to allow nodes to send traffic with each other's IPs.
@@ -375,7 +418,7 @@ calicoctl patch felixconfiguration default --patch='{"spec": {"bpfExternalServic
 
 Switching external traffic mode can disrupt in-progress connections.
 
-### Reversing the process
+## Reversing the process
 
 To revert to standard Linux networking:
 
@@ -398,7 +441,7 @@ To revert to standard Linux networking:
     </TabItem>
     </Tabs>
 
-1. If you disabled `kube-proxy`, re-enable it (for example, by removing the node selector added above).
+1. If you disabled `kube-proxy` **manually**, re-enable it (for example, by removing the node selector added above). If you chose the **Auto config**, Operator will revert the changes and re-deploy `kube-proxy`.
 
    ```
    kubectl patch ds -n kube-system kube-proxy --type merge -p '{"spec":{"template":{"spec":{"nodeSelector":{"non-calico": null}}}}}'

--- a/calico/operations/ebpf/install-ebpf.mdx
+++ b/calico/operations/ebpf/install-ebpf.mdx
@@ -1,0 +1,124 @@
+---
+description: Install Calico in eBPF mode with auto configuration.
+---
+
+# Auto configuration
+
+## Before you begin
+- Learn more [about eBPF](../ebpf/overview.mdx): Concepts, Supported platforms, Performance, etc.
+
+## Requirements
+
+Your cluster must meet the following requirements to proceed with the auto-configuration process:
+- Install $[prodname] with the Operator.
+- Your cluster has <code>kube-proxy</code> running in the <code>kube-system</code> namespace.
+- <code>kube-proxy</code> is <strong>not</strong> managed by an automated tool, such as Helm or ArgoCD.
+- The Operator can access <code>kubernetes</code> service and endpoints.
+
+## How to
+
+The steps below outline how to install $[prodname] directly in eBPF mode:
+
+- [Create a cluster](#create-a-suitable-cluster) suitable to run $[prodname] **with the added requirement that the nodes must use a recent
+  enough kernel**.
+- [Install the Tigera Operator](#install-the-tigera-operator) (possibly via a Helm chart), and the associated Custom Resource Definitions.
+- **[Download and tweak the installation Custom Resource](#tweak-and-apply-installation-custom-resources) to tell the operator to use eBPF mode.**
+- [Apply a set of Custom Resources](#tweak-and-apply-installation-custom-resources) to tell the operator what to install.
+- [Wait for the operator to provision all the associated resources and report back via its status resource](#monitor-the-progress-of-the-installation).
+
+### Create a suitable cluster
+
+The basic requirement for eBPF mode is to have a recent-enough kernel (see [Overview page](../ebpf/overview.mdx#supported)).
+
+At this time, we recommend `kubeadm`-provisioned clusters for **auto-configuration**, which are supported as long as the chosen base OS (such as Ubuntu 20.04) meets the kernel requirements.
+
+### Install the Tigera Operator
+
+Install the Tigera Operator without applying the `custom-resources.yaml` - you will update this file in a later step in this doc. 
+
+```bash
+ kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
+```
+
+### Tweak and apply installation Custom Resources
+
+When the main install guide tells you to apply the `custom-resources.yaml`, typically by running `kubectl create` with
+the URL of the file directly, you should instead download the file, so that you can edit it:
+
+```bash
+ curl -o custom-resources.yaml $[manifestsUrl]/manifests/custom-resources.yaml
+```
+
+Edit the file in your editor of choice and find the `Installation` resource, which should be at the top of the file.
+To enable eBPF mode, we need to add a new `calicoNetwork` section inside the `spec` of the Installation resource,
+including the `linuxDataplane`, `bpfNetworkBootstrap`, and `kubeProxyManagement` fields. For EKS Bottlerocket OS only, you should also add the `flexVolumePath` setting
+as shown below.
+
+For example:
+
+```yaml
+# This section includes base $[prodname] installation configuration.
+
+apiVersion: operator.tigera.io/v1
+kind: Installation
+metadata:
+  name: default
+spec:
+   # Added calicoNetwork section with linuxDataplane field
+  calicoNetwork:
+    linuxDataplane: BPF
+    bpfNetworkBootstrap: Enabled
+    kubeProxyManagement: Enabled
+
+   # EKS with Bottlerocket as node image only:
+   # flexVolumePath: /var/lib/kubelet/plugins
+
+   # Install Calico Open Source
+   variant: Calico
+
+# This section configures the Calico API server.
+
+apiVersion: operator.tigera.io/v1
+kind: APIServer 
+metadata: 
+  name: default 
+spec: {}
+```
+
+Then apply the edited file:
+
+```bash
+kubectl create -f custom-resources.yaml
+```
+
+:::note
+
+If you are running kube-proxy in IPVS mode, switch to iptables mode before creating the Custom Resources.
+
+:::
+
+:::tip
+
+If you already created the custom resources, you can switch your cluster over to eBPF mode by updating the
+installation resource. The operator will automatically roll out the change.
+
+```bash
+kubectl patch installation.operator.tigera.io default --type merge -p '{"spec":{"calicoNetwork":{"linuxDataplane":"BPF", "bpfNetworkBootstrap":"Enabled", "kubeProxyManagement":"Enabled", "hostPorts":null}}}'
+```
+
+:::
+
+### Monitor the progress of the installation
+
+You can monitor progress of the installation with the following command:
+
+```bash
+watch kubectl get tigerastatus
+```
+
+## Next steps
+
+**Recommended**
+
+- [Learn more about eBPF](use-cases-ebpf.mdx)
+- [Debug eBPF policies](../../network-policy/policy-rules/log-rules.mdx)

--- a/calico/operations/ebpf/install-ebpf.mdx
+++ b/calico/operations/ebpf/install-ebpf.mdx
@@ -5,7 +5,7 @@ description: Install Calico in eBPF mode with auto configuration.
 # Auto configuration
 
 ## Before you begin
-- Learn more [about eBPF](../ebpf/overview.mdx): Concepts, Supported platforms, Performance, etc.
+- Learn more [about eBPF] (../ebpf/overview.mdx): Concepts, Supported platforms, Performance, etc.
 
 ## Requirements
 
@@ -28,7 +28,7 @@ The steps below outline how to install $[prodname] directly in eBPF mode:
 
 ### Create a suitable cluster
 
-The basic requirement for eBPF mode is to have a recent-enough kernel (see [Overview page](../ebpf/overview.mdx#supported)).
+The basic requirement for eBPF mode is to have a recent-enough kernel (see [Overview page] (../ebpf/overview.mdx#supported)).
 
 At this time, we recommend `kubeadm`-provisioned clusters for **auto-configuration**, which are supported as long as the chosen base OS (such as Ubuntu 20.04) meets the kernel requirements.
 

--- a/calico/operations/ebpf/install.mdx
+++ b/calico/operations/ebpf/install.mdx
@@ -56,7 +56,7 @@ and in particular, pushing the networking capabilities of the latest Linux kerne
 - IPv6
 
 Limitations:
-  
+
   - IPIP is not supported ($[prodname] iptables does not support it either). VXLAN is the recommended overlay for eBPF mode.
 
 To enable IPv6 in eBPF mode, see [Configure dual stack or IPv6 only](../../networking/ipam/ipv6.mdx). You may be able to run with non-Calico IPAM. eks-cni is known to work.
@@ -271,7 +271,7 @@ MKE runs a reverse proxy in each node which can be used to reach the api-server.
 
 ### Install the Tigera Operator
 
-Follow the steps in the main install for your platform that installs the Tigera Operator, without applying the custom-resources.yaml (you will update this file in a later step in this doc). 
+Follow the steps in the main install for your platform that installs the Tigera Operator, without applying the custom-resources.yaml (you will update this file in a later step in this doc).
 
 For clusters in AWS, such as kOps and EKS, you must also patch the tigera-operator deployment with DNS config so the operator can resolve the apiserver DNS.
 AWS DNS server's address is 169.254.169.253.
@@ -334,10 +334,10 @@ spec:
 # This section configures the Calico API server.
 
 apiVersion: operator.tigera.io/v1
-kind: APIServer 
-metadata: 
-  name: default 
-spec: {}  
+kind: APIServer
+metadata:
+  name: default
+spec: {}
 ```
 
 Then apply the edited file:

--- a/sidebars-calico.js
+++ b/sidebars-calico.js
@@ -41,6 +41,7 @@ module.exports = {
         'getting-started/kubernetes/quickstart',
         'getting-started/kubernetes/requirements',
         'getting-started/kubernetes/community-tested',
+        'getting-started/kubernetes/install-kubeadm',
         'getting-started/kubernetes/managed-public-cloud/eks',
         'getting-started/kubernetes/managed-public-cloud/gke',
         'getting-started/kubernetes/managed-public-cloud/iks',


### PR DESCRIPTION
- **Condense Lucas docs**
- **Rough out kubeadm guide with ebpf default**

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://deploy-preview-2287--calico-docs-preview-next.netlify.app/calico/next/getting-started/kubernetes/install-kubeadm

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->