### PR TITLE
DOCS-2757: Update non-cluster host doc to use calicoctl command

### DIFF
--- a/calico-enterprise/getting-started/bare-metal/about.mdx
+++ b/calico-enterprise/getting-started/bare-metal/about.mdx
@@ -44,12 +44,7 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
 
 1. Create a `NonClusterHost` custom resource.
 
-    This resource enables the cluster-side ingestion endpoint to receive logs from non-cluster hosts. Additionally, it provides a dedicated Typha deployment for managing communication between the non-cluster host agent and Typha.
-
-    | Field         | Description                                                          | Accepted Values                                                          | Schema |
-    | ------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------ |
-    | endpoint      | Required. Location of the log ingestion point for non-cluster hosts. | Any HTTPS URL with a domain name and a port number                       | string |
-    | typhaEndpoint | Required. Location of the Typha endpoint for non-cluster host agent and Typha communication. | Any IP address or domain name with a port number | string |
+    This resource enables the cluster-side ingestion endpoint to receive logs from non-cluster hosts. It also provides a dedicated Typha deployment to manage communication between the non-cluster host agent and Typha. To ensure proper operation, verify that the non-cluster hosts or VMs have network connectivity to your Kubernetes cluster.
 
     ```bash
     kubectl create -f - <<EOF
@@ -63,52 +58,33 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
     EOF
     ```
 
+    | Field         | Description                                                          | Accepted Values                                                          | Schema |
+    | ------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------ |
+    | endpoint      | Required. Location of the log ingestion point for non-cluster hosts. | Any HTTPS URL with a domain name and a port number                       | string |
+    | typhaEndpoint | Required. Location of the Typha endpoint for non-cluster host agent and Typha communication. If you are using an ingress controller or an external load balancer, ensure it is configured to allow TCP Layer 4 passthrough. This is required for non-cluster host agent to establish a mutual TLS (mTLS) connection to the cluster. | Any IP address or domain name with a port number | string |
+
     Wait until the Tigera Manager and non-cluster Typha deployments reach the Available status before proceeding to the next step.
 
-2. Obtain the token for `tigera-noncluster-host` service account.
+1. Create a `kubeconfig` file for your non-cluster host or VM:
 
     ```bash
-    kubectl get secret -n calico-system tigera-noncluster-host -o jsonpath='{.data.token}' | base64 --decode
+    calicoctl nonclusterhost generate-config [--namespace=<namespace>] [--serviceaccount=<service-account>] [--certfile=<certificate-file>] > kubeconfig
     ```
 
-3. Create a `kubeconfig` file for your non-cluster host or VM similar to the following:
+    | Parameter      | Description                                                                                              | Default Values         |
+    | -------------- | -------------------------------------------------------------------------------------------------------- | ---------------------- |
+    | namespace      | Optional. The namespace where the service account for non-cluster hosts resides.                         | calico-system          |
+    | serviceaccount | Optional. The service account used by non-cluster hosts to authenticate and securely access the cluster. | tigera-noncluster-host |
+    | certfile       | Optional. Path to the file containing the PEM-encoded authority certificates. Use this option if you are providing your own [TLS certificates for Calico Enterprise Manager](../../operations/comms/manager-tls.mdx). If not specified, the Tigera root CA certificate will be used by default. | |
 
-    ```yaml
-    apiVersion: v1
-    kind: Config
-    current-context: noncluster-hosts
-    preferences: {}
-    clusters:
-    - cluster:
-        certificate-authority-data: <certificate-authority-data>
-        server: <server>
-      name: noncluster-hosts
-    contexts:
-    - context:
-        cluster: noncluster-hosts
-        user: tigera-noncluster-host
-      name: noncluster-hosts
-    users:
-    - name: tigera-noncluster-host
-      user:
-        token: <token>
-    ```
-
-    Replace the following:
-    - Cluster:
-      - `<server>`: The URL of the Kubernetes API server.
-      - `<certificate-authority-data>`: Base64 encoded CA certificate to verify the Kubernetes API server's certificate.
-    - User:
-      - `<token>`: A bearer token associated with the `tigera-noncluster-host` service account obtained in the previous step.
-
-4. Create a [`HostEndpoint` resource](../../reference/host-endpoints/overview.mdx) for each non-cluster host or VM. The `node` and `expectedIPs` fields are required to match the hostname and the expected interface IP addresses.
+1. Create a [`HostEndpoint` resource](../../reference/host-endpoints/overview.mdx) for each non-cluster host or VM. The `node` and `expectedIPs` fields are required to match the hostname and the expected interface IP addresses.
 
 ### Set up your non-cluster host or VM
 
 1. Configure the Calico Enterprise repository.
 
     ```bash
-    curl -sfL https://downloads.tigera.io/ee/rpms/v3.21/calico_enterprise.repo -o /etc/yum.repos.d/calico-enterprise.repo
+    curl -sfL https://downloads.tigera.io/ee/rpms/v3.22/calico_enterprise.repo -o /etc/yum.repos.d/calico-enterprise.repo
     ```
 
     Only Red Hat Enterprise Linux 8 and 9 x86-64 operating systems are supported in this version of $[prodname].
@@ -121,7 +97,7 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
       dnf install calico-node calico-fluent-bit
       ```
 
-1. Copy the kubeconfig created in cluster setup step 3 to host folder `/etc/calico/kubeconfig` and change ownership to `calico:calico`.
+1. Copy the `kubeconfig` created in cluster setup step 2 to host folder `/etc/calico/kubeconfig`.
 
 1. Start Calico node and log forwarder.
 
@@ -131,23 +107,6 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
     ```
 
     You can configure the Calico node by tuning the environment variables defined in the `/etc/calico/calico-node/calico-node.env` file. For more information, see the [Felix configuration reference](../../reference/resources/felixconfig.mdx).
-
-### Configure hosts to communicate with your Kubernetes cluster
-
-You must ensure that the non-cluster hosts or VMs can communicate with your Kubernetes cluster. If you are using an ingress controller or an external load balancer, ensure it is configured to allow TCP Layer 4 passthrough. This is required for non-cluster host agent to establish a mutual TLS (mTLS) connection to the cluster via the `typhaEndpoint` endpoint.
-
-Below are some vendor-specific considerations:
-
-#### AWS
-
-- The node must reside in the same VPC as the nodes in your Kubernetes cluster, and utilize the AWS VPC CNI plugin (the default for Amazon EKS).
-- Ensure that the Kubernetes cluster's security group permits inbound traffic from the host. You may need to add a rule allowing traffic from the hosts or VMs.
-- For successful communication with an EKS cluster, the appropriate IAM roles must be configured.
-- The host or VM must also be authenticated to access the cluster using tools such as [aws-iam-authenticator](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html) and the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
-
-#### GKE
-
-- To enable communication with your Kubernetes cluster from a non-cluster host, the host must be directly reachable or routable. This configuration is not enabled by default when using GKE’s VPC-native network routing.
 
 ## Additional resources
 


### PR DESCRIPTION
This changeset updates the non-cluster host documentation to use the new `calicoctl nonclusterhost` subcommand for genertating the bootstrap configuration. It also refines the explanation of the `typhaEndpoint` field, providing more details on its usage.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
Calico Enterprise v3.22 EP2.

Issue:
https://tigera.atlassian.net/browse/DOCS-2757

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->