### PR TITLE
DOCS-2721: Add eBPF to kubeadm pages

### DIFF
--- a/calico/getting-started/kubernetes/k8s-single-node.mdx
+++ b/calico/getting-started/kubernetes/k8s-single-node.mdx
@@ -92,6 +92,7 @@ The geeky details of what you get:
 1. Install the Tigera Operator and custom resource definitions.
 
    ```
+   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 
@@ -104,8 +105,10 @@ The geeky details of what you get:
 1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
 
    ```
-   kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml
+   kubectl create -f $[manifestsUrl]/manifests/custom-resources-bpf.yaml
    ```
+
+   This will complete the Calico Open Source installation with the eBPF data plane as the default.
 
    :::note
 
@@ -141,20 +144,24 @@ The geeky details of what you get:
    node/<your-hostname> untainted
    ```
 
-1. Confirm that you now have a node in your cluster with the following command.
+3. Monitor the deployment by running the following command:
 
-   ```
-   kubectl get nodes -o wide
-   ```
-
-   It should return something like the following.
-
-   ```
-   NAME              STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION    CONTAINER-RUNTIME
-   <your-hostname>   Ready    master   52m   v1.12.2   10.128.0.28   <none>        Ubuntu 18.04.1 LTS   4.15.0-1023-gcp   docker://18.6.1
+   ```shell
+   watch kubectl get tigerastatus
    ```
 
-Congratulations! You now have a single-host Kubernetes cluster with $[prodname].
+   After a few minutes, all the Calico components display `True` in the `AVAILABLE` column.
+
+   ```bash title="Expected output"
+   NAME                            AVAILABLE   PROGRESSING   DEGRADED   SINCE
+   apiserver                       True        False         False      4m9s
+   calico                          True        False         False      3m29s
+   goldmane                        True        False         False      3m39s
+   ippools                         True        False         False      6m4s
+   whisker                         True        False         False      3m19s
+   ```
+
+   Congratulations! You now have a single-host Kubernetes cluster with $[prodname].
 
 ## Next steps
 

--- a/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
+++ b/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
@@ -50,29 +50,52 @@ $[prodname] can also be installed using raw manifests as an alternative to the o
 
 1. Download the custom resources necessary to configure $[prodname].
 
+   :::tip Automatic data plane deployment
+   You can select either eBPF or iptables to be deployed automatically.
+   :::
+   <Tabs groupId="data-plane" defaultValue="eBPF">
+   <TabItem label="eBPF" value = "eBPF">
+   ```shell
+   curl -O $[manifestsUrl]/manifests/custom-resources-bpf.yaml
    ```
-   curl $[manifestsUrl]/manifests/custom-resources.yaml -O
+   </TabItem>
+   <TabItem label="iptables" value = "iptables">
+   ```shell
+   curl -O $[manifestsUrl]/manifests/custom-resources.yaml
    ```
-
+   </TabItem>
+   </Tabs>
    If you wish to customize the $[prodname] install, customize the downloaded custom-resources.yaml manifest locally.
 
 1. Create the manifest to install $[prodname].
-
+    <Tabs groupId="data-plane" defaultValue="eBPF">
+   <TabItem label="eBPF" value = "eBPF">
+   ```shell
+   kubectl create -f custom-resources-bpf.yaml
    ```
+   </TabItem>
+   <TabItem label="iptables" value = "iptables">
+   ```shell
    kubectl create -f custom-resources.yaml
    ```
+   </TabItem>
+   </Tabs>
 
-1. Verify $[prodname] installation in your cluster.
+3. Monitor the deployment by running the following command:
 
+   ```shell
+   watch kubectl get tigerastatus
    ```
-   watch kubectl get pods -n calico-system
-   ```
 
-   You should see a result similar to the below.
+   After a few minutes, all the Calico components display `True` in the `AVAILABLE` column.
 
-   ```
-   NAMESPACE     NAME                READY   STATUS                  RESTARTS         AGE
-   kube-system   calico-node-txngh   1/1     Running                   0              54s
+   ```bash title="Expected output"
+   NAME                            AVAILABLE   PROGRESSING   DEGRADED   SINCE
+   apiserver                       True        False         False      4m9s
+   calico                          True        False         False      3m29s
+   goldmane                        True        False         False      3m39s
+   ippools                         True        False         False      6m4s
+   whisker                         True        False         False      3m19s
    ```
 
 <GeekDetails

--- a/calico/variables.js
+++ b/calico/variables.js
@@ -17,7 +17,7 @@ const variables = {
   noderunning: 'calico-node',
   rootDirWindows: 'C:\\CalicoWindows',
   ppa_repo_name: 'calico-master',
-  manifestsUrl: 'https://2025-04-16-v3-30-rehydrate.docs.eng.tigera.net', //Replace with hashrelease
+  manifestsUrl: 'https://2025-10-03-v3-31-quarterly.docs.eng.tigera.net', //Replace with hashrelease
   releases,
   registry: '',
   vppbranch: 'master',


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://deploy-preview-2303--calico-docs-preview-next.netlify.app/calico/next/getting-started/kubernetes/self-managed-onprem/onpremises/

https://deploy-preview-2303--calico-docs-preview-next.netlify.app/calico/next/getting-started/kubernetes/k8s-single-node


SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->