### PR TITLE
DOCS-2757: Add a high availability section to the host or VM setup documentation

### DIFF
--- a/calico-enterprise/getting-started/bare-metal/about.mdx
+++ b/calico-enterprise/getting-started/bare-metal/about.mdx
@@ -110,16 +110,16 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
 
 ### Configure high availability mode
 
-High availability (HA) mode helps protect workloads running on hosts and VMs by providing an automated disaster recovery setup. This works by running one active and one passive Kubernetes clusters that share configurations.
+High availability (HA) mode helps protect workloads running on hosts and VMs by providing an automated disaster recovery setup. It operates with two Kubernetes clusters: an active cluster and a passive cluster that remains synchronized and ready to take over if the active cluster becomes unavailable.
 
-For HA mode to function correctly, the customer's load balancer (LB) must be configured to switch traffic between the active and passive clusters during failover and failback events. Without proper LB configuration, HA mode will not work as expected.
+For HA mode to function correctly, a correctly configured load balancer (LB) is required to switch traffic between clusters during failover and failback events. The LB must detect failures, redirect traffic to the passive cluster, and restore traffic to the active cluster once it is healthy. Without a proper configuration, HA mode will not work as expected.
 
-To enable this functionality, system administrators are responsible for the following prerequisites:
+Your hosts or VMs are inherently HA-ready once you completed the setup steps. They automatically connect to the appropriate cluster. To enable HA mode, system administrators must perform the following steps:
 
-- Clusters are in place: Both the active and passive Kubernetes clusters are deployed and maintained.
-- Resources are synchronized: Key resources (such as network policies, configurations, and non-cluser host resources) are kept in sync from the active cluster to the passive cluster.
-- Domain names are used: Log ingestion and Typha endpoints in the `NonClusterHost` resource must be set up with domain names, not IP addresses.
-- Secrets are copied: The `tigera-ca-private` secret from the active cluster must be copied to the passive cluster under the `tigera-operator` namespace. After copying, wait until all Calico components are running and healthy in the passive cluster before proceeding.
+- Deploy and maintain both clusters: Provision and manage both the active and passive Kubernetes clusters.
+- Synchronize resources: Keep all relevant resources (such as network policies, configurations, and non-cluser host resources) synchronized from the active cluster to the passive cluster.
+- Configure domain names: Use domain names (not static IP addresses) for log ingestion and Typha endpoints in the `NonClusterHost` resource.
+- Replicate secrets: Copy the `tigera-ca-private` secret from the active cluster to the passive cluster under the `tigera-operator` namespace. After copying, verify that all Calico components in the passive cluster are running and healthy.
 
 ## Additional resources
 

--- a/calico-enterprise/getting-started/bare-metal/about.mdx
+++ b/calico-enterprise/getting-started/bare-metal/about.mdx
@@ -108,6 +108,19 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
 
     You can configure the Calico node by tuning the environment variables defined in the `/etc/calico/calico-node/calico-node.env` file. For more information, see the [Felix configuration reference](../../reference/resources/felixconfig.mdx).
 
+### Configure high availability mode
+
+High availability (HA) mode helps protect workloads running on hosts and VMs by providing an automated disaster recovery setup. This works by running one active and one passive Kubernetes clusters that share configurations.
+
+For HA mode to function correctly, the customer's load balancer (LB) must be configured to switch traffic between the active and passive clusters during failover and failback events. Without proper LB configuration, HA mode will not work as expected.
+
+To enable this functionality, system administrators are responsible for the following prerequisites:
+
+- Clusters are in place: Both the active and passive Kubernetes clusters are deployed and maintained.
+- Resources are synchronized: Key resources (such as network policies, configurations, and non-cluser host resources) are kept in sync from the active cluster to the passive cluster.
+- Domain names are used: Log ingestion and Typha endpoints in the `NonClusterHost` resource must be set up with domain names, not IP addresses.
+- Secrets are copied: The `tigera-ca-private` secret from the active cluster must be copied to the passive cluster under the `tigera-operator` namespace. After copying, wait until all Calico components are running and healthy in the passive cluster before proceeding.
+
 ## Additional resources
 
 - [Protect hosts and VMs](../../network-policy/hosts/protect-hosts.mdx)


### PR DESCRIPTION
This changeset adds a high availability section to the host or VM setup documentation.

Product Version(s):

Calico Enterprise v3.22 EP2.

Issue:

https://tigera.atlassian.net/browse/DOCS-2757

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->