### PR TITLE
[CORE-11948] QoS: Add 'tcx' requirement and troubleshooting for bandwidth on eBPF

### DIFF
--- a/calico-enterprise/networking/configuring/qos-controls.mdx
+++ b/calico-enterprise/networking/configuring/qos-controls.mdx
@@ -14,6 +14,10 @@ Additionally, it allows configuring Differentiated Services (DiffServ) on egress
 With QoS controls, $[prodname] enforces network resource limits (bandwidth, packet rate, connections) for Kubernetes pods and OpenStack VMs, ensuring fair resource allocation and preventing performance degradation for other workloads.
 $[prodname] can also apply DiffServ on egress traffic to allow upstream devices to prioritise forwarding accordingly.
 
+## Requirements
+
+* Configuring limits for **bandwidth** on installations that use the **eBPF data plane** requires `tcx bpf_link`, which is available in the **Linux kernel v6.6 or newer**.
+
 ## Limitations
 
 * Configuring limits for established connections is not supported on installations that use the eBPF data plane.
@@ -130,3 +134,16 @@ spec:
 |---------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `qos.projectcalico.org/dscp` | Specifies the DSCP value of egress traffic toward an endpoint outside cluser or another host in cluster.<br/>Min value: `0`<br/>Max value: `63`<br/>String values: DF, EF, AF11, AF12, AF13, AF21, AF22, AF23, AF31, AF32, AF33, AF41, AF42, AF43, CS0, CS1, CS2, CS3, CS4, CS5, CS6                                                                                                                                     |
 
+## Troubleshooting
+
+If limits for **bandwidth** on installations that use the **eBPF data plane** don't seem to be enforced correctly, check calico-node logs to see if `tcx` may not be supported by
+the operating system with `kubectl logs`. For example:
+
+```
+$ kubectl logs -n calico-system calico-node-cc7q2 | grep "tcx"
+Defaulted container "calico-node" out of: calico-node, flexvol-driver (init), ebpf-bootstrap (init), install-cni (init)
+libbpf: prog 'cali_tcx_test': failed to attach to tcx: Invalid argument
+2025-10-14 20:13:06.961 [INFO][47] felix/bpf_ep_mgr.go 595: tcx is not supported. Falling back to tc
+```
+
+The log messages above mean `tcx` is not supported and thus, QoS limits for bandwidth are not supported on this node.

--- a/calico-enterprise/networking/configuring/qos-controls.mdx
+++ b/calico-enterprise/networking/configuring/qos-controls.mdx
@@ -14,9 +14,9 @@ Additionally, it allows configuring Differentiated Services (DiffServ) on egress
 With QoS controls, $[prodname] enforces network resource limits (bandwidth, packet rate, connections) for Kubernetes pods and OpenStack VMs, ensuring fair resource allocation and preventing performance degradation for other workloads.
 $[prodname] can also apply DiffServ on egress traffic to allow upstream devices to prioritise forwarding accordingly.
 
-## Requirements
+## Prerequisites
 
-* Configuring limits for **bandwidth** on installations that use the **eBPF data plane** requires `tcx bpf_link`, which is available in the **Linux kernel v6.6 or newer**.
+* If you use the eBPF data plane, your Linux nodes must be running kernel version 6.6 or higher in order to configure bandwidth QoS controls.
 
 ## Limitations
 
@@ -136,14 +136,18 @@ spec:
 
 ## Troubleshooting
 
-If limits for **bandwidth** on installations that use the **eBPF data plane** don't seem to be enforced correctly, check calico-node logs to see if `tcx` may not be supported by
+### Bandwidth is not enforced on eBPF
+
+If limits for bandwidth on installations that use the eBPF data plane don't seem to be enforced, check calico-node logs to see if `tcx` may not be supported by
 the operating system with `kubectl logs`. For example:
 
 ```
-$ kubectl logs -n calico-system calico-node-cc7q2 | grep "tcx"
+$ kubectl logs -n calico-system ds/calico-node | grep tcx
+Found 4 pods, using pod/calico-node-j9z5d
 Defaulted container "calico-node" out of: calico-node, flexvol-driver (init), ebpf-bootstrap (init), install-cni (init)
-libbpf: prog 'cali_tcx_test': failed to attach to tcx: Invalid argument
-2025-10-14 20:13:06.961 [INFO][47] felix/bpf_ep_mgr.go 595: tcx is not supported. Falling back to tc
+bird: libbpf: prog 'cali_tcx_test': failed to attach to tcx: Invalid argument
+2025-10-15 16:31:48.522 [INFO][81] felix/bpf_ep_mgr.go 595: tcx is not supported. Falling back to tc
 ```
 
-The log messages above mean `tcx` is not supported and thus, QoS limits for bandwidth are not supported on this node.
+The log messages above mean `tcx` is not supported and thus, QoS limits for bandwidth are not supported on this node. In order to solve this, upgrade the Linux kernel version on
+the node to 6.6 or later.

--- a/calico-enterprise/networking/configuring/qos-controls.mdx
+++ b/calico-enterprise/networking/configuring/qos-controls.mdx
@@ -138,8 +138,10 @@ spec:
 
 ### Bandwidth is not enforced on eBPF
 
-If limits for bandwidth on installations that use the eBPF data plane don't seem to be enforced, check calico-node logs to see if `tcx` may not be supported by
-the operating system with `kubectl logs`. For example:
+If you use the eBPF data plane and bandwidth limits aren't being enforced, check the calico-node logs to see if `tcx` is supported by the operating system.
+`tcx` is present in the Linux kernel version 6.6 and later, and it is required for bandwidth limits to work with the eBPF data plane.
+
+The following example shows logs that indicate an unsupported kernel version:
 
 ```
 $ kubectl logs -n calico-system ds/calico-node | grep tcx
@@ -148,6 +150,3 @@ Defaulted container "calico-node" out of: calico-node, flexvol-driver (init), eb
 bird: libbpf: prog 'cali_tcx_test': failed to attach to tcx: Invalid argument
 2025-10-15 16:31:48.522 [INFO][81] felix/bpf_ep_mgr.go 595: tcx is not supported. Falling back to tc
 ```
-
-The log messages above mean `tcx` is not supported and thus, QoS limits for bandwidth are not supported on this node. In order to solve this, upgrade the Linux kernel version on
-the node to 6.6 or later.

--- a/calico-enterprise/networking/configuring/qos-controls.mdx
+++ b/calico-enterprise/networking/configuring/qos-controls.mdx
@@ -132,7 +132,7 @@ spec:
 
 | Annotation                                  | Description                                                                                                                                                                                                                        |
 |---------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `qos.projectcalico.org/dscp` | Specifies the DSCP value of egress traffic toward an endpoint outside cluser or another host in cluster.<br/>Min value: `0`<br/>Max value: `63`<br/>String values: DF, EF, AF11, AF12, AF13, AF21, AF22, AF23, AF31, AF32, AF33, AF41, AF42, AF43, CS0, CS1, CS2, CS3, CS4, CS5, CS6                                                                                                                                     |
+| `qos.projectcalico.org/dscp` | Specifies the DSCP value of egress traffic toward an endpoint outside cluster or another host in cluster.<br/>Min value: `0`<br/>Max value: `63`<br/>String values: DF, EF, AF11, AF12, AF13, AF21, AF22, AF23, AF31, AF32, AF33, AF41, AF42, AF43, CS0, CS1, CS2, CS3, CS4, CS5, CS6                                                                                                                                     |
 
 ## Troubleshooting
 

--- a/calico/networking/configuring/qos-controls.mdx
+++ b/calico/networking/configuring/qos-controls.mdx
@@ -14,6 +14,10 @@ Additionally, it allows configuring Differentiated Services (DiffServ) on egress
 With QoS controls, $[prodname] enforces network resource limits (bandwidth, packet rate, connections) for Kubernetes pods and OpenStack VMs, ensuring fair resource allocation and preventing performance degradation for other workloads.
 $[prodname] can also apply DiffServ on egress traffic to allow upstream devices to prioritise forwarding accordingly.
 
+## Requirements
+
+* Configuring limits for **bandwidth** on installations that use the **eBPF data plane** requires `tcx bpf_link`, which is available in the **Linux kernel v6.6 or newer**.
+
 ## Limitations
 
 * Configuring limits for established connections is not supported on installations that use the eBPF data plane.
@@ -129,6 +133,20 @@ spec:
 | Annotation                                  | Description                                                                                                                                                                                                                        |
 |---------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `qos.projectcalico.org/dscp` | Specifies the DSCP value of egress traffic toward an endpoint outside cluser or another host in cluster.<br/>Min value: `0`<br/>Max value: `63`<br/>String values: DF, EF, AF11, AF12, AF13, AF21, AF22, AF23, AF31, AF32, AF33, AF41, AF42, AF43, CS0, CS1, CS2, CS3, CS4, CS5, CS6                                                                                                                                     |
+
+## Troubleshooting
+
+If limits for **bandwidth** on installations that use the **eBPF data plane** don't seem to be enforced correctly, check calico-node logs to see if `tcx` may not be supported by
+the operating system with `kubectl logs`. For example:
+
+```
+$ kubectl logs -n calico-system calico-node-cc7q2 | grep "tcx"
+Defaulted container "calico-node" out of: calico-node, flexvol-driver (init), ebpf-bootstrap (init), install-cni (init)
+libbpf: prog 'cali_tcx_test': failed to attach to tcx: Invalid argument
+2025-10-14 20:13:06.961 [INFO][47] felix/bpf_ep_mgr.go 595: tcx is not supported. Falling back to tc
+```
+
+The log messages above mean `tcx` is not supported and thus, QoS limits for bandwidth are not supported on this node.
 
 ## Additional resources
 

--- a/calico/networking/configuring/qos-controls.mdx
+++ b/calico/networking/configuring/qos-controls.mdx
@@ -138,8 +138,10 @@ spec:
 
 ### Bandwidth is not enforced on eBPF
 
-If limits for bandwidth on installations that use the eBPF data plane don't seem to be enforced, check calico-node logs to see if `tcx` may not be supported by
-the operating system with `kubectl logs`. For example:
+If you use the eBPF data plane and bandwidth limits aren't being enforced, check the calico-node logs to see if `tcx` is supported by the operating system.
+`tcx` is present in the Linux kernel version 6.6 and later, and it is required for bandwidth limits to work with the eBPF data plane.
+
+The following example shows logs that indicate an unsupported kernel version:
 
 ```
 $ kubectl logs -n calico-system ds/calico-node | grep tcx
@@ -148,9 +150,6 @@ Defaulted container "calico-node" out of: calico-node, flexvol-driver (init), eb
 bird: libbpf: prog 'cali_tcx_test': failed to attach to tcx: Invalid argument
 2025-10-15 16:31:48.522 [INFO][81] felix/bpf_ep_mgr.go 595: tcx is not supported. Falling back to tc
 ```
-
-The log messages above mean `tcx` is not supported and thus, QoS limits for bandwidth are not supported on this node. In order to solve this, upgrade the Linux kernel version on
-the node to 6.6 or later.
 
 ## Additional resources
 

--- a/calico/networking/configuring/qos-controls.mdx
+++ b/calico/networking/configuring/qos-controls.mdx
@@ -14,9 +14,9 @@ Additionally, it allows configuring Differentiated Services (DiffServ) on egress
 With QoS controls, $[prodname] enforces network resource limits (bandwidth, packet rate, connections) for Kubernetes pods and OpenStack VMs, ensuring fair resource allocation and preventing performance degradation for other workloads.
 $[prodname] can also apply DiffServ on egress traffic to allow upstream devices to prioritise forwarding accordingly.
 
-## Requirements
+## Prerequisites
 
-* Configuring limits for **bandwidth** on installations that use the **eBPF data plane** requires `tcx bpf_link`, which is available in the **Linux kernel v6.6 or newer**.
+* If you use the eBPF data plane, your Linux nodes must be running kernel version 6.6 or higher in order to configure bandwidth QoS controls.
 
 ## Limitations
 
@@ -136,17 +136,21 @@ spec:
 
 ## Troubleshooting
 
-If limits for **bandwidth** on installations that use the **eBPF data plane** don't seem to be enforced correctly, check calico-node logs to see if `tcx` may not be supported by
+### Bandwidth is not enforced on eBPF
+
+If limits for bandwidth on installations that use the eBPF data plane don't seem to be enforced, check calico-node logs to see if `tcx` may not be supported by
 the operating system with `kubectl logs`. For example:
 
 ```
-$ kubectl logs -n calico-system calico-node-cc7q2 | grep "tcx"
+$ kubectl logs -n calico-system ds/calico-node | grep tcx
+Found 4 pods, using pod/calico-node-j9z5d
 Defaulted container "calico-node" out of: calico-node, flexvol-driver (init), ebpf-bootstrap (init), install-cni (init)
-libbpf: prog 'cali_tcx_test': failed to attach to tcx: Invalid argument
-2025-10-14 20:13:06.961 [INFO][47] felix/bpf_ep_mgr.go 595: tcx is not supported. Falling back to tc
+bird: libbpf: prog 'cali_tcx_test': failed to attach to tcx: Invalid argument
+2025-10-15 16:31:48.522 [INFO][81] felix/bpf_ep_mgr.go 595: tcx is not supported. Falling back to tc
 ```
 
-The log messages above mean `tcx` is not supported and thus, QoS limits for bandwidth are not supported on this node.
+The log messages above mean `tcx` is not supported and thus, QoS limits for bandwidth are not supported on this node. In order to solve this, upgrade the Linux kernel version on
+the node to 6.6 or later.
 
 ## Additional resources
 

--- a/calico/networking/configuring/qos-controls.mdx
+++ b/calico/networking/configuring/qos-controls.mdx
@@ -132,7 +132,7 @@ spec:
 
 | Annotation                                  | Description                                                                                                                                                                                                                        |
 |---------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `qos.projectcalico.org/dscp` | Specifies the DSCP value of egress traffic toward an endpoint outside cluser or another host in cluster.<br/>Min value: `0`<br/>Max value: `63`<br/>String values: DF, EF, AF11, AF12, AF13, AF21, AF22, AF23, AF31, AF32, AF33, AF41, AF42, AF43, CS0, CS1, CS2, CS3, CS4, CS5, CS6                                                                                                                                     |
+| `qos.projectcalico.org/dscp` | Specifies the DSCP value of egress traffic toward an endpoint outside cluster or another host in cluster.<br/>Min value: `0`<br/>Max value: `63`<br/>String values: DF, EF, AF11, AF12, AF13, AF21, AF22, AF23, AF31, AF32, AF33, AF41, AF42, AF43, CS0, CS1, CS2, CS3, CS4, CS5, CS6                                                                                                                                     |
 
 ## Troubleshooting
 


### PR DESCRIPTION
Add 'tcx' requirement for QoS bandwidth limits on the eBPF data plane and troubleshooting information to check for it.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue: CORE-11948
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->