### PR TITLE
DOCS-2745: Remove TP status for native dashboards

### DIFF
--- a/calico-cloud/observability/dashboards.mdx
+++ b/calico-cloud/observability/dashboards.mdx
@@ -30,15 +30,15 @@ The **Cluster Health** dashboard provides a birds-eye view of cluster activity.
 
 <Screenshot src="/img/calico-enterprise/dashboards.png" alt="Cluster Health Dashboard" />
 
-### Data Volume
+### Traffic Volume
 
 The **Traffic Volume** dashboard provides a high-level view of traffic in your cluster.
 
-<Screenshot src="/img/calico-cloud/dashboard-data-volume.png" alt="Data Volume Dashboard" />
+<Screenshot src="/img/calico-cloud/dashboard-data-volume.png" alt="Traffic Volume Dashboard" />
 
 ### DNS Logs
 
-The **DNS Dashboard** summarizes DNS data and logs into metrics, providing high-level information on the types of DNS lookups made, responses, and overall DNS performance.
+The **DNS Logs** dashboard summarizes DNS data and logs into metrics, providing high-level information on the types of DNS lookups made, responses, and overall DNS performance.
 
 <Screenshot src="/img/calico-cloud/dashboard-dns-logs.png" alt="DNS Logs Dashboard" />
 

--- a/calico-cloud/observability/dashboards.mdx
+++ b/calico-cloud/observability/dashboards.mdx
@@ -30,26 +30,26 @@ The **Cluster Health** dashboard provides a birds-eye view of cluster activity.
 
 <Screenshot src="/img/calico-enterprise/dashboards.png" alt="Cluster Health Dashboard" />
 
-### Data Volume (tech preview)
+### Data Volume
 
 The **Traffic Volume** dashboard provides a high-level view of traffic in your cluster.
 
 <Screenshot src="/img/calico-cloud/dashboard-data-volume.png" alt="Data Volume Dashboard" />
 
-### DNS Logs (tech preview)
+### DNS Logs
 
 The **DNS Dashboard** summarizes DNS data and logs into metrics, providing high-level information on the types of DNS lookups made, responses, and overall DNS performance.
 
 <Screenshot src="/img/calico-cloud/dashboard-dns-logs.png" alt="DNS Logs Dashboard" />
 
-### Flow Logs (tech preview)
+### Flow Logs
 
 The **Flow Logs** dashboard gives you an overview of how packets are being sent and received by all the pods in your cluster.
 Seeing this data helps you spot unusual flow activity, which may indicate a compromise.
 
 <Screenshot src="/img/calico-cloud/dashboard-flow-logs.png" alt="Flow Logs Dashboard" />
 
-### HTTP Traffic (tech preview)
+### HTTP Traffic
 
 The **HTTP Traffic**  dashboard provides application performance metrics for inscope Kubernetes services.
 The data can assist service owners and platform personnel in assessing the health of cluster workloads without the need for a full service mesh.
@@ -57,7 +57,7 @@ The data can assist service owners and platform personnel in assessing the healt
 
 <Screenshot src="/img/calico-cloud/dashboard-l7.png" alt="HTTP Traffic dashboard" />
 
-### Network Performance (tech preview)
+### Network Performance
 
 The **Network Performance** dashboard provides TCP metrics to help you identify bottlenecks, packet loss, and performance issues.
 [Additional TCP statistics](elastic/flow/tcpstats.mdx) such as Round Trip Time, Retransmission and Packet Loss are not enabled by default, and must be configured.

--- a/calico-cloud/tutorials/calico-cloud-features/tour.mdx
+++ b/calico-cloud/tutorials/calico-cloud-features/tour.mdx
@@ -24,7 +24,7 @@ Each dashboard is made up of categorized graphs, charts, and diagrams that visua
 * The **Cluster Health** dashboard provides a birds-eye view of cluster activity.
 
 * The **Traffic Volume** dashboard provides a high-level view of traffic in your cluster.
-* The **DNS Dashboard** summarizes DNS data and logs into metrics, providing high-level information on the types of DNS lookups made, responses, and overall DNS performance.
+* The **DNS Logs** dashboard summarizes DNS data and logs into metrics, providing high-level information on the types of DNS lookups made, responses, and overall DNS performance.
 * The **Flow Logs** dashboard gives you an overview of how packets are being sent and received by all the pods in your cluster.
 * The **HTTP Traffic**  dashboard provides application performance metrics for inscope Kubernetes services.
 * The **Network Performance** dashboard provides TCP metrics to help you identify bottlenecks, packet loss, and performance issues.

--- a/calico-cloud_versioned_docs/version-22-1/observability/dashboards.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/observability/dashboards.mdx
@@ -34,11 +34,11 @@ The **Cluster Health** dashboard provides a birds-eye view of cluster activity.
 
 The **Traffic Volume** dashboard provides a high-level view of traffic in your cluster.
 
-<Screenshot src="/img/calico-cloud/dashboard-data-volume.png" alt="Data Volume Dashboard" />
+<Screenshot src="/img/calico-cloud/dashboard-data-volume.png" alt="Traffic Volume Dashboard" />
 
 ### DNS Logs (tech preview)
 
-The **DNS Dashboard** summarizes DNS data and logs into metrics, providing high-level information on the types of DNS lookups made, responses, and overall DNS performance.
+The **DNS Logs** dashboard summarizes DNS data and logs into metrics, providing high-level information on the types of DNS lookups made, responses, and overall DNS performance.
 
 <Screenshot src="/img/calico-cloud/dashboard-dns-logs.png" alt="DNS Logs Dashboard" />
 

--- a/calico-cloud_versioned_docs/version-22-1/tutorials/calico-cloud-features/tour.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/tutorials/calico-cloud-features/tour.mdx
@@ -24,7 +24,7 @@ Each dashboard is made up of categorized graphs, charts, and diagrams that visua
 * The **Cluster Health** dashboard provides a birds-eye view of cluster activity.
 
 * The **Traffic Volume** dashboard provides a high-level view of traffic in your cluster.
-* The **DNS Dashboard** summarizes DNS data and logs into metrics, providing high-level information on the types of DNS lookups made, responses, and overall DNS performance.
+* The **DNS Logs** dashboard summarizes DNS data and logs into metrics, providing high-level information on the types of DNS lookups made, responses, and overall DNS performance.
 * The **Flow Logs** dashboard gives you an overview of how packets are being sent and received by all the pods in your cluster.
 * The **HTTP Traffic**  dashboard provides application performance metrics for inscope Kubernetes services.
 * The **Network Performance** dashboard provides TCP metrics to help you identify bottlenecks, packet loss, and performance issues.

--- a/calico-enterprise/observability/dashboards.mdx
+++ b/calico-enterprise/observability/dashboards.mdx
@@ -26,15 +26,15 @@ The **Cluster Health** dashboard provides a birds-eye view of cluster activity.
 
 <Screenshot src="/img/calico-enterprise/dashboards.png" alt="Cluster Health Dashboard" />
 
-### Data Volume
+### Traffic Volume
 
 The **Traffic Volume** dashboard provides a high-level view of traffic in your cluster.
 
-<Screenshot src="/img/calico-enterprise/dashboard-data-volume.png" alt="Data Volume Dashboard" />
+<Screenshot src="/img/calico-enterprise/dashboard-data-volume.png" alt="Traffic Volume Dashboard" />
 
 ### DNS Logs
 
-The **DNS Dashboard** summarizes DNS data and logs into metrics, providing high-level information on the types of DNS lookups made, responses, and overall DNS performance.
+The **DNS Logs** dashboard summarizes DNS data and logs into metrics, providing high-level information on the types of DNS lookups made, responses, and overall DNS performance.
 
 <Screenshot src="/img/calico-enterprise/dashboard-dns-logs.png" alt="DNS Logs Dashboard" />
 

--- a/calico-enterprise/observability/dashboards.mdx
+++ b/calico-enterprise/observability/dashboards.mdx
@@ -26,26 +26,26 @@ The **Cluster Health** dashboard provides a birds-eye view of cluster activity.
 
 <Screenshot src="/img/calico-enterprise/dashboards.png" alt="Cluster Health Dashboard" />
 
-### Data Volume (tech preview)
+### Data Volume
 
 The **Traffic Volume** dashboard provides a high-level view of traffic in your cluster.
 
 <Screenshot src="/img/calico-enterprise/dashboard-data-volume.png" alt="Data Volume Dashboard" />
 
-### DNS Logs (tech preview)
+### DNS Logs
 
 The **DNS Dashboard** summarizes DNS data and logs into metrics, providing high-level information on the types of DNS lookups made, responses, and overall DNS performance.
 
 <Screenshot src="/img/calico-enterprise/dashboard-dns-logs.png" alt="DNS Logs Dashboard" />
 
-### Flow Logs (tech preview)
+### Flow Logs
 
 The **Flow Logs** dashboard gives you an overview of how packets are being sent and received by all the pods in your cluster.
 Seeing this data helps you spot unusual flow activity, which may indicate a compromise.
 
 <Screenshot src="/img/calico-enterprise/dashboard-flow-logs.png" alt="Flow Logs Dashboard" />
 
-### HTTP Traffic (tech preview)
+### HTTP Traffic
 
 The **HTTP Traffic**  dashboard provides application performance metrics for inscope Kubernetes services.
 The data can assist service owners and platform personnel in assessing the health of cluster workloads without the need for a full service mesh.
@@ -53,7 +53,7 @@ The data can assist service owners and platform personnel in assessing the healt
 
 <Screenshot src="/img/calico-enterprise/dashboard-l7.png" alt="HTTP Traffic dashboard" />
 
-### Network Performance (tech preview)
+### Network Performance
 
 The **Network Performance** dashboard provides TCP metrics to help you identify bottlenecks, packet loss, and performance issues.
 [Additional TCP statistics](elastic/flow/tcpstats.mdx) such as Round Trip Time, Retransmission and Packet Loss are not enabled by default, and must be configured.


### PR DESCRIPTION
- **Remove TP status for dashboards**
- **Fix dashboard naming consistency**

This PR does two things:
* Removes tech preview markers for dashboards from CE 3.22-2 and the corresponding CC release.
* Fixes inconsistencies in dashboard names throughout.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->