### PR TITLE
Use the default keys for TLS secrets

### DIFF
--- a/calico-cloud/operations/comms/typha-node-tls.mdx
+++ b/calico-cloud/operations/comms/typha-node-tls.mdx
@@ -45,7 +45,7 @@ By default, $[prodname] Typha and Node components are configured with self-signe
 
    ```bash
    kubectl create secret generic typha-certs -n tigera-operator \
-     --from-file=cert.crt=</path/to/typha/cert> --from-file=key.key=</path/to/typha/key> \
+     --from-file=tls.crt=</path/to/typha/cert> --from-file=tls.key=</path/to/typha/key> \
      --from-literal=common-name=<typha certificate common name> --dry-run -o yaml --save-config >> typha-node-tls.yaml
    echo '---' >> typha-node-tls.yaml
    ```
@@ -60,7 +60,7 @@ By default, $[prodname] Typha and Node components are configured with self-signe
 
    ```bash
    kubectl create secret generic node-certs -n tigera-operator \
-     --from-file=cert.crt=</path/to/node/cert> --from-file=key.key=</path/to/node/key> \
+     --from-file=tls.crt=</path/to/node/cert> --from-file=tls.key=</path/to/node/key> \
      --from-literal=common-name=<node certificate common name> --dry-run -o yaml --save-config >> typha-node-tls.yaml
    ```
 

--- a/calico-cloud_versioned_docs/version-22-1/operations/comms/typha-node-tls.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/operations/comms/typha-node-tls.mdx
@@ -45,7 +45,7 @@ By default, $[prodname] Typha and Node components are configured with self-signe
 
    ```bash
    kubectl create secret generic typha-certs -n tigera-operator \
-     --from-file=cert.crt=</path/to/typha/cert> --from-file=key.key=</path/to/typha/key> \
+     --from-file=tls.crt=</path/to/typha/cert> --from-file=tls.key=</path/to/typha/key> \
      --from-literal=common-name=<typha certificate common name> --dry-run -o yaml --save-config >> typha-node-tls.yaml
    echo '---' >> typha-node-tls.yaml
    ```
@@ -60,7 +60,7 @@ By default, $[prodname] Typha and Node components are configured with self-signe
 
    ```bash
    kubectl create secret generic node-certs -n tigera-operator \
-     --from-file=cert.crt=</path/to/node/cert> --from-file=key.key=</path/to/node/key> \
+     --from-file=tls.crt=</path/to/node/cert> --from-file=tls.key=</path/to/node/key> \
      --from-literal=common-name=<node certificate common name> --dry-run -o yaml --save-config >> typha-node-tls.yaml
    ```
 

--- a/calico-enterprise/operations/comms/typha-node-tls.mdx
+++ b/calico-enterprise/operations/comms/typha-node-tls.mdx
@@ -45,7 +45,7 @@ By default, $[prodname] Typha and Node components are configured with self-signe
 
    ```bash
    kubectl create secret generic typha-certs -n tigera-operator \
-     --from-file=cert.crt=</path/to/typha/cert> --from-file=key.key=</path/to/typha/key> \
+     --from-file=tls.crt=</path/to/typha/cert> --from-file=tls.key=</path/to/typha/key> \
      --from-literal=common-name=<typha certificate common name> --dry-run -o yaml --save-config >> typha-node-tls.yaml
    echo '---' >> typha-node-tls.yaml
    ```
@@ -60,7 +60,7 @@ By default, $[prodname] Typha and Node components are configured with self-signe
 
    ```bash
    kubectl create secret generic node-certs -n tigera-operator \
-     --from-file=cert.crt=</path/to/node/cert> --from-file=key.key=</path/to/node/key> \
+     --from-file=tls.crt=</path/to/node/cert> --from-file=tls.key=</path/to/node/key> \
      --from-literal=common-name=<node certificate common name> --dry-run -o yaml --save-config >> typha-node-tls.yaml
    ```
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/operations/comms/typha-node-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/operations/comms/typha-node-tls.mdx
@@ -45,7 +45,7 @@ By default, $[prodname] Typha and Node components are configured with self-signe
 
    ```bash
    kubectl create secret generic typha-certs -n tigera-operator \
-     --from-file=cert.crt=</path/to/typha/cert> --from-file=key.key=</path/to/typha/key> \
+     --from-file=tls.crt=</path/to/typha/cert> --from-file=tls.key=</path/to/typha/key> \
      --from-literal=common-name=<typha certificate common name> --dry-run -o yaml --save-config >> typha-node-tls.yaml
    echo '---' >> typha-node-tls.yaml
    ```
@@ -60,7 +60,7 @@ By default, $[prodname] Typha and Node components are configured with self-signe
 
    ```bash
    kubectl create secret generic node-certs -n tigera-operator \
-     --from-file=cert.crt=</path/to/node/cert> --from-file=key.key=</path/to/node/key> \
+     --from-file=tls.crt=</path/to/node/cert> --from-file=tls.key=</path/to/node/key> \
      --from-literal=common-name=<node certificate common name> --dry-run -o yaml --save-config >> typha-node-tls.yaml
    ```
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/operations/comms/typha-node-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/operations/comms/typha-node-tls.mdx
@@ -45,7 +45,7 @@ By default, $[prodname] Typha and Node components are configured with self-signe
 
    ```bash
    kubectl create secret generic typha-certs -n tigera-operator \
-     --from-file=cert.crt=</path/to/typha/cert> --from-file=key.key=</path/to/typha/key> \
+     --from-file=tls.crt=</path/to/typha/cert> --from-file=tls.key=</path/to/typha/key> \
      --from-literal=common-name=<typha certificate common name> --dry-run -o yaml --save-config >> typha-node-tls.yaml
    echo '---' >> typha-node-tls.yaml
    ```
@@ -60,7 +60,7 @@ By default, $[prodname] Typha and Node components are configured with self-signe
 
    ```bash
    kubectl create secret generic node-certs -n tigera-operator \
-     --from-file=cert.crt=</path/to/node/cert> --from-file=key.key=</path/to/node/key> \
+     --from-file=tls.crt=</path/to/node/cert> --from-file=tls.key=</path/to/node/key> \
      --from-literal=common-name=<node certificate common name> --dry-run -o yaml --save-config >> typha-node-tls.yaml
    ```
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/operations/comms/typha-node-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/operations/comms/typha-node-tls.mdx
@@ -45,7 +45,7 @@ By default, $[prodname] Typha and Node components are configured with self-signe
 
    ```bash
    kubectl create secret generic typha-certs -n tigera-operator \
-     --from-file=cert.crt=</path/to/typha/cert> --from-file=key.key=</path/to/typha/key> \
+     --from-file=tls.crt=</path/to/typha/cert> --from-file=tls.key=</path/to/typha/key> \
      --from-literal=common-name=<typha certificate common name> --dry-run -o yaml --save-config >> typha-node-tls.yaml
    echo '---' >> typha-node-tls.yaml
    ```
@@ -60,7 +60,7 @@ By default, $[prodname] Typha and Node components are configured with self-signe
 
    ```bash
    kubectl create secret generic node-certs -n tigera-operator \
-     --from-file=cert.crt=</path/to/node/cert> --from-file=key.key=</path/to/node/key> \
+     --from-file=tls.crt=</path/to/node/cert> --from-file=tls.key=</path/to/node/key> \
      --from-literal=common-name=<node certificate common name> --dry-run -o yaml --save-config >> typha-node-tls.yaml
    ```
 

--- a/calico-enterprise_versioned_docs/version-3.22-1/operations/comms/typha-node-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/operations/comms/typha-node-tls.mdx
@@ -45,7 +45,7 @@ By default, $[prodname] Typha and Node components are configured with self-signe
 
    ```bash
    kubectl create secret generic typha-certs -n tigera-operator \
-     --from-file=cert.crt=</path/to/typha/cert> --from-file=key.key=</path/to/typha/key> \
+     --from-file=tls.crt=</path/to/typha/cert> --from-file=tls.key=</path/to/typha/key> \
      --from-literal=common-name=<typha certificate common name> --dry-run -o yaml --save-config >> typha-node-tls.yaml
    echo '---' >> typha-node-tls.yaml
    ```
@@ -60,7 +60,7 @@ By default, $[prodname] Typha and Node components are configured with self-signe
 
    ```bash
    kubectl create secret generic node-certs -n tigera-operator \
-     --from-file=cert.crt=</path/to/node/cert> --from-file=key.key=</path/to/node/key> \
+     --from-file=tls.crt=</path/to/node/cert> --from-file=tls.key=</path/to/node/key> \
      --from-literal=common-name=<node certificate common name> --dry-run -o yaml --save-config >> typha-node-tls.yaml
    ```
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):

Calico, Calico Enterprise, and Calico Cloud.

Issue:

`key.key` and `cert.crt` are deprecated and we should use the standard keys in our doc.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->