### PR TITLE
fix-document: Add command to install operator CRDs

### DIFF
--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/k8s-single-node.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/k8s-single-node.mdx
@@ -93,6 +93,7 @@ The geeky details of what you get:
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
+   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
    ```
 
    :::note

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/k8s-single-node.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/k8s-single-node.mdx
@@ -92,8 +92,8 @@ The geeky details of what you get:
 1. Install the Tigera Operator and custom resource definitions.
 
    ```
-   kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
+   kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 
    :::note


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue: The current document does mention installing CRDs but the command is missing
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->