### PR TITLE
Fix GatewayAPI reference doc link

### DIFF
--- a/calico-cloud/networking/gateway-api.mdx
+++ b/calico-cloud/networking/gateway-api.mdx
@@ -437,7 +437,7 @@ All gateway customization is done through the single `GatewayAPI` resource.  Thi
 - `spec.gatewayDeployment.service.spec.*loadbalancer*` allows control over the corresponding `*loadbalancer*` fields in the Service that is provisioned for each Gateway; in some clouds these can also be used to configure the type and properties of the associated external load balancer.
 - `spec.gatewayClasses` allows the provisioning of multiple GatewayClasses, each with its own set of customizations, instead of the single GatewayClass that the Tigera operator provisions by default.
 
-For full details please see [the `GatewayAPI` reference documentation](../reference/installation/api.mdx#operator.tigera.io/v1.GatewayAPI).
+For full details please see [the `GatewayAPI` reference documentation](../reference/installation/api.mdx#gatewayapi).
 
 To make use of these customization fields, use `kubectl edit gatewayapi tigera-secure` to edit the YAML for the `GatewayAPI` resource, and add or modify the customization fields that you require.  Following are a few examples of possible customizations.
 

--- a/calico-cloud_versioned_docs/version-22-1/networking/gateway-api.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/networking/gateway-api.mdx
@@ -437,7 +437,7 @@ All gateway customization is done through the single `GatewayAPI` resource.  Thi
 - `spec.gatewayDeployment.service.spec.*loadbalancer*` allows control over the corresponding `*loadbalancer*` fields in the Service that is provisioned for each Gateway; in some clouds these can also be used to configure the type and properties of the associated external load balancer.
 - `spec.gatewayClasses` allows the provisioning of multiple GatewayClasses, each with its own set of customizations, instead of the single GatewayClass that the Tigera operator provisions by default.
 
-For full details please see [the `GatewayAPI` reference documentation](../reference/installation/api.mdx#operator.tigera.io/v1.GatewayAPI).
+For full details please see [the `GatewayAPI` reference documentation](../reference/installation/api.mdx#gatewayapi).
 
 To make use of these customization fields, use `kubectl edit gatewayapi tigera-secure` to edit the YAML for the `GatewayAPI` resource, and add or modify the customization fields that you require.  Following are a few examples of possible customizations.
 

--- a/calico-enterprise/networking/gateway-api.mdx
+++ b/calico-enterprise/networking/gateway-api.mdx
@@ -437,7 +437,7 @@ All gateway customization is done through the single `GatewayAPI` resource.  Thi
 - `spec.gatewayDeployment.service.spec.*loadbalancer*` allows control over the corresponding `*loadbalancer*` fields in the Service that is provisioned for each Gateway; in some clouds these can also be used to configure the type and properties of the associated external load balancer.
 - `spec.gatewayClasses` allows the provisioning of multiple GatewayClasses, each with its own set of customizations, instead of the single GatewayClass that the Tigera operator provisions by default.
 
-For full details please see [the `GatewayAPI` reference documentation](../reference/installation/api.mdx#operator.tigera.io/v1.GatewayAPI).
+For full details please see [the `GatewayAPI` reference documentation](../reference/installation/api.mdx#gatewayapi).
 
 To make use of these customization fields, use `kubectl edit gatewayapi tigera-secure` to edit the YAML for the `GatewayAPI` resource, and add or modify the customization fields that you require.  Following are a few examples of possible customizations.
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/networking/gateway-api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/networking/gateway-api.mdx
@@ -430,6 +430,6 @@ The `GatewayAPI` resource has fields that allow some aspects of Gateway deployme
 - `spec.gatewayDeployment.spec.template.spec.containers` allows control over the memory and CPU that Gateway implementation pods can use
 - `spec.gatewayControllerDeployment.spec.template.spec.nodeSelector` allows control over where the gateway controller is scheduled.
 
-For full details please see [the `GatewayAPI` reference documentation](../reference/installation/api.mdx#operator.tigera.io/v1.GatewayAPI).
+For full details please see [the `GatewayAPI` reference documentation](../reference/installation/api.mdx#gatewayapi).
 
 To make use of these customization fields, use `kubectl edit gatewayapi tigera-secure` to edit the YAML for the `GatewayAPI` resource, and add or modify the customization fields that you require.

--- a/calico-enterprise_versioned_docs/version-3.22-1/networking/gateway-api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/networking/gateway-api.mdx
@@ -427,7 +427,7 @@ All gateway customization is done through the single `GatewayAPI` resource.  Thi
 - `spec.gatewayDeployment.service.spec.*loadbalancer*` allows control over the corresponding `*loadbalancer*` fields in the Service that is provisioned for each Gateway; in some clouds these can also be used to configure the type and properties of the associated external load balancer.
 - `spec.gatewayClasses` allows the provisioning of multiple GatewayClasses, each with its own set of customizations, instead of the single GatewayClass that the Tigera operator provisions by default.
 
-For full details please see [the `GatewayAPI` reference documentation](../reference/installation/api.mdx#operator.tigera.io/v1.GatewayAPI).
+For full details please see [the `GatewayAPI` reference documentation](../reference/installation/api.mdx#gatewayapi).
 
 To make use of these customization fields, use `kubectl edit gatewayapi tigera-secure` to edit the YAML for the `GatewayAPI` resource, and add or modify the customization fields that you require.  Following are a few examples of possible customizations.
 

--- a/calico/networking/gateway-api.mdx
+++ b/calico/networking/gateway-api.mdx
@@ -437,7 +437,7 @@ All gateway customization is done through the single `GatewayAPI` resource.  Thi
 - `spec.gatewayDeployment.service.spec.*loadbalancer*` allows control over the corresponding `*loadbalancer*` fields in the Service that is provisioned for each Gateway; in some clouds these can also be used to configure the type and properties of the associated external load balancer.
 - `spec.gatewayClasses` allows the provisioning of multiple GatewayClasses, each with its own set of customizations, instead of the single GatewayClass that the Tigera operator provisions by default.
 
-For full details please see [the `GatewayAPI` reference documentation](../reference/installation/api.mdx#operator.tigera.io/v1.GatewayAPI).
+For full details please see [the `GatewayAPI` reference documentation](../reference/installation/api.mdx#gatewayapi).
 
 To make use of these customization fields, use `kubectl edit gatewayapi default` to edit the YAML for the `GatewayAPI` resource, and add or modify the customization fields that you require.  Following are a few examples of possible customizations.
 

--- a/calico_versioned_docs/version-3.30/networking/gateway-api.mdx
+++ b/calico_versioned_docs/version-3.30/networking/gateway-api.mdx
@@ -431,7 +431,7 @@ The `GatewayAPI` resource has fields that allow some aspects of Gateway deployme
 - `spec.gatewayDeployment.spec.template.spec.containers` allows control over the memory and CPU that Gateway implementation pods can use
 - `spec.gatewayControllerDeployment.spec.template.spec.nodeSelector` allows control over where the gateway controller is scheduled.
 
-For full details please see [the `GatewayAPI` reference documentation](../reference/installation/api.mdx#operator.tigera.io/v1.GatewayAPI).
+For full details please see [the `GatewayAPI` reference documentation](../reference/installation/api.mdx#gatewayapi).
 
 To make use of these customization fields, use `kubectl edit gatewayapi default` to edit the YAML for the `GatewayAPI` resource, and add or modify the customization fields that you require.
 

--- a/calico_versioned_docs/version-3.31/networking/gateway-api.mdx
+++ b/calico_versioned_docs/version-3.31/networking/gateway-api.mdx
@@ -437,7 +437,7 @@ All gateway customization is done through the single `GatewayAPI` resource.  Thi
 - `spec.gatewayDeployment.service.spec.*loadbalancer*` allows control over the corresponding `*loadbalancer*` fields in the Service that is provisioned for each Gateway; in some clouds these can also be used to configure the type and properties of the associated external load balancer.
 - `spec.gatewayClasses` allows the provisioning of multiple GatewayClasses, each with its own set of customizations, instead of the single GatewayClass that the Tigera operator provisions by default.
 
-For full details please see [the `GatewayAPI` reference documentation](../reference/installation/api.mdx#operator.tigera.io/v1.GatewayAPI).
+For full details please see [the `GatewayAPI` reference documentation](../reference/installation/api.mdx#gatewayapi).
 
 To make use of these customization fields, use `kubectl edit gatewayapi default` to edit the YAML for the `GatewayAPI` resource, and add or modify the customization fields that you require.  Following are a few examples of possible customizations.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
* https://docs.tigera.io/calico-enterprise/latest/reference/installation/api#operator.tigera.io/v1.GatewayAPI -> https://docs.tigera.io/calico-enterprise/latest/reference/installation/api#gatewayapi


Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->