### PR TITLE
Move automatic API generation to the new makefile target

### DIFF
--- a/calico-enterprise/reference/installation/_api.mdx
+++ b/calico-enterprise/reference/installation/_api.mdx
@@ -3519,6 +3519,22 @@ _Appears in:_
 | `images` _[Image](#image) array_ | Images is the list of images to use digests. All images that the operator will deploy must be specified. |
 
 
+### Impersonation
+
+
+
+Impersonation defines the rules for allowing impersonation.
+
+_Appears in:_
+- [ManagementClusterConnectionSpec](#managementclusterconnectionspec)
+
+| Field | Description |
+| --- | --- |
+| `users` _string array_ | (Optional) Users is a list of users that can be impersonated. An empty list infers all users can be impersonated, a null value means none. |
+| `groups` _string array_ | (Optional) Groups is a list of group names that can be impersonated. An empty list infers all groups can be impersonated, a null values means none. |
+| `serviceAccounts` _string array_ | (Optional) ServiceAccounts is a list of service account names that can be impersonated. An empty list infers all service accounts can be impersonated, a null values means none. |
+
+
 
 
 ### Indices
@@ -4375,6 +4391,7 @@ _Appears in:_
 | `managementClusterAddr` _string_ | (Optional) Specify where the managed cluster can reach the management cluster. Ex.: "10.128.0.10:30449". A managed cluster should be able to access this address. This field is used by managed clusters only. |
 | `tls` _[ManagementClusterTLS](#managementclustertls)_ | (Optional) TLS provides options for configuring how Managed Clusters can establish an mTLS connection with the Management Cluster. |
 | `guardianDeployment` _[GuardianDeployment](#guardiandeployment)_ | GuardianDeployment configures the guardian Deployment. |
+| `impersonation` _[Impersonation](#impersonation)_ | (Optional) Impersonation configures the RBAC impersonation permissions for the guardian deployment. This field is not applicable to installation variant Calico as no impersonation is ever used. Otherwise, if this field is left nil, a default set of permissions will be applied.<br />WARNING: If this field is specified, it completely replaces the default permissions. For example, providing an empty `impersonation: \{\}` block will result in guardian having NO impersonation permissions. Similarly, if you specify `users` but omit `groups`, guardian will lose its default permissions to impersonate groups. |
 
 
 ### ManagementClusterConnectionStatus
@@ -5250,7 +5267,7 @@ _Appears in:_
 _Underlying type:_ _string_
 
 Provider represents a particular provider or flavor of Kubernetes. Valid options
-are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG.
+are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG, Kind.
 
 _Appears in:_
 - [InstallationSpec](#installationspec)

--- a/calico/reference/installation/_api.mdx
+++ b/calico/reference/installation/_api.mdx
@@ -63,7 +63,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name is an enum which identifies the API server Deployment container by name. Supported values are: calico-apiserver, tigera-queryserver, calico-l7-admission-controller |
+| `name` _string_ | Name is an enum which identifies the API server Deployment container by name.<br />Supported values are: calico-apiserver, tigera-queryserver, calico-l7-admission-controller |
 | `ports` _[APIServerDeploymentContainerPort](#apiserverdeploymentcontainerport) array_ | (Optional) Ports allows customization of container's ports. If specified, this overrides the named APIServer Deployment container's ports. If omitted, the API server Deployment will use its default value for this container's port. |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional) Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named API server Deployment container's resources. If omitted, the API server Deployment will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence. |
 
@@ -79,7 +79,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name is an enum which identifies the API server Deployment Container port by name. Supported values are: apiserver, queryserver, l7admctrl |
+| `name` _string_ | Name is an enum which identifies the API server Deployment Container port by name.<br />Supported values are: apiserver, queryserver, l7admctrl |
 | `containerPort` _integer_ | Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536. |
 
 
@@ -94,7 +94,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name is an enum which identifies the API server Deployment init container by name. Supported values are: calico-apiserver-certs-key-cert-provisioner |
+| `name` _string_ | Name is an enum which identifies the API server Deployment init container by name.<br />Supported values are: calico-apiserver-certs-key-cert-provisioner |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional) Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named API server Deployment init container's resources. If omitted, the API server Deployment will use its default value for this init container's resources. |
 
 
@@ -111,10 +111,10 @@ _Appears in:_
 | --- | --- |
 | `initContainers` _[APIServerDeploymentInitContainer](#apiserverdeploymentinitcontainer) array_ | (Optional) InitContainers is a list of API server init containers. If specified, this overrides the specified API server Deployment init containers. If omitted, the API server Deployment will use its default values for its init containers. |
 | `containers` _[APIServerDeploymentContainer](#apiserverdeploymentcontainer) array_ | (Optional) Containers is a list of API server containers. If specified, this overrides the specified API server Deployment containers. If omitted, the API server Deployment will use its default values for its containers. |
-| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) Affinity is a group of affinity scheduling rules for the API server pods. If specified, this overrides any affinity that may be set on the API server Deployment. If omitted, the API server Deployment will use its default value for affinity. WARNING: Please note that this field will override the default API server Deployment affinity. |
-| `nodeSelector` _object (keys:string, values:string)_ | NodeSelector is the API server pod's scheduling constraints. If specified, each of the key/value pairs are added to the API server Deployment nodeSelector provided the key does not already exist in the object's nodeSelector. If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on the API server Deployment and each of this field's key/value pairs are added to the API server Deployment nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the API server Deployment will use its default value for nodeSelector. WARNING: Please note that this field will modify the default API server Deployment nodeSelector. |
+| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) Affinity is a group of affinity scheduling rules for the API server pods. If specified, this overrides any affinity that may be set on the API server Deployment. If omitted, the API server Deployment will use its default value for affinity.<br />WARNING: Please note that this field will override the default API server Deployment affinity. |
+| `nodeSelector` _object (keys:string, values:string)_ | NodeSelector is the API server pod's scheduling constraints. If specified, each of the key/value pairs are added to the API server Deployment nodeSelector provided the key does not already exist in the object's nodeSelector. If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on the API server Deployment and each of this field's key/value pairs are added to the API server Deployment nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the API server Deployment will use its default value for nodeSelector.<br />WARNING: Please note that this field will modify the default API server Deployment nodeSelector. |
 | `topologySpreadConstraints` _[TopologySpreadConstraint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#topologyspreadconstraint-v1-core) array_ | (Optional) TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed. |
-| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) Tolerations is the API server pod's tolerations. If specified, this overrides any tolerations that may be set on the API server Deployment. If omitted, the API server Deployment will use its default value for tolerations. WARNING: Please note that this field will override the default API server Deployment tolerations. |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) Tolerations is the API server pod's tolerations. If specified, this overrides any tolerations that may be set on the API server Deployment. If omitted, the API server Deployment will use its default value for tolerations.<br />WARNING: Please note that this field will override the default API server Deployment tolerations. |
 | `priorityClassName` _string_ | (Optional) PriorityClassName allows to specify a PriorityClass resource to be used. |
 
 
@@ -235,7 +235,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `policyMode` _[PolicyMode](#policymode)_ | (Optional) PolicyMode determines whether the "control-plane" label is applied to namespaces. It offers two options: Default and Manual. The Default option adds the "control-plane" label to the required namespaces. The Manual option does not apply the "control-plane" label to any namespace. Default: Default |
+| `policyMode` _[PolicyMode](#policymode)_ | (Optional) PolicyMode determines whether the "control-plane" label is applied to namespaces. It offers two options: Default and Manual. The Default option adds the "control-plane" label to the required namespaces. The Manual option does not apply the "control-plane" label to any namespace.<br />Default: Default |
 
 
 ### BGPOption
@@ -283,10 +283,10 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `logSeverity` _[LogLevel](#loglevel)_ | (Optional) Default: Info |
-| `logFileMaxSize` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#quantity-resource-api)_ | (Optional) Default: 100Mi |
-| `logFileMaxAgeDays` _integer_ | (Optional) Default: 30 (days) |
-| `logFileMaxCount` _integer_ | (Optional) Default: 10 |
+| `logSeverity` _[LogLevel](#loglevel)_ | (Optional)<br />Default: Info |
+| `logFileMaxSize` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#quantity-resource-api)_ | (Optional)<br />Default: 100Mi |
+| `logFileMaxAgeDays` _integer_ | (Optional)<br />Default: 30 (days) |
+| `logFileMaxCount` _integer_ | (Optional)<br />Default: 10 |
 
 
 ### CNIPluginType
@@ -319,7 +319,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `type` _[CNIPluginType](#cniplugintype)_ | Specifies the CNI plugin that will be used in the Calico or Calico Enterprise installation. * For KubernetesProvider GKE, this field defaults to GKE. * For KubernetesProvider AKS, this field defaults to AzureVNET. * For KubernetesProvider EKS, this field defaults to AmazonVPC. * If aws-node daemonset exists in kube-system when the Installation resource is created, this field defaults to AmazonVPC. * For all other cases this field defaults to Calico. For the value Calico, the CNI plugin binaries and CNI config will be installed as part of deployment, for all other values the CNI plugin binaries and CNI config is a dependency that is expected to be installed separately. Default: Calico |
+| `type` _[CNIPluginType](#cniplugintype)_ | Specifies the CNI plugin that will be used in the Calico or Calico Enterprise installation. * For KubernetesProvider GKE, this field defaults to GKE. * For KubernetesProvider AKS, this field defaults to AzureVNET. * For KubernetesProvider EKS, this field defaults to AmazonVPC. * If aws-node daemonset exists in kube-system when the Installation resource is created, this field defaults to AmazonVPC. * For all other cases this field defaults to Calico. For the value Calico, the CNI plugin binaries and CNI config will be installed as part of deployment, for all other values the CNI plugin binaries and CNI config is a dependency that is expected to be installed separately.<br />Default: Calico |
 | `ipam` _[IPAMSpec](#ipamspec)_ | (Optional) IPAM specifies the pod IP address management that will be used in the Calico or Calico Enterprise installation. |
 | `binDir` _string_ | (Optional) BinDir is the path to the CNI binaries directory. If you have changed the installation directory for CNI binaries in the container runtime configuration, please ensure that this field points to the same directory as specified in the container runtime settings. Default directory depends on the KubernetesProvider. * For KubernetesProvider GKE, this field defaults to "/home/kubernetes/bin". * For KubernetesProvider OpenShift, this field defaults to "/var/lib/cni/bin". * Otherwise, this field defaults to "/opt/cni/bin". |
 | `confDir` _string_ | (Optional) ConfDir is the path to the CNI config directory. If you have changed the installation directory for CNI configuration in the container runtime configuration, please ensure that this field points to the same directory as specified in the container runtime settings. Default directory depends on the KubernetesProvider. * For KubernetesProvider GKE, this field defaults to "/etc/cni/net.d". * For KubernetesProvider OpenShift, this field defaults to "/var/run/multus/cni/net.d". * Otherwise, this field defaults to "/etc/cni/net.d". |
@@ -370,7 +370,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name is an enum which identifies the csi-node-driver DaemonSet container by name. Supported values are: calico-csi, csi-node-driver-registrar. |
+| `name` _string_ | Name is an enum which identifies the csi-node-driver DaemonSet container by name.<br />Supported values are: calico-csi, csi-node-driver-registrar. |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional) Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named csi-node-driver DaemonSet container's resources. If omitted, the csi-node-driver DaemonSet will use its default value for this container's resources. |
 
 
@@ -386,9 +386,9 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `containers` _[CSINodeDriverDaemonSetContainer](#csinodedriverdaemonsetcontainer) array_ | (Optional) Containers is a list of csi-node-driver containers. If specified, this overrides the specified csi-node-driver DaemonSet containers. If omitted, the csi-node-driver DaemonSet will use its default values for its containers. |
-| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) Affinity is a group of affinity scheduling rules for the csi-node-driver pods. If specified, this overrides any affinity that may be set on the csi-node-driver DaemonSet. If omitted, the csi-node-driver DaemonSet will use its default value for affinity. WARNING: Please note that this field will override the default csi-node-driver DaemonSet affinity. |
-| `nodeSelector` _object (keys:string, values:string)_ | (Optional) NodeSelector is the csi-node-driver pod's scheduling constraints. If specified, each of the key/value pairs are added to the csi-node-driver DaemonSet nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the csi-node-driver DaemonSet will use its default value for nodeSelector. WARNING: Please note that this field will modify the default csi-node-driver DaemonSet nodeSelector. |
-| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) Tolerations is the csi-node-driver pod's tolerations. If specified, this overrides any tolerations that may be set on the csi-node-driver DaemonSet. If omitted, the csi-node-driver DaemonSet will use its default value for tolerations. WARNING: Please note that this field will override the default csi-node-driver DaemonSet tolerations. |
+| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) Affinity is a group of affinity scheduling rules for the csi-node-driver pods. If specified, this overrides any affinity that may be set on the csi-node-driver DaemonSet. If omitted, the csi-node-driver DaemonSet will use its default value for affinity.<br />WARNING: Please note that this field will override the default csi-node-driver DaemonSet affinity. |
+| `nodeSelector` _object (keys:string, values:string)_ | (Optional) NodeSelector is the csi-node-driver pod's scheduling constraints. If specified, each of the key/value pairs are added to the csi-node-driver DaemonSet nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the csi-node-driver DaemonSet will use its default value for nodeSelector.<br />WARNING: Please note that this field will modify the default csi-node-driver DaemonSet nodeSelector. |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) Tolerations is the csi-node-driver pod's tolerations. If specified, this overrides any tolerations that may be set on the csi-node-driver DaemonSet. If omitted, the csi-node-driver DaemonSet will use its default value for tolerations.<br />WARNING: Please note that this field will override the default csi-node-driver DaemonSet tolerations. |
 
 
 ### CSINodeDriverDaemonSetPodTemplateSpec
@@ -447,7 +447,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name is an enum which identifies the calico-kube-controllers Deployment container by name. Supported values are: calico-kube-controllers, es-calico-kube-controllers |
+| `name` _string_ | Name is an enum which identifies the calico-kube-controllers Deployment container by name.<br />Supported values are: calico-kube-controllers, es-calico-kube-controllers |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional) Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named calico-kube-controllers Deployment container's resources. If omitted, the calico-kube-controllers Deployment will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence. |
 
 
@@ -463,9 +463,9 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `containers` _[CalicoKubeControllersDeploymentContainer](#calicokubecontrollersdeploymentcontainer) array_ | (Optional) Containers is a list of calico-kube-controllers containers. If specified, this overrides the specified calico-kube-controllers Deployment containers. If omitted, the calico-kube-controllers Deployment will use its default values for its containers. |
-| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) Affinity is a group of affinity scheduling rules for the calico-kube-controllers pods. If specified, this overrides any affinity that may be set on the calico-kube-controllers Deployment. If omitted, the calico-kube-controllers Deployment will use its default value for affinity. WARNING: Please note that this field will override the default calico-kube-controllers Deployment affinity. |
-| `nodeSelector` _object (keys:string, values:string)_ | NodeSelector is the calico-kube-controllers pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-kube-controllers Deployment nodeSelector provided the key does not already exist in the object's nodeSelector. If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on the calico-kube-controllers Deployment and each of this field's key/value pairs are added to the calico-kube-controllers Deployment nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-kube-controllers Deployment will use its default value for nodeSelector. WARNING: Please note that this field will modify the default calico-kube-controllers Deployment nodeSelector. |
-| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) Tolerations is the calico-kube-controllers pod's tolerations. If specified, this overrides any tolerations that may be set on the calico-kube-controllers Deployment. If omitted, the calico-kube-controllers Deployment will use its default value for tolerations. WARNING: Please note that this field will override the default calico-kube-controllers Deployment tolerations. |
+| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) Affinity is a group of affinity scheduling rules for the calico-kube-controllers pods. If specified, this overrides any affinity that may be set on the calico-kube-controllers Deployment. If omitted, the calico-kube-controllers Deployment will use its default value for affinity.<br />WARNING: Please note that this field will override the default calico-kube-controllers Deployment affinity. |
+| `nodeSelector` _object (keys:string, values:string)_ | NodeSelector is the calico-kube-controllers pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-kube-controllers Deployment nodeSelector provided the key does not already exist in the object's nodeSelector. If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on the calico-kube-controllers Deployment and each of this field's key/value pairs are added to the calico-kube-controllers Deployment nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-kube-controllers Deployment will use its default value for nodeSelector.<br />WARNING: Please note that this field will modify the default calico-kube-controllers Deployment nodeSelector. |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) Tolerations is the calico-kube-controllers pod's tolerations. If specified, this overrides any tolerations that may be set on the calico-kube-controllers Deployment. If omitted, the calico-kube-controllers Deployment will use its default value for tolerations.<br />WARNING: Please note that this field will override the default calico-kube-controllers Deployment tolerations. |
 
 
 ### CalicoKubeControllersDeploymentPodTemplateSpec
@@ -509,20 +509,20 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `linuxDataplane` _[LinuxDataplaneOption](#linuxdataplaneoption)_ | (Optional) LinuxDataplane is used to select the dataplane used for Linux nodes. In particular, it causes the operator to add required mounts and environment variables for the particular dataplane. If not specified, iptables mode is used. Default: Iptables |
-| `windowsDataplane` _[WindowsDataplaneOption](#windowsdataplaneoption)_ | (Optional) WindowsDataplane is used to select the dataplane used for Windows nodes. In particular, it causes the operator to add required mounts and environment variables for the particular dataplane. If not specified, it is disabled and the operator will not render the Calico Windows nodes daemonset. Default: Disabled |
-| `bpfNetworkBootstrap` _[BPFNetworkBootstrapType](#bpfnetworkbootstraptype)_ | (Optional) BPFNetworkBootstrap manages the initial networking setup required to configure the BPF dataplane. When enabled, the operator tries to bootstraps access to the Kubernetes API Server by using the Kubernetes service and its associated endpoints. This field should be enabled only if linuxDataplane is set to "BPF". If another dataplane is selected, this field must be omitted or explicitly set to Disabled. When disabled and linuxDataplane is BPF, you must manually provide the Kubernetes API Server information via the "kubernetes-service-endpoint" ConfigMap. It is invalid to use both the ConfigMap and have this field set to true at the same time. Default: Disabled |
-| `kubeProxyManagement` _[KubeProxyManagementType](#kubeproxymanagementtype)_ | (Optional) KubeProxyManagement controls whether the operator manages the kube-proxy DaemonSet. When enabled, the operator will manage the DaemonSet by patching it: it disables kube-proxy if the dataplane is BPF, or enables it otherwise. Default: Disabled |
+| `linuxDataplane` _[LinuxDataplaneOption](#linuxdataplaneoption)_ | (Optional) LinuxDataplane is used to select the dataplane used for Linux nodes. In particular, it causes the operator to add required mounts and environment variables for the particular dataplane. If not specified, iptables mode is used.<br />Default: Iptables |
+| `windowsDataplane` _[WindowsDataplaneOption](#windowsdataplaneoption)_ | (Optional) WindowsDataplane is used to select the dataplane used for Windows nodes. In particular, it causes the operator to add required mounts and environment variables for the particular dataplane. If not specified, it is disabled and the operator will not render the Calico Windows nodes daemonset.<br />Default: Disabled |
+| `bpfNetworkBootstrap` _[BPFNetworkBootstrapType](#bpfnetworkbootstraptype)_ | (Optional) BPFNetworkBootstrap manages the initial networking setup required to configure the BPF dataplane. When enabled, the operator tries to bootstraps access to the Kubernetes API Server by using the Kubernetes service and its associated endpoints. This field should be enabled only if linuxDataplane is set to "BPF". If another dataplane is selected, this field must be omitted or explicitly set to Disabled. When disabled and linuxDataplane is BPF, you must manually provide the Kubernetes API Server information via the "kubernetes-service-endpoint" ConfigMap. It is invalid to use both the ConfigMap and have this field set to true at the same time.<br />Default: Disabled |
+| `kubeProxyManagement` _[KubeProxyManagementType](#kubeproxymanagementtype)_ | (Optional) KubeProxyManagement controls whether the operator manages the kube-proxy DaemonSet. When enabled, the operator will manage the DaemonSet by patching it: it disables kube-proxy if the dataplane is BPF, or enables it otherwise.<br />Default: Disabled |
 | `bgp` _[BGPOption](#bgpoption)_ | (Optional) BGP configures whether or not to enable Calico's BGP capabilities. |
 | `ipPools` _[IPPool](#ippool) array_ | (Optional) IPPools contains a list of IP pools to manage. If nil, a single IPv4 IP pool will be created by the operator. If an empty list is provided, the operator will not create any IP pools and will instead wait for IP pools to be created out-of-band. IP pools in this list will be reconciled by the operator and should not be modified out-of-band. |
 | `mtu` _integer_ | (Optional) MTU specifies the maximum transmission unit to use on the pod network. If not specified, Calico will perform MTU auto-detection based on the cluster network. |
 | `nodeAddressAutodetectionV4` _[NodeAddressAutodetection](#nodeaddressautodetection)_ | (Optional) NodeAddressAutodetectionV4 specifies an approach to automatically detect node IPv4 addresses. If not specified, will use default auto-detection settings to acquire an IPv4 address for each node. |
 | `nodeAddressAutodetectionV6` _[NodeAddressAutodetection](#nodeaddressautodetection)_ | (Optional) NodeAddressAutodetectionV6 specifies an approach to automatically detect node IPv6 addresses. If not specified, IPv6 addresses will not be auto-detected. |
-| `hostPorts` _[HostPortsType](#hostportstype)_ | (Optional) HostPorts configures whether or not Calico will support Kubernetes HostPorts. Valid only when using the Calico CNI plugin. Default: Enabled |
-| `multiInterfaceMode` _[MultiInterfaceMode](#multiinterfacemode)_ | (Optional) MultiInterfaceMode configures what will configure multiple interface per pod. Only valid for Calico Enterprise installations using the Calico CNI plugin. Default: None |
-| `containerIPForwarding` _[ContainerIPForwardingType](#containeripforwardingtype)_ | (Optional) ContainerIPForwarding configures whether ip forwarding will be enabled for containers in the CNI configuration. Default: Disabled |
+| `hostPorts` _[HostPortsType](#hostportstype)_ | (Optional) HostPorts configures whether or not Calico will support Kubernetes HostPorts. Valid only when using the Calico CNI plugin.<br />Default: Enabled |
+| `multiInterfaceMode` _[MultiInterfaceMode](#multiinterfacemode)_ | (Optional) MultiInterfaceMode configures what will configure multiple interface per pod. Only valid for Calico Enterprise installations using the Calico CNI plugin.<br />Default: None |
+| `containerIPForwarding` _[ContainerIPForwardingType](#containeripforwardingtype)_ | (Optional) ContainerIPForwarding configures whether ip forwarding will be enabled for containers in the CNI configuration.<br />Default: Disabled |
 | `sysctl` _[Sysctl](#sysctl) array_ | (Optional) Sysctl configures sysctl parameters for tuning plugin |
-| `linuxPolicySetupTimeoutSeconds` _integer_ | (Optional) LinuxPolicySetupTimeoutSeconds delays new pods from running containers until their policy has been programmed in the dataplane. The specified delay defines the maximum amount of time that the Calico CNI plugin will wait for policy to be programmed. Only applies to pods created on Linux nodes. * A value of 0 disables pod startup delays. Default: 0 |
+| `linuxPolicySetupTimeoutSeconds` _integer_ | (Optional) LinuxPolicySetupTimeoutSeconds delays new pods from running containers until their policy has been programmed in the dataplane. The specified delay defines the maximum amount of time that the Calico CNI plugin will wait for policy to be programmed. Only applies to pods created on Linux nodes. * A value of 0 disables pod startup delays.<br />Default: 0 |
 
 
 ### CalicoNodeDaemonSet
@@ -551,7 +551,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name is an enum which identifies the calico-node DaemonSet container by name. Supported values are: calico-node |
+| `name` _string_ | Name is an enum which identifies the calico-node DaemonSet container by name.<br />Supported values are: calico-node |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional) Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named calico-node DaemonSet container's resources. If omitted, the calico-node DaemonSet will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence. |
 
 
@@ -566,7 +566,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name is an enum which identifies the calico-node DaemonSet init container by name. Supported values are: install-cni, hostpath-init, flexvol-driver, ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner, mount-bpffs (deprecated, replaced by ebpf-bootstrap) |
+| `name` _string_ | Name is an enum which identifies the calico-node DaemonSet init container by name.<br />Supported values are: install-cni, hostpath-init, flexvol-driver, ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner, mount-bpffs (deprecated, replaced by ebpf-bootstrap) |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional) Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named calico-node DaemonSet init container's resources. If omitted, the calico-node DaemonSet will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence. |
 
 
@@ -583,9 +583,9 @@ _Appears in:_
 | --- | --- |
 | `initContainers` _[CalicoNodeDaemonSetInitContainer](#caliconodedaemonsetinitcontainer) array_ | (Optional) InitContainers is a list of calico-node init containers. If specified, this overrides the specified calico-node DaemonSet init containers. If omitted, the calico-node DaemonSet will use its default values for its init containers. |
 | `containers` _[CalicoNodeDaemonSetContainer](#caliconodedaemonsetcontainer) array_ | (Optional) Containers is a list of calico-node containers. If specified, this overrides the specified calico-node DaemonSet containers. If omitted, the calico-node DaemonSet will use its default values for its containers. |
-| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) Affinity is a group of affinity scheduling rules for the calico-node pods. If specified, this overrides any affinity that may be set on the calico-node DaemonSet. If omitted, the calico-node DaemonSet will use its default value for affinity. WARNING: Please note that this field will override the default calico-node DaemonSet affinity. |
-| `nodeSelector` _object (keys:string, values:string)_ | (Optional) NodeSelector is the calico-node pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-node DaemonSet nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-node DaemonSet will use its default value for nodeSelector. WARNING: Please note that this field will modify the default calico-node DaemonSet nodeSelector. |
-| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) Tolerations is the calico-node pod's tolerations. If specified, this overrides any tolerations that may be set on the calico-node DaemonSet. If omitted, the calico-node DaemonSet will use its default value for tolerations. WARNING: Please note that this field will override the default calico-node DaemonSet tolerations. |
+| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) Affinity is a group of affinity scheduling rules for the calico-node pods. If specified, this overrides any affinity that may be set on the calico-node DaemonSet. If omitted, the calico-node DaemonSet will use its default value for affinity.<br />WARNING: Please note that this field will override the default calico-node DaemonSet affinity. |
+| `nodeSelector` _object (keys:string, values:string)_ | (Optional) NodeSelector is the calico-node pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-node DaemonSet nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-node DaemonSet will use its default value for nodeSelector.<br />WARNING: Please note that this field will modify the default calico-node DaemonSet nodeSelector. |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) Tolerations is the calico-node pod's tolerations. If specified, this overrides any tolerations that may be set on the calico-node DaemonSet. If omitted, the calico-node DaemonSet will use its default value for tolerations.<br />WARNING: Please note that this field will override the default calico-node DaemonSet tolerations. |
 | `dnsPolicy` _[DNSPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#dnspolicy-v1-core)_ | (Optional) DNSPolicy is the DNS policy for the calico-node pods. |
 | `dnsConfig` _[PodDNSConfig](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#poddnsconfig-v1-core)_ | (Optional) DNSConfig allows customization of the DNS configuration for the calico-node pods. |
 
@@ -646,7 +646,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name is an enum which identifies the calico-node-windows DaemonSet container by name. Supported values are: calico-node-windows |
+| `name` _string_ | Name is an enum which identifies the calico-node-windows DaemonSet container by name.<br />Supported values are: calico-node-windows |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional) Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named calico-node-windows DaemonSet container's resources. If omitted, the calico-node-windows DaemonSet will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence. |
 
 
@@ -661,7 +661,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name is an enum which identifies the calico-node-windows DaemonSet init container by name. Supported values are: install-cni;hostpath-init, flexvol-driver, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner |
+| `name` _string_ | Name is an enum which identifies the calico-node-windows DaemonSet init container by name.<br />Supported values are: install-cni;hostpath-init, flexvol-driver, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional) Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named calico-node-windows DaemonSet init container's resources. If omitted, the calico-node-windows DaemonSet will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence. |
 
 
@@ -678,9 +678,9 @@ _Appears in:_
 | --- | --- |
 | `initContainers` _[CalicoNodeWindowsDaemonSetInitContainer](#caliconodewindowsdaemonsetinitcontainer) array_ | (Optional) InitContainers is a list of calico-node-windows init containers. If specified, this overrides the specified calico-node-windows DaemonSet init containers. If omitted, the calico-node-windows DaemonSet will use its default values for its init containers. |
 | `containers` _[CalicoNodeWindowsDaemonSetContainer](#caliconodewindowsdaemonsetcontainer) array_ | (Optional) Containers is a list of calico-node-windows containers. If specified, this overrides the specified calico-node-windows DaemonSet containers. If omitted, the calico-node-windows DaemonSet will use its default values for its containers. |
-| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) Affinity is a group of affinity scheduling rules for the calico-node-windows pods. If specified, this overrides any affinity that may be set on the calico-node-windows DaemonSet. If omitted, the calico-node-windows DaemonSet will use its default value for affinity. WARNING: Please note that this field will override the default calico-node-windows DaemonSet affinity. |
-| `nodeSelector` _object (keys:string, values:string)_ | (Optional) NodeSelector is the calico-node-windows pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-node-windows DaemonSet nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-node-windows DaemonSet will use its default value for nodeSelector. WARNING: Please note that this field will modify the default calico-node-windows DaemonSet nodeSelector. |
-| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) Tolerations is the calico-node-windows pod's tolerations. If specified, this overrides any tolerations that may be set on the calico-node-windows DaemonSet. If omitted, the calico-node-windows DaemonSet will use its default value for tolerations. WARNING: Please note that this field will override the default calico-node-windows DaemonSet tolerations. |
+| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) Affinity is a group of affinity scheduling rules for the calico-node-windows pods. If specified, this overrides any affinity that may be set on the calico-node-windows DaemonSet. If omitted, the calico-node-windows DaemonSet will use its default value for affinity.<br />WARNING: Please note that this field will override the default calico-node-windows DaemonSet affinity. |
+| `nodeSelector` _object (keys:string, values:string)_ | (Optional) NodeSelector is the calico-node-windows pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-node-windows DaemonSet nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-node-windows DaemonSet will use its default value for nodeSelector.<br />WARNING: Please note that this field will modify the default calico-node-windows DaemonSet nodeSelector. |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) Tolerations is the calico-node-windows pod's tolerations. If specified, this overrides any tolerations that may be set on the calico-node-windows DaemonSet. If omitted, the calico-node-windows DaemonSet will use its default value for tolerations.<br />WARNING: Please note that this field will override the default calico-node-windows DaemonSet tolerations. |
 
 
 ### CalicoNodeWindowsDaemonSetPodTemplateSpec
@@ -756,9 +756,9 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `containers` _[CalicoWindowsUpgradeDaemonSetContainer](#calicowindowsupgradedaemonsetcontainer) array_ | (Optional) Containers is a list of calico-windows-upgrade containers. If specified, this overrides the specified calico-windows-upgrade DaemonSet containers. If omitted, the calico-windows-upgrade DaemonSet will use its default values for its containers. |
-| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) Affinity is a group of affinity scheduling rules for the calico-windows-upgrade pods. If specified, this overrides any affinity that may be set on the calico-windows-upgrade DaemonSet. If omitted, the calico-windows-upgrade DaemonSet will use its default value for affinity. WARNING: Please note that this field will override the default calico-windows-upgrade DaemonSet affinity. |
-| `nodeSelector` _object (keys:string, values:string)_ | (Optional) NodeSelector is the calico-windows-upgrade pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-windows-upgrade DaemonSet nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-windows-upgrade DaemonSet will use its default value for nodeSelector. WARNING: Please note that this field will modify the default calico-windows-upgrade DaemonSet nodeSelector. |
-| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) Tolerations is the calico-windows-upgrade pod's tolerations. If specified, this overrides any tolerations that may be set on the calico-windows-upgrade DaemonSet. If omitted, the calico-windows-upgrade DaemonSet will use its default value for tolerations. WARNING: Please note that this field will override the default calico-windows-upgrade DaemonSet tolerations. |
+| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) Affinity is a group of affinity scheduling rules for the calico-windows-upgrade pods. If specified, this overrides any affinity that may be set on the calico-windows-upgrade DaemonSet. If omitted, the calico-windows-upgrade DaemonSet will use its default value for affinity.<br />WARNING: Please note that this field will override the default calico-windows-upgrade DaemonSet affinity. |
+| `nodeSelector` _object (keys:string, values:string)_ | (Optional) NodeSelector is the calico-windows-upgrade pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-windows-upgrade DaemonSet nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-windows-upgrade DaemonSet will use its default value for nodeSelector.<br />WARNING: Please note that this field will modify the default calico-windows-upgrade DaemonSet nodeSelector. |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) Tolerations is the calico-windows-upgrade pod's tolerations. If specified, this overrides any tolerations that may be set on the calico-windows-upgrade DaemonSet. If omitted, the calico-windows-upgrade DaemonSet will use its default value for tolerations.<br />WARNING: Please note that this field will override the default calico-windows-upgrade DaemonSet tolerations. |
 
 
 ### CalicoWindowsUpgradeDaemonSetPodTemplateSpec
@@ -806,8 +806,8 @@ _Appears in:_
 | --- | --- |
 | `caCert` _integer array_ | Certificate of the authority that signs the CertificateSigningRequests in PEM format. |
 | `signerName` _string_ | When a CSR is issued to the certificates.k8s.io API, the signerName is added to the request in order to accommodate for clusters with multiple signers. Must be formatted as: `<my-domain>/<my-signername>`. |
-| `keyAlgorithm` _string_ | (Optional) Specify the algorithm used by pods to generate a key pair that is associated with the X.509 certificate request. Default: RSAWithSize2048 |
-| `signatureAlgorithm` _string_ | (Optional) Specify the algorithm used for the signature of the X.509 certificate request. Default: SHA256WithRSA |
+| `keyAlgorithm` _string_ | (Optional) Specify the algorithm used by pods to generate a key pair that is associated with the X.509 certificate request.<br />Default: RSAWithSize2048 |
+| `signatureAlgorithm` _string_ | (Optional) Specify the algorithm used for the signature of the X.509 certificate request.<br />Default: SHA256WithRSA |
 
 
 
@@ -1558,7 +1558,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `type` _[IPAMPluginType](#ipamplugintype)_ | Specifies the IPAM plugin that will be used in the Calico or Calico Enterprise installation. * For CNI Plugin Calico, this field defaults to Calico. * For CNI Plugin GKE, this field defaults to HostLocal. * For CNI Plugin AzureVNET, this field defaults to AzureVNET. * For CNI Plugin AmazonVPC, this field defaults to AmazonVPC. The IPAM plugin is installed and configured only if the CNI plugin is set to Calico, for all other values of the CNI plugin the plugin binaries and CNI config is a dependency that is expected to be installed separately. Default: Calico |
+| `type` _[IPAMPluginType](#ipamplugintype)_ | Specifies the IPAM plugin that will be used in the Calico or Calico Enterprise installation. * For CNI Plugin Calico, this field defaults to Calico. * For CNI Plugin GKE, this field defaults to HostLocal. * For CNI Plugin AzureVNET, this field defaults to AzureVNET. * For CNI Plugin AmazonVPC, this field defaults to AmazonVPC. The IPAM plugin is installed and configured only if the CNI plugin is set to Calico, for all other values of the CNI plugin the plugin binaries and CNI config is a dependency that is expected to be installed separately.<br />Default: Calico |
 
 
 ### IPPool
@@ -1574,11 +1574,11 @@ _Appears in:_
 | --- | --- |
 | `name` _string_ | Name is the name of the IP pool. If omitted, this will be generated. |
 | `cidr` _string_ | CIDR contains the address range for the IP Pool in classless inter-domain routing format. |
-| `encapsulation` _[EncapsulationType](#encapsulationtype)_ | (Optional) Encapsulation specifies the encapsulation type that will be used with the IP Pool. Default: IPIP |
-| `natOutgoing` _[NATOutgoingType](#natoutgoingtype)_ | (Optional) NATOutgoing specifies if NAT will be enabled or disabled for outgoing traffic. Default: Enabled |
-| `nodeSelector` _string_ | (Optional) NodeSelector specifies the node selector that will be set for the IP Pool. Default: 'all()' |
-| `blockSize` _integer_ | (Optional) BlockSize specifies the CIDR prefex length to use when allocating per-node IP blocks from the main IP pool CIDR. Default: 26 (IPv4), 122 (IPv6) |
-| `disableBGPExport` _boolean_ | (Optional) DisableBGPExport specifies whether routes from this IP pool's CIDR are exported over BGP. Default: false |
+| `encapsulation` _[EncapsulationType](#encapsulationtype)_ | (Optional) Encapsulation specifies the encapsulation type that will be used with the IP Pool.<br />Default: IPIP |
+| `natOutgoing` _[NATOutgoingType](#natoutgoingtype)_ | (Optional) NATOutgoing specifies if NAT will be enabled or disabled for outgoing traffic.<br />Default: Enabled |
+| `nodeSelector` _string_ | (Optional) NodeSelector specifies the node selector that will be set for the IP Pool.<br />Default: 'all()' |
+| `blockSize` _integer_ | (Optional) BlockSize specifies the CIDR prefex length to use when allocating per-node IP blocks from the main IP pool CIDR.<br />Default: 26 (IPv4), 122 (IPv6) |
+| `disableBGPExport` _boolean_ | (Optional) DisableBGPExport specifies whether routes from this IP pool's CIDR are exported over BGP.<br />Default: false |
 | `disableNewAllocations` _boolean_ | DisableNewAllocations specifies whether or not new IP allocations are allowed from this pool. This is useful when you want to prevent new pods from receiving IP addresses from this pool, without impacting any existing pods that have already been assigned addresses from this pool. |
 | `allowedUses` _[IPPoolAllowedUse](#ippoolalloweduse) array_ | AllowedUse controls what the IP pool will be used for.  If not specified or empty, defaults to ["Tunnel", "Workload"] for back-compatibility |
 | `assignmentMode` _[AssignmentMode](#assignmentmode)_ | AssignmentMode determines if IP addresses from this pool should be  assigned automatically or on request only |
@@ -1648,6 +1648,8 @@ _Appears in:_
 | `images` _[Image](#image) array_ | Images is the list of images to use digests. All images that the operator will deploy must be specified. |
 
 
+
+
 ### Installation
 
 
@@ -1677,7 +1679,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `variant` _[ProductVariant](#productvariant)_ | (Optional) Variant is the product to install - one of Calico or TigeraSecureEnterprise Default: Calico |
+| `variant` _[ProductVariant](#productvariant)_ | (Optional) Variant is the product to install - one of Calico or TigeraSecureEnterprise<br />Default: Calico |
 | `registry` _string_ | (Optional) Registry is the default Docker registry used for component Docker images. If specified then the given value must end with a slash character (`/`) and all images will be pulled from this registry. If not specified then the default registries will be used. A special case value, UseDefault, is supported to explicitly specify the default registries will be used. Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>` This option allows configuring the `<registry>` portion of the above format. |
 | `imagePath` _string_ | (Optional) ImagePath allows for the path part of an image to be specified. If specified then the specified value will be used as the image path for each image. If not specified or empty, the default for each image will be used. A special case value, UseDefault, is supported to explicitly specify the default image path will be used for each image. Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>` This option allows configuring the `<imagePath>` portion of the above format. |
 | `imagePrefix` _string_ | (Optional) ImagePrefix allows for the prefix part of an image to be specified. If specified then the given value will be used as a prefix on each image. If not specified or empty, no prefix will be used. A special case value, UseDefault, is supported to explicitly specify the default image prefix will be used for each image. Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>` This option allows configuring the `<imagePrefix>` portion of the above format. |
@@ -1692,7 +1694,7 @@ _Appears in:_
 | `nodeMetricsPort` _integer_ | (Optional) NodeMetricsPort specifies which port calico/node serves prometheus metrics on. By default, metrics are not enabled. If specified, this overrides any FelixConfiguration resources which may exist. If omitted, then prometheus metrics may still be configured through FelixConfiguration. |
 | `typhaMetricsPort` _integer_ | (Optional) TyphaMetricsPort specifies which port calico/typha serves prometheus metrics on. By default, metrics are not enabled. |
 | `flexVolumePath` _string_ | (Optional) FlexVolumePath optionally specifies a custom path for FlexVolume. If not specified, FlexVolume will be enabled by default. If set to 'None', FlexVolume will be disabled. The default is based on the kubernetesProvider. |
-| `kubeletVolumePluginPath` _string_ | (Optional) KubeletVolumePluginPath optionally specifies enablement of Calico CSI plugin. If not specified, CSI will be enabled by default. If set to 'None', CSI will be disabled. Default: /var/lib/kubelet |
+| `kubeletVolumePluginPath` _string_ | (Optional) KubeletVolumePluginPath optionally specifies enablement of Calico CSI plugin. If not specified, CSI will be enabled by default. If set to 'None', CSI will be disabled.<br />Default: /var/lib/kubelet |
 | `nodeUpdateStrategy` _[DaemonSetUpdateStrategy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#daemonsetupdatestrategy-v1-apps)_ | (Optional) NodeUpdateStrategy can be used to customize the desired update strategy, such as the MaxUnavailable field. |
 | `componentResources` _[ComponentResource](#componentresource) array_ | (Optional) Deprecated. Please use CalicoNodeDaemonSet, TyphaDeployment, and KubeControllersDeployment. ComponentResources can be used to customize the resource requirements for each component. Node, Typha, and KubeControllers are supported for installations. |
 | `certificateManagement` _[CertificateManagement](#certificatemanagement)_ | (Optional) CertificateManagement configures pods to submit a CertificateSigningRequest to the certificates.k8s.io/v1 API in order to obtain TLS certificates. This feature requires that you bring your own CSR signing and approval process, otherwise pods will be stuck during initialization. |
@@ -1704,7 +1706,7 @@ _Appears in:_
 | `typhaDeployment` _[TyphaDeployment](#typhadeployment)_ | (Optional) TyphaDeployment configures the typha Deployment. If used in conjunction with the deprecated ComponentResources or TyphaAffinity, then these overrides take precedence. |
 | `calicoWindowsUpgradeDaemonSet` _[CalicoWindowsUpgradeDaemonSet](#calicowindowsupgradedaemonset)_ | Deprecated. The CalicoWindowsUpgradeDaemonSet is deprecated and will be removed from the API in the future. CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet. |
 | `calicoNodeWindowsDaemonSet` _[CalicoNodeWindowsDaemonSet](#caliconodewindowsdaemonset)_ | CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet. |
-| `fipsMode` _[FIPSMode](#fipsmode)_ | (Optional) FIPSMode uses images and features only that are using FIPS 140-2 validated cryptographic modules and standards. Only supported for Variant=Calico. Default: Disabled |
+| `fipsMode` _[FIPSMode](#fipsmode)_ | (Optional) FIPSMode uses images and features only that are using FIPS 140-2 validated cryptographic modules and standards. Only supported for Variant=Calico.<br />Default: Disabled |
 | `logging` _[Logging](#logging)_ | (Optional) Logging Configuration for Components |
 | `windowsNodes` _[WindowsNodeSpec](#windowsnodespec)_ | (Optional) Windows Configuration |
 | `serviceCIDRs` _string array_ | (Optional) Kubernetes Service CIDRs. Specifying this is required when using Calico for Windows. |
@@ -1972,7 +1974,7 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `preferredDuringSchedulingIgnoredDuringExecution` _[PreferredSchedulingTerm](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#preferredschedulingterm-v1-core) array_ | (Optional) The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. |
-| `requiredDuringSchedulingIgnoredDuringExecution` _[NodeSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#nodeselector-v1-core)_ | (Optional) WARNING: Please note that if the affinity requirements specified by this field are not met at scheduling time, the pod will NOT be scheduled onto the node. There is no fallback to another affinity rules with this setting. This may cause networking disruption or even catastrophic failure! PreferredDuringSchedulingIgnoredDuringExecution should be used for affinity unless there is a specific well understood reason to use RequiredDuringSchedulingIgnoredDuringExecution and you can guarantee that the RequiredDuringSchedulingIgnoredDuringExecution will always have sufficient nodes to satisfy the requirement. NOTE: RequiredDuringSchedulingIgnoredDuringExecution is set by default for AKS nodes, to avoid scheduling Typhas on virtual-nodes. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node. |
+| `requiredDuringSchedulingIgnoredDuringExecution` _[NodeSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#nodeselector-v1-core)_ | (Optional)<br />WARNING: Please note that if the affinity requirements specified by this field are not met at scheduling time, the pod will NOT be scheduled onto the node. There is no fallback to another affinity rules with this setting. This may cause networking disruption or even catastrophic failure! PreferredDuringSchedulingIgnoredDuringExecution should be used for affinity unless there is a specific well understood reason to use RequiredDuringSchedulingIgnoredDuringExecution and you can guarantee that the RequiredDuringSchedulingIgnoredDuringExecution will always have sufficient nodes to satisfy the requirement. NOTE: RequiredDuringSchedulingIgnoredDuringExecution is set by default for AKS nodes, to avoid scheduling Typhas on virtual-nodes. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node. |
 
 
 ### NonPrivilegedType
@@ -2047,7 +2049,7 @@ _Appears in:_
 _Underlying type:_ _string_
 
 Provider represents a particular provider or flavor of Kubernetes. Valid options
-are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG.
+are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG, Kind.
 
 _Appears in:_
 - [InstallationSpec](#installationspec)
@@ -2287,7 +2289,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name is an enum which identifies the typha Deployment container by name. Supported values are: calico-typha |
+| `name` _string_ | Name is an enum which identifies the typha Deployment container by name.<br />Supported values are: calico-typha |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional) Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named typha Deployment container's resources. If omitted, the typha Deployment will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence. |
 
 
@@ -2302,7 +2304,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name is an enum which identifies the typha Deployment init container by name. Supported values are: typha-certs-key-cert-provisioner |
+| `name` _string_ | Name is an enum which identifies the typha Deployment init container by name.<br />Supported values are: typha-certs-key-cert-provisioner |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional) Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named typha Deployment init container's resources. If omitted, the typha Deployment will use its default value for this init container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence. |
 
 
@@ -2319,11 +2321,11 @@ _Appears in:_
 | --- | --- |
 | `initContainers` _[TyphaDeploymentInitContainer](#typhadeploymentinitcontainer) array_ | (Optional) InitContainers is a list of typha init containers. If specified, this overrides the specified typha Deployment init containers. If omitted, the typha Deployment will use its default values for its init containers. |
 | `containers` _[TyphaDeploymentContainer](#typhadeploymentcontainer) array_ | (Optional) Containers is a list of typha containers. If specified, this overrides the specified typha Deployment containers. If omitted, the typha Deployment will use its default values for its containers. |
-| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) Affinity is a group of affinity scheduling rules for the typha pods. If specified, this overrides any affinity that may be set on the typha Deployment. If omitted, the typha Deployment will use its default value for affinity. If used in conjunction with the deprecated TyphaAffinity, then this value takes precedence. WARNING: Please note that this field will override the default calico-typha Deployment affinity. |
-| `nodeSelector` _object (keys:string, values:string)_ | NodeSelector is the calico-typha pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-typha Deployment nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-typha Deployment will use its default value for nodeSelector. WARNING: Please note that this field will modify the default calico-typha Deployment nodeSelector. |
+| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) Affinity is a group of affinity scheduling rules for the typha pods. If specified, this overrides any affinity that may be set on the typha Deployment. If omitted, the typha Deployment will use its default value for affinity. If used in conjunction with the deprecated TyphaAffinity, then this value takes precedence.<br />WARNING: Please note that this field will override the default calico-typha Deployment affinity. |
+| `nodeSelector` _object (keys:string, values:string)_ | NodeSelector is the calico-typha pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-typha Deployment nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-typha Deployment will use its default value for nodeSelector.<br />WARNING: Please note that this field will modify the default calico-typha Deployment nodeSelector. |
 | `terminationGracePeriodSeconds` _integer_ | (Optional) Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds. |
 | `topologySpreadConstraints` _[TopologySpreadConstraint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#topologyspreadconstraint-v1-core) array_ | (Optional) TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed. |
-| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) Tolerations is the typha pod's tolerations. If specified, this overrides any tolerations that may be set on the typha Deployment. If omitted, the typha Deployment will use its default value for tolerations. WARNING: Please note that this field will override the default calico-typha Deployment tolerations. |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) Tolerations is the typha pod's tolerations. If specified, this overrides any tolerations that may be set on the typha Deployment. If omitted, the typha Deployment will use its default value for tolerations.<br />WARNING: Please note that this field will override the default calico-typha Deployment tolerations. |
 
 
 ### TyphaDeploymentPodTemplateSpec
@@ -2496,7 +2498,7 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `whiskerDeployment` _[WhiskerDeployment](#whiskerdeployment)_ |  |
-| `notifications` _[NotificationMode](#notificationmode)_ | (Optional) Default: Enabled This setting enables calls to an external API to retrieve notification banner text in the Whisker UI. Allowed values are Enabled or Disabled. Defaults to Enabled. |
+| `notifications` _[NotificationMode](#notificationmode)_ | (Optional)<br />Default: Enabled This setting enables calls to an external API to retrieve notification banner text in the Whisker UI. Allowed values are Enabled or Disabled. Defaults to Enabled. |
 
 
 ### WhiskerStatus

--- a/calico_versioned_docs/version-3.31/reference/installation/_api.mdx
+++ b/calico_versioned_docs/version-3.31/reference/installation/_api.mdx
@@ -189,7 +189,7 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `logging` _[APIServerPodLogging](#apiserverpodlogging)_ | (Optional)  |
-| `apiServerDeployment` _[APIServerDeployment](#apiserverdeployment)_ | APIServerDeployment configures the calico-apiserver Deployment. If used in conjunction with ControlPlaneNodeSelector or ControlPlaneTolerations, then these overrides take precedence. |
+| `apiServerDeployment` _[APIServerDeployment](#apiserverdeployment)_ | APIServerDeployment configures the calico-apiserver (or tigera-apiserver in Enterprise) Deployment. If used in conjunction with ControlPlaneNodeSelector or ControlPlaneTolerations, then these overrides take precedence. |
 
 
 ### APIServerStatus
@@ -207,21 +207,6 @@ _Appears in:_
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta) array_ | (Optional) Conditions represents the latest observed set of conditions for the component. A component may be one or more of Ready, Progressing, Degraded or other customer types. |
 
 
-
-
-### AssignmentMode
-
-_Underlying type:_ _string_
-
-
-
-_Appears in:_
-- [IPPool](#ippool)
-
-| Value | Description |
-| --- | --- |
-| `Automatic` |  |
-| `Manual` |  |
 
 
 ### Azure
@@ -245,21 +230,6 @@ _Underlying type:_ _string_
 BGPOption describes the mode of BGP to use.
 
 One of: Enabled, Disabled
-
-_Appears in:_
-- [CalicoNetworkSpec](#caliconetworkspec)
-
-| Value | Description |
-| --- | --- |
-| `Enabled` |  |
-| `Disabled` |  |
-
-
-### BPFNetworkBootstrapType
-
-_Underlying type:_ _string_
-
-BPFNetworkBootstrapType defines how the initial networking configuration is executed.
 
 _Appears in:_
 - [CalicoNetworkSpec](#caliconetworkspec)
@@ -321,8 +291,6 @@ _Appears in:_
 | --- | --- |
 | `type` _[CNIPluginType](#cniplugintype)_ | Specifies the CNI plugin that will be used in the Calico or Calico Enterprise installation. * For KubernetesProvider GKE, this field defaults to GKE. * For KubernetesProvider AKS, this field defaults to AzureVNET. * For KubernetesProvider EKS, this field defaults to AmazonVPC. * If aws-node daemonset exists in kube-system when the Installation resource is created, this field defaults to AmazonVPC. * For all other cases this field defaults to Calico. For the value Calico, the CNI plugin binaries and CNI config will be installed as part of deployment, for all other values the CNI plugin binaries and CNI config is a dependency that is expected to be installed separately.<br />Default: Calico |
 | `ipam` _[IPAMSpec](#ipamspec)_ | (Optional) IPAM specifies the pod IP address management that will be used in the Calico or Calico Enterprise installation. |
-| `binDir` _string_ | (Optional) BinDir is the path to the CNI binaries directory. If you have changed the installation directory for CNI binaries in the container runtime configuration, please ensure that this field points to the same directory as specified in the container runtime settings. Default directory depends on the KubernetesProvider. * For KubernetesProvider GKE, this field defaults to "/home/kubernetes/bin". * For KubernetesProvider OpenShift, this field defaults to "/var/lib/cni/bin". * Otherwise, this field defaults to "/opt/cni/bin". |
-| `confDir` _string_ | (Optional) ConfDir is the path to the CNI config directory. If you have changed the installation directory for CNI configuration in the container runtime configuration, please ensure that this field points to the same directory as specified in the container runtime settings. Default directory depends on the KubernetesProvider. * For KubernetesProvider GKE, this field defaults to "/etc/cni/net.d". * For KubernetesProvider OpenShift, this field defaults to "/var/run/multus/cni/net.d". * Otherwise, this field defaults to "/etc/cni/net.d". |
 
 
 ### CRDManagement
@@ -511,8 +479,6 @@ _Appears in:_
 | --- | --- |
 | `linuxDataplane` _[LinuxDataplaneOption](#linuxdataplaneoption)_ | (Optional) LinuxDataplane is used to select the dataplane used for Linux nodes. In particular, it causes the operator to add required mounts and environment variables for the particular dataplane. If not specified, iptables mode is used.<br />Default: Iptables |
 | `windowsDataplane` _[WindowsDataplaneOption](#windowsdataplaneoption)_ | (Optional) WindowsDataplane is used to select the dataplane used for Windows nodes. In particular, it causes the operator to add required mounts and environment variables for the particular dataplane. If not specified, it is disabled and the operator will not render the Calico Windows nodes daemonset.<br />Default: Disabled |
-| `bpfNetworkBootstrap` _[BPFNetworkBootstrapType](#bpfnetworkbootstraptype)_ | (Optional) BPFNetworkBootstrap manages the initial networking setup required to configure the BPF dataplane. When enabled, the operator tries to bootstraps access to the Kubernetes API Server by using the Kubernetes service and its associated endpoints. This field should be enabled only if linuxDataplane is set to "BPF". If another dataplane is selected, this field must be omitted or explicitly set to Disabled. When disabled and linuxDataplane is BPF, you must manually provide the Kubernetes API Server information via the "kubernetes-service-endpoint" ConfigMap. It is invalid to use both the ConfigMap and have this field set to true at the same time.<br />Default: Disabled |
-| `kubeProxyManagement` _[KubeProxyManagementType](#kubeproxymanagementtype)_ | (Optional) KubeProxyManagement controls whether the operator manages the kube-proxy DaemonSet. When enabled, the operator will manage the DaemonSet by patching it: it disables kube-proxy if the dataplane is BPF, or enables it otherwise.<br />Default: Disabled |
 | `bgp` _[BGPOption](#bgpoption)_ | (Optional) BGP configures whether or not to enable Calico's BGP capabilities. |
 | `ipPools` _[IPPool](#ippool) array_ | (Optional) IPPools contains a list of IP pools to manage. If nil, a single IPv4 IP pool will be created by the operator. If an empty list is provided, the operator will not create any IP pools and will instead wait for IP pools to be created out-of-band. IP pools in this list will be reconciled by the operator and should not be modified out-of-band. |
 | `mtu` _integer_ | (Optional) MTU specifies the maximum transmission unit to use on the pod network. If not specified, Calico will perform MTU auto-detection based on the cluster network. |
@@ -566,7 +532,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name is an enum which identifies the calico-node DaemonSet init container by name.<br />Supported values are: install-cni, hostpath-init, flexvol-driver, ebpf-bootstrap, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner, mount-bpffs (deprecated, replaced by ebpf-bootstrap) |
+| `name` _string_ | Name is an enum which identifies the calico-node DaemonSet init container by name.<br />Supported values are: install-cni, hostpath-init, flexvol-driver, mount-bpffs, node-certs-key-cert-provisioner, calico-node-prometheus-server-tls-key-cert-provisioner |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional) Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named calico-node DaemonSet init container's resources. If omitted, the calico-node DaemonSet will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence. |
 
 
@@ -586,8 +552,6 @@ _Appears in:_
 | `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) Affinity is a group of affinity scheduling rules for the calico-node pods. If specified, this overrides any affinity that may be set on the calico-node DaemonSet. If omitted, the calico-node DaemonSet will use its default value for affinity.<br />WARNING: Please note that this field will override the default calico-node DaemonSet affinity. |
 | `nodeSelector` _object (keys:string, values:string)_ | (Optional) NodeSelector is the calico-node pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-node DaemonSet nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-node DaemonSet will use its default value for nodeSelector.<br />WARNING: Please note that this field will modify the default calico-node DaemonSet nodeSelector. |
 | `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) Tolerations is the calico-node pod's tolerations. If specified, this overrides any tolerations that may be set on the calico-node DaemonSet. If omitted, the calico-node DaemonSet will use its default value for tolerations.<br />WARNING: Please note that this field will override the default calico-node DaemonSet tolerations. |
-| `dnsPolicy` _[DNSPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#dnspolicy-v1-core)_ | (Optional) DNSPolicy is the DNS policy for the calico-node pods. |
-| `dnsConfig` _[PodDNSConfig](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#poddnsconfig-v1-core)_ | (Optional) DNSConfig allows customization of the DNS configuration for the calico-node pods. |
 
 
 ### CalicoNodeDaemonSetPodTemplateSpec
@@ -661,7 +625,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name is an enum which identifies the calico-node-windows DaemonSet init container by name.<br />Supported values are: install-cni;hostpath-init, flexvol-driver, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner |
+| `name` _string_ | Name is an enum which identifies the calico-node-windows DaemonSet init container by name.<br />Supported values are: install-cni;hostpath-init, flexvol-driver, mount-bpffs, node-certs-key-cert-provisioner, calico-node-windows-prometheus-server-tls-key-cert-provisioner |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional) Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named calico-node-windows DaemonSet init container's resources. If omitted, the calico-node-windows DaemonSet will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence. |
 
 
@@ -952,11 +916,10 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `envoyGatewayConfigRef` _[NamespacedName](#namespacedname)_ | (Optional) Reference to a custom EnvoyGateway YAML to use as the base EnvoyGateway configuration for the gateway controller.  When specified, must identify a ConfigMap resource with an "envoy-gateway.yaml" key whose value is the desired EnvoyGateway YAML (i.e. following the same pattern as the default `envoy-gateway-config` ConfigMap). When not specified, the Tigera operator uses the `envoy-gateway-config` from the Envoy Gateway helm chart as its base. Starting from that base, the Tigera operator copies and modifies the EnvoyGateway resource as follows: 1. If not already specified, it sets the ControllerName to "gateway.envoyproxy.io/gatewayclass-controller". 2. It configures the `tigera/envoy-gateway` and `tigera/envoy-ratelimit` images that will be used (according to the current Calico version, private registry and image set settings) and any pull secrets that are needed to pull those images. 3. It enables use of the Backend API. The resulting EnvoyGateway is provisioned as the `envoy-gateway-config` ConfigMap (which the gateway controller then uses as its config). |
-| `gatewayClasses` _[GatewayClassSpec](#gatewayclassspec) array_ | (Optional) Configures the GatewayClasses that will be available; please see GatewayClassSpec for more detail.  If GatewayClasses is nil, the Tigera operator defaults to provisioning a single GatewayClass named "tigera-gateway-class", without any of the detailed customizations that are allowed within GatewayClassSpec. |
-| `gatewayControllerDeployment` _[GatewayControllerDeployment](#gatewaycontrollerdeployment)_ | (Optional) Allows customization of the gateway controller deployment. |
-| `gatewayCertgenJob` _[GatewayCertgenJob](#gatewaycertgenjob)_ | (Optional) Allows customization of the gateway certgen job. |
-| `crdManagement` _[CRDManagement](#crdmanagement)_ | (Optional) Configures how to manage and update Gateway API CRDs.  The default behaviour - which is used when this field is not set, or is set to "PreferExisting" - is that the Tigera operator will create the Gateway API CRDs if they do not already exist, but will not overwrite any existing Gateway API CRDs.  This setting may be preferable if the customer is using other implementations of the Gateway API concurrently with the Gateway API support in Calico Enterprise.  It is then the customer's responsibility to ensure that CRDs are installed that meet the needs of all the Gateway API implementations in their cluster. Alternatively, if this field is set to "Reconcile", the Tigera operator will keep the cluster's Gateway API CRDs aligned with those that it would install on a cluster that does not yet have any version of those CRDs. |
+| `gatewayControllerDeployment` _[GatewayControllerDeployment](#gatewaycontrollerdeployment)_ | Allow optional customization of the gateway controller deployment. |
+| `gatewayCertgenJob` _[GatewayCertgenJob](#gatewaycertgenjob)_ | Allow optional customization of the gateway certgen job. |
+| `gatewayDeployment` _[GatewayDeployment](#gatewaydeployment)_ | Allow optional customization of gateway deployments. |
+| `crdManagement` _[CRDManagement](#crdmanagement)_ | Configure how to manage and update Gateway API CRDs.  The default behaviour - which is used when this field is not set, or is set to "PreferExisting" - is that the Tigera operator will create the Gateway API CRDs if they do not already exist, but will not overwrite any existing Gateway API CRDs.  This setting may be preferable if the customer is using other implementations of the Gateway API concurrently with the Gateway API support in Calico Enterprise.  It is then the customer's responsibility to ensure that CRDs are installed that meet the needs of all the Gateway API implementations in their cluster. Alternatively, if this field is set to "Reconcile", the Tigera operator will keep the cluster's Gateway API CRDs aligned with those that it would install on a cluster that does not yet have any version of those CRDs. |
 
 
 ### GatewayCertgenJob
@@ -964,6 +927,11 @@ _Appears in:_
 
 
 GatewayCertgenJob allows customization of the gateway certgen job.
+
+If GatewayCertgenJob.Metadata is non-nil, non-clashing labels and annotations from that metadata
+are added into the job's top-level metadata.
+
+For customization of the job spec see GatewayCertgenJobSpec.
 
 _Appears in:_
 - [GatewayAPISpec](#gatewayapispec)
@@ -981,13 +949,16 @@ _Appears in:_
 GatewayCertgenJobContainer allows customization of the gateway certgen job's resource
 requirements.
 
+If GatewayCertgenJob.Spec.Template.Spec.Containers["envoy-gateway-certgen"].Resources is non-nil,
+it overrides the ResourceRequirements of the job's "envoy-gateway-certgen" container.
+
 _Appears in:_
 - [GatewayCertgenJobPodSpec](#gatewaycertgenjobpodspec)
 
 | Field | Description |
 | --- | --- |
 | `name` _string_ |  |
-| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional) If non-nil, Resources sets the ResourceRequirements of the job's "envoy-gateway-certgen" container. |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional)  |
 
 
 ### GatewayCertgenJobPodSpec
@@ -996,15 +967,26 @@ _Appears in:_
 
 GatewayCertgenJobPodSpec allows customization of the gateway certgen job's pod spec.
 
+If GatewayCertgenJob.Spec.Template.Spec.Affinity is non-nil, it sets the affinity field of the
+job's pod template.
+
+If GatewayCertgenJob.Spec.Template.Spec.NodeSelector is non-nil, it sets a node selector for
+where job pods may be scheduled.
+
+If GatewayCertgenJob.Spec.Template.Spec.Tolerations is non-nil, it sets the tolerations field of
+the job's pod template.
+
+For customization of job container resources see GatewayCertgenJobContainer.
+
 _Appears in:_
 - [GatewayCertgenJobPodTemplate](#gatewaycertgenjobpodtemplate)
 
 | Field | Description |
 | --- | --- |
-| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) If non-nil, Affinity sets the affinity field of the job's pod template. |
+| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional)  |
 | `containers` _[GatewayCertgenJobContainer](#gatewaycertgenjobcontainer) array_ | (Optional)  |
-| `nodeSelector` _object (keys:string, values:string)_ | (Optional) If non-nil, NodeSelector sets the node selector for where job pods may be scheduled. |
-| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) If non-nil, Tolerations sets the tolerations field of the job's pod template. |
+| `nodeSelector` _object (keys:string, values:string)_ | (Optional)  |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional)  |
 
 
 ### GatewayCertgenJobPodTemplate
@@ -1012,6 +994,11 @@ _Appears in:_
 
 
 GatewayCertgenJobPodTemplate allows customization of the gateway certgen job's pod template.
+
+If GatewayCertgenJob.Spec.Template.Metadata is non-nil, non-clashing labels and
+annotations from that metadata are added into the job's pod template.
+
+For customization of the pod template spec see GatewayCertgenJobPodSpec.
 
 _Appears in:_
 - [GatewayCertgenJobSpec](#gatewaycertgenjobspec)
@@ -1028,6 +1015,8 @@ _Appears in:_
 
 GatewayCertgenJobSpec allows customization of the gateway certgen job spec.
 
+For customization of the job template see GatewayCertgenJobPodTemplate.
+
 _Appears in:_
 - [GatewayCertgenJob](#gatewaycertgenjob)
 
@@ -1036,30 +1025,16 @@ _Appears in:_
 | `template` _[GatewayCertgenJobPodTemplate](#gatewaycertgenjobpodtemplate)_ | (Optional)  |
 
 
-### GatewayClassSpec
-
-
-
-
-
-_Appears in:_
-- [GatewayAPISpec](#gatewayapispec)
-
-| Field | Description |
-| --- | --- |
-| `name` _string_ | The name of this GatewayClass. |
-| `envoyProxyRef` _[NamespacedName](#namespacedname)_ | (Optional) Reference to a custom EnvoyProxy resource to use as the base EnvoyProxy configuration for this GatewayClass.  When specified, must identify an EnvoyProxy resource. When not specified, the Tigera operator uses an empty EnvoyProxy resource as its base. Starting from that base, the Tigera operator copies and modifies the EnvoyProxy resource as follows, in the order described: 1. It configures the `tigera/envoy-proxy` image that will be used (according to the current Calico version, private registry and image set settings) and any pull secrets that are needed to pull that image. 2. It applies customizations as specified by the following `GatewayKind`, `GatewayDeployment`, `GatewayDaemonSet` and `GatewayService` fields. The resulting EnvoyProxy is provisioned in the `tigera-gateway` namespace, together with a GatewayClass that references it. If a custom EnvoyProxy resource is specified and uses `EnvoyDaemonSet` instead of the default `EnvoyDeployment`, deployment-related customizations will be applied within `EnvoyDaemonSet` instead of within `EnvoyDeployment`. |
-| `gatewayKind` _[GatewayKind](#gatewaykind)_ | (Optional) Specifies whether Gateways in this class are deployed as Deployments (default) or as DaemonSets.  It is an error for GatewayKind to specify a choice that is incompatible with the custom EnvoyProxy, when EnvoyProxyRef is also specified. |
-| `gatewayDeployment` _[GatewayDeployment](#gatewaydeployment)_ | (Optional) Allows customization of Gateways when deployed as Kubernetes Deployments, for Gateways in this GatewayClass. |
-| `gatewayDaemonSet` _[GatewayDaemonSet](#gatewaydaemonset)_ | (Optional) Allows customization of Gateways when deployed as Kubernetes DaemonSets, for Gateways in this GatewayClass. |
-| `gatewayService` _[GatewayService](#gatewayservice)_ | (Optional) Allows customization of gateway services, for Gateways in this GatewayClass. |
-
-
 ### GatewayControllerDeployment
 
 
 
 GatewayControllerDeployment allows customization of the gateway controller deployment.
+
+If GatewayControllerDeployment.Metadata is non-nil, non-clashing labels and annotations from that
+metadata are added into the deployment's top-level metadata.
+
+For customization of the deployment spec see GatewayControllerDeploymentSpec.
 
 _Appears in:_
 - [GatewayAPISpec](#gatewayapispec)
@@ -1077,13 +1052,16 @@ _Appears in:_
 GatewayControllerDeploymentContainer allows customization of the gateway controller's resource
 requirements.
 
+If GatewayControllerDeployment.Spec.Template.Spec.Containers["envoy-gateway"].Resources is
+non-nil, it overrides the ResourceRequirements of the controller's "envoy-gateway" container.
+
 _Appears in:_
 - [GatewayControllerDeploymentPodSpec](#gatewaycontrollerdeploymentpodspec)
 
 | Field | Description |
 | --- | --- |
 | `name` _string_ |  |
-| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional) If non-nil, Resources sets the ResourceRequirements of the controller's "envoy-gateway" container. |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional)  |
 
 
 ### GatewayControllerDeploymentPodSpec
@@ -1093,16 +1071,26 @@ _Appears in:_
 GatewayControllerDeploymentPodSpec allows customization of the gateway controller deployment pod
 spec.
 
+If GatewayControllerDeployment.Spec.Template.Spec.Affinity is non-nil, it sets the affinity field
+of the deployment's pod template.
+
+If GatewayControllerDeployment.Spec.Template.Spec.NodeSelector is non-nil, it sets a node
+selector for where controller pods may be scheduled.
+
+If GatewayControllerDeployment.Spec.Template.Spec.Tolerations is non-nil, it sets the tolerations
+field of the deployment's pod template.
+
+For customization of container resources see GatewayControllerDeploymentContainer.
+
 _Appears in:_
 - [GatewayControllerDeploymentPodTemplate](#gatewaycontrollerdeploymentpodtemplate)
 
 | Field | Description |
 | --- | --- |
-| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) If non-nil, Affinity sets the affinity field of the deployment's pod template. |
+| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional)  |
 | `containers` _[GatewayControllerDeploymentContainer](#gatewaycontrollerdeploymentcontainer) array_ | (Optional)  |
-| `nodeSelector` _object (keys:string, values:string)_ | (Optional) If non-nil, NodeSelector sets the node selector for where deployment pods may be scheduled. |
-| `topologySpreadConstraints` _[TopologySpreadConstraint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#topologyspreadconstraint-v1-core) array_ | (Optional) If non-nil, TopologySpreadConstraints sets the topology spread constraints of the deployment's pod template.  TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints.  All topologySpreadConstraints are ANDed. |
-| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) If non-nil, Tolerations sets the tolerations field of the deployment's pod template. |
+| `nodeSelector` _object (keys:string, values:string)_ | (Optional)  |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional)  |
 
 
 ### GatewayControllerDeploymentPodTemplate
@@ -1111,6 +1099,11 @@ _Appears in:_
 
 GatewayControllerDeploymentPodTemplate allows customization of the gateway controller deployment
 pod template.
+
+If GatewayControllerDeployment.Spec.Template.Metadata is non-nil, non-clashing labels and
+annotations from that metadata are added into the deployment's pod template.
+
+For customization of the pod template spec see GatewayControllerDeploymentPodSpec.
 
 _Appears in:_
 - [GatewayControllerDeploymentSpec](#gatewaycontrollerdeploymentspec)
@@ -1127,101 +1120,30 @@ _Appears in:_
 
 GatewayControllerDeploymentSpec allows customization of the gateway controller deployment spec.
 
+If GatewayControllerDeployment.Spec.MinReadySeconds is non-nil, it sets the minReadySeconds field
+for the deployment.
+
+For customization of the pod template see GatewayControllerDeploymentPodTemplate.
+
 _Appears in:_
 - [GatewayControllerDeployment](#gatewaycontrollerdeployment)
 
 | Field | Description |
 | --- | --- |
-| `replicas` _integer_ | (Optional) If non-nil, Replicas sets the number of replicas for the deployment. |
-| `minReadySeconds` _integer_ | (Optional) If non-nil, MinReadySeconds sets the minReadySeconds field for the deployment. |
+| `minReadySeconds` _integer_ | (Optional)  |
 | `template` _[GatewayControllerDeploymentPodTemplate](#gatewaycontrollerdeploymentpodtemplate)_ | (Optional)  |
-
-
-### GatewayDaemonSet
-
-
-
-GatewayDeployment allows customization of Gateways when deployed as Kubernetes DaemonSets.
-
-_Appears in:_
-- [GatewayClassSpec](#gatewayclassspec)
-
-| Field | Description |
-| --- | --- |
-| `spec` _[GatewayDaemonSetSpec](#gatewaydaemonsetspec)_ | (Optional)  |
-
-
-### GatewayDaemonSetContainer
-
-
-
-GatewayDaemonSetContainer allows customization of the resource requirements of gateway
-daemonsets.
-
-_Appears in:_
-- [GatewayDaemonSetPodSpec](#gatewaydaemonsetpodspec)
-
-| Field | Description |
-| --- | --- |
-| `name` _string_ |  |
-| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional) If non-nil, Resources sets the ResourceRequirements of the daemonset's "envoy" container. |
-
-
-### GatewayDaemonSetPodSpec
-
-
-
-GatewayDaemonSetPodSpec allows customization of the pod spec of gateway daemonsets.
-
-_Appears in:_
-- [GatewayDaemonSetPodTemplate](#gatewaydaemonsetpodtemplate)
-
-| Field | Description |
-| --- | --- |
-| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) If non-nil, Affinity sets the affinity field of the daemonset's pod template. |
-| `containers` _[GatewayDaemonSetContainer](#gatewaydaemonsetcontainer) array_ | (Optional)  |
-| `nodeSelector` _object (keys:string, values:string)_ | (Optional) If non-nil, NodeSelector sets the node selector for where daemonset pods may be scheduled. |
-| `topologySpreadConstraints` _[TopologySpreadConstraint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#topologyspreadconstraint-v1-core) array_ | (Optional) If non-nil, TopologySpreadConstraints sets the topology spread constraints of the daemonset's pod template.  TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints.  All topologySpreadConstraints are ANDed. |
-| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) If non-nil, Tolerations sets the tolerations field of the daemonset's pod template. |
-
-
-### GatewayDaemonSetPodTemplate
-
-
-
-GatewayDeploymentPodTemplate allows customization of the pod template of gateway daemonsets.
-
-_Appears in:_
-- [GatewayDaemonSetSpec](#gatewaydaemonsetspec)
-
-| Field | Description |
-| --- | --- |
-| `metadata` _[Metadata](#metadata)_ | (Optional) Refer to Kubernetes API documentation for fields of `metadata`. |
-| `spec` _[GatewayDaemonSetPodSpec](#gatewaydaemonsetpodspec)_ | (Optional)  |
-
-
-### GatewayDaemonSetSpec
-
-
-
-GatewayDeploymentSpec allows customization of the spec of gateway daemonsets.
-
-_Appears in:_
-- [GatewayDaemonSet](#gatewaydaemonset)
-
-| Field | Description |
-| --- | --- |
-| `template` _[GatewayDaemonSetPodTemplate](#gatewaydaemonsetpodtemplate)_ | (Optional)  |
 
 
 ### GatewayDeployment
 
 
 
-GatewayDeployment allows customization of Gateways when deployed as Kubernetes Deployments.
+GatewayDeployment allows customization of gateway deployments.
+
+For detail see GatewayDeploymentSpec.
 
 _Appears in:_
-- [GatewayClassSpec](#gatewayclassspec)
+- [GatewayAPISpec](#gatewayapispec)
 
 | Field | Description |
 | --- | --- |
@@ -1235,13 +1157,16 @@ _Appears in:_
 GatewayDeploymentContainer allows customization of the resource requirements of gateway
 deployments.
 
+If GatewayDeployment.Spec.Template.Spec.Containers["envoy"].Resources is non-nil, it overrides
+the ResourceRequirements of the "envoy" container in each gateway deployment.
+
 _Appears in:_
 - [GatewayDeploymentPodSpec](#gatewaydeploymentpodspec)
 
 | Field | Description |
 | --- | --- |
 | `name` _string_ |  |
-| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional) If non-nil, Resources sets the ResourceRequirements of the deployment's "envoy" container. |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional)  |
 
 
 ### GatewayDeploymentPodSpec
@@ -1250,16 +1175,30 @@ _Appears in:_
 
 GatewayDeploymentPodSpec allows customization of the pod spec of gateway deployments.
 
+If GatewayDeployment.Spec.Template.Spec.Affinity is non-nil, it sets the affinity field of each
+deployment's pod template.
+
+If GatewayDeployment.Spec.Template.Spec.NodeSelector is non-nil, it sets a node selector for
+where gateway pods may be scheduled.
+
+If GatewayDeployment.Spec.Template.Spec.Tolerations is non-nil, it sets the tolerations field of
+each deployment's pod template.
+
+If GatewayDeployment.Spec.Template.Spec.TopologySpreadConstraints is non-nil, it sets the
+topology spread constraints of each deployment's pod template.
+
+For customization of container resources see GatewayControllerDeploymentContainer.
+
 _Appears in:_
 - [GatewayDeploymentPodTemplate](#gatewaydeploymentpodtemplate)
 
 | Field | Description |
 | --- | --- |
-| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional) If non-nil, Affinity sets the affinity field of the deployment's pod template. |
+| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | (Optional)  |
 | `containers` _[GatewayDeploymentContainer](#gatewaydeploymentcontainer) array_ | (Optional)  |
-| `nodeSelector` _object (keys:string, values:string)_ | (Optional) If non-nil, NodeSelector sets the node selector for where deployment pods may be scheduled. |
-| `topologySpreadConstraints` _[TopologySpreadConstraint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#topologyspreadconstraint-v1-core) array_ | (Optional) If non-nil, TopologySpreadConstraints sets the topology spread constraints of the deployment's pod template.  TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints.  All topologySpreadConstraints are ANDed. |
-| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional) If non-nil, Tolerations sets the tolerations field of the deployment's pod template. |
+| `nodeSelector` _object (keys:string, values:string)_ | (Optional)  |
+| `topologySpreadConstraints` _[TopologySpreadConstraint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#topologyspreadconstraint-v1-core) array_ | (Optional) TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed. |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | (Optional)  |
 
 
 ### GatewayDeploymentPodTemplate
@@ -1267,6 +1206,11 @@ _Appears in:_
 
 
 GatewayDeploymentPodTemplate allows customization of the pod template of gateway deployments.
+
+If GatewayDeployment.Spec.Template.Metadata is non-nil, non-clashing labels and annotations from
+that metadata are added into each deployment's pod template.
+
+For customization of the pod template spec see GatewayDeploymentPodSpec.
 
 _Appears in:_
 - [GatewayDeploymentSpec](#gatewaydeploymentspec)
@@ -1283,12 +1227,15 @@ _Appears in:_
 
 GatewayDeploymentSpec allows customization of the spec of gateway deployments.
 
+For customization of the pod template see GatewayDeploymentPodTemplate.
+
+For customization of the deployment strategy see GatewayDeploymentStrategy.
+
 _Appears in:_
 - [GatewayDeployment](#gatewaydeployment)
 
 | Field | Description |
 | --- | --- |
-| `replicas` _integer_ | (Optional) If non-nil, Replicas sets the number of replicas for the deployment. |
 | `template` _[GatewayDeploymentPodTemplate](#gatewaydeploymentpodtemplate)_ | (Optional)  |
 | `strategy` _[GatewayDeploymentStrategy](#gatewaydeploymentstrategy)_ | (Optional) The deployment strategy to use to replace existing pods with new ones. |
 
@@ -1311,62 +1258,6 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `rollingUpdate` _[RollingUpdateDeployment](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#rollingupdatedeployment-v1-apps)_ | (Optional)  |
-
-
-### GatewayKind
-
-_Underlying type:_ _string_
-
-
-
-_Validation:_
-- Enum: [Deployment DaemonSet]
-
-
-_Appears in:_
-- [GatewayClassSpec](#gatewayclassspec)
-
-| Value | Description |
-| --- | --- |
-| `Deployment` |  |
-| `DaemonSet` |  |
-
-
-### GatewayService
-
-
-
-GatewayService allows customization of the Services that front Gateways.
-
-_Appears in:_
-- [GatewayClassSpec](#gatewayclassspec)
-
-| Field | Description |
-| --- | --- |
-| `metadata` _[Metadata](#metadata)_ | (Optional) Refer to Kubernetes API documentation for fields of `metadata`. |
-| `spec` _[GatewayServiceSpec](#gatewayservicespec)_ | (Optional)  |
-
-
-### GatewayServiceSpec
-
-
-
-GatewayServiceSpec allows customization of the services that front gateway deployments.
-
-The LoadBalancer fields allow customization of the corresponding fields in the Kubernetes
-ServiceSpec.  These can be used for some cloud-independent control of the external load balancer
-that is provisioned for each Gateway.  For finer-grained cloud-specific control please use
-the Metadata.Annotations field in GatewayService.
-
-_Appears in:_
-- [GatewayService](#gatewayservice)
-
-| Field | Description |
-| --- | --- |
-| `loadBalancerClass` _string_ | (Optional)  |
-| `allocateLoadBalancerNodePorts` _boolean_ | (Optional)  |
-| `loadBalancerSourceRanges` _string array_ | (Optional)  |
-| `loadBalancerIP` _string_ | (Optional)  |
 
 
 ### Goldmane
@@ -1528,8 +1419,6 @@ _Appears in:_
 
 
 
-
-
 ### IPAMPluginType
 
 _Underlying type:_ _string_
@@ -1648,8 +1537,6 @@ _Appears in:_
 | `images` _[Image](#image) array_ | Images is the list of images to use digests. All images that the operator will deploy must be specified. |
 
 
-
-
 ### Installation
 
 
@@ -1697,13 +1584,12 @@ _Appears in:_
 | `kubeletVolumePluginPath` _string_ | (Optional) KubeletVolumePluginPath optionally specifies enablement of Calico CSI plugin. If not specified, CSI will be enabled by default. If set to 'None', CSI will be disabled.<br />Default: /var/lib/kubelet |
 | `nodeUpdateStrategy` _[DaemonSetUpdateStrategy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#daemonsetupdatestrategy-v1-apps)_ | (Optional) NodeUpdateStrategy can be used to customize the desired update strategy, such as the MaxUnavailable field. |
 | `componentResources` _[ComponentResource](#componentresource) array_ | (Optional) Deprecated. Please use CalicoNodeDaemonSet, TyphaDeployment, and KubeControllersDeployment. ComponentResources can be used to customize the resource requirements for each component. Node, Typha, and KubeControllers are supported for installations. |
-| `certificateManagement` _[CertificateManagement](#certificatemanagement)_ | (Optional) CertificateManagement configures pods to submit a CertificateSigningRequest to the certificates.k8s.io/v1 API in order to obtain TLS certificates. This feature requires that you bring your own CSR signing and approval process, otherwise pods will be stuck during initialization. |
-| `tlsCipherSuites` _[TLSCipherSuites](#tlsciphersuites)_ | (Optional) TLSCipherSuites defines the cipher suite list that the TLS protocol should use during secure communication. |
+| `certificateManagement` _[CertificateManagement](#certificatemanagement)_ | (Optional) CertificateManagement configures pods to submit a CertificateSigningRequest to the certificates.k8s.io/v1beta1 API in order to obtain TLS certificates. This feature requires that you bring your own CSR signing and approval process, otherwise pods will be stuck during initialization. |
 | `nonPrivileged` _[NonPrivilegedType](#nonprivilegedtype)_ | (Optional) NonPrivileged configures Calico to be run in non-privileged containers as non-root users where possible. |
-| `calicoNodeDaemonSet` _[CalicoNodeDaemonSet](#caliconodedaemonset)_ | (Optional) CalicoNodeDaemonSet configures the calico-node DaemonSet. If used in conjunction with the deprecated ComponentResources, then these overrides take precedence. |
-| `csiNodeDriverDaemonSet` _[CSINodeDriverDaemonSet](#csinodedriverdaemonset)_ | (Optional) CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet. |
-| `calicoKubeControllersDeployment` _[CalicoKubeControllersDeployment](#calicokubecontrollersdeployment)_ | (Optional) CalicoKubeControllersDeployment configures the calico-kube-controllers Deployment. If used in conjunction with the deprecated ComponentResources, then these overrides take precedence. |
-| `typhaDeployment` _[TyphaDeployment](#typhadeployment)_ | (Optional) TyphaDeployment configures the typha Deployment. If used in conjunction with the deprecated ComponentResources or TyphaAffinity, then these overrides take precedence. |
+| `calicoNodeDaemonSet` _[CalicoNodeDaemonSet](#caliconodedaemonset)_ | CalicoNodeDaemonSet configures the calico-node DaemonSet. If used in conjunction with the deprecated ComponentResources, then these overrides take precedence. |
+| `csiNodeDriverDaemonSet` _[CSINodeDriverDaemonSet](#csinodedriverdaemonset)_ | CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet. |
+| `calicoKubeControllersDeployment` _[CalicoKubeControllersDeployment](#calicokubecontrollersdeployment)_ | CalicoKubeControllersDeployment configures the calico-kube-controllers Deployment. If used in conjunction with the deprecated ComponentResources, then these overrides take precedence. |
+| `typhaDeployment` _[TyphaDeployment](#typhadeployment)_ | TyphaDeployment configures the typha Deployment. If used in conjunction with the deprecated ComponentResources or TyphaAffinity, then these overrides take precedence. |
 | `calicoWindowsUpgradeDaemonSet` _[CalicoWindowsUpgradeDaemonSet](#calicowindowsupgradedaemonset)_ | Deprecated. The CalicoWindowsUpgradeDaemonSet is deprecated and will be removed from the API in the future. CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet. |
 | `calicoNodeWindowsDaemonSet` _[CalicoNodeWindowsDaemonSet](#caliconodewindowsdaemonset)_ | CalicoNodeWindowsDaemonSet configures the calico-node-windows DaemonSet. |
 | `fipsMode` _[FIPSMode](#fipsmode)_ | (Optional) FIPSMode uses images and features only that are using FIPS 140-2 validated cryptographic modules and standards. Only supported for Variant=Calico.<br />Default: Disabled |
@@ -1731,21 +1617,6 @@ _Appears in:_
 | `computed` _[InstallationSpec](#installationspec)_ | (Optional) Computed is the final installation including overlaid resources. |
 | `calicoVersion` _string_ | CalicoVersion shows the current running version of calico. CalicoVersion along with Variant is needed to know the exact version deployed. |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta) array_ | (Optional) Conditions represents the latest observed set of conditions for the component. A component may be one or more of Ready, Progressing, Degraded or other customer types. |
-
-
-### KubeProxyManagementType
-
-_Underlying type:_ _string_
-
-KubeProxyManagementType specifies whether kube-proxy management is enabled.
-
-_Appears in:_
-- [CalicoNetworkSpec](#caliconetworkspec)
-
-| Value | Description |
-| --- | --- |
-| `Enabled` |  |
-| `Disabled` |  |
 
 
 ### KubernetesAutodetectionMethod
@@ -1869,9 +1740,7 @@ _Appears in:_
 - [GatewayCertgenJobPodTemplate](#gatewaycertgenjobpodtemplate)
 - [GatewayControllerDeployment](#gatewaycontrollerdeployment)
 - [GatewayControllerDeploymentPodTemplate](#gatewaycontrollerdeploymentpodtemplate)
-- [GatewayDaemonSetPodTemplate](#gatewaydaemonsetpodtemplate)
 - [GatewayDeploymentPodTemplate](#gatewaydeploymentpodtemplate)
-- [GatewayService](#gatewayservice)
 - [GoldmaneDeployment](#goldmanedeployment)
 - [GoldmaneDeploymentPodTemplateSpec](#goldmanedeploymentpodtemplatespec)
 - [TyphaDeployment](#typhadeployment)
@@ -1921,22 +1790,6 @@ _Appears in:_
 | --- | --- |
 | `Enabled` |  |
 | `Disabled` |  |
-
-
-### NamespacedName
-
-
-
-NamespacedName references an object of a known type in any namespace.
-
-_Appears in:_
-- [GatewayAPISpec](#gatewayapispec)
-- [GatewayClassSpec](#gatewayclassspec)
-
-| Field | Description |
-| --- | --- |
-| `namespace` _string_ |  |
-| `name` _string_ |  |
 
 
 
@@ -2049,7 +1902,7 @@ _Appears in:_
 _Underlying type:_ _string_
 
 Provider represents a particular provider or flavor of Kubernetes. Valid options
-are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG, Kind.
+are: EKS, GKE, AKS, RKE2, OpenShift, DockerEnterprise, TKG.
 
 _Appears in:_
 - [InstallationSpec](#installationspec)
@@ -2124,65 +1977,6 @@ _Appears in:_
 | `value` _string_ |  |
 
 
-
-
-### TLSCipher
-
-_Underlying type:_ _string_
-
-
-
-_Validation:_
-- Enum: [TLS_AES_256_GCM_SHA384 TLS_CHACHA20_POLY1305_SHA256 TLS_AES_128_GCM_SHA256 TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 TLS_RSA_WITH_AES_256_GCM_SHA384 TLS_RSA_WITH_AES_128_GCM_SHA256 TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA]
-
-
-_Appears in:_
-- [TLSCipherSuite](#tlsciphersuite)
-
-| Value | Description |
-| --- | --- |
-| `TLS_AES_256_GCM_SHA384` | TLS 1.3  |
-| `TLS_CHACHA20_POLY1305_SHA256` |  |
-| `TLS_AES_128_GCM_SHA256` |  |
-| `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384` | TLS 1.2  |
-| `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384` |  |
-| `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256` |  |
-| `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256` |  |
-| `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256` |  |
-| `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256` |  |
-| `TLS_RSA_WITH_AES_256_GCM_SHA384` |  |
-| `TLS_RSA_WITH_AES_128_GCM_SHA256` |  |
-| `TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA` |  |
-| `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA` |  |
-| `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA` |  |
-
-
-### TLSCipherSuite
-
-
-
-
-
-_Appears in:_
-- [TLSCipherSuites](#tlsciphersuites)
-
-| Field | Description |
-| --- | --- |
-| `name` _[TLSCipher](#tlscipher)_ | (Optional) This should be a valid TLS cipher suite name. |
-
-
-### TLSCipherSuites
-
-_Underlying type:_ _[TLSCipherSuite](#tlsciphersuite)_
-
-
-
-_Appears in:_
-- [InstallationSpec](#installationspec)
-
-| Field | Description |
-| --- | --- |
-| `name` _[TLSCipher](#tlscipher)_ | (Optional) This should be a valid TLS cipher suite name. |
 
 
 


### PR DESCRIPTION
A few minor changes:
1. Move the usage of `sed -i` to a conditional so that it works on macos and Linux both
2. Update the non-cloud `autogen_*` targets to use the new API generation makefile targets

While testing I saw that some of the API docs did need updating, so we update those as well.