### PR TITLE
Fix broken anchors

### DIFF
--- a/calico-cloud/networking/configuring/dual-tor.mdx
+++ b/calico-cloud/networking/configuring/dual-tor.mdx
@@ -635,7 +635,7 @@ The only connections using interface-specific addresses should be BGP.
 If you plan to use [Egress Gateways](../egress/egress-gateway-on-prem.mdx) in your cluster, you must also adjust the $[nodecontainer] IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-$[prodname] [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+$[prodname] [Installation resource](../../reference/installation/api.mdx#nodeaddressautodetection).
 
 :::
 

--- a/calico-cloud/networking/configuring/multiple-networks.mdx
+++ b/calico-cloud/networking/configuring/multiple-networks.mdx
@@ -77,7 +77,7 @@ Although the following $[prodname] features are supported for your default $[pro
 
 ### Configure cluster for multiple networks
 
-In the [Installation custom resource](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoNetworkSpec), set the `MultiInterfaceMode` to **Multus**.
+In the [Installation custom resource](../../reference/installation/api.mdx#caliconetworkspec), set the `MultiInterfaceMode` to **Multus**.
 
 ### Create a new network
 

--- a/calico-cloud/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-cloud/networking/egress/egress-gateway-on-prem.mdx
@@ -348,7 +348,7 @@ To modify the iptables backend for egress gateways, you must change the `iptable
 If you plan to use Egress Gateways in a [dual-ToR cluster](../configuring/dual-tor.mdx), you must also adjust the $[nodecontainer] IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-$[prodname] [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+$[prodname] [Installation resource](../../reference/installation/api.mdx#nodeaddressautodetection).
 
 ### Configure namespaces and pods to use egress gateways
 

--- a/calico-cloud/networking/ipam/initial-ippool.mdx
+++ b/calico-cloud/networking/ipam/initial-ippool.mdx
@@ -22,7 +22,7 @@ The **Kubernetes pod CIDR** is the expected IP address range for pod IPs. It is 
 
 [Calico IP pools](../../reference/resources/ippool.mdx) are ranges of IP addresses that Calico uses to assign to pods; the ranges must within the Kubernetes pod CIDR.
 
-The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#installation)
 resource and configures the default Calico IP pool. Note the following:
 
 - Default fields for any that are omitted:
@@ -42,7 +42,7 @@ resource and configures the default Calico IP pool. Note the following:
 ## How to
 
 1. Download the custom-resource.yaml file.
-1. Edit the [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation).  
+1. Edit the [Installation resource](../../reference/installation/api.mdx#installation).
    **Required values**: `cidr:`  
    **Empty values**: Defaulted
 

--- a/calico-cloud/networking/ipam/ip-autodetection.mdx
+++ b/calico-cloud/networking/ipam/ip-autodetection.mdx
@@ -49,7 +49,7 @@ By default, $[prodname] uses the **firstFound** method; the first valid IP addre
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the operator Installation reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-cloud/observability/elastic/archive-storage.mdx
+++ b/calico-cloud/observability/elastic/archive-storage.mdx
@@ -46,8 +46,8 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
     -n tigera-operator
    ```
 
-3. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#operator.tigera.io/v1.S3StoreSpec)
+3. Update the [LogCollector](../../reference/installation/api.mdx#logcollector)
+   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#s3storespec)
    with your information noted from above.
    Example:
 
@@ -74,8 +74,8 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
 </TabItem>
 <TabItem label="Syslog" value="Syslog-1">
 
-1. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+1. Update the [LogCollector](../../reference/installation/api.mdx#logcollector)
+   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#syslogstorespec)
    with your syslog information.
    Example:
    ```yaml
@@ -102,7 +102,7 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
    kubectl edit logcollector tigera-secure
    ```
 2. You can control which types of $[prodname] log data you would like to send to syslog.
-   The [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+   The [Syslog section](../../reference/installation/api.mdx#syslogstorespec)
    contains a field called `logTypes` which allows you to list which log types you would like to include.
    The allowable log types are:
 
@@ -111,11 +111,11 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
    - Flows
    - IDSEvents
 
-   Refer to the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec) for more details on what data each log type represents.
+   Refer to the [Syslog section](../../reference/installation/api.mdx#syslogstorespec) for more details on what data each log type represents.
 
    :::note
 
-   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
+   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#logstorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
 
    :::
 
@@ -123,7 +123,7 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
 
 **TLS configuration**
 
-3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec).
+3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#syslogstorespec).
 
    ```yaml
    apiVersion: operator.tigera.io/v1
@@ -180,9 +180,9 @@ $[prodname] uses Splunk's **HTTP Event Collector** to send data to Splunk server
    ```
 
 3. Update the
-   [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
+   [LogCollector](../../reference/installation/api.mdx#logcollector)
    resource named `tigera-secure` to include
-   a [Splunk section](../../reference/installation/api.mdx#operator.tigera.io/v1.SplunkStoreSpec)
+   a [Splunk section](../../reference/installation/api.mdx#splunkstorespec)
    with your Splunk information.
    Example:
 

--- a/calico-cloud/observability/elastic/l7/configure.mdx
+++ b/calico-cloud/observability/elastic/l7/configure.mdx
@@ -60,7 +60,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
 
 **Configure the ApplicationLayer resource for L7 logs**
 
-1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) resource named, `tigera-secure`.
+1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#applicationlayer) resource named, `tigera-secure`.
 
    Example:
 
@@ -81,7 +81,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
    EOF
    ```
 
-   Read more about the log collection specification [here](../../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector).
+   Read more about the log collection specification [here](../../../reference/installation/api.mdx#logcollector).
    
    Applying this resource creates an `l7-log-collector` daemonset in `calico-system` namespace.
 

--- a/calico-cloud/observability/elastic/overview.mdx
+++ b/calico-cloud/observability/elastic/overview.mdx
@@ -91,7 +91,7 @@ $[prodname] compliance reports are based on archived **flow logs** and **audit l
 - Global network policies
 - Network sets
 
-$[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec).
+$[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#logcollectorspec).
 
 ## Additional resources
 
@@ -100,4 +100,4 @@ $[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../refere
 - [BGP logs](bgp.mdx)
 - [DNS logs](dns/dns-logs.mdx)
 - [Archive logs](archive-storage.mdx)
-- [Log collection options](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../reference/installation/api.mdx#logcollectorspec)

--- a/calico-cloud/operations/comms/certificate-management.mdx
+++ b/calico-cloud/operations/comms/certificate-management.mdx
@@ -19,7 +19,7 @@ certificate issuance, $[prodname] provides a simple configuration option that yo
 **Limitations**
 
 If your cluster is already running $[prodname] and you would like to enable certificate management, you need to
-temporarily remove [the logstorage resource](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+temporarily remove [the logstorage resource](../../reference/installation/api.mdx#logstorage)
 before following the steps to enable certificate management and then re-apply afterwards.
 
 {/*TODO-XREFS-CC
@@ -38,7 +38,7 @@ Currently, this feature is not supported in combination with [Multi-cluster mana
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../../reference/installation/api.mdx#installation)
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
 ```yaml

--- a/calico-cloud/reference/component-resources/configuration.mdx
+++ b/calico-cloud/reference/component-resources/configuration.mdx
@@ -239,7 +239,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#installation) API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico-cloud/reference/component-resources/configure-resources.mdx
+++ b/calico-cloud/reference/component-resources/configure-resources.mdx
@@ -14,11 +14,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the installation CR using the below command:
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#apiserverdeployment), patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch apiserver tigera-secure  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -66,11 +66,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## ApplicationLayer custom resource
 
-The [ApplicationLayer](../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
+The [ApplicationLayer](../../reference/installation/api.mdx#applicationlayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
 
 ### L7LogCollectorDaemonSet
 
-To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.L7LogCollectorDaemonSet), patch the ApplicationLayer CR using the below command:
+To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#l7logcollectordaemonset), patch the ApplicationLayer CR using the below command:
 
 ```bash
 $ kubectl patch applicationlayer tigera-secure  --type=merge --patch='{"spec": {"l7LogCollectorDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"l7-collector","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"envoy-proxy","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -119,11 +119,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Compliance custom resource
 
-The [Compliance](../../reference/installation/api.mdx#operator.tigera.io/v1.Compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
+The [Compliance](../../reference/installation/api.mdx#compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
 
 ### ComplianceControllerDeployment
 
-To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceControllerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#compliancecontrollerdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -159,7 +159,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceSnapshotterDeployment
 
-To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceSnapshotterDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#compliancesnapshotterdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceSnapshotterDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-snapshotter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -195,7 +195,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceBenchmarkerDaemonSet
 
-To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#compliancebenchmarkerdaemonset), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceBenchmarkerDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-benchmarker","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -230,7 +230,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceServerDeployment
 
-To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceServerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#complianceserverdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -266,7 +266,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceReporterPodTemplate.
 
-To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceReporterPodTemplate), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#compliancereporterpodtemplate), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceReporterPodTemplate": {"template": {"spec": {"containers":[{"name":"reporter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}'
@@ -308,7 +308,7 @@ Example Configurations:
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#typhadeployment), patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -344,7 +344,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#caliconodedaemonset) component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -379,7 +379,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#caliconodewindowsdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -414,7 +414,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#calicokubecontrollersdeployment) component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -450,7 +450,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#csinodedriverdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -498,11 +498,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## IntrusionDetection custom resource
 
-The [IntrusionDetection](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
+The [IntrusionDetection](../../reference/installation/api.mdx#intrusiondetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
 
 ### IntrusionDetectionControllerDeployment.
 
-To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionControllerDeployment), patch the IntrusionDetection CR using the below command:
+To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#intrusiondetectioncontrollerdeployment), patch the IntrusionDetection CR using the below command:
 
 ```bash
 $ kubectl patch intrusiondetection tigera-secure  --type=merge --patch='{"spec": {"intrusionDetectionControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"webhooks-processor","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}},{"name":"controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -550,11 +550,11 @@ This command will output the configured resource requests and limits for the Int
 
 ## LogCollector custom resource
 
-The [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
+The [LogCollector](../../reference/installation/api.mdx#logcollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
 
 ### FluentdDaemonSet.
 
-To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.FluentdDaemonSet), patch the LogCollector CR using the below command:
+To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#fluentddaemonset), patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"fluentdDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"fluentd","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -590,7 +590,7 @@ This command will output the configured resource requests and limits for the Flu
 
 ### EKSLogForwarderDeployment.
 
-To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.EKSLogForwarderDeployment), patch the LogCollector CR using the below command:
+To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#ekslogforwarderdeployment), patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"eksLogForwarderDeployment": {"spec": {"template": {"spec": {"containers":[{"name":"eks-log-forwarder","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -625,11 +625,11 @@ This command will output the configured resource requests and limits for the EKS
 
 ## ManagementClusterConnection custom resource
 
-The [ManagementClusterConnection](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
+The [ManagementClusterConnection](../../reference/installation/api.mdx#managementclusterconnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
 
 ### GuardianDeployment.
 
-To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.GuardianDeployment), patch the ManagementClusterConnection CR using the below command:
+To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#guardiandeployment), patch the ManagementClusterConnection CR using the below command:
 
 ```bash
 kubectl patch managementclusterconnection tigera-secure  --type=merge --patch='{"spec": {"guardianDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-guardian","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -661,11 +661,11 @@ This command will output the configured resource requests and limits for the Gua
 
 ## PacketCaptureAPI custom resource
 
-The [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
+The [PacketCaptureAPI](../../reference/installation/api.mdx#packetcaptureapi) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
 
 ### PacketCaptureAPIDeployment
 
-To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI), patch the PacketCapture CR using the below command:
+To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#packetcaptureapi), patch the PacketCapture CR using the below command:
 
 ```bash
 kubectl patch packetcaptureapis tigera-secure  --type=merge --patch='{"spec": {"packetCaptureAPIDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-packetcapture-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'

--- a/calico-cloud/release-notes/index.mdx
+++ b/calico-cloud/release-notes/index.mdx
@@ -437,7 +437,7 @@ For more information, see [Optimize egress networking for workloads with long-li
 
 We've added support for XFF to propagate the original IP address when proxying application layer traffic with Envoy within a Kubernetes cluster.
 
-For more information, see [Installation reference](../reference/installation/api.mdx#operator.tigera.io/v1.EnvoySettings).
+For more information, see [Installation reference](../reference/installation/api.mdx#envoysettings).
 
 #### Alert-only mode for workload-based Web Application Firewall (WAF)
 

--- a/calico-cloud/threat/deeppacketinspection.mdx
+++ b/calico-cloud/threat/deeppacketinspection.mdx
@@ -79,7 +79,7 @@ spec:
 
 ### Configure resource requirements
 
-Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionComponentResource).
+Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#intrusiondetectioncomponentresource).
 
 For a data transfer rate of 1GB/sec on workload endpoints being monitored, we recommend a minimum of 1 CPU and 1GB RAM.
 

--- a/calico-cloud/threat/web-application-firewall.mdx
+++ b/calico-cloud/threat/web-application-firewall.mdx
@@ -351,9 +351,9 @@ kubectl delete applicationlayer tigera-secure
 
 ### Keep some ApplicationLayer features enabled
 
-To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) custom resource.
+To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#applicationlayer) custom resource.
 
-Note that the [ApplicationLayer Specification](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerSpec) can specify configuration for [Application Logging](../reference/installation/api#operator.tigera.io/v1.LogCollectionSpec) and [Application Layer Policy](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerPolicyStatusType) also.
+Note that the [ApplicationLayer Specification](../reference/installation/api#applicationlayerspec) can specify configuration for [application logging](../reference/installation/api#operator.tigera.io/v1.logcollectionspec) and [application layer policy](../reference/installation/api#operator.tigera.io/v1.applicationlayerpolicystatustype) also.
 
 For the ApplicationLayer custom resource to be valid, at least one of these features have to be enabled, for example:
 

--- a/calico-cloud_versioned_docs/version-22-1/networking/configuring/dual-tor.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/networking/configuring/dual-tor.mdx
@@ -635,7 +635,7 @@ The only connections using interface-specific addresses should be BGP.
 If you plan to use [Egress Gateways](../egress/egress-gateway-on-prem.mdx) in your cluster, you must also adjust the $[nodecontainer] IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-$[prodname] [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+$[prodname] [Installation resource](../../reference/installation/api.mdx#nodeaddressautodetection).
 
 :::
 

--- a/calico-cloud_versioned_docs/version-22-1/networking/configuring/multiple-networks.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/networking/configuring/multiple-networks.mdx
@@ -77,7 +77,7 @@ Although the following $[prodname] features are supported for your default $[pro
 
 ### Configure cluster for multiple networks
 
-In the [Installation custom resource](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoNetworkSpec), set the `MultiInterfaceMode` to **Multus**.
+In the [Installation custom resource](../../reference/installation/api.mdx#caliconetworkspec), set the `MultiInterfaceMode` to **Multus**.
 
 ### Create a new network
 

--- a/calico-cloud_versioned_docs/version-22-1/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/networking/egress/egress-gateway-on-prem.mdx
@@ -348,7 +348,7 @@ To modify the iptables backend for egress gateways, you must change the `iptable
 If you plan to use Egress Gateways in a [dual-ToR cluster](../configuring/dual-tor.mdx), you must also adjust the $[nodecontainer] IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-$[prodname] [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+$[prodname] [Installation resource](../../reference/installation/api.mdx#nodeaddressautodetection).
 
 ### Configure namespaces and pods to use egress gateways
 

--- a/calico-cloud_versioned_docs/version-22-1/networking/ipam/initial-ippool.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/networking/ipam/initial-ippool.mdx
@@ -22,7 +22,7 @@ The **Kubernetes pod CIDR** is the expected IP address range for pod IPs. It is 
 
 [Calico IP pools](../../reference/resources/ippool.mdx) are ranges of IP addresses that Calico uses to assign to pods; the ranges must within the Kubernetes pod CIDR.
 
-The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#installation)
 resource and configures the default Calico IP pool. Note the following:
 
 - Default fields for any that are omitted:
@@ -42,7 +42,7 @@ resource and configures the default Calico IP pool. Note the following:
 ## How to
 
 1. Download the custom-resource.yaml file.
-1. Edit the [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation).  
+1. Edit the [Installation resource](../../reference/installation/api.mdx#installation).
    **Required values**: `cidr:`  
    **Empty values**: Defaulted
 

--- a/calico-cloud_versioned_docs/version-22-1/networking/ipam/ip-autodetection.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/networking/ipam/ip-autodetection.mdx
@@ -49,7 +49,7 @@ By default, $[prodname] uses the **firstFound** method; the first valid IP addre
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the operator Installation reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-cloud_versioned_docs/version-22-1/observability/elastic/archive-storage.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/observability/elastic/archive-storage.mdx
@@ -46,8 +46,8 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
     -n tigera-operator
    ```
 
-3. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#operator.tigera.io/v1.S3StoreSpec)
+3. Update the [LogCollector](../../reference/installation/api.mdx#logcollector)
+   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#s3storespec)
    with your information noted from above.
    Example:
 
@@ -74,8 +74,8 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
 </TabItem>
 <TabItem label="Syslog" value="Syslog-1">
 
-1. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+1. Update the [LogCollector](../../reference/installation/api.mdx#logcollector)
+   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#syslogstorespec)
    with your syslog information.
    Example:
    ```yaml
@@ -102,7 +102,7 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
    kubectl edit logcollector tigera-secure
    ```
 2. You can control which types of $[prodname] log data you would like to send to syslog.
-   The [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+   The [Syslog section](../../reference/installation/api.mdx#syslogstorespec)
    contains a field called `logTypes` which allows you to list which log types you would like to include.
    The allowable log types are:
 
@@ -111,11 +111,11 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
    - Flows
    - IDSEvents
 
-   Refer to the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec) for more details on what data each log type represents.
+   Refer to the [Syslog section](../../reference/installation/api.mdx#syslogstorespec) for more details on what data each log type represents.
 
    :::note
 
-   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
+   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#logstorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
 
    :::
 
@@ -123,7 +123,7 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
 
 **TLS configuration**
 
-3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec).
+3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#syslogstorespec).
 
    ```yaml
    apiVersion: operator.tigera.io/v1
@@ -180,9 +180,9 @@ $[prodname] uses Splunk's **HTTP Event Collector** to send data to Splunk server
    ```
 
 3. Update the
-   [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
+   [LogCollector](../../reference/installation/api.mdx#logcollector)
    resource named `tigera-secure` to include
-   a [Splunk section](../../reference/installation/api.mdx#operator.tigera.io/v1.SplunkStoreSpec)
+   a [Splunk section](../../reference/installation/api.mdx#splunkstorespec)
    with your Splunk information.
    Example:
 

--- a/calico-cloud_versioned_docs/version-22-1/observability/elastic/l7/configure.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/observability/elastic/l7/configure.mdx
@@ -60,7 +60,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
 
 **Configure the ApplicationLayer resource for L7 logs**
 
-1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) resource named, `tigera-secure`.
+1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#applicationlayer) resource named, `tigera-secure`.
 
    Example:
 
@@ -81,7 +81,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
    EOF
    ```
 
-   Read more about the log collection specification [here](../../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector).
+   Read more about the log collection specification [here](../../../reference/installation/api.mdx#logcollector).
    
    Applying this resource creates an `l7-log-collector` daemonset in `calico-system` namespace.
 

--- a/calico-cloud_versioned_docs/version-22-1/observability/elastic/overview.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/observability/elastic/overview.mdx
@@ -91,7 +91,7 @@ $[prodname] compliance reports are based on archived **flow logs** and **audit l
 - Global network policies
 - Network sets
 
-$[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec).
+$[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#logcollectorspec).
 
 ## Additional resources
 
@@ -100,4 +100,4 @@ $[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../refere
 - [BGP logs](bgp.mdx)
 - [DNS logs](dns/dns-logs.mdx)
 - [Archive logs](archive-storage.mdx)
-- [Log collection options](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../reference/installation/api.mdx#logcollectorspec)

--- a/calico-cloud_versioned_docs/version-22-1/operations/comms/certificate-management.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/operations/comms/certificate-management.mdx
@@ -19,7 +19,7 @@ certificate issuance, $[prodname] provides a simple configuration option that yo
 **Limitations**
 
 If your cluster is already running $[prodname] and you would like to enable certificate management, you need to
-temporarily remove [the logstorage resource](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+temporarily remove [the logstorage resource](../../reference/installation/api.mdx#logstorage)
 before following the steps to enable certificate management and then re-apply afterwards.
 
 {/*TODO-XREFS-CC
@@ -38,7 +38,7 @@ Currently, this feature is not supported in combination with [Multi-cluster mana
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../../reference/installation/api.mdx#installation)
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
 ```yaml

--- a/calico-cloud_versioned_docs/version-22-1/reference/component-resources/configuration.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/reference/component-resources/configuration.mdx
@@ -239,7 +239,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#installation) API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico-cloud_versioned_docs/version-22-1/reference/component-resources/configure-resources.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/reference/component-resources/configure-resources.mdx
@@ -14,11 +14,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the installation CR using the below command:
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#apiserverdeployment), patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch apiserver tigera-secure  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -66,11 +66,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## ApplicationLayer custom resource
 
-The [ApplicationLayer](../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
+The [ApplicationLayer](../../reference/installation/api.mdx#applicationlayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
 
 ### L7LogCollectorDaemonSet
 
-To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.L7LogCollectorDaemonSet), patch the ApplicationLayer CR using the below command:
+To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#l7logcollectordaemonset), patch the ApplicationLayer CR using the below command:
 
 ```bash
 $ kubectl patch applicationlayer tigera-secure  --type=merge --patch='{"spec": {"l7LogCollectorDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"l7-collector","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"envoy-proxy","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -119,11 +119,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Compliance custom resource
 
-The [Compliance](../../reference/installation/api.mdx#operator.tigera.io/v1.Compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
+The [Compliance](../../reference/installation/api.mdx#compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
 
 ### ComplianceControllerDeployment
 
-To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceControllerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#compliancecontrollerdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -159,7 +159,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceSnapshotterDeployment
 
-To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceSnapshotterDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#compliancesnapshotterdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceSnapshotterDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-snapshotter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -195,7 +195,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceBenchmarkerDaemonSet
 
-To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#compliancebenchmarkerdaemonset), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceBenchmarkerDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-benchmarker","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -230,7 +230,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceServerDeployment
 
-To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceServerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#complianceserverdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -266,7 +266,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceReporterPodTemplate.
 
-To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceReporterPodTemplate), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#compliancereporterpodtemplate), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceReporterPodTemplate": {"template": {"spec": {"containers":[{"name":"reporter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}'
@@ -308,7 +308,7 @@ Example Configurations:
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#typhadeployment), patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -344,7 +344,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#caliconodedaemonset) component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -379,7 +379,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#caliconodewindowsdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -414,7 +414,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#calicokubecontrollersdeployment) component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -450,7 +450,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#csinodedriverdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 $ kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -498,11 +498,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## IntrusionDetection custom resource
 
-The [IntrusionDetection](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
+The [IntrusionDetection](../../reference/installation/api.mdx#intrusiondetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
 
 ### IntrusionDetectionControllerDeployment.
 
-To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionControllerDeployment), patch the IntrusionDetection CR using the below command:
+To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#intrusiondetectioncontrollerdeployment), patch the IntrusionDetection CR using the below command:
 
 ```bash
 $ kubectl patch intrusiondetection tigera-secure  --type=merge --patch='{"spec": {"intrusionDetectionControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"webhooks-processor","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}},{"name":"controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -550,11 +550,11 @@ This command will output the configured resource requests and limits for the Int
 
 ## LogCollector custom resource
 
-The [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
+The [LogCollector](../../reference/installation/api.mdx#logcollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
 
 ### FluentdDaemonSet.
 
-To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.FluentdDaemonSet), patch the LogCollector CR using the below command:
+To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#fluentddaemonset), patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"fluentdDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"fluentd","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -590,7 +590,7 @@ This command will output the configured resource requests and limits for the Flu
 
 ### EKSLogForwarderDeployment.
 
-To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.EKSLogForwarderDeployment), patch the LogCollector CR using the below command:
+To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#ekslogforwarderdeployment), patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"eksLogForwarderDeployment": {"spec": {"template": {"spec": {"containers":[{"name":"eks-log-forwarder","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -625,11 +625,11 @@ This command will output the configured resource requests and limits for the EKS
 
 ## ManagementClusterConnection custom resource
 
-The [ManagementClusterConnection](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
+The [ManagementClusterConnection](../../reference/installation/api.mdx#managementclusterconnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
 
 ### GuardianDeployment.
 
-To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.GuardianDeployment), patch the ManagementClusterConnection CR using the below command:
+To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#guardiandeployment), patch the ManagementClusterConnection CR using the below command:
 
 ```bash
 kubectl patch managementclusterconnection tigera-secure  --type=merge --patch='{"spec": {"guardianDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-guardian","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -661,11 +661,11 @@ This command will output the configured resource requests and limits for the Gua
 
 ## PacketCaptureAPI custom resource
 
-The [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
+The [PacketCaptureAPI](../../reference/installation/api.mdx#packetcaptureapi) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
 
 ### PacketCaptureAPIDeployment
 
-To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI), patch the PacketCapture CR using the below command:
+To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#packetcaptureapi), patch the PacketCapture CR using the below command:
 
 ```bash
 kubectl patch packetcaptureapis tigera-secure  --type=merge --patch='{"spec": {"packetCaptureAPIDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-packetcapture-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'

--- a/calico-cloud_versioned_docs/version-22-1/release-notes/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/release-notes/index.mdx
@@ -761,7 +761,7 @@ For more information, see [Optimize egress networking for workloads with long-li
 
 We've added support for XFF to propagate the original IP address when proxying application layer traffic with Envoy within a Kubernetes cluster.
 
-For more information, see [Installation reference](../reference/installation/api.mdx#operator.tigera.io/v1.EnvoySettings).
+For more information, see [Installation reference](../reference/installation/api.mdx#envoysettings).
 
 #### Alert-only mode for workload-based Web Application Firewall (WAF)
 

--- a/calico-cloud_versioned_docs/version-22-1/threat/deeppacketinspection.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/threat/deeppacketinspection.mdx
@@ -79,7 +79,7 @@ spec:
 
 ### Configure resource requirements
 
-Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionComponentResource).
+Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#intrusiondetectioncomponentresource).
 
 For a data transfer rate of 1GB/sec on workload endpoints being monitored, we recommend a minimum of 1 CPU and 1GB RAM.
 

--- a/calico-cloud_versioned_docs/version-22-1/threat/web-application-firewall.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/threat/web-application-firewall.mdx
@@ -351,9 +351,9 @@ kubectl delete applicationlayer tigera-secure
 
 ### Keep some ApplicationLayer features enabled
 
-To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) custom resource.
+To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#applicationlayer) custom resource.
 
-Note that the [ApplicationLayer Specification](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerSpec) can specify configuration for [Application Logging](../reference/installation/api#operator.tigera.io/v1.LogCollectionSpec) and [Application Layer Policy](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerPolicyStatusType) also.
+Note that the [ApplicationLayer Specification](../reference/installation/api#applicationlayerspec) can specify configuration for [application logging](../reference/installation/api#operator.tigera.io/v1.logcollectionspec) and [application layer policy](../reference/installation/api#operator.tigera.io/v1.applicationlayerpolicystatustype) also.
 
 For the ApplicationLayer custom resource to be valid, at least one of these features have to be enabled, for example:
 

--- a/calico-enterprise/_includes/components/ConfigureManagedCluster.js
+++ b/calico-enterprise/_includes/components/ConfigureManagedCluster.js
@@ -75,7 +75,7 @@ export default function ConfigureManagedCluster(props) {
         <li>
           <p>
             Add a managed cluster and save the manifest containing a{' '}
-            <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementClusterConnection`}>
+            <Link href={`${baseUrl}/reference/installation/api#managementclusterconnection`}>
               ManagementClusterConnection
             </Link>{' '}
             and a Secret.

--- a/calico-enterprise/_includes/components/InstallAKS.js
+++ b/calico-enterprise/_includes/components/InstallAKS.js
@@ -294,7 +294,7 @@ EOF`}
             <li>
               <p>
                 Apply the{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise/_includes/components/InstallEKS.js
+++ b/calico-enterprise/_includes/components/InstallEKS.js
@@ -365,7 +365,7 @@ EOF`}
             <li>
               <p>
                 Apply the{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise/_includes/components/InstallGKE.js
+++ b/calico-enterprise/_includes/components/InstallGKE.js
@@ -181,7 +181,7 @@ EOF`}
           <li>
             <p>
               Apply the{' '}
-              <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+              <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                 ManagementCluster
               </Link>{' '}
               CR.

--- a/calico-enterprise/_includes/components/InstallGeneric.js
+++ b/calico-enterprise/_includes/components/InstallGeneric.js
@@ -191,7 +191,7 @@ EOF`}
             </li>
             <li>
               <p>
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise/_includes/components/InstallOpenShift.js
+++ b/calico-enterprise/_includes/components/InstallOpenShift.js
@@ -329,7 +329,7 @@ EOF`}
             <li>
               <p>
                 Apply the{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise/_includes/components/UpgradeOperatorSimple.js
+++ b/calico-enterprise/_includes/components/UpgradeOperatorSimple.js
@@ -182,7 +182,7 @@ export default function UpgradeOperatorSimple(props) {
             <li>
               <p>
                 If your cluster is a management cluster using v3.1 or older, apply a{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster{' '}
                 </Link>
                 CR to your cluster.
@@ -199,7 +199,7 @@ EOF`}
             <li>
               <p>
                 If your cluster is v3.7 or older, apply a new{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.Monitor`}>Monitor </Link>
+                <Link href={`${baseUrl}/reference/installation/api#monitor`}>Monitor </Link>
                 CR to your cluster.
               </p>
               <CodeBlock language='bash'>
@@ -214,7 +214,7 @@ EOF`}
             <li>
               <p>
                 If your cluster is v3.16 or older, apply a new{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.PolicyRecommendation`}>PolicyRecommendation </Link>
+                <Link href={`${baseUrl}/reference/installation/api#policyrecommendation`}>PolicyRecommendation </Link>
                 CR to your cluster.
               </p>
               <CodeBlock language='bash'>
@@ -229,7 +229,7 @@ EOF`}
             <li>
               <p>
                 If your cluster is v3.19 or older, apply a new{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.PacketCaptureAPI`}>PacketCaptureAPI </Link>
+                <Link href={`${baseUrl}/reference/installation/api#packetcaptureapi`}>PacketCaptureAPI </Link>
                  CR to your cluster.
               </p>
               <CodeBlock language='bash'>

--- a/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -47,7 +47,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
@@ -44,4 +44,4 @@ $[prodnameWindows] flow logs are enabled and configured the same way as [Flow lo
 - [Configure flow log aggregation](../../../observability/elastic/flow/aggregation.mdx)
 - [Log storage recommendations](../../../operations/logstorage/log-storage-recommendations.mdx)
 - [Archive logs](../../../observability/elastic/archive-storage.mdx)
-- [Log collection options](../../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../../reference/installation/api.mdx#logcollectorspec)

--- a/calico-enterprise/getting-started/install-on-clusters/windows-calico/requirements.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/windows-calico/requirements.mdx
@@ -36,7 +36,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#bgpoption).
 
 :::
 

--- a/calico-enterprise/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
@@ -113,7 +113,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
 
 1. <OpenShiftPrometheusOperator operation='upgrade' />
 
-1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster)
+1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#managementcluster)
    CR to your cluster.
 
    ```bash
@@ -125,7 +125,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#operator.tigera.io/v1.Monitor)
+1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#monitor)
    CR to your cluster.
 
    ```bash
@@ -137,7 +137,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendation)
+1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#policyrecommendation)
    CR to your cluster.
 
    ```bash
@@ -149,7 +149,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster was at one time v3.18 or older, remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#operator.tigera.io/v1.Manager).
+1. If your cluster was at one time v3.18 or older, remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#manager).
 
    ```bash
    oc apply -f - <<EOF
@@ -160,7 +160,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.19 or older, apply a new [PacketCaptureAPI](../../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI)
+1. If your cluster is v3.19 or older, apply a new [PacketCaptureAPI](../../../reference/installation/api.mdx#packetcaptureapi)
     CR to your cluster.
 
    ```bash

--- a/calico-enterprise/multicluster/fine-tune-deployment.mdx
+++ b/calico-enterprise/multicluster/fine-tune-deployment.mdx
@@ -151,4 +151,4 @@ To filter log data by a given managed cluster you can include the filter criteri
 
 # Additional resources
 
-- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection)
+- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#managementclusterconnection)

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -47,7 +47,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -49,7 +49,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
@@ -52,7 +52,7 @@ To control managed clusters from your central management plane, you must ensure 
     ```bash
     export MANAGEMENT_CLUSTER_ADDR=<your-management-cluster-addr>
     ```
-1.  Apply the [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) CR.
+1.  Apply the [ManagementCluster](../../../reference/installation/api.mdx#managementcluster) CR.
 
     ```bash
     kubectl apply -f - <<EOF

--- a/calico-enterprise/networking/configuring/dual-tor.mdx
+++ b/calico-enterprise/networking/configuring/dual-tor.mdx
@@ -633,7 +633,7 @@ The only connections using interface-specific addresses should be BGP.
 If you plan to use [Egress Gateways](../egress/egress-gateway-on-prem.mdx) in your cluster, you must also adjust the $[nodecontainer] IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-$[prodname] [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+$[prodname] [Installation resource](../../reference/installation/api.mdx#nodeaddressautodetection).
 
 :::
 

--- a/calico-enterprise/networking/configuring/multiple-networks.mdx
+++ b/calico-enterprise/networking/configuring/multiple-networks.mdx
@@ -77,7 +77,7 @@ Although the following $[prodname] features are supported for your default $[pro
 
 ### Configure cluster for multiple networks
 
-In the [Installation custom resource](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoNetworkSpec), set the `MultiInterfaceMode` to **Multus**.
+In the [Installation custom resource](../../reference/installation/api.mdx#caliconetworkspec), set the `MultiInterfaceMode` to **Multus**.
 
 ### Create a new network
 

--- a/calico-enterprise/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-on-prem.mdx
@@ -348,7 +348,7 @@ To modify the iptables backend for egress gateways, you must change the `iptable
 If you plan to use Egress Gateways in a [dual-ToR cluster](../configuring/dual-tor.mdx), you must also adjust the $[nodecontainer] IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-$[prodname] [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+$[prodname] [Installation resource](../../reference/installation/api.mdx#nodeaddressautodetection).
 
 ### Configure namespaces and pods to use egress gateways
 

--- a/calico-enterprise/networking/ipam/initial-ippool.mdx
+++ b/calico-enterprise/networking/ipam/initial-ippool.mdx
@@ -22,7 +22,7 @@ The **Kubernetes pod CIDR** is the expected IP address range for pod IPs. It is 
 
 [Calico IP pools](../../reference/resources/ippool.mdx) are ranges of IP addresses that Calico uses to assign to pods; the ranges must within the Kubernetes pod CIDR.
 
-The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#installation)
 resource and configures the default Calico IP pool. Note the following:
 
 - Default fields for any that are omitted:
@@ -42,7 +42,7 @@ resource and configures the default Calico IP pool. Note the following:
 ## How to
 
 1. Download the custom-resource.yaml file.
-1. Edit the [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation).
+1. Edit the [Installation resource](../../reference/installation/api.mdx#installation).
    **Required values**: `cidr:`
    **Empty values**: Defaulted
 

--- a/calico-enterprise/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise/networking/ipam/ip-autodetection.mdx
@@ -49,7 +49,7 @@ By default, $[prodname] uses the **firstFound** method; the first valid IP addre
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the operator Installation reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-enterprise/observability/elastic/archive-storage.mdx
+++ b/calico-enterprise/observability/elastic/archive-storage.mdx
@@ -53,8 +53,8 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
     -n tigera-operator
    ```
 
-3. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#operator.tigera.io/v1.S3StoreSpec)
+3. Update the [LogCollector](../../reference/installation/api.mdx#logcollector)
+   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#s3storespec)
    with your information noted from above.
    Example:
 
@@ -81,8 +81,8 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
 </TabItem>
 <TabItem label="Syslog" value="Syslog-1">
 
-1. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+1. Update the [LogCollector](../../reference/installation/api.mdx#logcollector)
+   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#syslogstorespec)
    with your syslog information.
    Example:
    ```yaml
@@ -109,7 +109,7 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
    kubectl edit logcollector tigera-secure
    ```
 2. You can control which types of $[prodname] log data you would like to send to syslog.
-   The [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+   The [Syslog section](../../reference/installation/api.mdx#syslogstorespec)
    contains a field called `logTypes` which allows you to list which log types you would like to include.
    The allowable log types are:
 
@@ -118,11 +118,11 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
    - Flows
    - IDSEvents
 
-   Refer to the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec) for more details on what data each log type represents.
+   Refer to the [Syslog section](../../reference/installation/api.mdx#syslogstorespec) for more details on what data each log type represents.
 
    :::note
 
-   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
+   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#logstorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
 
    :::
 
@@ -130,7 +130,7 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
 
 **TLS configuration**
 
-3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec).
+3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#syslogstorespec).
 
    ```yaml
    apiVersion: operator.tigera.io/v1
@@ -185,9 +185,9 @@ $[prodname] uses Splunk's **HTTP Event Collector** to send data to Splunk server
    ```
 
 3. Update the
-   [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
+   [LogCollector](../../reference/installation/api.mdx#logcollector)
    resource named `tigera-secure` to include
-   a [Splunk section](../../reference/installation/api.mdx#operator.tigera.io/v1.SplunkStoreSpec)
+   a [Splunk section](../../reference/installation/api.mdx#splunkstorespec)
    with your Splunk information.
    Example:
 
@@ -215,7 +215,7 @@ $[prodname] uses Splunk's **HTTP Event Collector** to send data to Splunk server
 </Tabs>
 
 ### Control which hosts have their logs archived
-By default, logs are archived from both Kubernetes cluster hosts and [non-cluster hosts](../../getting-started/bare-metal/about). To archive logs for only non-cluster hosts or VMs, use the [`hostScope`](../../reference/installation/api.mdx#operator.tigera.io/v1.AdditionalLogStoreSpec) field when you set your additional storage spec on the `LogCollector` resource.
+By default, logs are archived from both Kubernetes cluster hosts and [non-cluster hosts](../../getting-started/bare-metal/about). To archive logs for only non-cluster hosts or VMs, use the [`hostScope`](../../reference/installation/api.mdx#additionallogstorespec) field when you set your additional storage spec on the `LogCollector` resource.
 
 ```yaml title="Example spec for Splunk"
 apiVersion: operator.tigera.io/v1

--- a/calico-enterprise/observability/elastic/l7/configure.mdx
+++ b/calico-enterprise/observability/elastic/l7/configure.mdx
@@ -61,7 +61,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
 
 ### Configure the ApplicationLayer resource for L7 logs
 
-1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) resource named, `tigera-secure`.
+1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#applicationlayer) resource named, `tigera-secure`.
 
    Example:
 
@@ -82,7 +82,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
    EOF
    ```
 
-   Read more about the log collection specification [here](../../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector).
+   Read more about the log collection specification [here](../../../reference/installation/api.mdx#logcollector).
    
    Applying this resource creates an `l7-log-collector` daemonset in `calico-system` namespace.
 

--- a/calico-enterprise/observability/elastic/overview.mdx
+++ b/calico-enterprise/observability/elastic/overview.mdx
@@ -91,7 +91,7 @@ $[prodname] compliance reports are based on archived **flow logs** and **audit l
 - Global network policies
 - Network sets
 
-$[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec).
+$[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#logcollectorspec).
 
 ## Additional resources
 
@@ -102,4 +102,4 @@ $[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../refere
 - [BGP logs](bgp.mdx)
 - [DNS logs](dns/dns-logs.mdx)
 - [Archive logs](archive-storage.mdx)
-- [Log collection options](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../reference/installation/api.mdx#logcollectorspec)

--- a/calico-enterprise/observability/elastic/rbac-elasticsearch.mdx
+++ b/calico-enterprise/observability/elastic/rbac-elasticsearch.mdx
@@ -211,4 +211,4 @@ status:
 ## Additional resources
 
 - Configure [RBAC for tiered policies](../../network-policy/policy-tiers/rbac-tiered-policies.mdx).
-- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) resource.
+- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#managementcluster) resource.

--- a/calico-enterprise/observability/elastic/retention.mdx
+++ b/calico-enterprise/observability/elastic/retention.mdx
@@ -10,7 +10,7 @@ Configure how long to retain logs and compliance reports.
 
 ## Before you begin...
 
-Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#operator.tigera.io/v1.Retention) and determine the appropriate values for your deployment.
+Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#retention) and determine the appropriate values for your deployment.
 
 ## How to
 

--- a/calico-enterprise/observability/elastic/troubleshoot.mdx
+++ b/calico-enterprise/observability/elastic/troubleshoot.mdx
@@ -8,7 +8,7 @@ description: Learn how to troubleshoot common issues with Elasticsearch.
 
 The following user-configured resources are related to Elasticsearch:
 
-- [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage). It has settings for:
+- [LogStorage](../../reference/installation/api.mdx#logstorage). It has settings for:
 
   - Elasticsearch (for example, nodeCount and replicas)
   - Kubernetes (for example, resourceRequirements, storage and nodeSelectors)
@@ -111,7 +111,7 @@ As a last resort, create a new [Elasticsearch cluster](#how-to-create-a-new-clus
 
 ### Elasticsearch is slow
 
-**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorageSpec).
+**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#logstoragespec).
 
 ### Elasticsearch crashes during booting
 

--- a/calico-enterprise/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise/operations/cnx/configure-identity-provider.mdx
@@ -15,7 +15,7 @@ Configure an external identity provider (IdP), create a user, and log in to the 
 
 ## Concepts
 
-The $[prodname] authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Authentication) named, `tigera-secure`.
+The $[prodname] authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#authentication) named, `tigera-secure`.
 
 When configuring your cluster, you may be asked for the following inputs:
 

--- a/calico-enterprise/operations/cnx/roles-and-permissions.mdx
+++ b/calico-enterprise/operations/cnx/roles-and-permissions.mdx
@@ -16,7 +16,7 @@ Self-service is an important part of your Kubernetes platform networking and net
 
 ### Kubernetes RBAC authorization
 
-The [Calico Enterprise API server](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) is an extension to the standard [Kubernetes RBAC Authorization APIs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
+The [Calico Enterprise API server](../../reference/installation/api.mdx#apiserver) is an extension to the standard [kubernetes rbac authorization apis](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
 
 | Features                       | RBAC controls for...                                                                                                                                                                                                                            |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/calico-enterprise/operations/comms/certificate-management.mdx
+++ b/calico-enterprise/operations/comms/certificate-management.mdx
@@ -19,7 +19,7 @@ certificate issuance, $[prodname] provides a simple configuration option that yo
 **Limitations**
 
 If your cluster is already running $[prodname] and you would like to enable certificate management, you need to
-temporarily remove [the logstorage resource](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+temporarily remove [the logstorage resource](../../reference/installation/api.mdx#logstorage)
 before following the steps to enable certificate management and then re-apply afterwards. For detailed steps on
 re-creating logstorage, read more on [how to create a new Elasticsearch cluster](../../observability/elastic/troubleshoot.mdx#how-to-create-a-new-cluster).
 
@@ -38,7 +38,7 @@ Currently, this feature is not supported in combination with [Multi-cluster mana
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../../reference/installation/api.mdx#installation)
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
    ```yaml

--- a/calico-enterprise/operations/logstorage/log-storage-recommendations.mdx
+++ b/calico-enterprise/operations/logstorage/log-storage-recommendations.mdx
@@ -80,4 +80,4 @@ is no tolerance for removing/restarting a node.
 
 - Read the [LogStorage overview page](../logstorage/index.mdx)
 - [Troubleshooting Elasticsearch](../../observability/elastic/troubleshoot.mdx)
-- [LogStorage Specification](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+- [LogStorage Specification](../../reference/installation/api.mdx#logstorage)

--- a/calico-enterprise/reference/architecture/overview.mdx
+++ b/calico-enterprise/reference/architecture/overview.mdx
@@ -122,7 +122,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### Manager
 
-**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#operator.tigera.io/v1.Manager).
+**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#manager).
 
 ### Packet capture API
 
@@ -150,7 +150,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### API server
 
-**Main task**: Allows users to manage $[prodname] resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#operator.tigera.io/v1.APIServer).
+**Main task**: Allows users to manage $[prodname] resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#apiserver).
 
 ### BIRD
 

--- a/calico-enterprise/reference/component-resources/configuration.mdx
+++ b/calico-enterprise/reference/component-resources/configuration.mdx
@@ -239,7 +239,7 @@ By enabling this feature, you can avoid errors that can occur when a pod tries t
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](../installation/api#operator.tigera.io/v1.CalicoNetworkSpec) of the default `operator.tigera.io/v1/installation` resource.
+The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](../installation/api#caliconetworkspec) of the default `operator.tigera.io/v1/installation` resource.
 
 The following example configures the CNI to delay a pod from starting its containers for up to 10 seconds, or until the pod's data plane has been programmed:
 
@@ -309,7 +309,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-2">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#installation) API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico-enterprise/reference/component-resources/configure-resources.mdx
+++ b/calico-enterprise/reference/component-resources/configure-resources.mdx
@@ -14,11 +14,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the APIServer CR using the below command:
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#apiserverdeployment), patch the APIServer CR using the below command:
 
 ```bash
 kubectl patch apiserver tigera-secure  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -66,11 +66,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## ApplicationLayer custom resource
 
-The [ApplicationLayer](../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
+The [ApplicationLayer](../../reference/installation/api.mdx#applicationlayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
 
 ### L7LogCollectorDaemonSet
 
-To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.L7LogCollectorDaemonSet), patch the ApplicationLayer CR using the below command:
+To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#l7logcollectordaemonset), patch the ApplicationLayer CR using the below command:
 
 ```bash
 kubectl patch applicationlayer tigera-secure  --type=merge --patch='{"spec": {"l7LogCollectorDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"l7-collector","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"envoy-proxy","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -118,11 +118,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Authentication custom resource
 
-The [Authentication](../../reference/installation/api.mdx#operator.tigera.io/v1.Authentication) CR provides a way to configure resources for DexDeployment. The following sections provide example configurations for this CR.
+The [Authentication](../../reference/installation/api.mdx#authentication) CR provides a way to configure resources for DexDeployment. The following sections provide example configurations for this CR.
 
 ### DexDeployment
 
-To configure resource specification for the [DexDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.DexDeployment), patch the Authentication CR using the below command:
+To configure resource specification for the [DexDeployment](../../reference/installation/api.mdx#dexdeployment), patch the Authentication CR using the below command:
 
 ```bash
 kubectl patch authentication tigera-secure  --type=merge --patch='{"spec": {"dexDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-dex","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -157,13 +157,13 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Compliance custom resource
 
-The [Compliance](../../reference/installation/api.mdx#operator.tigera.io/v1.Compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
+The [Compliance](../../reference/installation/api.mdx#compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
 
 Example Configurations:
 
 ### ComplianceControllerDeployment
 
-To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceControllerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#compliancecontrollerdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -198,7 +198,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceSnapshotterDeployment
 
-To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceSnapshotterDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#compliancesnapshotterdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceSnapshotterDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-snapshotter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -233,7 +233,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceBenchmarkerDaemonSet
 
-To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#compliancebenchmarkerdaemonset), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceBenchmarkerDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-benchmarker","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -268,7 +268,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceServerDeployment
 
-To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceServerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#complianceserverdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -303,7 +303,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceReporterPodTemplate.
 
-To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceReporterPodTemplate), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#compliancereporterpodtemplate), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceReporterPodTemplate": {"template": {"spec": {"containers":[{"name":"reporter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}'
@@ -342,7 +342,7 @@ The [Installation CR](../../reference/installation/api.mdx) provides a way to co
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#typhadeployment), patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -377,7 +377,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#caliconodedaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -412,7 +412,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#caliconodewindowsdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -447,7 +447,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#calicokubecontrollersdeployment) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -483,7 +483,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#csinodedriverdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -531,11 +531,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## IntrusionDetection custom resource
 
-The [IntrusionDetection](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
+The [IntrusionDetection](../../reference/installation/api.mdx#intrusiondetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
 
 ### IntrusionDetectionControllerDeployment.
 
-To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionControllerDeployment), patch the IntrusionDetection CR using the below command:
+To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#intrusiondetectioncontrollerdeployment), patch the IntrusionDetection CR using the below command:
 
 ```bash
 kubectl patch intrusiondetection tigera-secure  --type=merge --patch='{"spec": {"intrusionDetectionControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"webhooks-processor","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}},{"name":"controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -583,11 +583,11 @@ This command will output the configured resource requests and limits for the Int
 
 ## LogCollector custom resource
 
-The [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
+The [LogCollector](../../reference/installation/api.mdx#logcollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
 
 ### FluentdDaemonSet.
 
-To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.FluentdDaemonSet), patch the LogCollector CR using the below command:
+To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#fluentddaemonset), patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"fluentdDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"fluentd","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -622,7 +622,7 @@ This command will output the configured resource requests and limits for the Flu
 
 ### EKSLogForwarderDeployment.
 
-To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.EKSLogForwarderDeployment), patch the LogCollector CR using the below command:
+To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#ekslogforwarderdeployment), patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"eksLogForwarderDeployment": {"spec": {"template": {"spec": {"containers":[{"name":"eks-log-forwarder","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -657,11 +657,11 @@ This command will output the configured resource requests and limits for the EKS
 
 ## LogStorage custom resource
 
-The [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) CR provides a way to configure resources for ECKOperatorStatefulSet, Kibana, LinseedDeployment, ElasticsearchMetricsDeployment. The following sections provide example configurations for this CR.
+The [LogStorage](../../reference/installation/api.mdx#logstorage) CR provides a way to configure resources for ECKOperatorStatefulSet, Kibana, LinseedDeployment, ElasticsearchMetricsDeployment. The following sections provide example configurations for this CR.
 
 ### ECKOperatorStatefulSet.
 
-To configure resource specification for the [ECKOperatorStatefulSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ECKOperatorStatefulSet), patch the LogStorage CR using the below command:
+To configure resource specification for the [ECKOperatorStatefulSet](../../reference/installation/api.mdx#eckoperatorstatefulset), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"eckOperatorStatefulSet":{"spec": {"template": {"spec": {"containers":[{"name":"manager","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -696,7 +696,7 @@ This command will output the configured resource requests and limits for the ECK
 
 ### Kibana
 
-To configure resource specification for the [Kibana](../../reference/installation/api.mdx#operator.tigera.io/v1.Kibana), patch the LogStorage CR using the below command:
+To configure resource specification for the [Kibana](../../reference/installation/api.mdx#kibana), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"kibana":{"spec": {"template": {"spec": {"containers":[{"name":"kibana","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -731,7 +731,7 @@ This command will output the configured resource requests and limits for the Kib
 
 ### LinseedDeployment
 
-To configure resource specification for the [LinseedDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.LinseedDeployment), patch the LogStorage CR using the below command:
+To configure resource specification for the [LinseedDeployment](../../reference/installation/api.mdx#linseeddeployment), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"linseedDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-linseed","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -766,7 +766,7 @@ This command will output the configured resource requests and limits for the Lin
 
 ### ElasticsearchMetricsDeployment
 
-To configure resource specification for the [ElasticsearchMetricsDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ElasticsearchMetricsDeployment), patch the LogStorage CR using the below command:
+To configure resource specification for the [ElasticsearchMetricsDeployment](../../reference/installation/api.mdx#elasticsearchmetricsdeployment), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"elasticsearchMetricsDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-elasticsearch-metrics","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -801,11 +801,11 @@ This command will output the configured resource requests and limits for the Ela
 
 ## ManagementClusterConnection custom resource
 
-The [ManagementClusterConnection](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
+The [ManagementClusterConnection](../../reference/installation/api.mdx#managementclusterconnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
 
 ### GuardianDeployment
 
-To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.GuardianDeployment), patch the ManagementClusterConnection CR using the below command:
+To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#guardiandeployment), patch the ManagementClusterConnection CR using the below command:
 
 ```bash
 kubectl patch managementclusterconnection tigera-secure  --type=merge --patch='{"spec": {"guardianDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-guardian","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -840,11 +840,11 @@ This command will output the configured resource requests and limits for the Gua
 
 ## Manager custom resource
 
-The [Manager](../../reference/installation/api.mdx#operator.tigera.io/v1.Manager) CR provides a way to configure resources for ManagerDeployment. The following sections provide example configurations for this CR.
+The [Manager](../../reference/installation/api.mdx#manager) CR provides a way to configure resources for ManagerDeployment. The following sections provide example configurations for this CR.
 
 ### ManagerDeployment
 
-To configure resource specification for the [ManagerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagerDeployment), patch the Manager CR using the below command:
+To configure resource specification for the [ManagerDeployment](../../reference/installation/api.mdx#managerdeployment), patch the Manager CR using the below command:
 
 ```bash
 kubectl patch manager tigera-secure  --type=merge --patch='{"spec": {"managerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-voltron","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-ui-apis","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-manager","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -906,11 +906,11 @@ This command will output the configured resource requests and limits for the Man
 
 ## Monitor custom resource
 
-The [Monitor](../../reference/installation/api.mdx#operator.tigera.io/v1.Monitor) CR provides a way to configure resources for Prometheus, AlertManager. The following sections provide example configurations for this CR.
+The [Monitor](../../reference/installation/api.mdx#monitor) CR provides a way to configure resources for Prometheus, AlertManager. The following sections provide example configurations for this CR.
 
 ### Prometheus
 
-To configure resource specification for the [Prometheus](../../reference/installation/api.mdx#operator.tigera.io/v1.Prometheus), Resources for the default container "prometheus" can be configured using the "resources" field under "commonPrometheusFields". For all other injected containers, such as "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
+To configure resource specification for the [Prometheus](../../reference/installation/api.mdx#prometheus), Resources for the default container "prometheus" can be configured using the "resources" field under "commonPrometheusFields". For all other injected containers, such as "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
 
 ```bash
 kubectl patch monitor tigera-secure --type=merge --patch='{"spec": {"prometheus": {"spec":{ "commonPrometheusFields": {"resources": {"limits": {"cpu":"500m","memory":"500Mi"}, "requests": {"cpu":"50m", "memory":"50Mi"}}, "containers":[{"name":"authn-proxy","resources":{"limits": {"cpu":"250m","memory":"500Mi"},"requests": {"cpu":"25m","memory":"50Mi"}}}]}}}}}'
@@ -975,7 +975,7 @@ The "config-reloader" container has default resource values set based by the Pro
 
 ### AlertManager
 
-To configure resource specification for the [AlertManager](../../reference/installation/api.mdx#operator.tigera.io/v1.AlertManager),  you can set resources for the default container "prometheus" using the "resources" field under "commonPrometheusFields". For all other injected containers, like "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
+To configure resource specification for the [AlertManager](../../reference/installation/api.mdx#alertmanager),  you can set resources for the default container "prometheus" using the "resources" field under "commonPrometheusFields". For all other injected containers, like "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
 
 ```bash
 kubectl patch monitor tigera-secure  --type=merge --patch='{"spec": {"alertManager": {"spec": {"resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}}}}'
@@ -1027,11 +1027,11 @@ The "config-reloader" container has default resource values set by the AlertMana
 
 ## PacketCaptureAPI custom resource
 
-The [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
+The [PacketCaptureAPI](../../reference/installation/api.mdx#packetcaptureapi) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
 
 ### PacketCaptureAPIDeployment
 
-To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI), patch the PacketCapture CR using the below command:
+To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#packetcaptureapi), patch the PacketCapture CR using the below command:
 
 ```bash
 kubectl patch packetcaptureapis tigera-secure  --type=merge --patch='{"spec": {"packetCaptureAPIDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-packetcapture-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -1066,11 +1066,11 @@ This command will output the configured resource requests and limits for the Pac
 
 ## PolicyRecommendation custom resource
 
-The [PolicyRecommendation](../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendation) CR provides a way to configure resources for PolicyRecommendation. The following sections provide example configurations for this CR.
+The [PolicyRecommendation](../../reference/installation/api.mdx#policyrecommendation) CR provides a way to configure resources for PolicyRecommendation. The following sections provide example configurations for this CR.
 
 ### PolicyRecommendationDeployment
 
-To configure resource specification for the [PolicyRecommendationDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendationDeployment), patch the PolicyRecommendation CR using the below command:
+To configure resource specification for the [PolicyRecommendationDeployment](../../reference/installation/api.mdx#policyrecommendationdeployment), patch the PolicyRecommendation CR using the below command:
 
 ```bash
 kubectl patch policyrecommendation tigera-secure  --type=merge --patch='{"spec": {"policyRecommendationDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"policy-recommendation-controller","resources":{"requests":{"cpu":"100m", "memory":"100Mi"},"limits":{"cpu":"1", "memory":"512Mi"}}}]}}}}}}'
@@ -1114,11 +1114,11 @@ The provided example illustrates configuring the apiserver component. Follow a s
 
 ### APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
+The [APIServer](../../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
 
 #### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), update values.yaml with the appropriate resource values.
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#apiserverdeployment), update values.yaml with the appropriate resource values.
 
 ```bash
 apiServer:

--- a/calico-enterprise/reference/component-resources/typha/prometheus.mdx
+++ b/calico-enterprise/reference/component-resources/typha/prometheus.mdx
@@ -5,7 +5,7 @@ description: Review metrics for the Typha component if you are using Prometheus.
 # Prometheus metrics
 
 Typha can be configured to report a number of metrics through Prometheus. The Prometheus port can be controlled
-via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#operator.tigera.io/v1.Installation).
+via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#installation).
 
 ## Metric reference
 

--- a/calico-enterprise/reference/installation/helm_customization.mdx
+++ b/calico-enterprise/reference/installation/helm_customization.mdx
@@ -6,18 +6,18 @@ description: Helm installation reference
 
 You can customize the following resources and settings during $[prodname] Helm-based installation using the file, `values.yaml`.
 
-- [Installation](api.mdx#operator.tigera.io/v1.InstallationSpec)
-- [Api server](api.mdx#operator.tigera.io/v1.APIServerSpec)
-- [Compliance](api.mdx#operator.tigera.io/v1.ComplianceSpec)
-- [Intrusion detection](api.mdx#operator.tigera.io/v1.IntrusionDetectionSpec)
-- [Log collector](api.mdx#operator.tigera.io/v1.LogCollectorSpec)
-- [Log storage](api.mdx#operator.tigera.io/v1.LogStorageSpec)
-- [Manager](api.mdx#operator.tigera.io/v1.ManagerSpec)
-- [Monitor](api.mdx#operator.tigera.io/v1.MonitorSpec)
-- [Policy recommendation](api.mdx#operator.tigera.io/v1.PolicyRecommendationSpec)
-- [Authentication](api.mdx#operator.tigera.io/v1.AuthenticationSpec)
-- [Application layer](api.mdx#operator.tigera.io/v1.ApplicationLayerSpec)
-- [Amazon cloud integration](api.mdx#operator.tigera.io/v1.AmazonCloudIntegrationSpec)
+- [Installation](api.mdx#installationspec)
+- [Api server](api.mdx#apiserverspec)
+- [Compliance](api.mdx#compliancespec)
+- [Intrusion detection](api.mdx#intrusiondetectionspec)
+- [Log collector](api.mdx#logcollectorspec)
+- [Log storage](api.mdx#logstoragespec)
+- [Manager](api.mdx#managerspec)
+- [Monitor](api.mdx#monitorspec)
+- [Policy recommendation](api.mdx#policyrecommendationspec)
+- [Authentication](api.mdx#authenticationspec)
+- [Application layer](api.mdx#applicationlayerspec)
+- [Amazon cloud integration](api.mdx#amazoncloudintegrationspec)
 - [Default felix configuration](../resources/felixconfig.mdx#spec)
 
 :::note
@@ -92,7 +92,7 @@ Common customizations that you might want to configure are number of replicas, p
 
 ### Number of replicas
 This setting defines the number of replicas for $[prodname] components that can run simultaneously in multiple instances.
-To configure this setting, see [controlPlaneReplicas](api.mdx#operator.tigera.io/v1.InstallationSpec).
+To configure this setting, see [controlPlaneReplicas](api.mdx#installationspec).
 The components for the replicas are:
 
 - tigera-manager

--- a/calico-enterprise/threat/deeppacketinspection.mdx
+++ b/calico-enterprise/threat/deeppacketinspection.mdx
@@ -79,7 +79,7 @@ spec:
 
 ### Configure resource requirements
 
-Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionComponentResource).
+Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#intrusiondetectioncomponentresource).
 
 For a data transfer rate of 1GB/sec on workload endpoints being monitored, we recommend a minimum of 1 CPU and 1GB RAM.
 

--- a/calico-enterprise/threat/web-application-firewall.mdx
+++ b/calico-enterprise/threat/web-application-firewall.mdx
@@ -350,9 +350,9 @@ kubectl delete applicationlayer tigera-secure
 
 ### Keep some ApplicationLayer features enabled
 
-To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) custom resource.
+To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#applicationlayer) custom resource.
 
-Note that the [ApplicationLayer Specification](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerSpec) can specify configuration for [Application Logging](../reference/installation/api#operator.tigera.io/v1.LogCollectionSpec) and [Application Layer Policy](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerPolicyStatusType) also. 
+Note that the [ApplicationLayer Specification](../reference/installation/api#applicationlayerspec) can specify configuration for [application logging](../reference/installation/api#operator.tigera.io/v1.logcollectionspec) and [application layer policy](../reference/installation/api#operator.tigera.io/v1.applicationlayerpolicystatustype) also.
 
 For the ApplicationLayer custom resource to be valid, at least one of these features have to be enabled, for example:
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/ConfigureManagedCluster.js
+++ b/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/ConfigureManagedCluster.js
@@ -75,7 +75,7 @@ export default function ConfigureManagedCluster(props) {
         <li>
           <p>
             Add a managed cluster and save the manifest containing a{' '}
-            <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementClusterConnection`}>
+            <Link href={`${baseUrl}/reference/installation/api#managementclusterconnection`}>
               ManagementClusterConnection
             </Link>{' '}
             and a Secret.

--- a/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/InstallAKS.js
+++ b/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/InstallAKS.js
@@ -292,7 +292,7 @@ EOF`}
             <li>
               <p>
                 Apply the{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/InstallEKS.js
+++ b/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/InstallEKS.js
@@ -363,7 +363,7 @@ EOF`}
             <li>
               <p>
                 Apply the{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/InstallGKE.js
+++ b/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/InstallGKE.js
@@ -180,7 +180,7 @@ EOF`}
           <li>
             <p>
               Apply the{' '}
-              <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+              <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                 ManagementCluster
               </Link>{' '}
               CR.

--- a/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/InstallGeneric.js
+++ b/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/InstallGeneric.js
@@ -180,7 +180,7 @@ EOF`}
             </li>
             <li>
               <p>
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/InstallOpenShift.js
+++ b/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/InstallOpenShift.js
@@ -328,7 +328,7 @@ EOF`}
             <li>
               <p>
                 Apply the{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/UpgradeOperatorSimple.js
+++ b/calico-enterprise_versioned_docs/version-3.19-2/_includes/components/UpgradeOperatorSimple.js
@@ -182,7 +182,7 @@ export default function UpgradeOperatorSimple(props) {
             <li>
               <p>
                 If your cluster is a management cluster using v3.1 or older, apply a{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster{' '}
                 </Link>
                 CR to your cluster.
@@ -199,7 +199,7 @@ EOF`}
             <li>
               <p>
                 If your cluster is v3.7 or older, apply a new{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.Monitor`}>Monitor </Link>
+                <Link href={`${baseUrl}/reference/installation/api#monitor`}>Monitor </Link>
                 CR to your cluster.
               </p>
               <CodeBlock language='bash'>
@@ -214,7 +214,7 @@ EOF`}
             <li>
               <p>
                 If your cluster is v3.16 or older, apply a new{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.PolicyRecommendation`}>PolicyRecommendation </Link>
+                <Link href={`${baseUrl}/reference/installation/api#policyrecommendation`}>PolicyRecommendation </Link>
                 CR to your cluster.
               </p>
               <CodeBlock language='bash'>

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -47,7 +47,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
@@ -44,4 +44,4 @@ $[prodnameWindows] flow logs are enabled and configured the same way as [Flow lo
 - [Configure flow log aggregation](../../../observability/elastic/flow/aggregation.mdx)
 - [Log storage recommendations](../../../operations/logstorage/log-storage-recommendations.mdx)
 - [Archive logs](../../../observability/elastic/archive-storage.mdx)
-- [Log collection options](../../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../../reference/installation/api.mdx#logcollectorspec)

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/windows-calico/requirements.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/windows-calico/requirements.mdx
@@ -36,7 +36,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#bgpoption).
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
@@ -113,7 +113,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
 
 1. <OpenShiftPrometheusOperator operation='upgrade' />
 
-1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster)
+1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#managementcluster)
    CR to your cluster.
 
    ```bash
@@ -125,7 +125,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#operator.tigera.io/v1.Monitor)
+1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#monitor)
    CR to your cluster.
 
    ```bash
@@ -137,7 +137,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendation)
+1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#policyrecommendation)
    CR to your cluster.
 
    ```bash
@@ -149,7 +149,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. Remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#operator.tigera.io/v1.Manager).
+1. Remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#manager).
 
    ```bash
    oc apply -f - <<EOF

--- a/calico-enterprise_versioned_docs/version-3.19-2/multicluster/fine-tune-deployment.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/multicluster/fine-tune-deployment.mdx
@@ -151,4 +151,4 @@ To filter log data by a given managed cluster you can include the filter criteri
 
 # Additional resources
 
-- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection)
+- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#managementclusterconnection)

--- a/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -47,7 +47,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -49,7 +49,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
@@ -52,7 +52,7 @@ To control managed clusters from your central management plane, you must ensure 
     ```bash
     export MANAGEMENT_CLUSTER_ADDR=<your-management-cluster-addr>
     ```
-1.  Apply the [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) CR.
+1.  Apply the [ManagementCluster](../../../reference/installation/api.mdx#managementcluster) CR.
 
     ```bash
     kubectl apply -f - <<EOF

--- a/calico-enterprise_versioned_docs/version-3.19-2/networking/configuring/dual-tor.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/networking/configuring/dual-tor.mdx
@@ -632,7 +632,7 @@ The only connections using interface-specific addresses should be BGP.
 If you plan to use [Egress Gateways](../egress/egress-gateway-on-prem.mdx) in your cluster, you must also adjust the $[nodecontainer] IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-$[prodname] [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+$[prodname] [Installation resource](../../reference/installation/api.mdx#nodeaddressautodetection).
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/networking/configuring/multiple-networks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/networking/configuring/multiple-networks.mdx
@@ -77,7 +77,7 @@ Although the following $[prodname] features are supported for your default $[pro
 
 ### Configure cluster for multiple networks
 
-In the [Installation custom resource](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoNetworkSpec), set the `MultiInterfaceMode` to **Multus**.
+In the [Installation custom resource](../../reference/installation/api.mdx#caliconetworkspec), set the `MultiInterfaceMode` to **Multus**.
 
 ### Create a new network
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/networking/egress/egress-gateway-on-prem.mdx
@@ -348,7 +348,7 @@ To modify the iptables backend for egress gateways, you must change the `iptable
 If you plan to use Egress Gateways in a [dual-ToR cluster](../configuring/dual-tor.mdx), you must also adjust the $[nodecontainer] IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-$[prodname] [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+$[prodname] [Installation resource](../../reference/installation/api.mdx#nodeaddressautodetection).
 
 ### Configure namespaces and pods to use egress gateways
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/networking/ipam/initial-ippool.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/networking/ipam/initial-ippool.mdx
@@ -22,7 +22,7 @@ The **Kubernetes pod CIDR** is the expected IP address range for pod IPs. It is 
 
 [Calico IP pools](../../reference/resources/ippool.mdx) are ranges of IP addresses that Calico uses to assign to pods; the ranges must within the Kubernetes pod CIDR.
 
-The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#installation)
 resource and configures the default Calico IP pool. Note the following:
 
 - Default fields for any that are omitted:
@@ -42,7 +42,7 @@ resource and configures the default Calico IP pool. Note the following:
 ## How to
 
 1. Download the custom-resource.yaml file.
-1. Edit the [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation).
+1. Edit the [Installation resource](../../reference/installation/api.mdx#installation).
    **Required values**: `cidr:`
    **Empty values**: Defaulted
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/networking/ipam/ip-autodetection.mdx
@@ -49,7 +49,7 @@ By default, $[prodname] uses the **firstFound** method; the first valid IP addre
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the operator Installation reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-enterprise_versioned_docs/version-3.19-2/observability/elastic/archive-storage.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/observability/elastic/archive-storage.mdx
@@ -46,8 +46,8 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
     -n tigera-operator
    ```
 
-3. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#operator.tigera.io/v1.S3StoreSpec)
+3. Update the [LogCollector](../../reference/installation/api.mdx#logcollector)
+   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#s3storespec)
    with your information noted from above.
    Example:
 
@@ -74,8 +74,8 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
 </TabItem>
 <TabItem label="Syslog" value="Syslog-1">
 
-1. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+1. Update the [LogCollector](../../reference/installation/api.mdx#logcollector)
+   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#syslogstorespec)
    with your syslog information.
    Example:
    ```yaml
@@ -102,7 +102,7 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
    kubectl edit logcollector tigera-secure
    ```
 2. You can control which types of $[prodname] log data you would like to send to syslog.
-   The [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+   The [Syslog section](../../reference/installation/api.mdx#syslogstorespec)
    contains a field called `logTypes` which allows you to list which log types you would like to include.
    The allowable log types are:
 
@@ -111,11 +111,11 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
    - Flows
    - IDSEvents
 
-   Refer to the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec) for more details on what data each log type represents.
+   Refer to the [Syslog section](../../reference/installation/api.mdx#syslogstorespec) for more details on what data each log type represents.
 
    :::note
 
-   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
+   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#logstorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
 
    :::
 
@@ -123,7 +123,7 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
 
 **TLS configuration**
 
-3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec).
+3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#syslogstorespec).
 
    ```yaml
    apiVersion: operator.tigera.io/v1
@@ -178,9 +178,9 @@ $[prodname] uses Splunk's **HTTP Event Collector** to send data to Splunk server
    ```
 
 3. Update the
-   [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
+   [LogCollector](../../reference/installation/api.mdx#logcollector)
    resource named `tigera-secure` to include
-   a [Splunk section](../../reference/installation/api.mdx#operator.tigera.io/v1.SplunkStoreSpec)
+   a [Splunk section](../../reference/installation/api.mdx#splunkstorespec)
    with your Splunk information.
    Example:
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/observability/elastic/l7/configure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/observability/elastic/l7/configure.mdx
@@ -63,7 +63,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
 
 **Configure the ApplicationLayer resource for L7 logs**
 
-1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) resource named, `tigera-secure`.
+1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#applicationlayer) resource named, `tigera-secure`.
 
    Example:
 
@@ -79,7 +79,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
        logRequestsPerInterval: -1
    ```
 
-   Read more about the log collection specification [here](../../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector).
+   Read more about the log collection specification [here](../../../reference/installation/api.mdx#logcollector).
    
    Applying this resource creates an `l7-log-collector` daemonset in `calico-system` namespace.
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/observability/elastic/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/observability/elastic/overview.mdx
@@ -91,7 +91,7 @@ $[prodname] compliance reports are based on archived **flow logs** and **audit l
 - Global network policies
 - Network sets
 
-$[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec).
+$[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#logcollectorspec).
 
 ## Additional resources
 
@@ -102,4 +102,4 @@ $[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../refere
 - [BGP logs](bgp.mdx)
 - [DNS logs](dns/dns-logs.mdx)
 - [Archive logs](archive-storage.mdx)
-- [Log collection options](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../reference/installation/api.mdx#logcollectorspec)

--- a/calico-enterprise_versioned_docs/version-3.19-2/observability/elastic/rbac-elasticsearch.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/observability/elastic/rbac-elasticsearch.mdx
@@ -211,4 +211,4 @@ status:
 ## Additional resources
 
 - Configure [RBAC for tiered policies](../../network-policy/policy-tiers/rbac-tiered-policies.mdx).
-- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) resource.
+- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#managementcluster) resource.

--- a/calico-enterprise_versioned_docs/version-3.19-2/observability/elastic/retention.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/observability/elastic/retention.mdx
@@ -10,7 +10,7 @@ Configure how long to retain logs and compliance reports.
 
 ## Before you begin...
 
-Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#operator.tigera.io/v1.Retention) and determine the appropriate values for your deployment.
+Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#retention) and determine the appropriate values for your deployment.
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/observability/elastic/troubleshoot.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/observability/elastic/troubleshoot.mdx
@@ -8,7 +8,7 @@ description: Learn how to troubleshoot common issues with Elasticsearch.
 
 The following user-configured resources are related to Elasticsearch:
 
-- [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage). It has settings for:
+- [LogStorage](../../reference/installation/api.mdx#logstorage). It has settings for:
 
   - Elasticsearch (for example, nodeCount and replicas)
   - Kubernetes (for example, resourceRequirements, storage and nodeSelectors)
@@ -111,7 +111,7 @@ As a last resort, create a new [Elasticsearch cluster](#how-to-create-a-new-clus
 
 ### Elasticsearch is slow
 
-**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorageSpec).
+**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#logstoragespec).
 
 ### Elasticsearch crashes during booting
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/operations/cnx/configure-identity-provider.mdx
@@ -15,7 +15,7 @@ Configure an external identity provider (IdP), create a user, and log in to the 
 
 ## Concepts
 
-The $[prodname] authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Authentication) named, `tigera-secure`.
+The $[prodname] authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#authentication) named, `tigera-secure`.
 
 When configuring your cluster, you may be asked for the following inputs:
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/operations/cnx/roles-and-permissions.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/operations/cnx/roles-and-permissions.mdx
@@ -16,7 +16,7 @@ Self-service is an important part of your Kubernetes platform networking and net
 
 ### Kubernetes RBAC authorization
 
-The [Calico Enterprise API server](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) is an extension to the standard [Kubernetes RBAC Authorization APIs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
+The [Calico Enterprise API server](../../reference/installation/api.mdx#apiserver) is an extension to the standard [kubernetes rbac authorization apis](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
 
 | Features                       | RBAC controls for...                                                                                                                                                                                                                            |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/calico-enterprise_versioned_docs/version-3.19-2/operations/comms/certificate-management.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/operations/comms/certificate-management.mdx
@@ -19,7 +19,7 @@ certificate issuance, $[prodname] provides a simple configuration option that yo
 **Limitations**
 
 If your cluster is already running $[prodname] and you would like to enable certificate management, you need to
-temporarily remove [the logstorage resource](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+temporarily remove [the logstorage resource](../../reference/installation/api.mdx#logstorage)
 before following the steps to enable certificate management and then re-apply afterwards. For detailed steps on
 re-creating logstorage, read more on [how to create a new Elasticsearch cluster](../../observability/elastic/troubleshoot.mdx#how-to-create-a-new-cluster).
 
@@ -38,7 +38,7 @@ Currently, this feature is not supported in combination with [Multi-cluster mana
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../../reference/installation/api.mdx#installation)
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
    ```yaml

--- a/calico-enterprise_versioned_docs/version-3.19-2/operations/logstorage/log-storage-recommendations.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/operations/logstorage/log-storage-recommendations.mdx
@@ -80,4 +80,4 @@ is no tolerance for removing/restarting a node.
 
 - Read the [LogStorage overview page](../logstorage/index.mdx)
 - [Troubleshooting Elasticsearch](../../observability/elastic/troubleshoot.mdx)
-- [LogStorage Specification](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+- [LogStorage Specification](../../reference/installation/api.mdx#logstorage)

--- a/calico-enterprise_versioned_docs/version-3.19-2/reference/architecture/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/reference/architecture/overview.mdx
@@ -122,7 +122,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### Manager
 
-**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#operator.tigera.io/v1.Manager).
+**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#manager).
 
 ### Packet capture API
 
@@ -150,7 +150,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### API server
 
-**Main task**: Allows users to manage $[prodname] resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#operator.tigera.io/v1.APIServer).
+**Main task**: Allows users to manage $[prodname] resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#apiserver).
 
 ### BIRD
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/reference/component-resources/configuration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/reference/component-resources/configuration.mdx
@@ -241,7 +241,7 @@ By enabling this feature, you can avoid errors that can occur when a pod tries t
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](../installation/api#operator.tigera.io/v1.CalicoNetworkSpec) of the default `operator.tigera.io/v1/installation` resource.
+The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](../installation/api#caliconetworkspec) of the default `operator.tigera.io/v1/installation` resource.
 
 The following example configures the CNI to delay a pod from starting its containers for up to 10 seconds, or until the pod's data plane has been programmed:
 
@@ -311,7 +311,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-2">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#installation) API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico-enterprise_versioned_docs/version-3.19-2/reference/component-resources/configure-resources.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/reference/component-resources/configure-resources.mdx
@@ -14,11 +14,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the APIServer CR using the below command:
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#apiserverdeployment), patch the APIServer CR using the below command:
 
 ```bash
 kubectl patch apiserver tigera-secure  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -66,11 +66,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## ApplicationLayer custom resource
 
-The [ApplicationLayer](../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
+The [ApplicationLayer](../../reference/installation/api.mdx#applicationlayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
 
 ### L7LogCollectorDaemonSet
 
-To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.L7LogCollectorDaemonSet), patch the ApplicationLayer CR using the below command:
+To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#l7logcollectordaemonset), patch the ApplicationLayer CR using the below command:
 
 ```bash
 kubectl patch applicationlayer tigera-secure  --type=merge --patch='{"spec": {"l7LogCollectorDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"l7-collector","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"envoy-proxy","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -118,11 +118,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Authentication custom resource
 
-The [Authentication](../../reference/installation/api.mdx#operator.tigera.io/v1.Authentication) CR provides a way to configure resources for DexDeployment. The following sections provide example configurations for this CR.
+The [Authentication](../../reference/installation/api.mdx#authentication) CR provides a way to configure resources for DexDeployment. The following sections provide example configurations for this CR.
 
 ### DexDeployment
 
-To configure resource specification for the [DexDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.DexDeployment), patch the Authentication CR using the below command:
+To configure resource specification for the [DexDeployment](../../reference/installation/api.mdx#dexdeployment), patch the Authentication CR using the below command:
 
 ```bash
 kubectl patch authentication tigera-secure  --type=merge --patch='{"spec": {"dexDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-dex","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -157,13 +157,13 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Compliance custom resource
 
-The [Compliance](../../reference/installation/api.mdx#operator.tigera.io/v1.Compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
+The [Compliance](../../reference/installation/api.mdx#compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
 
 Example Configurations:
 
 ### ComplianceControllerDeployment
 
-To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceControllerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#compliancecontrollerdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -198,7 +198,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceSnapshotterDeployment
 
-To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceSnapshotterDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#compliancesnapshotterdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceSnapshotterDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-snapshotter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -233,7 +233,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceBenchmarkerDaemonSet
 
-To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#compliancebenchmarkerdaemonset), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceBenchmarkerDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-benchmarker","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -268,7 +268,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceServerDeployment
 
-To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceServerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#complianceserverdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -303,7 +303,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceReporterPodTemplate.
 
-To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceReporterPodTemplate), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#compliancereporterpodtemplate), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceReporterPodTemplate": {"template": {"spec": {"containers":[{"name":"reporter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}'
@@ -342,7 +342,7 @@ The [Installation CR](../../reference/installation/api.mdx) provides a way to co
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#typhadeployment), patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -377,7 +377,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#caliconodedaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -412,7 +412,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#caliconodewindowsdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -447,7 +447,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#calicokubecontrollersdeployment) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -483,7 +483,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#csinodedriverdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -531,11 +531,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## IntrusionDetection custom resource
 
-The [IntrusionDetection](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
+The [IntrusionDetection](../../reference/installation/api.mdx#intrusiondetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
 
 ### IntrusionDetectionControllerDeployment.
 
-To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionControllerDeployment), patch the IntrusionDetection CR using the below command:
+To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#intrusiondetectioncontrollerdeployment), patch the IntrusionDetection CR using the below command:
 
 ```bash
 kubectl patch intrusiondetection tigera-secure  --type=merge --patch='{"spec": {"intrusionDetectionControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"webhooks-processor","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}},{"name":"controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -583,11 +583,11 @@ This command will output the configured resource requests and limits for the Int
 
 ## LogCollector custom resource
 
-The [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
+The [LogCollector](../../reference/installation/api.mdx#logcollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
 
 ### FluentdDaemonSet.
 
-To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.FluentdDaemonSet), patch the LogCollector CR using the below command:
+To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#fluentddaemonset), patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"fluentdDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"fluentd","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -622,7 +622,7 @@ This command will output the configured resource requests and limits for the Flu
 
 ### EKSLogForwarderDeployment.
 
-To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.EKSLogForwarderDeployment), patch the LogCollector CR using the below command:
+To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#ekslogforwarderdeployment), patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"eksLogForwarderDeployment": {"spec": {"template": {"spec": {"containers":[{"name":"eks-log-forwarder","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -657,11 +657,11 @@ This command will output the configured resource requests and limits for the EKS
 
 ## LogStorage custom resource
 
-The [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) CR provides a way to configure resources for ECKOperatorStatefulSet, Kibana, LinseedDeployment, ElasticsearchMetricsDeployment. The following sections provide example configurations for this CR.
+The [LogStorage](../../reference/installation/api.mdx#logstorage) CR provides a way to configure resources for ECKOperatorStatefulSet, Kibana, LinseedDeployment, ElasticsearchMetricsDeployment. The following sections provide example configurations for this CR.
 
 ### ECKOperatorStatefulSet.
 
-To configure resource specification for the [ECKOperatorStatefulSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ECKOperatorStatefulSet), patch the LogStorage CR using the below command:
+To configure resource specification for the [ECKOperatorStatefulSet](../../reference/installation/api.mdx#eckoperatorstatefulset), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"eckOperatorStatefulSet":{"spec": {"template": {"spec": {"containers":[{"name":"manager","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -696,7 +696,7 @@ This command will output the configured resource requests and limits for the ECK
 
 ### Kibana
 
-To configure resource specification for the [Kibana](../../reference/installation/api.mdx#operator.tigera.io/v1.Kibana), patch the LogStorage CR using the below command:
+To configure resource specification for the [Kibana](../../reference/installation/api.mdx#kibana), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"kibana":{"spec": {"template": {"spec": {"containers":[{"name":"kibana","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -731,7 +731,7 @@ This command will output the configured resource requests and limits for the Kib
 
 ### LinseedDeployment
 
-To configure resource specification for the [LinseedDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.LinseedDeployment), patch the LogStorage CR using the below command:
+To configure resource specification for the [LinseedDeployment](../../reference/installation/api.mdx#linseeddeployment), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"linseedDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-linseed","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -766,7 +766,7 @@ This command will output the configured resource requests and limits for the Lin
 
 ### ElasticsearchMetricsDeployment
 
-To configure resource specification for the [ElasticsearchMetricsDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ElasticsearchMetricsDeployment), patch the LogStorage CR using the below command:
+To configure resource specification for the [ElasticsearchMetricsDeployment](../../reference/installation/api.mdx#elasticsearchmetricsdeployment), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"elasticsearchMetricsDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-elasticsearch-metrics","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -801,11 +801,11 @@ This command will output the configured resource requests and limits for the Ela
 
 ## ManagementClusterConnection custom resource
 
-The [ManagementClusterConnection](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
+The [ManagementClusterConnection](../../reference/installation/api.mdx#managementclusterconnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
 
 ### GuardianDeployment
 
-To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.GuardianDeployment), patch the ManagementClusterConnection CR using the below command:
+To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#guardiandeployment), patch the ManagementClusterConnection CR using the below command:
 
 ```bash
 kubectl patch managementclusterconnection tigera-secure  --type=merge --patch='{"spec": {"guardianDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-guardian","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -840,11 +840,11 @@ This command will output the configured resource requests and limits for the Gua
 
 ## Manager custom resource
 
-The [Manager](../../reference/installation/api.mdx#operator.tigera.io/v1.Manager) CR provides a way to configure resources for ManagerDeployment. The following sections provide example configurations for this CR.
+The [Manager](../../reference/installation/api.mdx#manager) CR provides a way to configure resources for ManagerDeployment. The following sections provide example configurations for this CR.
 
 ### ManagerDeployment
 
-To configure resource specification for the [ManagerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagerDeployment), patch the Manager CR using the below command:
+To configure resource specification for the [ManagerDeployment](../../reference/installation/api.mdx#managerdeployment), patch the Manager CR using the below command:
 
 ```bash
 kubectl patch manager tigera-secure  --type=merge --patch='{"spec": {"managerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-voltron","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-es-proxy","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-manager","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -906,11 +906,11 @@ This command will output the configured resource requests and limits for the Man
 
 ## Monitor custom resource
 
-The [Monitor](../../reference/installation/api.mdx#operator.tigera.io/v1.Monitor) CR provides a way to configure resources for Prometheus, AlertManager. The following sections provide example configurations for this CR.
+The [Monitor](../../reference/installation/api.mdx#monitor) CR provides a way to configure resources for Prometheus, AlertManager. The following sections provide example configurations for this CR.
 
 ### Prometheus
 
-To configure resource specification for the [Prometheus](../../reference/installation/api.mdx#operator.tigera.io/v1.Prometheus), Resources for the default container "prometheus" can be configured using the "resources" field under "commonPrometheusFields". For all other injected containers, such as "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
+To configure resource specification for the [Prometheus](../../reference/installation/api.mdx#prometheus), Resources for the default container "prometheus" can be configured using the "resources" field under "commonPrometheusFields". For all other injected containers, such as "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
 
 ```bash
 kubectl patch monitor tigera-secure --type=merge --patch='{"spec": {"prometheus": {"spec":{ "commonPrometheusFields": {"resources": {"limits": {"cpu":"500m","memory":"500Mi"}, "requests": {"cpu":"50m", "memory":"50Mi"}}, "containers":[{"name":"authn-proxy","resources":{"limits": {"cpu":"250m","memory":"500Mi"},"requests": {"cpu":"25m","memory":"50Mi"}}}]}}}}}'
@@ -975,7 +975,7 @@ The "config-reloader" container has default resource values set based by the Pro
 
 ### AlertManager
 
-To configure resource specification for the [AlertManager](../../reference/installation/api.mdx#operator.tigera.io/v1.AlertManager),  you can set resources for the default container "prometheus" using the "resources" field under "commonPrometheusFields". For all other injected containers, like "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
+To configure resource specification for the [AlertManager](../../reference/installation/api.mdx#alertmanager),  you can set resources for the default container "prometheus" using the "resources" field under "commonPrometheusFields". For all other injected containers, like "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
 
 ```bash
 kubectl patch monitor tigera-secure  --type=merge --patch='{"spec": {"alertManager": {"spec": {"resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}}}}'
@@ -1027,11 +1027,11 @@ The "config-reloader" container has default resource values set by the AlertMana
 
 ## PacketCapture custom resource
 
-The [PacketCapture](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCapture) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
+The [PacketCapture](../../reference/installation/api.mdx#packetcapture) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
 
 ### PacketCaptureDeployment
 
-To configure resource specification for the [PacketCapture](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCapture), patch the PacketCapture CR using the below command:
+To configure resource specification for the [PacketCapture](../../reference/installation/api.mdx#packetcapture), patch the PacketCapture CR using the below command:
 
 ```bash
 kubectl patch packetcaptures.operator.tigera.io tigera-secure  --type=merge --patch='{"spec": {"packetCaptureDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-packetcapture-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -1066,11 +1066,11 @@ This command will output the configured resource requests and limits for the Pac
 
 ## PolicyRecommendation custom resource
 
-The [PolicyRecommendation](../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendation) CR provides a way to configure resources for PolicyRecommendation. The following sections provide example configurations for this CR.
+The [PolicyRecommendation](../../reference/installation/api.mdx#policyrecommendation) CR provides a way to configure resources for PolicyRecommendation. The following sections provide example configurations for this CR.
 
 ### PolicyRecommendationDeployment
 
-To configure resource specification for the [PolicyRecommendationDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendationDeployment), patch the PolicyRecommendation CR using the below command:
+To configure resource specification for the [PolicyRecommendationDeployment](../../reference/installation/api.mdx#policyrecommendationdeployment), patch the PolicyRecommendation CR using the below command:
 
 ```bash
 kubectl patch policyrecommendation tigera-secure  --type=merge --patch='{"spec": {"policyRecommendationDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"policy-recommendation-controller","resources":{"requests":{"cpu":"100m", "memory":"100Mi"},"limits":{"cpu":"1", "memory":"512Mi"}}}]}}}}}}'
@@ -1114,11 +1114,11 @@ The provided example illustrates configuring the apiserver component. Follow a s
 
 ### APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
+The [APIServer](../../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
 
 #### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), update values.yaml with the appropriate resource values.
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#apiserverdeployment), update values.yaml with the appropriate resource values.
 
 ```bash
 apiServer:

--- a/calico-enterprise_versioned_docs/version-3.19-2/reference/component-resources/typha/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/reference/component-resources/typha/prometheus.mdx
@@ -5,7 +5,7 @@ description: Review metrics for the Typha component if you are using Prometheus.
 # Prometheus metrics
 
 Typha can be configured to report a number of metrics through Prometheus. The Prometheus port can be controlled
-via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#operator.tigera.io/v1.Installation).
+via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#installation).
 
 ## Metric reference
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/reference/installation/helm_customization.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/reference/installation/helm_customization.mdx
@@ -6,18 +6,18 @@ description: Helm installation reference
 
 You can customize the following resources and settings during $[prodname] Helm-based installation using the file, `values.yaml`.
 
-- [Installation](api.mdx#operator.tigera.io/v1.InstallationSpec)
-- [Api server](api.mdx#operator.tigera.io/v1.APIServerSpec)
-- [Compliance](api.mdx#operator.tigera.io/v1.ComplianceSpec)
-- [Intrusion detection](api.mdx#operator.tigera.io/v1.IntrusionDetectionSpec)
-- [Log collector](api.mdx#operator.tigera.io/v1.LogCollectorSpec)
-- [Log storage](api.mdx#operator.tigera.io/v1.LogStorageSpec)
-- [Manager](api.mdx#operator.tigera.io/v1.ManagerSpec)
-- [Monitor](api.mdx#operator.tigera.io/v1.MonitorSpec)
-- [Policy recommendation](api.mdx#operator.tigera.io/v1.PolicyRecommendationSpec)
-- [Authentication](api.mdx#operator.tigera.io/v1.AuthenticationSpec)
-- [Application layer](api.mdx#operator.tigera.io/v1.ApplicationLayerSpec)
-- [Amazon cloud integration](api.mdx#operator.tigera.io/v1.AmazonCloudIntegrationSpec)
+- [Installation](api.mdx#installationspec)
+- [Api server](api.mdx#apiserverspec)
+- [Compliance](api.mdx#compliancespec)
+- [Intrusion detection](api.mdx#intrusiondetectionspec)
+- [Log collector](api.mdx#logcollectorspec)
+- [Log storage](api.mdx#logstoragespec)
+- [Manager](api.mdx#managerspec)
+- [Monitor](api.mdx#monitorspec)
+- [Policy recommendation](api.mdx#policyrecommendationspec)
+- [Authentication](api.mdx#authenticationspec)
+- [Application layer](api.mdx#applicationlayerspec)
+- [Amazon cloud integration](api.mdx#amazoncloudintegrationspec)
 - [Default felix configuration](../resources/felixconfig.mdx#spec)
 
 :::note
@@ -92,7 +92,7 @@ Common customizations that you might want to configure are number of replicas, p
 
 ### Number of replicas
 This setting defines the number of replicas for $[prodname] components that can run simultaneously in multiple instances.
-To configure this setting, see [controlPlaneReplicas](api.mdx#operator.tigera.io/v1.InstallationSpec).
+To configure this setting, see [controlPlaneReplicas](api.mdx#installationspec).
 The components for the replicas are:
 
 - tigera-manager

--- a/calico-enterprise_versioned_docs/version-3.19-2/threat/deeppacketinspection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/threat/deeppacketinspection.mdx
@@ -74,7 +74,7 @@ spec:
 
 ### Configure resource requirements
 
-Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionComponentResource).
+Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#intrusiondetectioncomponentresource).
 
 For a data transfer rate of 1GB/sec on workload endpoints being monitored, we recommend a minimum of 1 CPU and 1GB RAM.
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/threat/web-application-firewall.mdx
@@ -349,9 +349,9 @@ kubectl delete applicationlayer tigera-secure
 
 #### Keep some ApplicationLayer features enabled
 
-To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) custom resource.
+To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#applicationlayer) custom resource.
 
-Note that the [ApplicationLayer Specification](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerSpec) can specify configuration for [Application Logging](../reference/installation/api#operator.tigera.io/v1.LogCollectionSpec) and [Application Layer Policy](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerPolicyStatusType) also. 
+Note that the [ApplicationLayer Specification](../reference/installation/api#applicationlayerspec) can specify configuration for [application logging](../reference/installation/api#operator.tigera.io/v1.logcollectionspec) and [application layer policy](../reference/installation/api#operator.tigera.io/v1.applicationlayerpolicystatustype) also.
 
 For the ApplicationLayer custom resource to be valid, at least one of these features have to be enabled, for example:
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/ConfigureManagedCluster.js
+++ b/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/ConfigureManagedCluster.js
@@ -75,7 +75,7 @@ export default function ConfigureManagedCluster(props) {
         <li>
           <p>
             Add a managed cluster and save the manifest containing a{' '}
-            <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementClusterConnection`}>
+            <Link href={`${baseUrl}/reference/installation/api#managementclusterconnection`}>
               ManagementClusterConnection
             </Link>{' '}
             and a Secret.

--- a/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/InstallAKS.js
+++ b/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/InstallAKS.js
@@ -292,7 +292,7 @@ EOF`}
             <li>
               <p>
                 Apply the{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/InstallEKS.js
+++ b/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/InstallEKS.js
@@ -363,7 +363,7 @@ EOF`}
             <li>
               <p>
                 Apply the{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/InstallGKE.js
+++ b/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/InstallGKE.js
@@ -180,7 +180,7 @@ EOF`}
           <li>
             <p>
               Apply the{' '}
-              <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+              <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                 ManagementCluster
               </Link>{' '}
               CR.

--- a/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/InstallGeneric.js
+++ b/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/InstallGeneric.js
@@ -188,7 +188,7 @@ EOF`}
             </li>
             <li>
               <p>
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/InstallOpenShift.js
+++ b/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/InstallOpenShift.js
@@ -328,7 +328,7 @@ EOF`}
             <li>
               <p>
                 Apply the{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/UpgradeOperatorSimple.js
+++ b/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/UpgradeOperatorSimple.js
@@ -182,7 +182,7 @@ export default function UpgradeOperatorSimple(props) {
             <li>
               <p>
                 If your cluster is a management cluster using v3.1 or older, apply a{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster{' '}
                 </Link>
                 CR to your cluster.
@@ -199,7 +199,7 @@ EOF`}
             <li>
               <p>
                 If your cluster is v3.7 or older, apply a new{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.Monitor`}>Monitor </Link>
+                <Link href={`${baseUrl}/reference/installation/api#monitor`}>Monitor </Link>
                 CR to your cluster.
               </p>
               <CodeBlock language='bash'>
@@ -214,7 +214,7 @@ EOF`}
             <li>
               <p>
                 If your cluster is v3.16 or older, apply a new{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.PolicyRecommendation`}>PolicyRecommendation </Link>
+                <Link href={`${baseUrl}/reference/installation/api#policyrecommendation`}>PolicyRecommendation </Link>
                 CR to your cluster.
               </p>
               <CodeBlock language='bash'>
@@ -229,7 +229,7 @@ EOF`}
             <li>
               <p>
                 If your cluster is v3.19 or older, apply a new{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.PacketCaptureAPI`}>PacketCaptureAPI </Link>
+                <Link href={`${baseUrl}/reference/installation/api#packetcaptureapi`}>PacketCaptureAPI </Link>
                  CR to your cluster.
               </p>
               <CodeBlock language='bash'>

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -47,7 +47,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
@@ -44,4 +44,4 @@ $[prodnameWindows] flow logs are enabled and configured the same way as [Flow lo
 - [Configure flow log aggregation](../../../observability/elastic/flow/aggregation.mdx)
 - [Log storage recommendations](../../../operations/logstorage/log-storage-recommendations.mdx)
 - [Archive logs](../../../observability/elastic/archive-storage.mdx)
-- [Log collection options](../../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../../reference/installation/api.mdx#logcollectorspec)

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/windows-calico/requirements.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/windows-calico/requirements.mdx
@@ -36,7 +36,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#bgpoption).
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
@@ -113,7 +113,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
 
 1. <OpenShiftPrometheusOperator operation='upgrade' />
 
-1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster)
+1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#managementcluster)
    CR to your cluster.
 
    ```bash
@@ -125,7 +125,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#operator.tigera.io/v1.Monitor)
+1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#monitor)
    CR to your cluster.
 
    ```bash
@@ -137,7 +137,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendation)
+1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#policyrecommendation)
    CR to your cluster.
 
    ```bash
@@ -149,7 +149,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster was at one time v3.18 or older, remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#operator.tigera.io/v1.Manager).
+1. If your cluster was at one time v3.18 or older, remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#manager).
 
    ```bash
    oc apply -f - <<EOF
@@ -160,7 +160,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.19 or older, apply a new [PacketCaptureAPI](../../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI)
+1. If your cluster is v3.19 or older, apply a new [PacketCaptureAPI](../../../reference/installation/api.mdx#packetcaptureapi)
     CR to your cluster.
 
    ```bash

--- a/calico-enterprise_versioned_docs/version-3.20-2/multicluster/fine-tune-deployment.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/multicluster/fine-tune-deployment.mdx
@@ -151,4 +151,4 @@ To filter log data by a given managed cluster you can include the filter criteri
 
 # Additional resources
 
-- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection)
+- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#managementclusterconnection)

--- a/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -47,7 +47,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -49,7 +49,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
@@ -52,7 +52,7 @@ To control managed clusters from your central management plane, you must ensure 
     ```bash
     export MANAGEMENT_CLUSTER_ADDR=<your-management-cluster-addr>
     ```
-1.  Apply the [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) CR.
+1.  Apply the [ManagementCluster](../../../reference/installation/api.mdx#managementcluster) CR.
 
     ```bash
     kubectl apply -f - <<EOF

--- a/calico-enterprise_versioned_docs/version-3.20-2/networking/configuring/dual-tor.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/networking/configuring/dual-tor.mdx
@@ -633,7 +633,7 @@ The only connections using interface-specific addresses should be BGP.
 If you plan to use [Egress Gateways](../egress/egress-gateway-on-prem.mdx) in your cluster, you must also adjust the $[nodecontainer] IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-$[prodname] [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+$[prodname] [Installation resource](../../reference/installation/api.mdx#nodeaddressautodetection).
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/networking/configuring/multiple-networks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/networking/configuring/multiple-networks.mdx
@@ -77,7 +77,7 @@ Although the following $[prodname] features are supported for your default $[pro
 
 ### Configure cluster for multiple networks
 
-In the [Installation custom resource](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoNetworkSpec), set the `MultiInterfaceMode` to **Multus**.
+In the [Installation custom resource](../../reference/installation/api.mdx#caliconetworkspec), set the `MultiInterfaceMode` to **Multus**.
 
 ### Create a new network
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/networking/egress/egress-gateway-on-prem.mdx
@@ -348,7 +348,7 @@ To modify the iptables backend for egress gateways, you must change the `iptable
 If you plan to use Egress Gateways in a [dual-ToR cluster](../configuring/dual-tor.mdx), you must also adjust the $[nodecontainer] IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-$[prodname] [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+$[prodname] [Installation resource](../../reference/installation/api.mdx#nodeaddressautodetection).
 
 ### Configure namespaces and pods to use egress gateways
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/networking/ipam/initial-ippool.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/networking/ipam/initial-ippool.mdx
@@ -22,7 +22,7 @@ The **Kubernetes pod CIDR** is the expected IP address range for pod IPs. It is 
 
 [Calico IP pools](../../reference/resources/ippool.mdx) are ranges of IP addresses that Calico uses to assign to pods; the ranges must within the Kubernetes pod CIDR.
 
-The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#installation)
 resource and configures the default Calico IP pool. Note the following:
 
 - Default fields for any that are omitted:
@@ -42,7 +42,7 @@ resource and configures the default Calico IP pool. Note the following:
 ## How to
 
 1. Download the custom-resource.yaml file.
-1. Edit the [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation).
+1. Edit the [Installation resource](../../reference/installation/api.mdx#installation).
    **Required values**: `cidr:`
    **Empty values**: Defaulted
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/networking/ipam/ip-autodetection.mdx
@@ -49,7 +49,7 @@ By default, $[prodname] uses the **firstFound** method; the first valid IP addre
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the operator Installation reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-enterprise_versioned_docs/version-3.20-2/observability/elastic/archive-storage.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/observability/elastic/archive-storage.mdx
@@ -46,8 +46,8 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
     -n tigera-operator
    ```
 
-3. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#operator.tigera.io/v1.S3StoreSpec)
+3. Update the [LogCollector](../../reference/installation/api.mdx#logcollector)
+   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#s3storespec)
    with your information noted from above.
    Example:
 
@@ -74,8 +74,8 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
 </TabItem>
 <TabItem label="Syslog" value="Syslog-1">
 
-1. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+1. Update the [LogCollector](../../reference/installation/api.mdx#logcollector)
+   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#syslogstorespec)
    with your syslog information.
    Example:
    ```yaml
@@ -102,7 +102,7 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
    kubectl edit logcollector tigera-secure
    ```
 2. You can control which types of $[prodname] log data you would like to send to syslog.
-   The [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+   The [Syslog section](../../reference/installation/api.mdx#syslogstorespec)
    contains a field called `logTypes` which allows you to list which log types you would like to include.
    The allowable log types are:
 
@@ -111,11 +111,11 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
    - Flows
    - IDSEvents
 
-   Refer to the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec) for more details on what data each log type represents.
+   Refer to the [Syslog section](../../reference/installation/api.mdx#syslogstorespec) for more details on what data each log type represents.
 
    :::note
 
-   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
+   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#logstorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
 
    :::
 
@@ -123,7 +123,7 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
 
 **TLS configuration**
 
-3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec).
+3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#syslogstorespec).
 
    ```yaml
    apiVersion: operator.tigera.io/v1
@@ -178,9 +178,9 @@ $[prodname] uses Splunk's **HTTP Event Collector** to send data to Splunk server
    ```
 
 3. Update the
-   [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
+   [LogCollector](../../reference/installation/api.mdx#logcollector)
    resource named `tigera-secure` to include
-   a [Splunk section](../../reference/installation/api.mdx#operator.tigera.io/v1.SplunkStoreSpec)
+   a [Splunk section](../../reference/installation/api.mdx#splunkstorespec)
    with your Splunk information.
    Example:
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/observability/elastic/l7/configure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/observability/elastic/l7/configure.mdx
@@ -61,7 +61,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
 
 ### Configure the ApplicationLayer resource for L7 logs
 
-1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) resource named, `tigera-secure`.
+1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#applicationlayer) resource named, `tigera-secure`.
 
    Example:
 
@@ -82,7 +82,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
    EOF
    ```
 
-   Read more about the log collection specification [here](../../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector).
+   Read more about the log collection specification [here](../../../reference/installation/api.mdx#logcollector).
    
    Applying this resource creates an `l7-log-collector` daemonset in `calico-system` namespace.
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/observability/elastic/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/observability/elastic/overview.mdx
@@ -91,7 +91,7 @@ $[prodname] compliance reports are based on archived **flow logs** and **audit l
 - Global network policies
 - Network sets
 
-$[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec).
+$[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#logcollectorspec).
 
 ## Additional resources
 
@@ -102,4 +102,4 @@ $[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../refere
 - [BGP logs](bgp.mdx)
 - [DNS logs](dns/dns-logs.mdx)
 - [Archive logs](archive-storage.mdx)
-- [Log collection options](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../reference/installation/api.mdx#logcollectorspec)

--- a/calico-enterprise_versioned_docs/version-3.20-2/observability/elastic/rbac-elasticsearch.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/observability/elastic/rbac-elasticsearch.mdx
@@ -211,4 +211,4 @@ status:
 ## Additional resources
 
 - Configure [RBAC for tiered policies](../../network-policy/policy-tiers/rbac-tiered-policies.mdx).
-- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) resource.
+- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#managementcluster) resource.

--- a/calico-enterprise_versioned_docs/version-3.20-2/observability/elastic/retention.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/observability/elastic/retention.mdx
@@ -10,7 +10,7 @@ Configure how long to retain logs and compliance reports.
 
 ## Before you begin...
 
-Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#operator.tigera.io/v1.Retention) and determine the appropriate values for your deployment.
+Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#retention) and determine the appropriate values for your deployment.
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/observability/elastic/troubleshoot.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/observability/elastic/troubleshoot.mdx
@@ -8,7 +8,7 @@ description: Learn how to troubleshoot common issues with Elasticsearch.
 
 The following user-configured resources are related to Elasticsearch:
 
-- [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage). It has settings for:
+- [LogStorage](../../reference/installation/api.mdx#logstorage). It has settings for:
 
   - Elasticsearch (for example, nodeCount and replicas)
   - Kubernetes (for example, resourceRequirements, storage and nodeSelectors)
@@ -111,7 +111,7 @@ As a last resort, create a new [Elasticsearch cluster](#how-to-create-a-new-clus
 
 ### Elasticsearch is slow
 
-**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorageSpec).
+**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#logstoragespec).
 
 ### Elasticsearch crashes during booting
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/operations/cnx/configure-identity-provider.mdx
@@ -15,7 +15,7 @@ Configure an external identity provider (IdP), create a user, and log in to the 
 
 ## Concepts
 
-The $[prodname] authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Authentication) named, `tigera-secure`.
+The $[prodname] authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#authentication) named, `tigera-secure`.
 
 When configuring your cluster, you may be asked for the following inputs:
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/operations/cnx/roles-and-permissions.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/operations/cnx/roles-and-permissions.mdx
@@ -16,7 +16,7 @@ Self-service is an important part of your Kubernetes platform networking and net
 
 ### Kubernetes RBAC authorization
 
-The [Calico Enterprise API server](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) is an extension to the standard [Kubernetes RBAC Authorization APIs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
+The [Calico Enterprise API server](../../reference/installation/api.mdx#apiserver) is an extension to the standard [kubernetes rbac authorization apis](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
 
 | Features                       | RBAC controls for...                                                                                                                                                                                                                            |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/calico-enterprise_versioned_docs/version-3.20-2/operations/comms/certificate-management.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/operations/comms/certificate-management.mdx
@@ -19,7 +19,7 @@ certificate issuance, $[prodname] provides a simple configuration option that yo
 **Limitations**
 
 If your cluster is already running $[prodname] and you would like to enable certificate management, you need to
-temporarily remove [the logstorage resource](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+temporarily remove [the logstorage resource](../../reference/installation/api.mdx#logstorage)
 before following the steps to enable certificate management and then re-apply afterwards. For detailed steps on
 re-creating logstorage, read more on [how to create a new Elasticsearch cluster](../../observability/elastic/troubleshoot.mdx#how-to-create-a-new-cluster).
 
@@ -38,7 +38,7 @@ Currently, this feature is not supported in combination with [Multi-cluster mana
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../../reference/installation/api.mdx#installation)
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
    ```yaml

--- a/calico-enterprise_versioned_docs/version-3.20-2/operations/logstorage/log-storage-recommendations.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/operations/logstorage/log-storage-recommendations.mdx
@@ -80,4 +80,4 @@ is no tolerance for removing/restarting a node.
 
 - Read the [LogStorage overview page](../logstorage/index.mdx)
 - [Troubleshooting Elasticsearch](../../observability/elastic/troubleshoot.mdx)
-- [LogStorage Specification](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+- [LogStorage Specification](../../reference/installation/api.mdx#logstorage)

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/architecture/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/architecture/overview.mdx
@@ -122,7 +122,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### Manager
 
-**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#operator.tigera.io/v1.Manager).
+**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#manager).
 
 ### Packet capture API
 
@@ -150,7 +150,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### API server
 
-**Main task**: Allows users to manage $[prodname] resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#operator.tigera.io/v1.APIServer).
+**Main task**: Allows users to manage $[prodname] resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#apiserver).
 
 ### BIRD
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/component-resources/configuration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/component-resources/configuration.mdx
@@ -239,7 +239,7 @@ By enabling this feature, you can avoid errors that can occur when a pod tries t
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](../installation/api#operator.tigera.io/v1.CalicoNetworkSpec) of the default `operator.tigera.io/v1/installation` resource.
+The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](../installation/api#caliconetworkspec) of the default `operator.tigera.io/v1/installation` resource.
 
 The following example configures the CNI to delay a pod from starting its containers for up to 10 seconds, or until the pod's data plane has been programmed:
 
@@ -309,7 +309,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-2">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#installation) API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/component-resources/configure-resources.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/component-resources/configure-resources.mdx
@@ -14,11 +14,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the APIServer CR using the below command:
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#apiserverdeployment), patch the APIServer CR using the below command:
 
 ```bash
 kubectl patch apiserver tigera-secure  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -66,11 +66,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## ApplicationLayer custom resource
 
-The [ApplicationLayer](../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
+The [ApplicationLayer](../../reference/installation/api.mdx#applicationlayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
 
 ### L7LogCollectorDaemonSet
 
-To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.L7LogCollectorDaemonSet), patch the ApplicationLayer CR using the below command:
+To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#l7logcollectordaemonset), patch the ApplicationLayer CR using the below command:
 
 ```bash
 kubectl patch applicationlayer tigera-secure  --type=merge --patch='{"spec": {"l7LogCollectorDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"l7-collector","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"envoy-proxy","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -118,11 +118,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Authentication custom resource
 
-The [Authentication](../../reference/installation/api.mdx#operator.tigera.io/v1.Authentication) CR provides a way to configure resources for DexDeployment. The following sections provide example configurations for this CR.
+The [Authentication](../../reference/installation/api.mdx#authentication) CR provides a way to configure resources for DexDeployment. The following sections provide example configurations for this CR.
 
 ### DexDeployment
 
-To configure resource specification for the [DexDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.DexDeployment), patch the Authentication CR using the below command:
+To configure resource specification for the [DexDeployment](../../reference/installation/api.mdx#dexdeployment), patch the Authentication CR using the below command:
 
 ```bash
 kubectl patch authentication tigera-secure  --type=merge --patch='{"spec": {"dexDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-dex","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -157,13 +157,13 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Compliance custom resource
 
-The [Compliance](../../reference/installation/api.mdx#operator.tigera.io/v1.Compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
+The [Compliance](../../reference/installation/api.mdx#compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
 
 Example Configurations:
 
 ### ComplianceControllerDeployment
 
-To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceControllerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#compliancecontrollerdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -198,7 +198,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceSnapshotterDeployment
 
-To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceSnapshotterDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#compliancesnapshotterdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceSnapshotterDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-snapshotter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -233,7 +233,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceBenchmarkerDaemonSet
 
-To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#compliancebenchmarkerdaemonset), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceBenchmarkerDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-benchmarker","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -268,7 +268,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceServerDeployment
 
-To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceServerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#complianceserverdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -303,7 +303,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceReporterPodTemplate.
 
-To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceReporterPodTemplate), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#compliancereporterpodtemplate), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceReporterPodTemplate": {"template": {"spec": {"containers":[{"name":"reporter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}'
@@ -342,7 +342,7 @@ The [Installation CR](../../reference/installation/api.mdx) provides a way to co
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#typhadeployment), patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -377,7 +377,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#caliconodedaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -412,7 +412,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#caliconodewindowsdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -447,7 +447,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#calicokubecontrollersdeployment) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -483,7 +483,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#csinodedriverdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -531,11 +531,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## IntrusionDetection custom resource
 
-The [IntrusionDetection](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
+The [IntrusionDetection](../../reference/installation/api.mdx#intrusiondetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
 
 ### IntrusionDetectionControllerDeployment.
 
-To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionControllerDeployment), patch the IntrusionDetection CR using the below command:
+To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#intrusiondetectioncontrollerdeployment), patch the IntrusionDetection CR using the below command:
 
 ```bash
 kubectl patch intrusiondetection tigera-secure  --type=merge --patch='{"spec": {"intrusionDetectionControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"webhooks-processor","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}},{"name":"controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -583,11 +583,11 @@ This command will output the configured resource requests and limits for the Int
 
 ## LogCollector custom resource
 
-The [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
+The [LogCollector](../../reference/installation/api.mdx#logcollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
 
 ### FluentdDaemonSet.
 
-To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.FluentdDaemonSet), patch the LogCollector CR using the below command:
+To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#fluentddaemonset), patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"fluentdDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"fluentd","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -622,7 +622,7 @@ This command will output the configured resource requests and limits for the Flu
 
 ### EKSLogForwarderDeployment.
 
-To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.EKSLogForwarderDeployment), patch the LogCollector CR using the below command:
+To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#ekslogforwarderdeployment), patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"eksLogForwarderDeployment": {"spec": {"template": {"spec": {"containers":[{"name":"eks-log-forwarder","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -657,11 +657,11 @@ This command will output the configured resource requests and limits for the EKS
 
 ## LogStorage custom resource
 
-The [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) CR provides a way to configure resources for ECKOperatorStatefulSet, Kibana, LinseedDeployment, ElasticsearchMetricsDeployment. The following sections provide example configurations for this CR.
+The [LogStorage](../../reference/installation/api.mdx#logstorage) CR provides a way to configure resources for ECKOperatorStatefulSet, Kibana, LinseedDeployment, ElasticsearchMetricsDeployment. The following sections provide example configurations for this CR.
 
 ### ECKOperatorStatefulSet.
 
-To configure resource specification for the [ECKOperatorStatefulSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ECKOperatorStatefulSet), patch the LogStorage CR using the below command:
+To configure resource specification for the [ECKOperatorStatefulSet](../../reference/installation/api.mdx#eckoperatorstatefulset), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"eckOperatorStatefulSet":{"spec": {"template": {"spec": {"containers":[{"name":"manager","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -696,7 +696,7 @@ This command will output the configured resource requests and limits for the ECK
 
 ### Kibana
 
-To configure resource specification for the [Kibana](../../reference/installation/api.mdx#operator.tigera.io/v1.Kibana), patch the LogStorage CR using the below command:
+To configure resource specification for the [Kibana](../../reference/installation/api.mdx#kibana), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"kibana":{"spec": {"template": {"spec": {"containers":[{"name":"kibana","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -731,7 +731,7 @@ This command will output the configured resource requests and limits for the Kib
 
 ### LinseedDeployment
 
-To configure resource specification for the [LinseedDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.LinseedDeployment), patch the LogStorage CR using the below command:
+To configure resource specification for the [LinseedDeployment](../../reference/installation/api.mdx#linseeddeployment), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"linseedDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-linseed","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -766,7 +766,7 @@ This command will output the configured resource requests and limits for the Lin
 
 ### ElasticsearchMetricsDeployment
 
-To configure resource specification for the [ElasticsearchMetricsDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ElasticsearchMetricsDeployment), patch the LogStorage CR using the below command:
+To configure resource specification for the [ElasticsearchMetricsDeployment](../../reference/installation/api.mdx#elasticsearchmetricsdeployment), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"elasticsearchMetricsDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-elasticsearch-metrics","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -801,11 +801,11 @@ This command will output the configured resource requests and limits for the Ela
 
 ## ManagementClusterConnection custom resource
 
-The [ManagementClusterConnection](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
+The [ManagementClusterConnection](../../reference/installation/api.mdx#managementclusterconnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
 
 ### GuardianDeployment
 
-To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.GuardianDeployment), patch the ManagementClusterConnection CR using the below command:
+To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#guardiandeployment), patch the ManagementClusterConnection CR using the below command:
 
 ```bash
 kubectl patch managementclusterconnection tigera-secure  --type=merge --patch='{"spec": {"guardianDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-guardian","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -840,11 +840,11 @@ This command will output the configured resource requests and limits for the Gua
 
 ## Manager custom resource
 
-The [Manager](../../reference/installation/api.mdx#operator.tigera.io/v1.Manager) CR provides a way to configure resources for ManagerDeployment. The following sections provide example configurations for this CR.
+The [Manager](../../reference/installation/api.mdx#manager) CR provides a way to configure resources for ManagerDeployment. The following sections provide example configurations for this CR.
 
 ### ManagerDeployment
 
-To configure resource specification for the [ManagerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagerDeployment), patch the Manager CR using the below command:
+To configure resource specification for the [ManagerDeployment](../../reference/installation/api.mdx#managerdeployment), patch the Manager CR using the below command:
 
 ```bash
 kubectl patch manager tigera-secure  --type=merge --patch='{"spec": {"managerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-voltron","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-es-proxy","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-manager","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -906,11 +906,11 @@ This command will output the configured resource requests and limits for the Man
 
 ## Monitor custom resource
 
-The [Monitor](../../reference/installation/api.mdx#operator.tigera.io/v1.Monitor) CR provides a way to configure resources for Prometheus, AlertManager. The following sections provide example configurations for this CR.
+The [Monitor](../../reference/installation/api.mdx#monitor) CR provides a way to configure resources for Prometheus, AlertManager. The following sections provide example configurations for this CR.
 
 ### Prometheus
 
-To configure resource specification for the [Prometheus](../../reference/installation/api.mdx#operator.tigera.io/v1.Prometheus), Resources for the default container "prometheus" can be configured using the "resources" field under "commonPrometheusFields". For all other injected containers, such as "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
+To configure resource specification for the [Prometheus](../../reference/installation/api.mdx#prometheus), Resources for the default container "prometheus" can be configured using the "resources" field under "commonPrometheusFields". For all other injected containers, such as "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
 
 ```bash
 kubectl patch monitor tigera-secure --type=merge --patch='{"spec": {"prometheus": {"spec":{ "commonPrometheusFields": {"resources": {"limits": {"cpu":"500m","memory":"500Mi"}, "requests": {"cpu":"50m", "memory":"50Mi"}}, "containers":[{"name":"authn-proxy","resources":{"limits": {"cpu":"250m","memory":"500Mi"},"requests": {"cpu":"25m","memory":"50Mi"}}}]}}}}}'
@@ -975,7 +975,7 @@ The "config-reloader" container has default resource values set based by the Pro
 
 ### AlertManager
 
-To configure resource specification for the [AlertManager](../../reference/installation/api.mdx#operator.tigera.io/v1.AlertManager),  you can set resources for the default container "prometheus" using the "resources" field under "commonPrometheusFields". For all other injected containers, like "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
+To configure resource specification for the [AlertManager](../../reference/installation/api.mdx#alertmanager),  you can set resources for the default container "prometheus" using the "resources" field under "commonPrometheusFields". For all other injected containers, like "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
 
 ```bash
 kubectl patch monitor tigera-secure  --type=merge --patch='{"spec": {"alertManager": {"spec": {"resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}}}}'
@@ -1027,11 +1027,11 @@ The "config-reloader" container has default resource values set by the AlertMana
 
 ## PacketCaptureAPI custom resource
 
-The [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
+The [PacketCaptureAPI](../../reference/installation/api.mdx#packetcaptureapi) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
 
 ### PacketCaptureAPIDeployment
 
-To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI), patch the PacketCapture CR using the below command:
+To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#packetcaptureapi), patch the PacketCapture CR using the below command:
 
 ```bash
 kubectl patch packetcaptureapis tigera-secure  --type=merge --patch='{"spec": {"packetCaptureAPIDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-packetcapture-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -1066,11 +1066,11 @@ This command will output the configured resource requests and limits for the Pac
 
 ## PolicyRecommendation custom resource
 
-The [PolicyRecommendation](../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendation) CR provides a way to configure resources for PolicyRecommendation. The following sections provide example configurations for this CR.
+The [PolicyRecommendation](../../reference/installation/api.mdx#policyrecommendation) CR provides a way to configure resources for PolicyRecommendation. The following sections provide example configurations for this CR.
 
 ### PolicyRecommendationDeployment
 
-To configure resource specification for the [PolicyRecommendationDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendationDeployment), patch the PolicyRecommendation CR using the below command:
+To configure resource specification for the [PolicyRecommendationDeployment](../../reference/installation/api.mdx#policyrecommendationdeployment), patch the PolicyRecommendation CR using the below command:
 
 ```bash
 kubectl patch policyrecommendation tigera-secure  --type=merge --patch='{"spec": {"policyRecommendationDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"policy-recommendation-controller","resources":{"requests":{"cpu":"100m", "memory":"100Mi"},"limits":{"cpu":"1", "memory":"512Mi"}}}]}}}}}}'
@@ -1114,11 +1114,11 @@ The provided example illustrates configuring the apiserver component. Follow a s
 
 ### APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
+The [APIServer](../../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
 
 #### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), update values.yaml with the appropriate resource values.
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#apiserverdeployment), update values.yaml with the appropriate resource values.
 
 ```bash
 apiServer:

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/component-resources/typha/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/component-resources/typha/prometheus.mdx
@@ -5,7 +5,7 @@ description: Review metrics for the Typha component if you are using Prometheus.
 # Prometheus metrics
 
 Typha can be configured to report a number of metrics through Prometheus. The Prometheus port can be controlled
-via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#operator.tigera.io/v1.Installation).
+via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#installation).
 
 ## Metric reference
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/installation/helm_customization.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/installation/helm_customization.mdx
@@ -6,18 +6,18 @@ description: Helm installation reference
 
 You can customize the following resources and settings during $[prodname] Helm-based installation using the file, `values.yaml`.
 
-- [Installation](api.mdx#operator.tigera.io/v1.InstallationSpec)
-- [Api server](api.mdx#operator.tigera.io/v1.APIServerSpec)
-- [Compliance](api.mdx#operator.tigera.io/v1.ComplianceSpec)
-- [Intrusion detection](api.mdx#operator.tigera.io/v1.IntrusionDetectionSpec)
-- [Log collector](api.mdx#operator.tigera.io/v1.LogCollectorSpec)
-- [Log storage](api.mdx#operator.tigera.io/v1.LogStorageSpec)
-- [Manager](api.mdx#operator.tigera.io/v1.ManagerSpec)
-- [Monitor](api.mdx#operator.tigera.io/v1.MonitorSpec)
-- [Policy recommendation](api.mdx#operator.tigera.io/v1.PolicyRecommendationSpec)
-- [Authentication](api.mdx#operator.tigera.io/v1.AuthenticationSpec)
-- [Application layer](api.mdx#operator.tigera.io/v1.ApplicationLayerSpec)
-- [Amazon cloud integration](api.mdx#operator.tigera.io/v1.AmazonCloudIntegrationSpec)
+- [Installation](api.mdx#installationspec)
+- [Api server](api.mdx#apiserverspec)
+- [Compliance](api.mdx#compliancespec)
+- [Intrusion detection](api.mdx#intrusiondetectionspec)
+- [Log collector](api.mdx#logcollectorspec)
+- [Log storage](api.mdx#logstoragespec)
+- [Manager](api.mdx#managerspec)
+- [Monitor](api.mdx#monitorspec)
+- [Policy recommendation](api.mdx#policyrecommendationspec)
+- [Authentication](api.mdx#authenticationspec)
+- [Application layer](api.mdx#applicationlayerspec)
+- [Amazon cloud integration](api.mdx#amazoncloudintegrationspec)
 - [Default felix configuration](../resources/felixconfig.mdx#spec)
 
 :::note
@@ -92,7 +92,7 @@ Common customizations that you might want to configure are number of replicas, p
 
 ### Number of replicas
 This setting defines the number of replicas for $[prodname] components that can run simultaneously in multiple instances.
-To configure this setting, see [controlPlaneReplicas](api.mdx#operator.tigera.io/v1.InstallationSpec).
+To configure this setting, see [controlPlaneReplicas](api.mdx#installationspec).
 The components for the replicas are:
 
 - tigera-manager

--- a/calico-enterprise_versioned_docs/version-3.20-2/threat/deeppacketinspection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/threat/deeppacketinspection.mdx
@@ -79,7 +79,7 @@ spec:
 
 ### Configure resource requirements
 
-Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionComponentResource).
+Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#intrusiondetectioncomponentresource).
 
 For a data transfer rate of 1GB/sec on workload endpoints being monitored, we recommend a minimum of 1 CPU and 1GB RAM.
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/threat/web-application-firewall.mdx
@@ -335,9 +335,9 @@ kubectl delete applicationlayer tigera-secure
 
 ### Keep some ApplicationLayer features enabled
 
-To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) custom resource.
+To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#applicationlayer) custom resource.
 
-Note that the [ApplicationLayer Specification](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerSpec) can specify configuration for [Application Logging](../reference/installation/api#operator.tigera.io/v1.LogCollectionSpec) and [Application Layer Policy](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerPolicyStatusType) also. 
+Note that the [ApplicationLayer Specification](../reference/installation/api#applicationlayerspec) can specify configuration for [application logging](../reference/installation/api#operator.tigera.io/v1.logcollectionspec) and [application layer policy](../reference/installation/api#operator.tigera.io/v1.applicationlayerpolicystatustype) also.
 
 For the ApplicationLayer custom resource to be valid, at least one of these features have to be enabled, for example:
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/ConfigureManagedCluster.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/ConfigureManagedCluster.js
@@ -75,7 +75,7 @@ export default function ConfigureManagedCluster(props) {
         <li>
           <p>
             Add a managed cluster and save the manifest containing a{' '}
-            <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementClusterConnection`}>
+            <Link href={`${baseUrl}/reference/installation/api#managementclusterconnection`}>
               ManagementClusterConnection
             </Link>{' '}
             and a Secret.

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallAKS.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallAKS.js
@@ -294,7 +294,7 @@ EOF`}
             <li>
               <p>
                 Apply the{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallEKS.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallEKS.js
@@ -365,7 +365,7 @@ EOF`}
             <li>
               <p>
                 Apply the{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallGKE.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallGKE.js
@@ -181,7 +181,7 @@ EOF`}
           <li>
             <p>
               Apply the{' '}
-              <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+              <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                 ManagementCluster
               </Link>{' '}
               CR.

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallGeneric.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallGeneric.js
@@ -191,7 +191,7 @@ EOF`}
             </li>
             <li>
               <p>
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallOpenShift.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallOpenShift.js
@@ -329,7 +329,7 @@ EOF`}
             <li>
               <p>
                 Apply the{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/UpgradeOperatorSimple.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/UpgradeOperatorSimple.js
@@ -182,7 +182,7 @@ export default function UpgradeOperatorSimple(props) {
             <li>
               <p>
                 If your cluster is a management cluster using v3.1 or older, apply a{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster{' '}
                 </Link>
                 CR to your cluster.
@@ -199,7 +199,7 @@ EOF`}
             <li>
               <p>
                 If your cluster is v3.7 or older, apply a new{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.Monitor`}>Monitor </Link>
+                <Link href={`${baseUrl}/reference/installation/api#monitor`}>Monitor </Link>
                 CR to your cluster.
               </p>
               <CodeBlock language='bash'>
@@ -214,7 +214,7 @@ EOF`}
             <li>
               <p>
                 If your cluster is v3.16 or older, apply a new{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.PolicyRecommendation`}>PolicyRecommendation </Link>
+                <Link href={`${baseUrl}/reference/installation/api#policyrecommendation`}>PolicyRecommendation </Link>
                 CR to your cluster.
               </p>
               <CodeBlock language='bash'>
@@ -229,7 +229,7 @@ EOF`}
             <li>
               <p>
                 If your cluster is v3.19 or older, apply a new{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.PacketCaptureAPI`}>PacketCaptureAPI </Link>
+                <Link href={`${baseUrl}/reference/installation/api#packetcaptureapi`}>PacketCaptureAPI </Link>
                  CR to your cluster.
               </p>
               <CodeBlock language='bash'>

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -47,7 +47,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
@@ -44,4 +44,4 @@ $[prodnameWindows] flow logs are enabled and configured the same way as [Flow lo
 - [Configure flow log aggregation](../../../observability/elastic/flow/aggregation.mdx)
 - [Log storage recommendations](../../../operations/logstorage/log-storage-recommendations.mdx)
 - [Archive logs](../../../observability/elastic/archive-storage.mdx)
-- [Log collection options](../../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../../reference/installation/api.mdx#logcollectorspec)

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/windows-calico/requirements.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/windows-calico/requirements.mdx
@@ -36,7 +36,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#bgpoption).
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
@@ -113,7 +113,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
 
 1. <OpenShiftPrometheusOperator operation='upgrade' />
 
-1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster)
+1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#managementcluster)
    CR to your cluster.
 
    ```bash
@@ -125,7 +125,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#operator.tigera.io/v1.Monitor)
+1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#monitor)
    CR to your cluster.
 
    ```bash
@@ -137,7 +137,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendation)
+1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#policyrecommendation)
    CR to your cluster.
 
    ```bash
@@ -149,7 +149,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster was at one time v3.18 or older, remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#operator.tigera.io/v1.Manager).
+1. If your cluster was at one time v3.18 or older, remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#manager).
 
    ```bash
    oc apply -f - <<EOF
@@ -160,7 +160,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.19 or older, apply a new [PacketCaptureAPI](../../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI)
+1. If your cluster is v3.19 or older, apply a new [PacketCaptureAPI](../../../reference/installation/api.mdx#packetcaptureapi)
     CR to your cluster.
 
    ```bash

--- a/calico-enterprise_versioned_docs/version-3.21-2/multicluster/fine-tune-deployment.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/multicluster/fine-tune-deployment.mdx
@@ -151,4 +151,4 @@ To filter log data by a given managed cluster you can include the filter criteri
 
 # Additional resources
 
-- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection)
+- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#managementclusterconnection)

--- a/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -47,7 +47,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -49,7 +49,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
@@ -52,7 +52,7 @@ To control managed clusters from your central management plane, you must ensure 
     ```bash
     export MANAGEMENT_CLUSTER_ADDR=<your-management-cluster-addr>
     ```
-1.  Apply the [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) CR.
+1.  Apply the [ManagementCluster](../../../reference/installation/api.mdx#managementcluster) CR.
 
     ```bash
     kubectl apply -f - <<EOF

--- a/calico-enterprise_versioned_docs/version-3.21-2/networking/configuring/dual-tor.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/networking/configuring/dual-tor.mdx
@@ -633,7 +633,7 @@ The only connections using interface-specific addresses should be BGP.
 If you plan to use [Egress Gateways](../egress/egress-gateway-on-prem.mdx) in your cluster, you must also adjust the $[nodecontainer] IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-$[prodname] [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+$[prodname] [Installation resource](../../reference/installation/api.mdx#nodeaddressautodetection).
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/networking/configuring/multiple-networks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/networking/configuring/multiple-networks.mdx
@@ -77,7 +77,7 @@ Although the following $[prodname] features are supported for your default $[pro
 
 ### Configure cluster for multiple networks
 
-In the [Installation custom resource](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoNetworkSpec), set the `MultiInterfaceMode` to **Multus**.
+In the [Installation custom resource](../../reference/installation/api.mdx#caliconetworkspec), set the `MultiInterfaceMode` to **Multus**.
 
 ### Create a new network
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/networking/egress/egress-gateway-on-prem.mdx
@@ -348,7 +348,7 @@ To modify the iptables backend for egress gateways, you must change the `iptable
 If you plan to use Egress Gateways in a [dual-ToR cluster](../configuring/dual-tor.mdx), you must also adjust the $[nodecontainer] IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-$[prodname] [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+$[prodname] [Installation resource](../../reference/installation/api.mdx#nodeaddressautodetection).
 
 ### Configure namespaces and pods to use egress gateways
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/networking/ipam/initial-ippool.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/networking/ipam/initial-ippool.mdx
@@ -22,7 +22,7 @@ The **Kubernetes pod CIDR** is the expected IP address range for pod IPs. It is 
 
 [Calico IP pools](../../reference/resources/ippool.mdx) are ranges of IP addresses that Calico uses to assign to pods; the ranges must within the Kubernetes pod CIDR.
 
-The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#installation)
 resource and configures the default Calico IP pool. Note the following:
 
 - Default fields for any that are omitted:
@@ -42,7 +42,7 @@ resource and configures the default Calico IP pool. Note the following:
 ## How to
 
 1. Download the custom-resource.yaml file.
-1. Edit the [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation).
+1. Edit the [Installation resource](../../reference/installation/api.mdx#installation).
    **Required values**: `cidr:`
    **Empty values**: Defaulted
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/networking/ipam/ip-autodetection.mdx
@@ -49,7 +49,7 @@ By default, $[prodname] uses the **firstFound** method; the first valid IP addre
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the operator Installation reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-enterprise_versioned_docs/version-3.21-2/observability/elastic/archive-storage.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/observability/elastic/archive-storage.mdx
@@ -46,8 +46,8 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
     -n tigera-operator
    ```
 
-3. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#operator.tigera.io/v1.S3StoreSpec)
+3. Update the [LogCollector](../../reference/installation/api.mdx#logcollector)
+   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#s3storespec)
    with your information noted from above.
    Example:
 
@@ -74,8 +74,8 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
 </TabItem>
 <TabItem label="Syslog" value="Syslog-1">
 
-1. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+1. Update the [LogCollector](../../reference/installation/api.mdx#logcollector)
+   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#syslogstorespec)
    with your syslog information.
    Example:
    ```yaml
@@ -102,7 +102,7 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
    kubectl edit logcollector tigera-secure
    ```
 2. You can control which types of $[prodname] log data you would like to send to syslog.
-   The [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+   The [Syslog section](../../reference/installation/api.mdx#syslogstorespec)
    contains a field called `logTypes` which allows you to list which log types you would like to include.
    The allowable log types are:
 
@@ -111,11 +111,11 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
    - Flows
    - IDSEvents
 
-   Refer to the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec) for more details on what data each log type represents.
+   Refer to the [Syslog section](../../reference/installation/api.mdx#syslogstorespec) for more details on what data each log type represents.
 
    :::note
 
-   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
+   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#logstorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
 
    :::
 
@@ -123,7 +123,7 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
 
 **TLS configuration**
 
-3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec).
+3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#syslogstorespec).
 
    ```yaml
    apiVersion: operator.tigera.io/v1
@@ -178,9 +178,9 @@ $[prodname] uses Splunk's **HTTP Event Collector** to send data to Splunk server
    ```
 
 3. Update the
-   [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
+   [LogCollector](../../reference/installation/api.mdx#logcollector)
    resource named `tigera-secure` to include
-   a [Splunk section](../../reference/installation/api.mdx#operator.tigera.io/v1.SplunkStoreSpec)
+   a [Splunk section](../../reference/installation/api.mdx#splunkstorespec)
    with your Splunk information.
    Example:
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/observability/elastic/l7/configure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/observability/elastic/l7/configure.mdx
@@ -61,7 +61,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
 
 ### Configure the ApplicationLayer resource for L7 logs
 
-1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) resource named, `tigera-secure`.
+1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#applicationlayer) resource named, `tigera-secure`.
 
    Example:
 
@@ -82,7 +82,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
    EOF
    ```
 
-   Read more about the log collection specification [here](../../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector).
+   Read more about the log collection specification [here](../../../reference/installation/api.mdx#logcollector).
    
    Applying this resource creates an `l7-log-collector` daemonset in `calico-system` namespace.
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/observability/elastic/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/observability/elastic/overview.mdx
@@ -91,7 +91,7 @@ $[prodname] compliance reports are based on archived **flow logs** and **audit l
 - Global network policies
 - Network sets
 
-$[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec).
+$[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#logcollectorspec).
 
 ## Additional resources
 
@@ -102,4 +102,4 @@ $[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../refere
 - [BGP logs](bgp.mdx)
 - [DNS logs](dns/dns-logs.mdx)
 - [Archive logs](archive-storage.mdx)
-- [Log collection options](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../reference/installation/api.mdx#logcollectorspec)

--- a/calico-enterprise_versioned_docs/version-3.21-2/observability/elastic/rbac-elasticsearch.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/observability/elastic/rbac-elasticsearch.mdx
@@ -211,4 +211,4 @@ status:
 ## Additional resources
 
 - Configure [RBAC for tiered policies](../../network-policy/policy-tiers/rbac-tiered-policies.mdx).
-- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) resource.
+- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#managementcluster) resource.

--- a/calico-enterprise_versioned_docs/version-3.21-2/observability/elastic/retention.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/observability/elastic/retention.mdx
@@ -10,7 +10,7 @@ Configure how long to retain logs and compliance reports.
 
 ## Before you begin...
 
-Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#operator.tigera.io/v1.Retention) and determine the appropriate values for your deployment.
+Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#retention) and determine the appropriate values for your deployment.
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/observability/elastic/troubleshoot.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/observability/elastic/troubleshoot.mdx
@@ -8,7 +8,7 @@ description: Learn how to troubleshoot common issues with Elasticsearch.
 
 The following user-configured resources are related to Elasticsearch:
 
-- [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage). It has settings for:
+- [LogStorage](../../reference/installation/api.mdx#logstorage). It has settings for:
 
   - Elasticsearch (for example, nodeCount and replicas)
   - Kubernetes (for example, resourceRequirements, storage and nodeSelectors)
@@ -111,7 +111,7 @@ As a last resort, create a new [Elasticsearch cluster](#how-to-create-a-new-clus
 
 ### Elasticsearch is slow
 
-**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorageSpec).
+**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#logstoragespec).
 
 ### Elasticsearch crashes during booting
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/operations/cnx/configure-identity-provider.mdx
@@ -15,7 +15,7 @@ Configure an external identity provider (IdP), create a user, and log in to the 
 
 ## Concepts
 
-The $[prodname] authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Authentication) named, `tigera-secure`.
+The $[prodname] authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#authentication) named, `tigera-secure`.
 
 When configuring your cluster, you may be asked for the following inputs:
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/operations/cnx/roles-and-permissions.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/operations/cnx/roles-and-permissions.mdx
@@ -16,7 +16,7 @@ Self-service is an important part of your Kubernetes platform networking and net
 
 ### Kubernetes RBAC authorization
 
-The [Calico Enterprise API server](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) is an extension to the standard [Kubernetes RBAC Authorization APIs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
+The [Calico Enterprise API server](../../reference/installation/api.mdx#apiserver) is an extension to the standard [kubernetes rbac authorization apis](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
 
 | Features                       | RBAC controls for...                                                                                                                                                                                                                            |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/calico-enterprise_versioned_docs/version-3.21-2/operations/comms/certificate-management.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/operations/comms/certificate-management.mdx
@@ -19,7 +19,7 @@ certificate issuance, $[prodname] provides a simple configuration option that yo
 **Limitations**
 
 If your cluster is already running $[prodname] and you would like to enable certificate management, you need to
-temporarily remove [the logstorage resource](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+temporarily remove [the logstorage resource](../../reference/installation/api.mdx#logstorage)
 before following the steps to enable certificate management and then re-apply afterwards. For detailed steps on
 re-creating logstorage, read more on [how to create a new Elasticsearch cluster](../../observability/elastic/troubleshoot.mdx#how-to-create-a-new-cluster).
 
@@ -38,7 +38,7 @@ Currently, this feature is not supported in combination with [Multi-cluster mana
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../../reference/installation/api.mdx#installation)
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
    ```yaml

--- a/calico-enterprise_versioned_docs/version-3.21-2/operations/logstorage/log-storage-recommendations.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/operations/logstorage/log-storage-recommendations.mdx
@@ -80,4 +80,4 @@ is no tolerance for removing/restarting a node.
 
 - Read the [LogStorage overview page](../logstorage/index.mdx)
 - [Troubleshooting Elasticsearch](../../observability/elastic/troubleshoot.mdx)
-- [LogStorage Specification](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+- [LogStorage Specification](../../reference/installation/api.mdx#logstorage)

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/architecture/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/architecture/overview.mdx
@@ -122,7 +122,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### Manager
 
-**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#operator.tigera.io/v1.Manager).
+**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#manager).
 
 ### Packet capture API
 
@@ -150,7 +150,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### API server
 
-**Main task**: Allows users to manage $[prodname] resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#operator.tigera.io/v1.APIServer).
+**Main task**: Allows users to manage $[prodname] resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#apiserver).
 
 ### BIRD
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/component-resources/configuration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/component-resources/configuration.mdx
@@ -239,7 +239,7 @@ By enabling this feature, you can avoid errors that can occur when a pod tries t
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](../installation/api#operator.tigera.io/v1.CalicoNetworkSpec) of the default `operator.tigera.io/v1/installation` resource.
+The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](../installation/api#caliconetworkspec) of the default `operator.tigera.io/v1/installation` resource.
 
 The following example configures the CNI to delay a pod from starting its containers for up to 10 seconds, or until the pod's data plane has been programmed:
 
@@ -309,7 +309,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-2">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#installation) API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/component-resources/configure-resources.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/component-resources/configure-resources.mdx
@@ -14,11 +14,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the APIServer CR using the below command:
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#apiserverdeployment), patch the APIServer CR using the below command:
 
 ```bash
 kubectl patch apiserver tigera-secure  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -66,11 +66,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## ApplicationLayer custom resource
 
-The [ApplicationLayer](../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
+The [ApplicationLayer](../../reference/installation/api.mdx#applicationlayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
 
 ### L7LogCollectorDaemonSet
 
-To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.L7LogCollectorDaemonSet), patch the ApplicationLayer CR using the below command:
+To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#l7logcollectordaemonset), patch the ApplicationLayer CR using the below command:
 
 ```bash
 kubectl patch applicationlayer tigera-secure  --type=merge --patch='{"spec": {"l7LogCollectorDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"l7-collector","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"envoy-proxy","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -118,11 +118,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Authentication custom resource
 
-The [Authentication](../../reference/installation/api.mdx#operator.tigera.io/v1.Authentication) CR provides a way to configure resources for DexDeployment. The following sections provide example configurations for this CR.
+The [Authentication](../../reference/installation/api.mdx#authentication) CR provides a way to configure resources for DexDeployment. The following sections provide example configurations for this CR.
 
 ### DexDeployment
 
-To configure resource specification for the [DexDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.DexDeployment), patch the Authentication CR using the below command:
+To configure resource specification for the [DexDeployment](../../reference/installation/api.mdx#dexdeployment), patch the Authentication CR using the below command:
 
 ```bash
 kubectl patch authentication tigera-secure  --type=merge --patch='{"spec": {"dexDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-dex","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -157,13 +157,13 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Compliance custom resource
 
-The [Compliance](../../reference/installation/api.mdx#operator.tigera.io/v1.Compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
+The [Compliance](../../reference/installation/api.mdx#compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
 
 Example Configurations:
 
 ### ComplianceControllerDeployment
 
-To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceControllerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#compliancecontrollerdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -198,7 +198,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceSnapshotterDeployment
 
-To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceSnapshotterDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#compliancesnapshotterdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceSnapshotterDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-snapshotter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -233,7 +233,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceBenchmarkerDaemonSet
 
-To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#compliancebenchmarkerdaemonset), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceBenchmarkerDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-benchmarker","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -268,7 +268,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceServerDeployment
 
-To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceServerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#complianceserverdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -303,7 +303,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceReporterPodTemplate.
 
-To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceReporterPodTemplate), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#compliancereporterpodtemplate), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceReporterPodTemplate": {"template": {"spec": {"containers":[{"name":"reporter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}'
@@ -342,7 +342,7 @@ The [Installation CR](../../reference/installation/api.mdx) provides a way to co
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#typhadeployment), patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -377,7 +377,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#caliconodedaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -412,7 +412,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#caliconodewindowsdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -447,7 +447,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#calicokubecontrollersdeployment) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -483,7 +483,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#csinodedriverdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -531,11 +531,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## IntrusionDetection custom resource
 
-The [IntrusionDetection](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
+The [IntrusionDetection](../../reference/installation/api.mdx#intrusiondetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
 
 ### IntrusionDetectionControllerDeployment.
 
-To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionControllerDeployment), patch the IntrusionDetection CR using the below command:
+To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#intrusiondetectioncontrollerdeployment), patch the IntrusionDetection CR using the below command:
 
 ```bash
 kubectl patch intrusiondetection tigera-secure  --type=merge --patch='{"spec": {"intrusionDetectionControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"webhooks-processor","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}},{"name":"controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -583,11 +583,11 @@ This command will output the configured resource requests and limits for the Int
 
 ## LogCollector custom resource
 
-The [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
+The [LogCollector](../../reference/installation/api.mdx#logcollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
 
 ### FluentdDaemonSet.
 
-To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.FluentdDaemonSet), patch the LogCollector CR using the below command:
+To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#fluentddaemonset), patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"fluentdDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"fluentd","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -622,7 +622,7 @@ This command will output the configured resource requests and limits for the Flu
 
 ### EKSLogForwarderDeployment.
 
-To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.EKSLogForwarderDeployment), patch the LogCollector CR using the below command:
+To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#ekslogforwarderdeployment), patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"eksLogForwarderDeployment": {"spec": {"template": {"spec": {"containers":[{"name":"eks-log-forwarder","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -657,11 +657,11 @@ This command will output the configured resource requests and limits for the EKS
 
 ## LogStorage custom resource
 
-The [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) CR provides a way to configure resources for ECKOperatorStatefulSet, Kibana, LinseedDeployment, ElasticsearchMetricsDeployment. The following sections provide example configurations for this CR.
+The [LogStorage](../../reference/installation/api.mdx#logstorage) CR provides a way to configure resources for ECKOperatorStatefulSet, Kibana, LinseedDeployment, ElasticsearchMetricsDeployment. The following sections provide example configurations for this CR.
 
 ### ECKOperatorStatefulSet.
 
-To configure resource specification for the [ECKOperatorStatefulSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ECKOperatorStatefulSet), patch the LogStorage CR using the below command:
+To configure resource specification for the [ECKOperatorStatefulSet](../../reference/installation/api.mdx#eckoperatorstatefulset), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"eckOperatorStatefulSet":{"spec": {"template": {"spec": {"containers":[{"name":"manager","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -696,7 +696,7 @@ This command will output the configured resource requests and limits for the ECK
 
 ### Kibana
 
-To configure resource specification for the [Kibana](../../reference/installation/api.mdx#operator.tigera.io/v1.Kibana), patch the LogStorage CR using the below command:
+To configure resource specification for the [Kibana](../../reference/installation/api.mdx#kibana), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"kibana":{"spec": {"template": {"spec": {"containers":[{"name":"kibana","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -731,7 +731,7 @@ This command will output the configured resource requests and limits for the Kib
 
 ### LinseedDeployment
 
-To configure resource specification for the [LinseedDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.LinseedDeployment), patch the LogStorage CR using the below command:
+To configure resource specification for the [LinseedDeployment](../../reference/installation/api.mdx#linseeddeployment), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"linseedDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-linseed","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -766,7 +766,7 @@ This command will output the configured resource requests and limits for the Lin
 
 ### ElasticsearchMetricsDeployment
 
-To configure resource specification for the [ElasticsearchMetricsDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ElasticsearchMetricsDeployment), patch the LogStorage CR using the below command:
+To configure resource specification for the [ElasticsearchMetricsDeployment](../../reference/installation/api.mdx#elasticsearchmetricsdeployment), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"elasticsearchMetricsDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-elasticsearch-metrics","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -801,11 +801,11 @@ This command will output the configured resource requests and limits for the Ela
 
 ## ManagementClusterConnection custom resource
 
-The [ManagementClusterConnection](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
+The [ManagementClusterConnection](../../reference/installation/api.mdx#managementclusterconnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
 
 ### GuardianDeployment
 
-To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.GuardianDeployment), patch the ManagementClusterConnection CR using the below command:
+To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#guardiandeployment), patch the ManagementClusterConnection CR using the below command:
 
 ```bash
 kubectl patch managementclusterconnection tigera-secure  --type=merge --patch='{"spec": {"guardianDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-guardian","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -840,11 +840,11 @@ This command will output the configured resource requests and limits for the Gua
 
 ## Manager custom resource
 
-The [Manager](../../reference/installation/api.mdx#operator.tigera.io/v1.Manager) CR provides a way to configure resources for ManagerDeployment. The following sections provide example configurations for this CR.
+The [Manager](../../reference/installation/api.mdx#manager) CR provides a way to configure resources for ManagerDeployment. The following sections provide example configurations for this CR.
 
 ### ManagerDeployment
 
-To configure resource specification for the [ManagerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagerDeployment), patch the Manager CR using the below command:
+To configure resource specification for the [ManagerDeployment](../../reference/installation/api.mdx#managerdeployment), patch the Manager CR using the below command:
 
 ```bash
 kubectl patch manager tigera-secure  --type=merge --patch='{"spec": {"managerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-voltron","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-ui-apis","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-manager","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -906,11 +906,11 @@ This command will output the configured resource requests and limits for the Man
 
 ## Monitor custom resource
 
-The [Monitor](../../reference/installation/api.mdx#operator.tigera.io/v1.Monitor) CR provides a way to configure resources for Prometheus, AlertManager. The following sections provide example configurations for this CR.
+The [Monitor](../../reference/installation/api.mdx#monitor) CR provides a way to configure resources for Prometheus, AlertManager. The following sections provide example configurations for this CR.
 
 ### Prometheus
 
-To configure resource specification for the [Prometheus](../../reference/installation/api.mdx#operator.tigera.io/v1.Prometheus), Resources for the default container "prometheus" can be configured using the "resources" field under "commonPrometheusFields". For all other injected containers, such as "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
+To configure resource specification for the [Prometheus](../../reference/installation/api.mdx#prometheus), Resources for the default container "prometheus" can be configured using the "resources" field under "commonPrometheusFields". For all other injected containers, such as "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
 
 ```bash
 kubectl patch monitor tigera-secure --type=merge --patch='{"spec": {"prometheus": {"spec":{ "commonPrometheusFields": {"resources": {"limits": {"cpu":"500m","memory":"500Mi"}, "requests": {"cpu":"50m", "memory":"50Mi"}}, "containers":[{"name":"authn-proxy","resources":{"limits": {"cpu":"250m","memory":"500Mi"},"requests": {"cpu":"25m","memory":"50Mi"}}}]}}}}}'
@@ -975,7 +975,7 @@ The "config-reloader" container has default resource values set based by the Pro
 
 ### AlertManager
 
-To configure resource specification for the [AlertManager](../../reference/installation/api.mdx#operator.tigera.io/v1.AlertManager),  you can set resources for the default container "prometheus" using the "resources" field under "commonPrometheusFields". For all other injected containers, like "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
+To configure resource specification for the [AlertManager](../../reference/installation/api.mdx#alertmanager),  you can set resources for the default container "prometheus" using the "resources" field under "commonPrometheusFields". For all other injected containers, like "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
 
 ```bash
 kubectl patch monitor tigera-secure  --type=merge --patch='{"spec": {"alertManager": {"spec": {"resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}}}}'
@@ -1027,11 +1027,11 @@ The "config-reloader" container has default resource values set by the AlertMana
 
 ## PacketCaptureAPI custom resource
 
-The [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
+The [PacketCaptureAPI](../../reference/installation/api.mdx#packetcaptureapi) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
 
 ### PacketCaptureAPIDeployment
 
-To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI), patch the PacketCapture CR using the below command:
+To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#packetcaptureapi), patch the PacketCapture CR using the below command:
 
 ```bash
 kubectl patch packetcaptureapis tigera-secure  --type=merge --patch='{"spec": {"packetCaptureAPIDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-packetcapture-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -1066,11 +1066,11 @@ This command will output the configured resource requests and limits for the Pac
 
 ## PolicyRecommendation custom resource
 
-The [PolicyRecommendation](../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendation) CR provides a way to configure resources for PolicyRecommendation. The following sections provide example configurations for this CR.
+The [PolicyRecommendation](../../reference/installation/api.mdx#policyrecommendation) CR provides a way to configure resources for PolicyRecommendation. The following sections provide example configurations for this CR.
 
 ### PolicyRecommendationDeployment
 
-To configure resource specification for the [PolicyRecommendationDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendationDeployment), patch the PolicyRecommendation CR using the below command:
+To configure resource specification for the [PolicyRecommendationDeployment](../../reference/installation/api.mdx#policyrecommendationdeployment), patch the PolicyRecommendation CR using the below command:
 
 ```bash
 kubectl patch policyrecommendation tigera-secure  --type=merge --patch='{"spec": {"policyRecommendationDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"policy-recommendation-controller","resources":{"requests":{"cpu":"100m", "memory":"100Mi"},"limits":{"cpu":"1", "memory":"512Mi"}}}]}}}}}}'
@@ -1114,11 +1114,11 @@ The provided example illustrates configuring the apiserver component. Follow a s
 
 ### APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
+The [APIServer](../../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
 
 #### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), update values.yaml with the appropriate resource values.
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#apiserverdeployment), update values.yaml with the appropriate resource values.
 
 ```bash
 apiServer:

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/component-resources/typha/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/component-resources/typha/prometheus.mdx
@@ -5,7 +5,7 @@ description: Review metrics for the Typha component if you are using Prometheus.
 # Prometheus metrics
 
 Typha can be configured to report a number of metrics through Prometheus. The Prometheus port can be controlled
-via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#operator.tigera.io/v1.Installation).
+via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#installation).
 
 ## Metric reference
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/installation/helm_customization.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/installation/helm_customization.mdx
@@ -6,18 +6,18 @@ description: Helm installation reference
 
 You can customize the following resources and settings during $[prodname] Helm-based installation using the file, `values.yaml`.
 
-- [Installation](api.mdx#operator.tigera.io/v1.InstallationSpec)
-- [Api server](api.mdx#operator.tigera.io/v1.APIServerSpec)
-- [Compliance](api.mdx#operator.tigera.io/v1.ComplianceSpec)
-- [Intrusion detection](api.mdx#operator.tigera.io/v1.IntrusionDetectionSpec)
-- [Log collector](api.mdx#operator.tigera.io/v1.LogCollectorSpec)
-- [Log storage](api.mdx#operator.tigera.io/v1.LogStorageSpec)
-- [Manager](api.mdx#operator.tigera.io/v1.ManagerSpec)
-- [Monitor](api.mdx#operator.tigera.io/v1.MonitorSpec)
-- [Policy recommendation](api.mdx#operator.tigera.io/v1.PolicyRecommendationSpec)
-- [Authentication](api.mdx#operator.tigera.io/v1.AuthenticationSpec)
-- [Application layer](api.mdx#operator.tigera.io/v1.ApplicationLayerSpec)
-- [Amazon cloud integration](api.mdx#operator.tigera.io/v1.AmazonCloudIntegrationSpec)
+- [Installation](api.mdx#installationspec)
+- [Api server](api.mdx#apiserverspec)
+- [Compliance](api.mdx#compliancespec)
+- [Intrusion detection](api.mdx#intrusiondetectionspec)
+- [Log collector](api.mdx#logcollectorspec)
+- [Log storage](api.mdx#logstoragespec)
+- [Manager](api.mdx#managerspec)
+- [Monitor](api.mdx#monitorspec)
+- [Policy recommendation](api.mdx#policyrecommendationspec)
+- [Authentication](api.mdx#authenticationspec)
+- [Application layer](api.mdx#applicationlayerspec)
+- [Amazon cloud integration](api.mdx#amazoncloudintegrationspec)
 - [Default felix configuration](../resources/felixconfig.mdx#spec)
 
 :::note
@@ -92,7 +92,7 @@ Common customizations that you might want to configure are number of replicas, p
 
 ### Number of replicas
 This setting defines the number of replicas for $[prodname] components that can run simultaneously in multiple instances.
-To configure this setting, see [controlPlaneReplicas](api.mdx#operator.tigera.io/v1.InstallationSpec).
+To configure this setting, see [controlPlaneReplicas](api.mdx#installationspec).
 The components for the replicas are:
 
 - tigera-manager

--- a/calico-enterprise_versioned_docs/version-3.21-2/threat/deeppacketinspection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/threat/deeppacketinspection.mdx
@@ -79,7 +79,7 @@ spec:
 
 ### Configure resource requirements
 
-Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionComponentResource).
+Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#intrusiondetectioncomponentresource).
 
 For a data transfer rate of 1GB/sec on workload endpoints being monitored, we recommend a minimum of 1 CPU and 1GB RAM.
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/threat/web-application-firewall.mdx
@@ -350,9 +350,9 @@ kubectl delete applicationlayer tigera-secure
 
 ### Keep some ApplicationLayer features enabled
 
-To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) custom resource.
+To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#applicationlayer) custom resource.
 
-Note that the [ApplicationLayer Specification](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerSpec) can specify configuration for [Application Logging](../reference/installation/api#operator.tigera.io/v1.LogCollectionSpec) and [Application Layer Policy](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerPolicyStatusType) also. 
+Note that the [ApplicationLayer Specification](../reference/installation/api#applicationlayerspec) can specify configuration for [application logging](../reference/installation/api#operator.tigera.io/v1.logcollectionspec) and [application layer policy](../reference/installation/api#operator.tigera.io/v1.applicationlayerpolicystatustype) also.
 
 For the ApplicationLayer custom resource to be valid, at least one of these features have to be enabled, for example:
 

--- a/calico-enterprise_versioned_docs/version-3.22-1/_includes/components/ConfigureManagedCluster.js
+++ b/calico-enterprise_versioned_docs/version-3.22-1/_includes/components/ConfigureManagedCluster.js
@@ -75,7 +75,7 @@ export default function ConfigureManagedCluster(props) {
         <li>
           <p>
             Add a managed cluster and save the manifest containing a{' '}
-            <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementClusterConnection`}>
+            <Link href={`${baseUrl}/reference/installation/api#managementclusterconnection`}>
               ManagementClusterConnection
             </Link>{' '}
             and a Secret.

--- a/calico-enterprise_versioned_docs/version-3.22-1/_includes/components/InstallAKS.js
+++ b/calico-enterprise_versioned_docs/version-3.22-1/_includes/components/InstallAKS.js
@@ -294,7 +294,7 @@ EOF`}
             <li>
               <p>
                 Apply the{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise_versioned_docs/version-3.22-1/_includes/components/InstallEKS.js
+++ b/calico-enterprise_versioned_docs/version-3.22-1/_includes/components/InstallEKS.js
@@ -365,7 +365,7 @@ EOF`}
             <li>
               <p>
                 Apply the{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise_versioned_docs/version-3.22-1/_includes/components/InstallGKE.js
+++ b/calico-enterprise_versioned_docs/version-3.22-1/_includes/components/InstallGKE.js
@@ -181,7 +181,7 @@ EOF`}
           <li>
             <p>
               Apply the{' '}
-              <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+              <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                 ManagementCluster
               </Link>{' '}
               CR.

--- a/calico-enterprise_versioned_docs/version-3.22-1/_includes/components/InstallGeneric.js
+++ b/calico-enterprise_versioned_docs/version-3.22-1/_includes/components/InstallGeneric.js
@@ -191,7 +191,7 @@ EOF`}
             </li>
             <li>
               <p>
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise_versioned_docs/version-3.22-1/_includes/components/InstallOpenShift.js
+++ b/calico-enterprise_versioned_docs/version-3.22-1/_includes/components/InstallOpenShift.js
@@ -329,7 +329,7 @@ EOF`}
             <li>
               <p>
                 Apply the{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster
                 </Link>{' '}
                 CR.

--- a/calico-enterprise_versioned_docs/version-3.22-1/_includes/components/UpgradeOperatorSimple.js
+++ b/calico-enterprise_versioned_docs/version-3.22-1/_includes/components/UpgradeOperatorSimple.js
@@ -182,7 +182,7 @@ export default function UpgradeOperatorSimple(props) {
             <li>
               <p>
                 If your cluster is a management cluster using v3.1 or older, apply a{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.ManagementCluster`}>
+                <Link href={`${baseUrl}/reference/installation/api#managementcluster`}>
                   ManagementCluster{' '}
                 </Link>
                 CR to your cluster.
@@ -199,7 +199,7 @@ EOF`}
             <li>
               <p>
                 If your cluster is v3.7 or older, apply a new{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.Monitor`}>Monitor </Link>
+                <Link href={`${baseUrl}/reference/installation/api#monitor`}>Monitor </Link>
                 CR to your cluster.
               </p>
               <CodeBlock language='bash'>
@@ -214,7 +214,7 @@ EOF`}
             <li>
               <p>
                 If your cluster is v3.16 or older, apply a new{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.PolicyRecommendation`}>PolicyRecommendation </Link>
+                <Link href={`${baseUrl}/reference/installation/api#policyrecommendation`}>PolicyRecommendation </Link>
                 CR to your cluster.
               </p>
               <CodeBlock language='bash'>
@@ -229,7 +229,7 @@ EOF`}
             <li>
               <p>
                 If your cluster is v3.19 or older, apply a new{' '}
-                <Link href={`${baseUrl}/reference/installation/api#operator.tigera.io/v1.PacketCaptureAPI`}>PacketCaptureAPI </Link>
+                <Link href={`${baseUrl}/reference/installation/api#packetcaptureapi`}>PacketCaptureAPI </Link>
                  CR to your cluster.
               </p>
               <CodeBlock language='bash'>

--- a/calico-enterprise_versioned_docs/version-3.22-1/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -47,7 +47,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.22-1/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/getting-started/install-on-clusters/windows-calico/flowlogs.mdx
@@ -44,4 +44,4 @@ $[prodnameWindows] flow logs are enabled and configured the same way as [Flow lo
 - [Configure flow log aggregation](../../../observability/elastic/flow/aggregation.mdx)
 - [Log storage recommendations](../../../operations/logstorage/log-storage-recommendations.mdx)
 - [Archive logs](../../../observability/elastic/archive-storage.mdx)
-- [Log collection options](../../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../../reference/installation/api.mdx#logcollectorspec)

--- a/calico-enterprise_versioned_docs/version-3.22-1/getting-started/install-on-clusters/windows-calico/requirements.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/getting-started/install-on-clusters/windows-calico/requirements.mdx
@@ -36,7 +36,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#bgpoption).
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.22-1/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
@@ -113,7 +113,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
 
 1. <OpenShiftPrometheusOperator operation='upgrade' />
 
-1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster)
+1. If your cluster is a management cluster, apply a [ManagementCluster](../../../reference/installation/api.mdx#managementcluster)
    CR to your cluster.
 
    ```bash
@@ -125,7 +125,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#operator.tigera.io/v1.Monitor)
+1. If your cluster is v3.7 or older, apply a new [Monitor](../../../reference/installation/api.mdx#monitor)
    CR to your cluster.
 
    ```bash
@@ -137,7 +137,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendation)
+1. If your cluster is v3.16 or older, apply a new [PolicyRecommendation](../../../reference/installation/api.mdx#policyrecommendation)
    CR to your cluster.
 
    ```bash
@@ -149,7 +149,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster was at one time v3.18 or older, remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#operator.tigera.io/v1.Manager).
+1. If your cluster was at one time v3.18 or older, remove deprecated fields from the [Manager](../../../reference/installation/api.mdx#manager).
 
    ```bash
    oc apply -f - <<EOF
@@ -160,7 +160,7 @@ The steps differ based on your cluster type. If you are unsure of your cluster t
    EOF
    ```
 
-1. If your cluster is v3.19 or older, apply a new [PacketCaptureAPI](../../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI)
+1. If your cluster is v3.19 or older, apply a new [PacketCaptureAPI](../../../reference/installation/api.mdx#packetcaptureapi)
     CR to your cluster.
 
    ```bash

--- a/calico-enterprise_versioned_docs/version-3.22-1/multicluster/fine-tune-deployment.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/multicluster/fine-tune-deployment.mdx
@@ -151,4 +151,4 @@ To filter log data by a given managed cluster you can include the filter criteri
 
 # Additional resources
 
-- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection)
+- [ManagementClusterConnection resource reference](../reference/installation/api.mdx#managementclusterconnection)

--- a/calico-enterprise_versioned_docs/version-3.22-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -47,7 +47,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.22-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -49,7 +49,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.Provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.22-1/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
@@ -52,7 +52,7 @@ To control managed clusters from your central management plane, you must ensure 
     ```bash
     export MANAGEMENT_CLUSTER_ADDR=<your-management-cluster-addr>
     ```
-1.  Apply the [ManagementCluster](../../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) CR.
+1.  Apply the [ManagementCluster](../../../reference/installation/api.mdx#managementcluster) CR.
 
     ```bash
     kubectl apply -f - <<EOF

--- a/calico-enterprise_versioned_docs/version-3.22-1/networking/configuring/dual-tor.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/networking/configuring/dual-tor.mdx
@@ -633,7 +633,7 @@ The only connections using interface-specific addresses should be BGP.
 If you plan to use [Egress Gateways](../egress/egress-gateway-on-prem.mdx) in your cluster, you must also adjust the $[nodecontainer] IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-$[prodname] [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+$[prodname] [Installation resource](../../reference/installation/api.mdx#nodeaddressautodetection).
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.22-1/networking/configuring/multiple-networks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/networking/configuring/multiple-networks.mdx
@@ -77,7 +77,7 @@ Although the following $[prodname] features are supported for your default $[pro
 
 ### Configure cluster for multiple networks
 
-In the [Installation custom resource](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoNetworkSpec), set the `MultiInterfaceMode` to **Multus**.
+In the [Installation custom resource](../../reference/installation/api.mdx#caliconetworkspec), set the `MultiInterfaceMode` to **Multus**.
 
 ### Create a new network
 

--- a/calico-enterprise_versioned_docs/version-3.22-1/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/networking/egress/egress-gateway-on-prem.mdx
@@ -348,7 +348,7 @@ To modify the iptables backend for egress gateways, you must change the `iptable
 If you plan to use Egress Gateways in a [dual-ToR cluster](../configuring/dual-tor.mdx), you must also adjust the $[nodecontainer] IP
 auto-detection method to pick up the stable IP, for example using the `interface: lo` setting
 (The default first-found setting skips over the lo interface). This can be configured via the
-$[prodname] [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection).
+$[prodname] [Installation resource](../../reference/installation/api.mdx#nodeaddressautodetection).
 
 ### Configure namespaces and pods to use egress gateways
 

--- a/calico-enterprise_versioned_docs/version-3.22-1/networking/ipam/initial-ippool.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/networking/ipam/initial-ippool.mdx
@@ -22,7 +22,7 @@ The **Kubernetes pod CIDR** is the expected IP address range for pod IPs. It is 
 
 [Calico IP pools](../../reference/resources/ippool.mdx) are ranges of IP addresses that Calico uses to assign to pods; the ranges must within the Kubernetes pod CIDR.
 
-The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+The Tigera Operator reads the [Installation](../../reference/installation/api.mdx#installation)
 resource and configures the default Calico IP pool. Note the following:
 
 - Default fields for any that are omitted:
@@ -42,7 +42,7 @@ resource and configures the default Calico IP pool. Note the following:
 ## How to
 
 1. Download the custom-resource.yaml file.
-1. Edit the [Installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation).
+1. Edit the [Installation resource](../../reference/installation/api.mdx#installation).
    **Required values**: `cidr:`
    **Empty values**: Defaulted
 

--- a/calico-enterprise_versioned_docs/version-3.22-1/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/networking/ipam/ip-autodetection.mdx
@@ -49,7 +49,7 @@ By default, $[prodname] uses the **firstFound** method; the first valid IP addre
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#operator.tigera.io/v1.NodeAddressAutodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the operator Installation reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-enterprise_versioned_docs/version-3.22-1/observability/elastic/archive-storage.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/observability/elastic/archive-storage.mdx
@@ -53,8 +53,8 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
     -n tigera-operator
    ```
 
-3. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#operator.tigera.io/v1.S3StoreSpec)
+3. Update the [LogCollector](../../reference/installation/api.mdx#logcollector)
+   resource named, `tigera-secure` to include an [S3 section](../../reference/installation/api.mdx#s3storespec)
    with your information noted from above.
    Example:
 
@@ -81,8 +81,8 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
 </TabItem>
 <TabItem label="Syslog" value="Syslog-1">
 
-1. Update the [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
-   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+1. Update the [LogCollector](../../reference/installation/api.mdx#logcollector)
+   resource named `tigera-secure` to include a [Syslog section](../../reference/installation/api.mdx#syslogstorespec)
    with your syslog information.
    Example:
    ```yaml
@@ -109,7 +109,7 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
    kubectl edit logcollector tigera-secure
    ```
 2. You can control which types of $[prodname] log data you would like to send to syslog.
-   The [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec)
+   The [Syslog section](../../reference/installation/api.mdx#syslogstorespec)
    contains a field called `logTypes` which allows you to list which log types you would like to include.
    The allowable log types are:
 
@@ -118,11 +118,11 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
    - Flows
    - IDSEvents
 
-   Refer to the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec) for more details on what data each log type represents.
+   Refer to the [Syslog section](../../reference/installation/api.mdx#syslogstorespec) for more details on what data each log type represents.
 
    :::note
 
-   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
+   The log type `IDSEvents` is only supported for a cluster that has [LogStorage](../../reference/installation/api.mdx#logstorage) configured. It is because intrusion detection event data is pulled from the corresponding LogStorage datastore directly.
 
    :::
 
@@ -130,7 +130,7 @@ Because $[prodname] and Kubernetes logs are integral to $[prodname] diagnostics,
 
 **TLS configuration**
 
-3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#operator.tigera.io/v1.SyslogStoreSpec).
+3. You can enable TLS option for syslog forwarding by including the "encryption" option in the [Syslog section](../../reference/installation/api.mdx#syslogstorespec).
 
    ```yaml
    apiVersion: operator.tigera.io/v1
@@ -185,9 +185,9 @@ $[prodname] uses Splunk's **HTTP Event Collector** to send data to Splunk server
    ```
 
 3. Update the
-   [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector)
+   [LogCollector](../../reference/installation/api.mdx#logcollector)
    resource named `tigera-secure` to include
-   a [Splunk section](../../reference/installation/api.mdx#operator.tigera.io/v1.SplunkStoreSpec)
+   a [Splunk section](../../reference/installation/api.mdx#splunkstorespec)
    with your Splunk information.
    Example:
 
@@ -215,7 +215,7 @@ $[prodname] uses Splunk's **HTTP Event Collector** to send data to Splunk server
 </Tabs>
 
 ### Control which hosts have their logs archived
-By default, logs are archived from both Kubernetes cluster hosts and [non-cluster hosts](../../getting-started/bare-metal/about). To archive logs for only non-cluster hosts or VMs, use the [`hostScope`](../../reference/installation/api.mdx#operator.tigera.io/v1.AdditionalLogStoreSpec) field when you set your additional storage spec on the `LogCollector` resource.
+By default, logs are archived from both Kubernetes cluster hosts and [non-cluster hosts](../../getting-started/bare-metal/about). To archive logs for only non-cluster hosts or VMs, use the [`hostScope`](../../reference/installation/api.mdx#additionallogstorespec) field when you set your additional storage spec on the `LogCollector` resource.
 
 ```yaml title="Example spec for Splunk"
 apiVersion: operator.tigera.io/v1

--- a/calico-enterprise_versioned_docs/version-3.22-1/observability/elastic/l7/configure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/observability/elastic/l7/configure.mdx
@@ -61,7 +61,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
 
 ### Configure the ApplicationLayer resource for L7 logs
 
-1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) resource named, `tigera-secure`.
+1. Create or update the [ApplicationLayer](../../../reference/installation/api.mdx#applicationlayer) resource named, `tigera-secure`.
 
    Example:
 
@@ -82,7 +82,7 @@ In this step, you will configure L7 logs, select logs for collection, and test t
    EOF
    ```
 
-   Read more about the log collection specification [here](../../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector).
+   Read more about the log collection specification [here](../../../reference/installation/api.mdx#logcollector).
    
    Applying this resource creates an `l7-log-collector` daemonset in `calico-system` namespace.
 

--- a/calico-enterprise_versioned_docs/version-3.22-1/observability/elastic/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/observability/elastic/overview.mdx
@@ -91,7 +91,7 @@ $[prodname] compliance reports are based on archived **flow logs** and **audit l
 - Global network policies
 - Network sets
 
-$[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec).
+$[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../reference/installation/api.mdx#logcollectorspec).
 
 ## Additional resources
 
@@ -102,4 +102,4 @@ $[prodname] also supports archiving [Cloudwatch for EKS audit logs](../../refere
 - [BGP logs](bgp.mdx)
 - [DNS logs](dns/dns-logs.mdx)
 - [Archive logs](archive-storage.mdx)
-- [Log collection options](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollectorSpec)
+- [Log collection options](../../reference/installation/api.mdx#logcollectorspec)

--- a/calico-enterprise_versioned_docs/version-3.22-1/observability/elastic/rbac-elasticsearch.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/observability/elastic/rbac-elasticsearch.mdx
@@ -211,4 +211,4 @@ status:
 ## Additional resources
 
 - Configure [RBAC for tiered policies](../../network-policy/policy-tiers/rbac-tiered-policies.mdx).
-- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementCluster) resource.
+- Learn more about the [ManagementCluster](../../reference/installation/api.mdx#managementcluster) resource.

--- a/calico-enterprise_versioned_docs/version-3.22-1/observability/elastic/retention.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/observability/elastic/retention.mdx
@@ -10,7 +10,7 @@ Configure how long to retain logs and compliance reports.
 
 ## Before you begin...
 
-Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#operator.tigera.io/v1.Retention) and determine the appropriate values for your deployment.
+Review [LogStorageSpec.Retention](../../reference/installation/api.mdx#retention) and determine the appropriate values for your deployment.
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.22-1/observability/elastic/troubleshoot.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/observability/elastic/troubleshoot.mdx
@@ -8,7 +8,7 @@ description: Learn how to troubleshoot common issues with Elasticsearch.
 
 The following user-configured resources are related to Elasticsearch:
 
-- [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage). It has settings for:
+- [LogStorage](../../reference/installation/api.mdx#logstorage). It has settings for:
 
   - Elasticsearch (for example, nodeCount and replicas)
   - Kubernetes (for example, resourceRequirements, storage and nodeSelectors)
@@ -111,7 +111,7 @@ As a last resort, create a new [Elasticsearch cluster](#how-to-create-a-new-clus
 
 ### Elasticsearch is slow
 
-**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorageSpec).
+**Solution/workaround**: Start with diagnostics using the Kibana monitoring dashboard. Then, check the QoS of your LogStorage custom resource to see if it is causing throttling (or via the Kubernetes node itself). If the shard count is high, close old shards. Also, another option is to increase the Elasticsearch [CPU and memory](../../reference/installation/api.mdx#logstoragespec).
 
 ### Elasticsearch crashes during booting
 

--- a/calico-enterprise_versioned_docs/version-3.22-1/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/operations/cnx/configure-identity-provider.mdx
@@ -15,7 +15,7 @@ Configure an external identity provider (IdP), create a user, and log in to the 
 
 ## Concepts
 
-The $[prodname] authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Authentication) named, `tigera-secure`.
+The $[prodname] authentication method is configured through the [Authentication API resource](../../reference/installation/api.mdx#authentication) named, `tigera-secure`.
 
 When configuring your cluster, you may be asked for the following inputs:
 

--- a/calico-enterprise_versioned_docs/version-3.22-1/operations/cnx/roles-and-permissions.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/operations/cnx/roles-and-permissions.mdx
@@ -16,7 +16,7 @@ Self-service is an important part of your Kubernetes platform networking and net
 
 ### Kubernetes RBAC authorization
 
-The [Calico Enterprise API server](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) is an extension to the standard [Kubernetes RBAC Authorization APIs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
+The [Calico Enterprise API server](../../reference/installation/api.mdx#apiserver) is an extension to the standard [kubernetes rbac authorization apis](https://kubernetes.io/docs/reference/access-authn-authz/rbac/). You configure fine-grained user permissions using `Role`, `ClusterRole`, `RoleBinding`and `ClusterRoleBinding` with the standard RBAC controls: get, list, watch, create, update, patch, delete.
 
 | Features                       | RBAC controls for...                                                                                                                                                                                                                            |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/calico-enterprise_versioned_docs/version-3.22-1/operations/comms/certificate-management.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/operations/comms/certificate-management.mdx
@@ -19,7 +19,7 @@ certificate issuance, $[prodname] provides a simple configuration option that yo
 **Limitations**
 
 If your cluster is already running $[prodname] and you would like to enable certificate management, you need to
-temporarily remove [the logstorage resource](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+temporarily remove [the logstorage resource](../../reference/installation/api.mdx#logstorage)
 before following the steps to enable certificate management and then re-apply afterwards. For detailed steps on
 re-creating logstorage, read more on [how to create a new Elasticsearch cluster](../../observability/elastic/troubleshoot.mdx#how-to-create-a-new-cluster).
 
@@ -38,7 +38,7 @@ Currently, this feature is not supported in combination with [Multi-cluster mana
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../../reference/installation/api.mdx#installation)
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
    ```yaml

--- a/calico-enterprise_versioned_docs/version-3.22-1/operations/logstorage/log-storage-recommendations.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/operations/logstorage/log-storage-recommendations.mdx
@@ -80,4 +80,4 @@ is no tolerance for removing/restarting a node.
 
 - Read the [LogStorage overview page](../logstorage/index.mdx)
 - [Troubleshooting Elasticsearch](../../observability/elastic/troubleshoot.mdx)
-- [LogStorage Specification](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage)
+- [LogStorage Specification](../../reference/installation/api.mdx#logstorage)

--- a/calico-enterprise_versioned_docs/version-3.22-1/reference/architecture/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/reference/architecture/overview.mdx
@@ -122,7 +122,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### Manager
 
-**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#operator.tigera.io/v1.Manager).
+**Main task**: Provides network traffic visibility, centralized multi-cluster management, threat-defense troubleshooting, policy lifecycle management, and compliance using a browser-based UI for multiple roles/stakeholders. [Manager](../installation/api.mdx#manager).
 
 ### Packet capture API
 
@@ -150,7 +150,7 @@ The Linseed API uses mTLS to connect to clients, and provides an API to access E
 
 ### API server
 
-**Main task**: Allows users to manage $[prodname] resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#operator.tigera.io/v1.APIServer).
+**Main task**: Allows users to manage $[prodname] resources such as policies and tiers through `kubectl` or the Kubernetes API. `kubectl` has significant advantages over `calicoctl` including: audit logging, RBAC using Kubernetes Roles and RoleBindings, and not needing to provide privileged Kubernetes CRD access to anyone who needs to manage resources. [API server](../installation/api.mdx#apiserver).
 
 ### BIRD
 

--- a/calico-enterprise_versioned_docs/version-3.22-1/reference/component-resources/configuration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/reference/component-resources/configuration.mdx
@@ -239,7 +239,7 @@ By enabling this feature, you can avoid errors that can occur when a pod tries t
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](../installation/api#operator.tigera.io/v1.CalicoNetworkSpec) of the default `operator.tigera.io/v1/installation` resource.
+The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](../installation/api#caliconetworkspec) of the default `operator.tigera.io/v1/installation` resource.
 
 The following example configures the CNI to delay a pod from starting its containers for up to 10 seconds, or until the pod's data plane has been programmed:
 
@@ -309,7 +309,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-2">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](../installation/api.mdx#installation) API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico-enterprise_versioned_docs/version-3.22-1/reference/component-resources/configure-resources.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/reference/component-resources/configure-resources.mdx
@@ -14,11 +14,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the APIServer CR using the below command:
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#apiserverdeployment), patch the APIServer CR using the below command:
 
 ```bash
 kubectl patch apiserver tigera-secure  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -66,11 +66,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## ApplicationLayer custom resource
 
-The [ApplicationLayer](../../reference/installation/api.mdx#operator.tigera.io/v1.ApplicationLayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
+The [ApplicationLayer](../../reference/installation/api.mdx#applicationlayer) CR provides a way to configure resources for L7LogCollectorDaemonSet. The following sections provide example configurations for this CR.
 
 ### L7LogCollectorDaemonSet
 
-To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.L7LogCollectorDaemonSet), patch the ApplicationLayer CR using the below command:
+To configure resource specification for the [L7LogCollectorDaemonSet](../../reference/installation/api.mdx#l7logcollectordaemonset), patch the ApplicationLayer CR using the below command:
 
 ```bash
 kubectl patch applicationlayer tigera-secure  --type=merge --patch='{"spec": {"l7LogCollectorDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"l7-collector","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"envoy-proxy","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -118,11 +118,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Authentication custom resource
 
-The [Authentication](../../reference/installation/api.mdx#operator.tigera.io/v1.Authentication) CR provides a way to configure resources for DexDeployment. The following sections provide example configurations for this CR.
+The [Authentication](../../reference/installation/api.mdx#authentication) CR provides a way to configure resources for DexDeployment. The following sections provide example configurations for this CR.
 
 ### DexDeployment
 
-To configure resource specification for the [DexDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.DexDeployment), patch the Authentication CR using the below command:
+To configure resource specification for the [DexDeployment](../../reference/installation/api.mdx#dexdeployment), patch the Authentication CR using the below command:
 
 ```bash
 kubectl patch authentication tigera-secure  --type=merge --patch='{"spec": {"dexDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-dex","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -157,13 +157,13 @@ This command will output the configured resource requests and limits for the Cal
 
 ## Compliance custom resource
 
-The [Compliance](../../reference/installation/api.mdx#operator.tigera.io/v1.Compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
+The [Compliance](../../reference/installation/api.mdx#compliance) CR provides a way to configure resources for ComplianceControllerDeployment, ComplianceSnapshotterDeployment, ComplianceBenchmarkerDaemonSet, ComplianceServerDeployment, ComplianceReporterPodTemplate. The following sections provide example configurations for this CR.
 
 Example Configurations:
 
 ### ComplianceControllerDeployment
 
-To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceControllerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceControllerDeployment](../../reference/installation/api.mdx#compliancecontrollerdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -198,7 +198,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceSnapshotterDeployment
 
-To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceSnapshotterDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceSnapshotterDeployment](../../reference/installation/api.mdx#compliancesnapshotterdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceSnapshotterDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-snapshotter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -233,7 +233,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceBenchmarkerDaemonSet
 
-To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceBenchmarkerDaemonSet), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceBenchmarkerDaemonSet](../../reference/installation/api.mdx#compliancebenchmarkerdaemonset), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceBenchmarkerDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-benchmarker","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -268,7 +268,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceServerDeployment
 
-To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceServerDeployment), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceServerDeployment](../../reference/installation/api.mdx#complianceserverdeployment), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"compliance-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -303,7 +303,7 @@ This command will output the configured resource requests and limits for the Com
 
 ### ComplianceReporterPodTemplate.
 
-To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#operator.tigera.io/v1.ComplianceReporterPodTemplate), patch the Compliance CR using the below command:
+To configure resource specification for the [ComplianceReporterPodTemplate](../../reference/installation/api.mdx#compliancereporterpodtemplate), patch the Compliance CR using the below command:
 
 ```bash
 kubectl patch compliance tigera-secure  --type=merge --patch='{"spec": {"complianceReporterPodTemplate": {"template": {"spec": {"containers":[{"name":"reporter","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}'
@@ -342,7 +342,7 @@ The [Installation CR](../../reference/installation/api.mdx) provides a way to co
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../../reference/installation/api.mdx#typhadeployment), patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -377,7 +377,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../../reference/installation/api.mdx#caliconodedaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -412,7 +412,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../../reference/installation/api.mdx#caliconodewindowsdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -447,7 +447,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../../reference/installation/api.mdx#calicokubecontrollersdeployment) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -483,7 +483,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../../reference/installation/api.mdx#csinodedriverdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -531,11 +531,11 @@ This command will output the configured resource requests and limits for the Cal
 
 ## IntrusionDetection custom resource
 
-The [IntrusionDetection](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
+The [IntrusionDetection](../../reference/installation/api.mdx#intrusiondetection) CR provides a way to configure resources for IntrusionDetectionControllerDeployment. The following sections provide example configurations for this CR.
 
 ### IntrusionDetectionControllerDeployment.
 
-To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionControllerDeployment), patch the IntrusionDetection CR using the below command:
+To configure resource specification for the [IntrusionDetectionControllerDeployment](../../reference/installation/api.mdx#intrusiondetectioncontrollerdeployment), patch the IntrusionDetection CR using the below command:
 
 ```bash
 kubectl patch intrusiondetection tigera-secure  --type=merge --patch='{"spec": {"intrusionDetectionControllerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"webhooks-processor","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}},{"name":"controller","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -583,11 +583,11 @@ This command will output the configured resource requests and limits for the Int
 
 ## LogCollector custom resource
 
-The [LogCollector](../../reference/installation/api.mdx#operator.tigera.io/v1.LogCollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
+The [LogCollector](../../reference/installation/api.mdx#logcollector) CR provides a way to configure resources for FluentdDaemonSet, EKSLogForwarderDeployment.
 
 ### FluentdDaemonSet.
 
-To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#operator.tigera.io/v1.FluentdDaemonSet), patch the LogCollector CR using the below command:
+To configure resource specification for the [FluentdDaemonSet](../../reference/installation/api.mdx#fluentddaemonset), patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"fluentdDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"fluentd","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -622,7 +622,7 @@ This command will output the configured resource requests and limits for the Flu
 
 ### EKSLogForwarderDeployment.
 
-To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.EKSLogForwarderDeployment), patch the LogCollector CR using the below command:
+To configure resource specification for the [EKSLogForwarderDeployment](../../reference/installation/api.mdx#ekslogforwarderdeployment), patch the LogCollector CR using the below command:
 
 ```bash
 kubectl patch logcollector tigera-secure  --type=merge --patch='{"spec": {"eksLogForwarderDeployment": {"spec": {"template": {"spec": {"containers":[{"name":"eks-log-forwarder","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -657,11 +657,11 @@ This command will output the configured resource requests and limits for the EKS
 
 ## LogStorage custom resource
 
-The [LogStorage](../../reference/installation/api.mdx#operator.tigera.io/v1.LogStorage) CR provides a way to configure resources for ECKOperatorStatefulSet, Kibana, LinseedDeployment, ElasticsearchMetricsDeployment. The following sections provide example configurations for this CR.
+The [LogStorage](../../reference/installation/api.mdx#logstorage) CR provides a way to configure resources for ECKOperatorStatefulSet, Kibana, LinseedDeployment, ElasticsearchMetricsDeployment. The following sections provide example configurations for this CR.
 
 ### ECKOperatorStatefulSet.
 
-To configure resource specification for the [ECKOperatorStatefulSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ECKOperatorStatefulSet), patch the LogStorage CR using the below command:
+To configure resource specification for the [ECKOperatorStatefulSet](../../reference/installation/api.mdx#eckoperatorstatefulset), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"eckOperatorStatefulSet":{"spec": {"template": {"spec": {"containers":[{"name":"manager","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -696,7 +696,7 @@ This command will output the configured resource requests and limits for the ECK
 
 ### Kibana
 
-To configure resource specification for the [Kibana](../../reference/installation/api.mdx#operator.tigera.io/v1.Kibana), patch the LogStorage CR using the below command:
+To configure resource specification for the [Kibana](../../reference/installation/api.mdx#kibana), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"kibana":{"spec": {"template": {"spec": {"containers":[{"name":"kibana","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -731,7 +731,7 @@ This command will output the configured resource requests and limits for the Kib
 
 ### LinseedDeployment
 
-To configure resource specification for the [LinseedDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.LinseedDeployment), patch the LogStorage CR using the below command:
+To configure resource specification for the [LinseedDeployment](../../reference/installation/api.mdx#linseeddeployment), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"linseedDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-linseed","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -766,7 +766,7 @@ This command will output the configured resource requests and limits for the Lin
 
 ### ElasticsearchMetricsDeployment
 
-To configure resource specification for the [ElasticsearchMetricsDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ElasticsearchMetricsDeployment), patch the LogStorage CR using the below command:
+To configure resource specification for the [ElasticsearchMetricsDeployment](../../reference/installation/api.mdx#elasticsearchmetricsdeployment), patch the LogStorage CR using the below command:
 
 ```bash
 kubectl patch logstorage tigera-secure  --type=merge --patch='{"spec": {"elasticsearchMetricsDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-elasticsearch-metrics","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"1000Mi"}}}]}}}}}}'
@@ -801,11 +801,11 @@ This command will output the configured resource requests and limits for the Ela
 
 ## ManagementClusterConnection custom resource
 
-The [ManagementClusterConnection](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagementClusterConnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
+The [ManagementClusterConnection](../../reference/installation/api.mdx#managementclusterconnection) CR provides a way to configure resources for GuardianDeployment. The following sections provide example configurations for this CR.
 
 ### GuardianDeployment
 
-To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.GuardianDeployment), patch the ManagementClusterConnection CR using the below command:
+To configure resource specification for the [GuardianDeployment](../../reference/installation/api.mdx#guardiandeployment), patch the ManagementClusterConnection CR using the below command:
 
 ```bash
 kubectl patch managementclusterconnection tigera-secure  --type=merge --patch='{"spec": {"guardianDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-guardian","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -840,11 +840,11 @@ This command will output the configured resource requests and limits for the Gua
 
 ## Manager custom resource
 
-The [Manager](../../reference/installation/api.mdx#operator.tigera.io/v1.Manager) CR provides a way to configure resources for ManagerDeployment. The following sections provide example configurations for this CR.
+The [Manager](../../reference/installation/api.mdx#manager) CR provides a way to configure resources for ManagerDeployment. The following sections provide example configurations for this CR.
 
 ### ManagerDeployment
 
-To configure resource specification for the [ManagerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.ManagerDeployment), patch the Manager CR using the below command:
+To configure resource specification for the [ManagerDeployment](../../reference/installation/api.mdx#managerdeployment), patch the Manager CR using the below command:
 
 ```bash
 kubectl patch manager tigera-secure  --type=merge --patch='{"spec": {"managerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-voltron","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-ui-apis","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-manager","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -906,11 +906,11 @@ This command will output the configured resource requests and limits for the Man
 
 ## Monitor custom resource
 
-The [Monitor](../../reference/installation/api.mdx#operator.tigera.io/v1.Monitor) CR provides a way to configure resources for Prometheus, AlertManager. The following sections provide example configurations for this CR.
+The [Monitor](../../reference/installation/api.mdx#monitor) CR provides a way to configure resources for Prometheus, AlertManager. The following sections provide example configurations for this CR.
 
 ### Prometheus
 
-To configure resource specification for the [Prometheus](../../reference/installation/api.mdx#operator.tigera.io/v1.Prometheus), Resources for the default container "prometheus" can be configured using the "resources" field under "commonPrometheusFields". For all other injected containers, such as "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
+To configure resource specification for the [Prometheus](../../reference/installation/api.mdx#prometheus), Resources for the default container "prometheus" can be configured using the "resources" field under "commonPrometheusFields". For all other injected containers, such as "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
 
 ```bash
 kubectl patch monitor tigera-secure --type=merge --patch='{"spec": {"prometheus": {"spec":{ "commonPrometheusFields": {"resources": {"limits": {"cpu":"500m","memory":"500Mi"}, "requests": {"cpu":"50m", "memory":"50Mi"}}, "containers":[{"name":"authn-proxy","resources":{"limits": {"cpu":"250m","memory":"500Mi"},"requests": {"cpu":"25m","memory":"50Mi"}}}]}}}}}'
@@ -975,7 +975,7 @@ The "config-reloader" container has default resource values set based by the Pro
 
 ### AlertManager
 
-To configure resource specification for the [AlertManager](../../reference/installation/api.mdx#operator.tigera.io/v1.AlertManager),  you can set resources for the default container "prometheus" using the "resources" field under "commonPrometheusFields". For all other injected containers, like "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
+To configure resource specification for the [AlertManager](../../reference/installation/api.mdx#alertmanager),  you can set resources for the default container "prometheus" using the "resources" field under "commonPrometheusFields". For all other injected containers, like "authn-proxy", resource configuration can be set using the "containers" struct, as shown below in the patch command below.
 
 ```bash
 kubectl patch monitor tigera-secure  --type=merge --patch='{"spec": {"alertManager": {"spec": {"resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}}}}'
@@ -1027,11 +1027,11 @@ The "config-reloader" container has default resource values set by the AlertMana
 
 ## PacketCaptureAPI custom resource
 
-The [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
+The [PacketCaptureAPI](../../reference/installation/api.mdx#packetcaptureapi) CR provides a way to configure resources for PacketCapture. The following sections provide example configurations for this CR.
 
 ### PacketCaptureAPIDeployment
 
-To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#operator.tigera.io/v1.PacketCaptureAPI), patch the PacketCapture CR using the below command:
+To configure resource specification for the [PacketCaptureAPI](../../reference/installation/api.mdx#packetcaptureapi), patch the PacketCapture CR using the below command:
 
 ```bash
 kubectl patch packetcaptureapis tigera-secure  --type=merge --patch='{"spec": {"packetCaptureAPIDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"tigera-packetcapture-server","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -1066,11 +1066,11 @@ This command will output the configured resource requests and limits for the Pac
 
 ## PolicyRecommendation custom resource
 
-The [PolicyRecommendation](../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendation) CR provides a way to configure resources for PolicyRecommendation. The following sections provide example configurations for this CR.
+The [PolicyRecommendation](../../reference/installation/api.mdx#policyrecommendation) CR provides a way to configure resources for PolicyRecommendation. The following sections provide example configurations for this CR.
 
 ### PolicyRecommendationDeployment
 
-To configure resource specification for the [PolicyRecommendationDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.PolicyRecommendationDeployment), patch the PolicyRecommendation CR using the below command:
+To configure resource specification for the [PolicyRecommendationDeployment](../../reference/installation/api.mdx#policyrecommendationdeployment), patch the PolicyRecommendation CR using the below command:
 
 ```bash
 kubectl patch policyrecommendation tigera-secure  --type=merge --patch='{"spec": {"policyRecommendationDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"policy-recommendation-controller","resources":{"requests":{"cpu":"100m", "memory":"100Mi"},"limits":{"cpu":"1", "memory":"512Mi"}}}]}}}}}}'
@@ -1114,11 +1114,11 @@ The provided example illustrates configuring the apiserver component. Follow a s
 
 ### APIServer custom resource
 
-The [APIServer](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
+The [APIServer](../../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
 
 #### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), update values.yaml with the appropriate resource values.
+To configure resource specification for the [APIServerDeployment](../../reference/installation/api.mdx#apiserverdeployment), update values.yaml with the appropriate resource values.
 
 ```bash
 apiServer:

--- a/calico-enterprise_versioned_docs/version-3.22-1/reference/component-resources/typha/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/reference/component-resources/typha/prometheus.mdx
@@ -5,7 +5,7 @@ description: Review metrics for the Typha component if you are using Prometheus.
 # Prometheus metrics
 
 Typha can be configured to report a number of metrics through Prometheus. The Prometheus port can be controlled
-via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#operator.tigera.io/v1.Installation).
+via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#installation).
 
 ## Metric reference
 

--- a/calico-enterprise_versioned_docs/version-3.22-1/reference/installation/helm_customization.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/reference/installation/helm_customization.mdx
@@ -6,18 +6,18 @@ description: Helm installation reference
 
 You can customize the following resources and settings during $[prodname] Helm-based installation using the file, `values.yaml`.
 
-- [Installation](api.mdx#operator.tigera.io/v1.InstallationSpec)
-- [Api server](api.mdx#operator.tigera.io/v1.APIServerSpec)
-- [Compliance](api.mdx#operator.tigera.io/v1.ComplianceSpec)
-- [Intrusion detection](api.mdx#operator.tigera.io/v1.IntrusionDetectionSpec)
-- [Log collector](api.mdx#operator.tigera.io/v1.LogCollectorSpec)
-- [Log storage](api.mdx#operator.tigera.io/v1.LogStorageSpec)
-- [Manager](api.mdx#operator.tigera.io/v1.ManagerSpec)
-- [Monitor](api.mdx#operator.tigera.io/v1.MonitorSpec)
-- [Policy recommendation](api.mdx#operator.tigera.io/v1.PolicyRecommendationSpec)
-- [Authentication](api.mdx#operator.tigera.io/v1.AuthenticationSpec)
-- [Application layer](api.mdx#operator.tigera.io/v1.ApplicationLayerSpec)
-- [Amazon cloud integration](api.mdx#operator.tigera.io/v1.AmazonCloudIntegrationSpec)
+- [Installation](api.mdx#installationspec)
+- [Api server](api.mdx#apiserverspec)
+- [Compliance](api.mdx#compliancespec)
+- [Intrusion detection](api.mdx#intrusiondetectionspec)
+- [Log collector](api.mdx#logcollectorspec)
+- [Log storage](api.mdx#logstoragespec)
+- [Manager](api.mdx#managerspec)
+- [Monitor](api.mdx#monitorspec)
+- [Policy recommendation](api.mdx#policyrecommendationspec)
+- [Authentication](api.mdx#authenticationspec)
+- [Application layer](api.mdx#applicationlayerspec)
+- [Amazon cloud integration](api.mdx#amazoncloudintegrationspec)
 - [Default felix configuration](../resources/felixconfig.mdx#spec)
 
 :::note
@@ -92,7 +92,7 @@ Common customizations that you might want to configure are number of replicas, p
 
 ### Number of replicas
 This setting defines the number of replicas for $[prodname] components that can run simultaneously in multiple instances.
-To configure this setting, see [controlPlaneReplicas](api.mdx#operator.tigera.io/v1.InstallationSpec).
+To configure this setting, see [controlPlaneReplicas](api.mdx#installationspec).
 The components for the replicas are:
 
 - tigera-manager

--- a/calico-enterprise_versioned_docs/version-3.22-1/threat/deeppacketinspection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/threat/deeppacketinspection.mdx
@@ -79,7 +79,7 @@ spec:
 
 ### Configure resource requirements
 
-Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#operator.tigera.io/v1.IntrusionDetectionComponentResource).
+Adjust the CPU and RAM used for performing deep packet inspection by updating the [component resource in IntrusionDetection](../reference/installation/api.mdx#intrusiondetectioncomponentresource).
 
 For a data transfer rate of 1GB/sec on workload endpoints being monitored, we recommend a minimum of 1 CPU and 1GB RAM.
 

--- a/calico-enterprise_versioned_docs/version-3.22-1/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/threat/web-application-firewall.mdx
@@ -350,9 +350,9 @@ kubectl delete applicationlayer tigera-secure
 
 ### Keep some ApplicationLayer features enabled
 
-To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#operator.tigera.io/v1.ApplicationLayer) custom resource.
+To disable WAF but keep some ApplicationLayer features enabled, you must update the [ApplicationLayer](../reference/installation/api#applicationlayer) custom resource.
 
-Note that the [ApplicationLayer Specification](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerSpec) can specify configuration for [Application Logging](../reference/installation/api#operator.tigera.io/v1.LogCollectionSpec) and [Application Layer Policy](../reference/installation/api#operator.tigera.io/v1.ApplicationLayerPolicyStatusType) also. 
+Note that the [ApplicationLayer Specification](../reference/installation/api#applicationlayerspec) can specify configuration for [application logging](../reference/installation/api#operator.tigera.io/v1.logcollectionspec) and [application layer policy](../reference/installation/api#operator.tigera.io/v1.applicationlayerpolicystatustype) also.
 
 For the ApplicationLayer custom resource to be valid, at least one of these features have to be enabled, for example:
 

--- a/calico/getting-started/kubernetes/helm.mdx
+++ b/calico/getting-started/kubernetes/helm.mdx
@@ -47,7 +47,7 @@ helm repo add projectcalico https://docs.tigera.io/calico/charts
 
 If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), or you need to customize TLS certificates, you **must** customize this Helm chart by creating a `values.yaml` file. Otherwise, you can skip this step.
 
-1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#operator.tigera.io/v1.Provider). For example:
+1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#provider). For example:
 
    ```
    echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico/getting-started/kubernetes/self-managed-onprem/config-options.mdx
+++ b/calico/getting-started/kubernetes/self-managed-onprem/config-options.mdx
@@ -33,9 +33,9 @@ $[prodname] can also be installed using raw manifests as an alternative to the o
 Operator installations read their configuration from a specific set of Kubernetes APIs. These APIs are installed on the cluster
 as part of `tigera-operator.yaml` in the `operator.tigera.io/v1` API group.
 
-- [Installation](../../../reference/installation/api.mdx#operator.tigera.io/v1.Installation): a singleton resource with name "default" that
+- [Installation](../../../reference/installation/api.mdx#installation): a singleton resource with name "default" that
   configures common installation parameters for a $[prodname] cluster.
-- [APIServer](../../../reference/installation/api.mdx#operator.tigera.io/v1.Installation): a singleton resource with name "default" that
+- [APIServer](../../../reference/installation/api.mdx#installation): a singleton resource with name "default" that
   configures installation of the $[prodname] API server extension.
 
 ### Configure the pod IP range

--- a/calico/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -35,7 +35,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#bgpoption).
 
 :::
 

--- a/calico/networking/ipam/ip-autodetection.mdx
+++ b/calico/networking/ipam/ip-autodetection.mdx
@@ -63,7 +63,7 @@ For more details on autodetection methods, see [node configuration](../../refere
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-As noted previously, the default autodetection method is **first valid interface found** (first-found). To use a different autodetection method, edit the default [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation) custom resource, specifying the method. Below are examples of the supported autodetection methods:
+As noted previously, the default autodetection method is **first valid interface found** (first-found). To use a different autodetection method, edit the default [Installation](../../reference/installation/api.mdx#installation) custom resource, specifying the method. Below are examples of the supported autodetection methods:
 
 :::note
 

--- a/calico/operations/certificate-management.mdx
+++ b/calico/operations/certificate-management.mdx
@@ -29,7 +29,7 @@ certificate issuance, $[prodname] provides a simple configuration option that yo
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../reference/installation/api.mdx#installation)
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
 ```yaml

--- a/calico/operations/image-options/imageset.mdx
+++ b/calico/operations/image-options/imageset.mdx
@@ -75,7 +75,7 @@ sed -ie "s|\(image: .*/operator\):.*|?\1@<put-digest-here>|" tigera-operator.yam
 
 ### Create an ImageSet
 
-Create an [ImageSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ImageSet) manifest file named `imageset.yaml` like the following:
+Create an [ImageSet](../../reference/installation/api.mdx#imageset) manifest file named `imageset.yaml` like the following:
 
 ```yaml
 apiVersion: operator.tigera.io/v1
@@ -139,7 +139,7 @@ You can create an ImageSet manifest manually or by script.
       docker pull <repo/image:tag> && docker inspect <repo/image:tag> -f '{{range .RepoDigests}}{{printf "%s\n" .}}{{end}}'
       ```
    1. Use the digest from the image that matches the repo/image you will use.
-      If you are using a private registry or have specified an [imagePath](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+      If you are using a private registry or have specified an [imagePath](../../reference/installation/api.mdx#installation)
       you will still use the "default" `<owner>/<image>` in the `image` field, for example if you your node image is coming from
       `example.com/registry/imagepath/node` you will still use `calico/node` in the image field of the ImageSet.
       :::note
@@ -225,7 +225,7 @@ Apply the created `imageset.yaml` to your cluster.
 
 ### Create new ImageSet when upgrading or downgrading
 
-Before upgrading to a new release or downgrading, you must create a new [ImageSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ImageSet)
+Before upgrading to a new release or downgrading, you must create a new [ImageSet](../../reference/installation/api.mdx#imageset)
 with updated image references and names for the new release. This must be done prior
 to upgrading the cluster so when the new manifests are applied, the appropriate ImageSet is available.
 
@@ -233,7 +233,7 @@ to upgrading the cluster so when the new manifests are applied, the appropriate 
 
 ### Why does the Installation Resource status not include my ImageSet?
 
-The [status.imageset](../../reference/installation/api.mdx#operator.tigera.io/v1.InstallationStatus) field of
+The [status.imageset](../../reference/installation/api.mdx#installationstatus) field of
 the Installation Resource will not be updated until the `calico` component has fully been deployed. `calico` is
 fully deployed when `kubectl get tigerastatus calico` reports Available True with Progressing and Degraded as False.
 

--- a/calico/reference/configure-cni-plugins.mdx
+++ b/calico/reference/configure-cni-plugins.mdx
@@ -260,7 +260,7 @@ By enabling this feature, you can avoid errors that can occur when a pod tries t
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](installation/api#operator.tigera.io/v1.CalicoNetworkSpec) of the default `operator.tigera.io/v1/installation` resource.
+The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](installation/api#caliconetworkspec) of the default `operator.tigera.io/v1/installation` resource.
 
 The following example configures the CNI to delay a pod from starting its containers for up to 10 seconds, or until the pod's data plane has been programmed:
 
@@ -330,7 +330,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](installation/api.mdx#installation) API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico/reference/configure-resources.mdx
+++ b/calico/reference/configure-resources.mdx
@@ -14,11 +14,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the APIServer CR using the below command:
+To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#apiserverdeployment), patch the APIServer CR using the below command:
 
 ```bash
 kubectl patch apiserver default  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -57,7 +57,7 @@ The [Installation CR](../reference/installation/api.mdx) provides a way to confi
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../reference/installation/api.mdx#typhadeployment), patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -93,7 +93,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../reference/installation/api.mdx#caliconodedaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -128,7 +128,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../reference/installation/api.mdx#caliconodewindowsdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -163,7 +163,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../reference/installation/api.mdx#calicokubecontrollersdeployment) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -199,7 +199,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../reference/installation/api.mdx#csinodedriverdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -256,11 +256,11 @@ The provided example illustrates configuring the apiserver component. Follow a s
 
 ### APIServer custom resource
 
-The [APIServer](../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
+The [APIServer](../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
 
 #### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), update values.yaml with the appropriate resource values.
+To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#apiserverdeployment), update values.yaml with the appropriate resource values.
 
 ```bash
 apiServer:

--- a/calico/reference/installation/helm_customization.mdx
+++ b/calico/reference/installation/helm_customization.mdx
@@ -6,7 +6,7 @@ description: Helm installation reference
 
 You can customize the following resources and settings during $[prodname] Helm-based installation using the file, `values.yaml`.
 
-- [Installation](api.mdx#operator.tigera.io/v1.InstallationSpec)
+- [Installation](api.mdx#installationspec)
 - [Default felix configuration](../resources/felixconfig.mdx#spec)
 
 :::note

--- a/calico_versioned_docs/version-3.28/getting-started/kubernetes/helm.mdx
+++ b/calico_versioned_docs/version-3.28/getting-started/kubernetes/helm.mdx
@@ -46,7 +46,7 @@ helm repo add projectcalico https://docs.tigera.io/calico/charts
 
 If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), or you need to customize TLS certificates, you **must** customize this Helm chart by creating a `values.yaml` file. Otherwise, you can skip this step.
 
-1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#operator.tigera.io/v1.Provider). For example:
+1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#provider). For example:
 
    ```
    echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico_versioned_docs/version-3.28/getting-started/kubernetes/self-managed-onprem/config-options.mdx
+++ b/calico_versioned_docs/version-3.28/getting-started/kubernetes/self-managed-onprem/config-options.mdx
@@ -32,9 +32,9 @@ $[prodname] can also be installed using raw manifests as an alternative to the o
 Operator installations read their configuration from a specific set of Kubernetes APIs. These APIs are installed on the cluster
 as part of `tigera-operator.yaml` in the `operator.tigera.io/v1` API group.
 
-- [Installation](../../../reference/installation/api.mdx#operator.tigera.io/v1.Installation): a singleton resource with name "default" that
+- [Installation](../../../reference/installation/api.mdx#installation): a singleton resource with name "default" that
   configures common installation parameters for a $[prodname] cluster.
-- [APIServer](../../../reference/installation/api.mdx#operator.tigera.io/v1.Installation): a singleton resource with name "default" that
+- [APIServer](../../../reference/installation/api.mdx#installation): a singleton resource with name "default" that
   configures installation of the $[prodname] API server extension.
 
 ### Configure the pod IP range

--- a/calico_versioned_docs/version-3.28/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico_versioned_docs/version-3.28/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -35,7 +35,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#bgpoption).
 
 :::
 

--- a/calico_versioned_docs/version-3.28/networking/ipam/ip-autodetection.mdx
+++ b/calico_versioned_docs/version-3.28/networking/ipam/ip-autodetection.mdx
@@ -63,7 +63,7 @@ For more details on autodetection methods, see [node configuration](../../refere
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-As noted previously, the default autodetection method is **first valid interface found** (first-found). To use a different autodetection method, edit the default [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation) custom resource, specifying the method. Below are examples of the supported autodetection methods:
+As noted previously, the default autodetection method is **first valid interface found** (first-found). To use a different autodetection method, edit the default [Installation](../../reference/installation/api.mdx#installation) custom resource, specifying the method. Below are examples of the supported autodetection methods:
 
 :::note
 

--- a/calico_versioned_docs/version-3.28/operations/certificate-management.mdx
+++ b/calico_versioned_docs/version-3.28/operations/certificate-management.mdx
@@ -29,7 +29,7 @@ certificate issuance, $[prodname] provides a simple configuration option that yo
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../reference/installation/api.mdx#installation)
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
 ```yaml

--- a/calico_versioned_docs/version-3.28/operations/image-options/imageset.mdx
+++ b/calico_versioned_docs/version-3.28/operations/image-options/imageset.mdx
@@ -75,7 +75,7 @@ sed -ie "s|\(image: .*/operator\):.*|?\1@<put-digest-here>|" tigera-operator.yam
 
 ### Create an ImageSet
 
-Create an [ImageSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ImageSet) manifest file named `imageset.yaml` like the following:
+Create an [ImageSet](../../reference/installation/api.mdx#imageset) manifest file named `imageset.yaml` like the following:
 
 ```yaml
 apiVersion: operator.tigera.io/v1
@@ -139,7 +139,7 @@ You can create an ImageSet manifest manually or by script.
       docker pull <repo/image:tag> && docker inspect <repo/image:tag> -f '{{range .RepoDigests}}{{printf "%s\n" .}}{{end}}'
       ```
    1. Use the digest from the image that matches the repo/image you will use.
-      If you are using a private registry or have specified an [imagePath](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+      If you are using a private registry or have specified an [imagePath](../../reference/installation/api.mdx#installation)
       you will still use the "default" `<owner>/<image>` in the `image` field, for example if you your node image is coming from
       `example.com/registry/imagepath/node` you will still use `calico/node` in the image field of the ImageSet.
       :::note
@@ -225,7 +225,7 @@ Apply the created `imageset.yaml` to your cluster.
 
 ### Create new ImageSet when upgrading or downgrading
 
-Before upgrading to a new release or downgrading, you must create a new [ImageSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ImageSet)
+Before upgrading to a new release or downgrading, you must create a new [ImageSet](../../reference/installation/api.mdx#imageset)
 with updated image references and names for the new release. This must be done prior
 to upgrading the cluster so when the new manifests are applied, the appropriate ImageSet is available.
 
@@ -233,7 +233,7 @@ to upgrading the cluster so when the new manifests are applied, the appropriate 
 
 ### Why does the Installation Resource status not include my ImageSet?
 
-The [status.imageset](../../reference/installation/api.mdx#operator.tigera.io/v1.InstallationStatus) field of
+The [status.imageset](../../reference/installation/api.mdx#installationstatus) field of
 the Installation Resource will not be updated until the `calico` component has fully been deployed. `calico` is
 fully deployed when `kubectl get tigerastatus calico` reports Available True with Progressing and Degraded as False.
 

--- a/calico_versioned_docs/version-3.28/reference/configure-cni-plugins.mdx
+++ b/calico_versioned_docs/version-3.28/reference/configure-cni-plugins.mdx
@@ -260,7 +260,7 @@ By enabling this feature, you can avoid errors that can occur when a pod tries t
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](installation/api#operator.tigera.io/v1.CalicoNetworkSpec) of the default `operator.tigera.io/v1/installation` resource.
+The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](installation/api#caliconetworkspec) of the default `operator.tigera.io/v1/installation` resource.
 
 The following example configures the CNI to delay a pod from starting its containers for up to 10 seconds, or until the pod's data plane has been programmed:
 
@@ -330,7 +330,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](installation/api.mdx#installation) API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico_versioned_docs/version-3.28/reference/configure-resources.mdx
+++ b/calico_versioned_docs/version-3.28/reference/configure-resources.mdx
@@ -14,11 +14,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the APIServer CR using the below command:
+To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#apiserverdeployment), patch the APIServer CR using the below command:
 
 ```bash
 kubectl patch apiserver default  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -57,7 +57,7 @@ The [Installation CR](../reference/installation/api.mdx) provides a way to confi
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../reference/installation/api.mdx#typhadeployment), patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -93,7 +93,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../reference/installation/api.mdx#caliconodedaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -128,7 +128,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../reference/installation/api.mdx#caliconodewindowsdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -163,7 +163,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../reference/installation/api.mdx#calicokubecontrollersdeployment) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -199,7 +199,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../reference/installation/api.mdx#csinodedriverdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -256,11 +256,11 @@ The provided example illustrates configuring the apiserver component. Follow a s
 
 ## APIServer custom resource
 
-The [APIServer](../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
+The [APIServer](../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), update values.yaml with the appropriate resource values.
+To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#apiserverdeployment), update values.yaml with the appropriate resource values.
 
 ```bash
 apiServer:

--- a/calico_versioned_docs/version-3.28/reference/installation/helm_customization.mdx
+++ b/calico_versioned_docs/version-3.28/reference/installation/helm_customization.mdx
@@ -6,7 +6,7 @@ description: Helm installation reference
 
 You can customize the following resources and settings during $[prodname] Helm-based installation using the file, `values.yaml`.
 
-- [Installation](api.mdx#operator.tigera.io/v1.InstallationSpec)
+- [Installation](api.mdx#installationspec)
 - [Default felix configuration](../resources/felixconfig.mdx#spec)
 
 :::note

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/helm.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/helm.mdx
@@ -47,7 +47,7 @@ helm repo add projectcalico https://docs.tigera.io/calico/charts
 
 If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), or you need to customize TLS certificates, you **must** customize this Helm chart by creating a `values.yaml` file. Otherwise, you can skip this step.
 
-1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#operator.tigera.io/v1.Provider). For example:
+1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#provider). For example:
 
    ```
    echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/self-managed-onprem/config-options.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/self-managed-onprem/config-options.mdx
@@ -33,9 +33,9 @@ $[prodname] can also be installed using raw manifests as an alternative to the o
 Operator installations read their configuration from a specific set of Kubernetes APIs. These APIs are installed on the cluster
 as part of `tigera-operator.yaml` in the `operator.tigera.io/v1` API group.
 
-- [Installation](../../../reference/installation/api.mdx#operator.tigera.io/v1.Installation): a singleton resource with name "default" that
+- [Installation](../../../reference/installation/api.mdx#installation): a singleton resource with name "default" that
   configures common installation parameters for a $[prodname] cluster.
-- [APIServer](../../../reference/installation/api.mdx#operator.tigera.io/v1.Installation): a singleton resource with name "default" that
+- [APIServer](../../../reference/installation/api.mdx#installation): a singleton resource with name "default" that
   configures installation of the $[prodname] API server extension.
 
 ### Configure the pod IP range

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -35,7 +35,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#bgpoption).
 
 :::
 

--- a/calico_versioned_docs/version-3.29/networking/ipam/ip-autodetection.mdx
+++ b/calico_versioned_docs/version-3.29/networking/ipam/ip-autodetection.mdx
@@ -63,7 +63,7 @@ For more details on autodetection methods, see [node configuration](../../refere
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-As noted previously, the default autodetection method is **first valid interface found** (first-found). To use a different autodetection method, edit the default [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation) custom resource, specifying the method. Below are examples of the supported autodetection methods:
+As noted previously, the default autodetection method is **first valid interface found** (first-found). To use a different autodetection method, edit the default [Installation](../../reference/installation/api.mdx#installation) custom resource, specifying the method. Below are examples of the supported autodetection methods:
 
 :::note
 

--- a/calico_versioned_docs/version-3.29/operations/certificate-management.mdx
+++ b/calico_versioned_docs/version-3.29/operations/certificate-management.mdx
@@ -29,7 +29,7 @@ certificate issuance, $[prodname] provides a simple configuration option that yo
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../reference/installation/api.mdx#installation)
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
 ```yaml

--- a/calico_versioned_docs/version-3.29/operations/image-options/imageset.mdx
+++ b/calico_versioned_docs/version-3.29/operations/image-options/imageset.mdx
@@ -75,7 +75,7 @@ sed -ie "s|\(image: .*/operator\):.*|?\1@<put-digest-here>|" tigera-operator.yam
 
 ### Create an ImageSet
 
-Create an [ImageSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ImageSet) manifest file named `imageset.yaml` like the following:
+Create an [ImageSet](../../reference/installation/api.mdx#imageset) manifest file named `imageset.yaml` like the following:
 
 ```yaml
 apiVersion: operator.tigera.io/v1
@@ -139,7 +139,7 @@ You can create an ImageSet manifest manually or by script.
       docker pull <repo/image:tag> && docker inspect <repo/image:tag> -f '{{range .RepoDigests}}{{printf "%s\n" .}}{{end}}'
       ```
    1. Use the digest from the image that matches the repo/image you will use.
-      If you are using a private registry or have specified an [imagePath](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+      If you are using a private registry or have specified an [imagePath](../../reference/installation/api.mdx#installation)
       you will still use the "default" `<owner>/<image>` in the `image` field, for example if you your node image is coming from
       `example.com/registry/imagepath/node` you will still use `calico/node` in the image field of the ImageSet.
       :::note
@@ -225,7 +225,7 @@ Apply the created `imageset.yaml` to your cluster.
 
 ### Create new ImageSet when upgrading or downgrading
 
-Before upgrading to a new release or downgrading, you must create a new [ImageSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ImageSet)
+Before upgrading to a new release or downgrading, you must create a new [ImageSet](../../reference/installation/api.mdx#imageset)
 with updated image references and names for the new release. This must be done prior
 to upgrading the cluster so when the new manifests are applied, the appropriate ImageSet is available.
 
@@ -233,7 +233,7 @@ to upgrading the cluster so when the new manifests are applied, the appropriate 
 
 ### Why does the Installation Resource status not include my ImageSet?
 
-The [status.imageset](../../reference/installation/api.mdx#operator.tigera.io/v1.InstallationStatus) field of
+The [status.imageset](../../reference/installation/api.mdx#installationstatus) field of
 the Installation Resource will not be updated until the `calico` component has fully been deployed. `calico` is
 fully deployed when `kubectl get tigerastatus calico` reports Available True with Progressing and Degraded as False.
 

--- a/calico_versioned_docs/version-3.29/reference/configure-cni-plugins.mdx
+++ b/calico_versioned_docs/version-3.29/reference/configure-cni-plugins.mdx
@@ -260,7 +260,7 @@ By enabling this feature, you can avoid errors that can occur when a pod tries t
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](installation/api#operator.tigera.io/v1.CalicoNetworkSpec) of the default `operator.tigera.io/v1/installation` resource.
+The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](installation/api#caliconetworkspec) of the default `operator.tigera.io/v1/installation` resource.
 
 The following example configures the CNI to delay a pod from starting its containers for up to 10 seconds, or until the pod's data plane has been programmed:
 
@@ -330,7 +330,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](installation/api.mdx#installation) API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico_versioned_docs/version-3.29/reference/configure-resources.mdx
+++ b/calico_versioned_docs/version-3.29/reference/configure-resources.mdx
@@ -14,11 +14,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the APIServer CR using the below command:
+To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#apiserverdeployment), patch the APIServer CR using the below command:
 
 ```bash
 kubectl patch apiserver default  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -57,7 +57,7 @@ The [Installation CR](../reference/installation/api.mdx) provides a way to confi
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../reference/installation/api.mdx#typhadeployment), patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -93,7 +93,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../reference/installation/api.mdx#caliconodedaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -128,7 +128,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../reference/installation/api.mdx#caliconodewindowsdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -163,7 +163,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../reference/installation/api.mdx#calicokubecontrollersdeployment) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -199,7 +199,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../reference/installation/api.mdx#csinodedriverdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -256,11 +256,11 @@ The provided example illustrates configuring the apiserver component. Follow a s
 
 ### APIServer custom resource
 
-The [APIServer](../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
+The [APIServer](../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
 
 #### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), update values.yaml with the appropriate resource values.
+To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#apiserverdeployment), update values.yaml with the appropriate resource values.
 
 ```bash
 apiServer:

--- a/calico_versioned_docs/version-3.29/reference/installation/helm_customization.mdx
+++ b/calico_versioned_docs/version-3.29/reference/installation/helm_customization.mdx
@@ -6,7 +6,7 @@ description: Helm installation reference
 
 You can customize the following resources and settings during $[prodname] Helm-based installation using the file, `values.yaml`.
 
-- [Installation](api.mdx#operator.tigera.io/v1.InstallationSpec)
+- [Installation](api.mdx#installationspec)
 - [Default felix configuration](../resources/felixconfig.mdx#spec)
 
 :::note

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/helm.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/helm.mdx
@@ -47,7 +47,7 @@ helm repo add projectcalico https://docs.tigera.io/calico/charts
 
 If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), or you need to customize TLS certificates, you **must** customize this Helm chart by creating a `values.yaml` file. Otherwise, you can skip this step.
 
-1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#operator.tigera.io/v1.Provider). For example:
+1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#provider). For example:
 
    ```
    echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/self-managed-onprem/config-options.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/self-managed-onprem/config-options.mdx
@@ -33,9 +33,9 @@ $[prodname] can also be installed using raw manifests as an alternative to the o
 Operator installations read their configuration from a specific set of Kubernetes APIs. These APIs are installed on the cluster
 as part of `tigera-operator.yaml` in the `operator.tigera.io/v1` API group.
 
-- [Installation](../../../reference/installation/api.mdx#operator.tigera.io/v1.Installation): a singleton resource with name "default" that
+- [Installation](../../../reference/installation/api.mdx#installation): a singleton resource with name "default" that
   configures common installation parameters for a $[prodname] cluster.
-- [APIServer](../../../reference/installation/api.mdx#operator.tigera.io/v1.Installation): a singleton resource with name "default" that
+- [APIServer](../../../reference/installation/api.mdx#installation): a singleton resource with name "default" that
   configures installation of the $[prodname] API server extension.
 
 ### Configure the pod IP range

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -35,7 +35,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#bgpoption).
 
 :::
 

--- a/calico_versioned_docs/version-3.30/networking/ipam/ip-autodetection.mdx
+++ b/calico_versioned_docs/version-3.30/networking/ipam/ip-autodetection.mdx
@@ -63,7 +63,7 @@ For more details on autodetection methods, see [node configuration](../../refere
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-As noted previously, the default autodetection method is **first valid interface found** (first-found). To use a different autodetection method, edit the default [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation) custom resource, specifying the method. Below are examples of the supported autodetection methods:
+As noted previously, the default autodetection method is **first valid interface found** (first-found). To use a different autodetection method, edit the default [Installation](../../reference/installation/api.mdx#installation) custom resource, specifying the method. Below are examples of the supported autodetection methods:
 
 :::note
 

--- a/calico_versioned_docs/version-3.30/operations/certificate-management.mdx
+++ b/calico_versioned_docs/version-3.30/operations/certificate-management.mdx
@@ -29,7 +29,7 @@ certificate issuance, $[prodname] provides a simple configuration option that yo
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../reference/installation/api.mdx#installation)
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
 ```yaml

--- a/calico_versioned_docs/version-3.30/operations/image-options/imageset.mdx
+++ b/calico_versioned_docs/version-3.30/operations/image-options/imageset.mdx
@@ -75,7 +75,7 @@ sed -ie "s|\(image: .*/operator\):.*|?\1@<put-digest-here>|" tigera-operator.yam
 
 ### Create an ImageSet
 
-Create an [ImageSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ImageSet) manifest file named `imageset.yaml` like the following:
+Create an [ImageSet](../../reference/installation/api.mdx#imageset) manifest file named `imageset.yaml` like the following:
 
 ```yaml
 apiVersion: operator.tigera.io/v1
@@ -139,7 +139,7 @@ You can create an ImageSet manifest manually or by script.
       docker pull <repo/image:tag> && docker inspect <repo/image:tag> -f '{{range .RepoDigests}}{{printf "%s\n" .}}{{end}}'
       ```
    1. Use the digest from the image that matches the repo/image you will use.
-      If you are using a private registry or have specified an [imagePath](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+      If you are using a private registry or have specified an [imagePath](../../reference/installation/api.mdx#installation)
       you will still use the "default" `<owner>/<image>` in the `image` field, for example if you your node image is coming from
       `example.com/registry/imagepath/node` you will still use `calico/node` in the image field of the ImageSet.
       :::note
@@ -225,7 +225,7 @@ Apply the created `imageset.yaml` to your cluster.
 
 ### Create new ImageSet when upgrading or downgrading
 
-Before upgrading to a new release or downgrading, you must create a new [ImageSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ImageSet)
+Before upgrading to a new release or downgrading, you must create a new [ImageSet](../../reference/installation/api.mdx#imageset)
 with updated image references and names for the new release. This must be done prior
 to upgrading the cluster so when the new manifests are applied, the appropriate ImageSet is available.
 
@@ -233,7 +233,7 @@ to upgrading the cluster so when the new manifests are applied, the appropriate 
 
 ### Why does the Installation Resource status not include my ImageSet?
 
-The [status.imageset](../../reference/installation/api.mdx#operator.tigera.io/v1.InstallationStatus) field of
+The [status.imageset](../../reference/installation/api.mdx#installationstatus) field of
 the Installation Resource will not be updated until the `calico` component has fully been deployed. `calico` is
 fully deployed when `kubectl get tigerastatus calico` reports Available True with Progressing and Degraded as False.
 

--- a/calico_versioned_docs/version-3.30/reference/configure-cni-plugins.mdx
+++ b/calico_versioned_docs/version-3.30/reference/configure-cni-plugins.mdx
@@ -260,7 +260,7 @@ By enabling this feature, you can avoid errors that can occur when a pod tries t
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](installation/api#operator.tigera.io/v1.CalicoNetworkSpec) of the default `operator.tigera.io/v1/installation` resource.
+The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](installation/api#caliconetworkspec) of the default `operator.tigera.io/v1/installation` resource.
 
 The following example configures the CNI to delay a pod from starting its containers for up to 10 seconds, or until the pod's data plane has been programmed:
 
@@ -330,7 +330,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](installation/api.mdx#installation) API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico_versioned_docs/version-3.30/reference/configure-resources.mdx
+++ b/calico_versioned_docs/version-3.30/reference/configure-resources.mdx
@@ -14,11 +14,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the APIServer CR using the below command:
+To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#apiserverdeployment), patch the APIServer CR using the below command:
 
 ```bash
 kubectl patch apiserver default  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -57,7 +57,7 @@ The [Installation CR](../reference/installation/api.mdx) provides a way to confi
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../reference/installation/api.mdx#typhadeployment), patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -93,7 +93,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../reference/installation/api.mdx#caliconodedaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -128,7 +128,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../reference/installation/api.mdx#caliconodewindowsdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -163,7 +163,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../reference/installation/api.mdx#calicokubecontrollersdeployment) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -199,7 +199,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../reference/installation/api.mdx#csinodedriverdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -256,11 +256,11 @@ The provided example illustrates configuring the apiserver component. Follow a s
 
 ### APIServer custom resource
 
-The [APIServer](../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
+The [APIServer](../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
 
 #### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), update values.yaml with the appropriate resource values.
+To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#apiserverdeployment), update values.yaml with the appropriate resource values.
 
 ```bash
 apiServer:

--- a/calico_versioned_docs/version-3.30/reference/installation/helm_customization.mdx
+++ b/calico_versioned_docs/version-3.30/reference/installation/helm_customization.mdx
@@ -6,7 +6,7 @@ description: Helm installation reference
 
 You can customize the following resources and settings during $[prodname] Helm-based installation using the file, `values.yaml`.
 
-- [Installation](api.mdx#operator.tigera.io/v1.InstallationSpec)
+- [Installation](api.mdx#installationspec)
 - [Default felix configuration](../resources/felixconfig.mdx#spec)
 
 :::note

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/helm.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/helm.mdx
@@ -47,7 +47,7 @@ helm repo add projectcalico https://docs.tigera.io/calico/charts
 
 If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), or you need to customize TLS certificates, you **must** customize this Helm chart by creating a `values.yaml` file. Otherwise, you can skip this step.
 
-1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#operator.tigera.io/v1.Provider). For example:
+1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#provider). For example:
 
    ```
    echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/self-managed-onprem/config-options.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/self-managed-onprem/config-options.mdx
@@ -33,9 +33,9 @@ $[prodname] can also be installed using raw manifests as an alternative to the o
 Operator installations read their configuration from a specific set of Kubernetes APIs. These APIs are installed on the cluster
 as part of `tigera-operator.yaml` in the `operator.tigera.io/v1` API group.
 
-- [Installation](../../../reference/installation/api.mdx#operator.tigera.io/v1.Installation): a singleton resource with name "default" that
+- [Installation](../../../reference/installation/api.mdx#installation): a singleton resource with name "default" that
   configures common installation parameters for a $[prodname] cluster.
-- [APIServer](../../../reference/installation/api.mdx#operator.tigera.io/v1.Installation): a singleton resource with name "default" that
+- [APIServer](../../../reference/installation/api.mdx#installation): a singleton resource with name "default" that
   configures installation of the $[prodname] API server extension.
 
 ### Configure the pod IP range

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -35,7 +35,7 @@ The following table summarizes the networking options and considerations.
 
 :::note
 
-If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#operator.tigera.io/v1.BGPOption).
+If Calico CNI with VXLAN is used, BGP must be disabled. See the [installation reference](../../../reference/installation/api.mdx#bgpoption).
 
 :::
 

--- a/calico_versioned_docs/version-3.31/networking/ipam/ip-autodetection.mdx
+++ b/calico_versioned_docs/version-3.31/networking/ipam/ip-autodetection.mdx
@@ -63,7 +63,7 @@ For more details on autodetection methods, see [node configuration](../../refere
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-As noted previously, the default autodetection method is **first valid interface found** (first-found). To use a different autodetection method, edit the default [Installation](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation) custom resource, specifying the method. Below are examples of the supported autodetection methods:
+As noted previously, the default autodetection method is **first valid interface found** (first-found). To use a different autodetection method, edit the default [Installation](../../reference/installation/api.mdx#installation) custom resource, specifying the method. Below are examples of the supported autodetection methods:
 
 :::note
 

--- a/calico_versioned_docs/version-3.31/operations/certificate-management.mdx
+++ b/calico_versioned_docs/version-3.31/operations/certificate-management.mdx
@@ -29,7 +29,7 @@ certificate issuance, $[prodname] provides a simple configuration option that yo
 
 ### Enable certificate management
 
-1. Modify your [the installation resource](../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+1. Modify your [the installation resource](../reference/installation/api.mdx#installation)
    resource and add the `certificateManagement` section. Apply the following change to your cluster.
 
 ```yaml

--- a/calico_versioned_docs/version-3.31/operations/image-options/imageset.mdx
+++ b/calico_versioned_docs/version-3.31/operations/image-options/imageset.mdx
@@ -75,7 +75,7 @@ sed -ie "s|\(image: .*/operator\):.*|?\1@<put-digest-here>|" tigera-operator.yam
 
 ### Create an ImageSet
 
-Create an [ImageSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ImageSet) manifest file named `imageset.yaml` like the following:
+Create an [ImageSet](../../reference/installation/api.mdx#imageset) manifest file named `imageset.yaml` like the following:
 
 ```yaml
 apiVersion: operator.tigera.io/v1
@@ -139,7 +139,7 @@ You can create an ImageSet manifest manually or by script.
       docker pull <repo/image:tag> && docker inspect <repo/image:tag> -f '{{range .RepoDigests}}{{printf "%s\n" .}}{{end}}'
       ```
    1. Use the digest from the image that matches the repo/image you will use.
-      If you are using a private registry or have specified an [imagePath](../../reference/installation/api.mdx#operator.tigera.io/v1.Installation)
+      If you are using a private registry or have specified an [imagePath](../../reference/installation/api.mdx#installation)
       you will still use the "default" `<owner>/<image>` in the `image` field, for example if you your node image is coming from
       `example.com/registry/imagepath/node` you will still use `calico/node` in the image field of the ImageSet.
       :::note
@@ -225,7 +225,7 @@ Apply the created `imageset.yaml` to your cluster.
 
 ### Create new ImageSet when upgrading or downgrading
 
-Before upgrading to a new release or downgrading, you must create a new [ImageSet](../../reference/installation/api.mdx#operator.tigera.io/v1.ImageSet)
+Before upgrading to a new release or downgrading, you must create a new [ImageSet](../../reference/installation/api.mdx#imageset)
 with updated image references and names for the new release. This must be done prior
 to upgrading the cluster so when the new manifests are applied, the appropriate ImageSet is available.
 
@@ -233,7 +233,7 @@ to upgrading the cluster so when the new manifests are applied, the appropriate 
 
 ### Why does the Installation Resource status not include my ImageSet?
 
-The [status.imageset](../../reference/installation/api.mdx#operator.tigera.io/v1.InstallationStatus) field of
+The [status.imageset](../../reference/installation/api.mdx#installationstatus) field of
 the Installation Resource will not be updated until the `calico` component has fully been deployed. `calico` is
 fully deployed when `kubectl get tigerastatus calico` reports Available True with Progressing and Degraded as False.
 

--- a/calico_versioned_docs/version-3.31/reference/configure-cni-plugins.mdx
+++ b/calico_versioned_docs/version-3.31/reference/configure-cni-plugins.mdx
@@ -260,7 +260,7 @@ By enabling this feature, you can avoid errors that can occur when a pod tries t
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](installation/api#operator.tigera.io/v1.CalicoNetworkSpec) of the default `operator.tigera.io/v1/installation` resource.
+The policy setup timeout can be configured by setting the `linuxPolicySetupTimeoutSeconds` field in the [calicoNetwork spec](installation/api#caliconetworkspec) of the default `operator.tigera.io/v1/installation` resource.
 
 The following example configures the CNI to delay a pod from starting its containers for up to 10 seconds, or until the pod's data plane has been programmed:
 
@@ -330,7 +330,7 @@ Note that some Calico features - such as the ability to request a specific addre
 <Tabs>
 <TabItem label="Operator" value="Operator-0">
 
-The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](installation/api.mdx#operator.tigera.io/v1.Installation) API.
+The `host-local` IPAM plugin can be configured by setting the `Spec.CNI.IPAM.Plugin` field to `HostLocal` on the [operator.tigera.io/Installation](installation/api.mdx#installation) API.
 
 Calico will use the `host-local` IPAM plugin to allocate IPv4 addresses from the node's IPv4 pod CIDR if there is an IPv4 pool configured in `Spec.IPPools`, and an IPv6 address from the node's IPv6 pod CIDR if
 there is an IPv6 pool configured in `Spec.IPPools`.

--- a/calico_versioned_docs/version-3.31/reference/configure-resources.mdx
+++ b/calico_versioned_docs/version-3.31/reference/configure-resources.mdx
@@ -14,11 +14,11 @@ It's important to note that the CPU and memory values used in the examples are f
 
 ## APIServer custom resource
 
-The [APIServer](../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
+The [APIServer](../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example configurations for this CR.
 
 ### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), patch the APIServer CR using the below command:
+To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#apiserverdeployment), patch the APIServer CR using the below command:
 
 ```bash
 kubectl patch apiserver default  --type=merge --patch='{"spec": {"apiServerDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-apiserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}},{"name":"tigera-queryserver","resources":{"limits":{"cpu":"1", "memory":"1000Mi"},"requests":{"cpu":"100m", "memory":"100Mi"}}}]}}}}}}'
@@ -57,7 +57,7 @@ The [Installation CR](../reference/installation/api.mdx) provides a way to confi
 
 ### TyphaDeployment
 
-To configure resource specification for the [TyphaDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.TyphaDeployment), patch the installation CR using the below command:
+To configure resource specification for the [TyphaDeployment](../reference/installation/api.mdx#typhadeployment), patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"typhaDeployment": {"spec": {"template": {"spec": {"containers": [{"name": "calico-typha", "resources": {"requests": {"cpu": "100m", "memory": "100Mi"}, "limits": {"cpu": "1", "memory": "1000Mi"}}}]}}}}}}'
@@ -93,7 +93,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoNodeDaemonSet
 
-To configure resource requests for the [calicoNodeDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeDaemonSet](../reference/installation/api.mdx#caliconodedaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -128,7 +128,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### calicoNodeWindowsDaemonSet
 
-To configure resource requests for the [calicoNodeWindowsDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.calicoNodeWindowsDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [calicoNodeWindowsDaemonSet](../reference/installation/api.mdx#caliconodewindowsdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoNodeWindowsDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-node-windows","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -163,7 +163,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CalicoKubeControllersDeployment
 
-To configure resource requests for the [CalicoKubeControllersDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.CalicoKubeControllersDeployment) component, patch the installation CR using the below command:
+To configure resource requests for the [CalicoKubeControllersDeployment](../reference/installation/api.mdx#calicokubecontrollersdeployment) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"calicoKubeControllersDeployment":{"spec": {"template": {"spec": {"containers":[{"name":"calico-kube-controllers","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -199,7 +199,7 @@ This command will output the configured resource requests and limits for the Cal
 
 ### CSINodeDriverDaemonSet
 
-To configure resource requests for the [CSINodeDriverDaemonSet](../reference/installation/api.mdx#operator.tigera.io/v1.CSINodeDriverDaemonSet) component, patch the installation CR using the below command:
+To configure resource requests for the [CSINodeDriverDaemonSet](../reference/installation/api.mdx#csinodedriverdaemonset) component, patch the installation CR using the below command:
 
 ```bash
 kubectl patch installations default --type=merge --patch='{"spec": {"csiNodeDriverDaemonSet":{"spec": {"template": {"spec": {"containers":[{"name":"calico-csi","resources":{"requests":{"cpu":"100m", "memory":"100Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}},{"name":"csi-node-driver-registrar","resources":{"requests":{"cpu":"50m", "memory":"50Mi"}, "limits":{"cpu":"1", "memory":"1000Mi"}}}]}}}}}}'
@@ -256,11 +256,11 @@ The provided example illustrates configuring the apiserver component. Follow a s
 
 ### APIServer custom resource
 
-The [APIServer](../reference/installation/api.mdx#operator.tigera.io/v1.APIServer) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
+The [APIServer](../reference/installation/api.mdx#apiserver) CR provides a way to configure APIServerDeployment. The following sections provide example values.yaml for apiserver component.
 
 #### APIServerDeployment
 
-To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#operator.tigera.io/v1.APIServerDeployment), update values.yaml with the appropriate resource values.
+To configure resource specification for the [APIServerDeployment](../reference/installation/api.mdx#apiserverdeployment), update values.yaml with the appropriate resource values.
 
 ```bash
 apiServer:

--- a/calico_versioned_docs/version-3.31/reference/installation/helm_customization.mdx
+++ b/calico_versioned_docs/version-3.31/reference/installation/helm_customization.mdx
@@ -6,7 +6,7 @@ description: Helm installation reference
 
 You can customize the following resources and settings during $[prodname] Helm-based installation using the file, `values.yaml`.
 
-- [Installation](api.mdx#operator.tigera.io/v1.InstallationSpec)
+- [Installation](api.mdx#installationspec)
 - [Default felix configuration](../resources/felixconfig.mdx#spec)
 
 :::note


### PR DESCRIPTION
When we moved to our new installation api doc generator, the
format for our page anchors changed. This PR modifies references
to the new format.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->