### PR TITLE
[CE v3.21] Add BYO Node and Typha certificate setup for non-cluster hosts

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/bare-metal/about.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/bare-metal/about.mdx
@@ -152,3 +152,4 @@ Below are some vendor-specific considerations:
 ## Additional resources
 
 - [Protect hosts and VMs](../../network-policy/hosts/protect-hosts.mdx)
+- [Use custom certificates for Node and Typha](typha-node-tls.mdx)

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/bare-metal/typha-node-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/bare-metal/typha-node-tls.mdx
@@ -1,0 +1,64 @@
+---
+description: Use custom TLS certificates for non-cluster Calico Node and Typha
+---
+
+# Use custom certificates for Node and Typha
+
+## Big picture
+
+Provide custom TLS certificates that allow mutual TLS authentication between non-cluster Calico Node and Typha.
+
+## Value
+
+By default, non-cluster Calico Node and Typha use a self-signed Certificate Authority (CA) and automatically generated certificates for mTLS authentication. You can optionally provide your own CA and certificates (BYO certificates) for enhanced security or compliance requirements.
+
+## Before you begin
+
+Get the Certificate Authority certificate and signed certificate and key pairs for Calico Node and Typha.
+
+## How to
+
+### Create the resource file
+
+1. Package your CA certificates into a ConfigMap.
+
+    Run the following command to create a ConfigMap containing your CA certificates. If you have already created the `typha-ca` ConfigMap following the steps in [Provide TLS certificates for Typha and Node](../../operations/comms/typha-node-tls.mdx), and your BYO certificates are signed by the same CA included in that ConfigMap, you can skip this step.
+
+    ```bash
+    kubectl create configmap typha-ca -n tigera-operator --from-file=caBundle=<path-to-ca-cert>
+    ```
+
+    :::tip
+
+    The `caBundle` can contain a single CA or multiple PEM blocks.  It must include the CAs trusted by both Node and Typha.
+
+    :::
+
+2. Create the Node TLS Secret for non-cluster hosts or VMs.
+
+    This secret stores the Calico Node TLS certificate and private key, and can be accessed by hosts or VMs outside of the cluster.
+
+    ```bash
+    kubectl create secret tls node-certs-noncluster-host \
+      -n tigera-operator \
+      --cert=<path-to-node-cert> --key=<path-to-node-key>
+    ```
+
+3. Replace the Typha TLS Secret for the non-cluster Typha deployment.
+
+    Update the secret used by the non-cluster Typha deployment with the appropriate TLS certificate and key.
+
+    ```bash
+    kubectl create secret generic typha-certs-noncluster-host \
+      -n tigera-operator \
+      --from-file=tls.crt=<path-to-typha-cert> \
+      --from-file=tls.key=<path-to-typha-key> \
+      --dry-run=client -o yaml | kubectl apply -f -
+    ```
+
+### Restart Calico Node service on non-cluster host or VM
+
+On each non-cluster host or VM:
+
+1. Remove any existing certificates and private keys from `/etc/calico/calico-node`.
+2. Restart the Calico Node service. The service will automatically retrieve and install the BYO certificates and private keys from the cluster.

--- a/calico-enterprise_versioned_sidebars/version-3.21-2-sidebars.json
+++ b/calico-enterprise_versioned_sidebars/version-3.21-2-sidebars.json
@@ -108,7 +108,8 @@
             "id": "getting-started/bare-metal/index"
           },
           "items": [
-            "getting-started/bare-metal/about"
+            "getting-started/bare-metal/about",
+            "getting-started/bare-metal/typha-node-tls"
           ]
         },
         {


### PR DESCRIPTION
Adds a new documentation section explaining how to bring your own (BYO) CA and TLS certificates for Node and Typha in non-cluster host environments.

Related to https://github.com/tigera/docs/pull/2299.

Product Version(s):

Calico Enterprise v3.21.

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->