### PR TITLE
[CORE-11223] Change EGW IP Pool block size recommendation to /32.

### DIFF
--- a/calico-enterprise/networking/egress/egress-gateway-azure.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-azure.mdx
@@ -188,14 +188,30 @@ metadata:
   name: egress-ip-red-pool
 spec:
   cidr: 10.10.10.0/30
-  blockSize: 31
+  blockSize: 32
   nodeSelector: "!all()"
   vxlanMode: Never
 EOF
 ```
 
 Where:
-- `blockSize` must be specified when the prefix length of the whole `cidr` is more than the default `blockSize` of 26.
+
+- It is best to set the `blockSize` to 32 so that each block contains only a single IP address:
+
+  - Scheduling a single egress gateway to a node causes the node to claim a whole block.  The other IPs in the block
+    are wasted unless a second egress gateway (with the same pool configuration) is scheduled to the same node.
+
+  - Empty /32 blocks can always be reclaimed from other nodes if the pool runs out of blocks.  This ensures that an
+    egress gateway can always be scheduled if there are free IPs in the pool.
+
+  Setting `strictAffinity` to `false` in the [IPAM configuration](../../reference/resources/ipamconfig) also prevents the
+  above problems by allowing nodes to "borrow" IPs from other nodes' blocks.  However, using /32 blocks:
+
+  - Avoids a dependency on a setting that is shared with other IP pools.
+
+  - Results in simpler, uniform route advertisements (rather than a mix of block size routes and /32 routes).
+
+  - Results in less route churn.
 
 - `nodeSelector: "!all()"` is recommended so that this egress IP pool is not accidentally used for cluster pods in general. Specifying this `nodeSelector` means that the IP pool is only used for pods that explicitly identify it in their `cni.projectcalico.org/ipv4pools` annotation.
 

--- a/calico-enterprise/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-on-prem.mdx
@@ -214,14 +214,29 @@ metadata:
   name: egress-ippool-1
 spec:
   cidr: 10.10.10.0/30
-  blockSize: 31
+  blockSize: 32
   nodeSelector: "!all()"
 EOF
 ```
 
 Where:
 
-- `blockSize` must be specified when the prefix length of the whole `cidr` is more than the default `blockSize` of 26.
+- It is best to set the `blockSize` to 32 so that each block contains only a single IP address:
+
+  - Scheduling a single egress gateway to a node causes the node to claim a whole block.  The other IPs in the block
+    are wasted unless a second egress gateway (with the same pool configuration) is scheduled to the same node.
+
+  - Empty /32 blocks can always be reclaimed from other nodes if the pool runs out of blocks.  This ensures that an
+    egress gateway can always be scheduled if there are free IPs in the pool.
+
+  Setting `strictAffinity` to `false` in the [IPAM configuration](../../reference/resources/ipamconfig) also prevents the
+  above problems by allowing nodes to "borrow" IPs from other nodes' blocks.  However, using /32 blocks:
+
+  - Avoids a dependency on a setting that is shared with other IP pools.
+
+  - Results in simpler, uniform route advertisements (rather than a mix of block size routes and /32 routes).
+
+  - Results in less route churn.
 
 - `nodeSelector: "!all()"` is recommended so that this egress IP pool is not accidentally used for cluster pods in general. Specifying this `nodeSelector` means that the IP pool is only used for pods that explicitly identify it in their `cni.projectcalico.org/ipv4pools` annotation.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Enterprise v3.23.0-1.0
Enterprise v3.22.0-2.0 (backport in progress)
Enterprise v3.21.3 (backport in progress)

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

- /31 pools rely on IP borrowing, which is a global setting that may be disabled for other reasons.
- As of projectcalico/calico#11149 the IPAM logic can reclaim /32 blocks from other nodes once they are empty avoiding problems with blocks getting stranded on the wrong node.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://deploy-preview-2351--calico-docs-preview-next.netlify.app/calico-enterprise/next/networking/egress/egress-gateway-on-prem
SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->