### PR TITLE
GH-2353: Add registry names in releases.json

### DIFF
--- a/calico/releases.json
+++ b/calico/releases.json
@@ -8,70 +8,92 @@
     },
     "components": {
       "calico/typha": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "calico/ctl": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "calico/node-windows": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "calico/cni-windows": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "calico/envoy-gateway": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "calico/envoy-proxy": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "calico/envoy-ratelimit": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
-      "coreos/flannel": {
-        "version": "v0.16.3"
+      "flannel": {
+        "version": "v0.24.4",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "calico/csi": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "calico/node-driver-registrar": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "calico/pod2daemon-flexvol": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "calico/key-cert-provisioner": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "calico/goldmane": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "calico/whisker": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       },
       "calico/whisker-backend": {
-        "version": "master"
+        "version": "master",
+        "registry": "quay.io"
       }
     }
   }

--- a/calico_versioned_docs/version-3.28/releases.json
+++ b/calico_versioned_docs/version-3.28/releases.json
@@ -8,52 +8,68 @@
     },
     "components": {
       "typha": {
-        "version": "v3.28.5"
+        "version": "v3.28.5",
+        "registry": "quay.io"
       },
       "calicoctl": {
-        "version": "v3.28.5"
+        "version": "v3.28.5",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.28.5"
+        "version": "v3.28.5",
+        "registry": "quay.io"
       },
       "calico/node-windows": {
-        "version": "v3.28.5"
+        "version": "v3.28.5",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.28.5"
+        "version": "v3.28.5",
+        "registry": "quay.io"
       },
       "calico/cni-windows": {
-        "version": "v3.28.5"
+        "version": "v3.28.5",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.28.5"
+        "version": "v3.28.5",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.28.5"
+        "version": "v3.28.5",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.28.5"
+        "version": "v3.28.5",
+        "registry": "quay.io"
       },
       "calico/windows": {
-        "version": "v3.28.5"
+        "version": "v3.28.5",
+        "registry": "quay.io"
       },
       "networking-calico": {
-        "version": "v3.28.5"
+        "version": "v3.28.5",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.3"
+        "version": "v0.24.3",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.28.5"
+        "version": "v3.28.5",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.28.5"
+        "version": "v3.28.5",
+        "registry": "quay.io"
       },
       "csi-driver": {
-        "version": "v3.28.5"
+        "version": "v3.28.5",
+        "registry": "quay.io"
       },
       "csi-node-driver-registrar": {
-        "version": "v3.28.5"
+        "version": "v3.28.5",
+        "registry": "quay.io"
       }
     }
   },
@@ -66,46 +82,60 @@
     },
     "components": {
       "typha": {
-        "version": "v3.28.4"
+        "version": "v3.28.4",
+        "registry": "quay.io"
       },
       "calicoctl": {
-        "version": "v3.28.4"
+        "version": "v3.28.4",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.28.4"
+        "version": "v3.28.4",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.28.4"
+        "version": "v3.28.4",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.28.4"
+        "version": "v3.28.4",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.28.4"
+        "version": "v3.28.4",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.28.4"
+        "version": "v3.28.4",
+        "registry": "quay.io"
       },
       "calico/windows": {
-        "version": "v3.28.4"
+        "version": "v3.28.4",
+        "registry": "quay.io"
       },
       "networking-calico": {
-        "version": "v3.28.4"
+        "version": "v3.28.4",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.3"
+        "version": "v0.24.3",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.28.4"
+        "version": "v3.28.4",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.28.4"
+        "version": "v3.28.4",
+        "registry": "quay.io"
       },
       "csi-driver": {
-        "version": "v3.28.4"
+        "version": "v3.28.4",
+        "registry": "quay.io"
       },
       "csi-node-driver-registrar": {
-        "version": "v3.28.4"
+        "version": "v3.28.4",
+        "registry": "quay.io"
       }
     }
   },
@@ -118,46 +148,60 @@
     },
     "components": {
       "typha": {
-        "version": "v3.28.3"
+        "version": "v3.28.3",
+        "registry": "quay.io"
       },
       "calicoctl": {
-        "version": "v3.28.3"
+        "version": "v3.28.3",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.28.3"
+        "version": "v3.28.3",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.28.3"
+        "version": "v3.28.3",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.28.3"
+        "version": "v3.28.3",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.28.3"
+        "version": "v3.28.3",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.28.3"
+        "version": "v3.28.3",
+        "registry": "quay.io"
       },
       "calico/windows": {
-        "version": "v3.28.3"
+        "version": "v3.28.3",
+        "registry": "quay.io"
       },
       "networking-calico": {
-        "version": "v3.28.3"
+        "version": "v3.28.3",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.3"
+        "version": "v0.24.3",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.28.3"
+        "version": "v3.28.3",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.28.3"
+        "version": "v3.28.3",
+        "registry": "quay.io"
       },
       "csi-driver": {
-        "version": "v3.28.3"
+        "version": "v3.28.3",
+        "registry": "quay.io"
       },
       "csi-node-driver-registrar": {
-        "version": "v3.28.3"
+        "version": "v3.28.3",
+        "registry": "quay.io"
       }
     }
   },
@@ -170,46 +214,60 @@
     },
     "components": {
       "typha": {
-        "version": "v3.28.2"
+        "version": "v3.28.2",
+        "registry": "quay.io"
       },
       "calicoctl": {
-        "version": "v3.28.2"
+        "version": "v3.28.2",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.28.2"
+        "version": "v3.28.2",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.28.2"
+        "version": "v3.28.2",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.28.2"
+        "version": "v3.28.2",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.28.2"
+        "version": "v3.28.2",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.28.2"
+        "version": "v3.28.2",
+        "registry": "quay.io"
       },
       "calico/windows": {
-        "version": "v3.28.2"
+        "version": "v3.28.2",
+        "registry": "quay.io"
       },
       "networking-calico": {
-        "version": "v3.28.2"
+        "version": "v3.28.2",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.3"
+        "version": "v0.24.3",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.28.2"
+        "version": "v3.28.2",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.28.2"
+        "version": "v3.28.2",
+        "registry": "quay.io"
       },
       "csi-driver": {
-        "version": "v3.28.2"
+        "version": "v3.28.2",
+        "registry": "quay.io"
       },
       "csi-node-driver-registrar": {
-        "version": "v3.28.2"
+        "version": "v3.28.2",
+        "registry": "quay.io"
       }
     }
   },
@@ -222,46 +280,60 @@
     },
     "components": {
       "typha": {
-        "version": "v3.28.1"
+        "version": "v3.28.1",
+        "registry": "quay.io"
       },
       "calicoctl": {
-        "version": "v3.28.1"
+        "version": "v3.28.1",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.28.1"
+        "version": "v3.28.1",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.28.1"
+        "version": "v3.28.1",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.28.1"
+        "version": "v3.28.1",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.28.1"
+        "version": "v3.28.1",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.28.1"
+        "version": "v3.28.1",
+        "registry": "quay.io"
       },
       "calico/windows": {
-        "version": "v3.28.1"
+        "version": "v3.28.1",
+        "registry": "quay.io"
       },
       "networking-calico": {
-        "version": "v3.28.1"
+        "version": "v3.28.1",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.3"
+        "version": "v0.24.3",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.28.1"
+        "version": "v3.28.1",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.28.1"
+        "version": "v3.28.1",
+        "registry": "quay.io"
       },
       "csi-driver": {
-        "version": "v3.28.1"
+        "version": "v3.28.1",
+        "registry": "quay.io"
       },
       "csi-node-driver-registrar": {
-        "version": "v3.28.1"
+        "version": "v3.28.1",
+        "registry": "quay.io"
       }
     }
   },
@@ -274,46 +346,60 @@
     },
     "components": {
       "typha": {
-        "version": "v3.28.0"
+        "version": "v3.28.0",
+        "registry": "quay.io"
       },
       "calicoctl": {
-        "version": "v3.28.0"
+        "version": "v3.28.0",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.28.0"
+        "version": "v3.28.0",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.28.0"
+        "version": "v3.28.0",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.28.0"
+        "version": "v3.28.0",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.28.0"
+        "version": "v3.28.0",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.28.0"
+        "version": "v3.28.0",
+        "registry": "quay.io"
       },
       "calico/windows": {
-        "version": "v3.28.0"
+        "version": "v3.28.0",
+        "registry": "quay.io"
       },
       "networking-calico": {
-        "version": "v3.28.0"
+        "version": "v3.28.0",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.3"
+        "version": "v0.24.3",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.28.0"
+        "version": "v3.28.0",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.28.0"
+        "version": "v3.28.0",
+        "registry": "quay.io"
       },
       "csi-driver": {
-        "version": "v3.28.0"
+        "version": "v3.28.0",
+        "registry": "quay.io"
       },
       "csi-node-driver-registrar": {
-        "version": "v3.28.0"
+        "version": "v3.28.0",
+        "registry": "quay.io"
       }
     }
   }

--- a/calico_versioned_docs/version-3.29/releases.json
+++ b/calico_versioned_docs/version-3.29/releases.json
@@ -8,52 +8,68 @@
     },
     "components": {
       "typha": {
-        "version": "v3.29.6"
+        "version": "v3.29.6",
+        "registry": "quay.io"
       },
       "calicoctl": {
-        "version": "v3.29.6"
+        "version": "v3.29.6",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.29.6"
+        "version": "v3.29.6",
+        "registry": "quay.io"
       },
       "calico/node-windows": {
-        "version": "v3.29.6"
+        "version": "v3.29.6",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.29.6"
+        "version": "v3.29.6",
+        "registry": "quay.io"
       },
       "calico/cni-windows": {
-        "version": "v3.29.6"
+        "version": "v3.29.6",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.29.6"
+        "version": "v3.29.6",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.29.6"
+        "version": "v3.29.6",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.29.6"
+        "version": "v3.29.6",
+        "registry": "quay.io"
       },
       "calico/windows": {
-        "version": "v3.29.6"
+        "version": "v3.29.6",
+        "registry": "quay.io"
       },
       "networking-calico": {
-        "version": "v3.29.6"
+        "version": "v3.29.6",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.4"
+        "version": "v0.24.4",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.29.6"
+        "version": "v3.29.6",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.29.6"
+        "version": "v3.29.6",
+        "registry": "quay.io"
       },
       "csi-driver": {
-        "version": "v3.29.6"
+        "version": "v3.29.6",
+        "registry": "quay.io"
       },
       "csi-node-driver-registrar": {
-        "version": "v3.29.6"
+        "version": "v3.29.6",
+        "registry": "quay.io"
       }
     }
   },
@@ -66,52 +82,68 @@
     },
     "components": {
       "typha": {
-        "version": "v3.29.5"
+        "version": "v3.29.5",
+        "registry": "quay.io"
       },
       "calicoctl": {
-        "version": "v3.29.5"
+        "version": "v3.29.5",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.29.5"
+        "version": "v3.29.5",
+        "registry": "quay.io"
       },
       "calico/node-windows": {
-        "version": "v3.29.5"
+        "version": "v3.29.5",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.29.5"
+        "version": "v3.29.5",
+        "registry": "quay.io"
       },
       "calico/cni-windows": {
-        "version": "v3.29.5"
+        "version": "v3.29.5",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.29.5"
+        "version": "v3.29.5",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.29.5"
+        "version": "v3.29.5",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.29.5"
+        "version": "v3.29.5",
+        "registry": "quay.io"
       },
       "calico/windows": {
-        "version": "v3.29.5"
+        "version": "v3.29.5",
+        "registry": "quay.io"
       },
       "networking-calico": {
-        "version": "v3.29.5"
+        "version": "v3.29.5",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.4"
+        "version": "v0.24.4",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.29.5"
+        "version": "v3.29.5",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.29.5"
+        "version": "v3.29.5",
+        "registry": "quay.io"
       },
       "csi-driver": {
-        "version": "v3.29.5"
+        "version": "v3.29.5",
+        "registry": "quay.io"
       },
       "csi-node-driver-registrar": {
-        "version": "v3.29.5"
+        "version": "v3.29.5",
+        "registry": "quay.io"
       }
     }
   },
@@ -124,52 +156,68 @@
     },
     "components": {
       "typha": {
-        "version": "v3.29.4"
+        "version": "v3.29.4",
+        "registry": "quay.io"
       },
       "calicoctl": {
-        "version": "v3.29.4"
+        "version": "v3.29.4",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.29.4"
+        "version": "v3.29.4",
+        "registry": "quay.io"
       },
       "calico/node-windows": {
-        "version": "v3.29.4"
+        "version": "v3.29.4",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.29.4"
+        "version": "v3.29.4",
+        "registry": "quay.io"
       },
       "calico/cni-windows": {
-        "version": "v3.29.4"
+        "version": "v3.29.4",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.29.4"
+        "version": "v3.29.4",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.29.4"
+        "version": "v3.29.4",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.29.4"
+        "version": "v3.29.4",
+        "registry": "quay.io"
       },
       "calico/windows": {
-        "version": "v3.29.4"
+        "version": "v3.29.4",
+        "registry": "quay.io"
       },
       "networking-calico": {
-        "version": "v3.29.4"
+        "version": "v3.29.4",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.4"
+        "version": "v0.24.4",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.29.4"
+        "version": "v3.29.4",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.29.4"
+        "version": "v3.29.4",
+        "registry": "quay.io"
       },
       "csi-driver": {
-        "version": "v3.29.4"
+        "version": "v3.29.4",
+        "registry": "quay.io"
       },
       "csi-node-driver-registrar": {
-        "version": "v3.29.4"
+        "version": "v3.29.4",
+        "registry": "quay.io"
       }
     }
   },
@@ -182,46 +230,60 @@
     },
     "components": {
       "typha": {
-        "version": "v3.29.3"
+        "version": "v3.29.3",
+        "registry": "quay.io"
       },
       "calicoctl": {
-        "version": "v3.29.3"
+        "version": "v3.29.3",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.29.3"
+        "version": "v3.29.3",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.29.3"
+        "version": "v3.29.3",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.29.3"
+        "version": "v3.29.3",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.29.3"
+        "version": "v3.29.3",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.29.3"
+        "version": "v3.29.3",
+        "registry": "quay.io"
       },
       "calico/windows": {
-        "version": "v3.29.3"
+        "version": "v3.29.3",
+        "registry": "quay.io"
       },
       "networking-calico": {
-        "version": "v3.29.3"
+        "version": "v3.29.3",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.4"
+        "version": "v0.24.4",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.29.3"
+        "version": "v3.29.3",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.29.3"
+        "version": "v3.29.3",
+        "registry": "quay.io"
       },
       "csi-driver": {
-        "version": "v3.29.3"
+        "version": "v3.29.3",
+        "registry": "quay.io"
       },
       "csi-node-driver-registrar": {
-        "version": "v3.29.3"
+        "version": "v3.29.3",
+        "registry": "quay.io"
       }
     }
   },
@@ -234,46 +296,60 @@
     },
     "components": {
       "typha": {
-        "version": "v3.29.2"
+        "version": "v3.29.2",
+        "registry": "quay.io"
       },
       "calicoctl": {
-        "version": "v3.29.2"
+        "version": "v3.29.2",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.29.2"
+        "version": "v3.29.2",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.29.2"
+        "version": "v3.29.2",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.29.2"
+        "version": "v3.29.2",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.29.2"
+        "version": "v3.29.2",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.29.2"
+        "version": "v3.29.2",
+        "registry": "quay.io"
       },
       "calico/windows": {
-        "version": "v3.29.2"
+        "version": "v3.29.2",
+        "registry": "quay.io"
       },
       "networking-calico": {
-        "version": "v3.29.2"
+        "version": "v3.29.2",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.4"
+        "version": "v0.24.4",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.29.2"
+        "version": "v3.29.2",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.29.2"
+        "version": "v3.29.2",
+        "registry": "quay.io"
       },
       "csi-driver": {
-        "version": "v3.29.2"
+        "version": "v3.29.2",
+        "registry": "quay.io"
       },
       "csi-node-driver-registrar": {
-        "version": "v3.29.2"
+        "version": "v3.29.2",
+        "registry": "quay.io"
       }
     }
   },
@@ -286,46 +362,60 @@
     },
     "components": {
       "typha": {
-        "version": "v3.29.1"
+        "version": "v3.29.1",
+        "registry": "quay.io"
       },
       "calicoctl": {
-        "version": "v3.29.1"
+        "version": "v3.29.1",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.29.1"
+        "version": "v3.29.1",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.29.1"
+        "version": "v3.29.1",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.29.1"
+        "version": "v3.29.1",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.29.1"
+        "version": "v3.29.1",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.29.1"
+        "version": "v3.29.1",
+        "registry": "quay.io"
       },
       "calico/windows": {
-        "version": "v3.29.1"
+        "version": "v3.29.1",
+        "registry": "quay.io"
       },
       "networking-calico": {
-        "version": "v3.29.1"
+        "version": "v3.29.1",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.4"
+        "version": "v0.24.4",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.29.1"
+        "version": "v3.29.1",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.29.1"
+        "version": "v3.29.1",
+        "registry": "quay.io"
       },
       "csi-driver": {
-        "version": "v3.29.1"
+        "version": "v3.29.1",
+        "registry": "quay.io"
       },
       "csi-node-driver-registrar": {
-        "version": "v3.29.1"
+        "version": "v3.29.1",
+        "registry": "quay.io"
       }
     }
   },
@@ -338,46 +428,60 @@
     },
     "components": {
       "typha": {
-        "version": "v3.29.0"
+        "version": "v3.29.0",
+        "registry": "quay.io"
       },
       "calicoctl": {
-        "version": "v3.29.0"
+        "version": "v3.29.0",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.29.0"
+        "version": "v3.29.0",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.29.0"
+        "version": "v3.29.0",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.29.0"
+        "version": "v3.29.0",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.29.0"
+        "version": "v3.29.0",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.29.0"
+        "version": "v3.29.0",
+        "registry": "quay.io"
       },
       "calico/windows": {
-        "version": "v3.29.0"
+        "version": "v3.29.0",
+        "registry": "quay.io"
       },
       "networking-calico": {
-        "version": "v3.29.0"
+        "version": "v3.29.0",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.4"
+        "version": "v0.24.4",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.29.0"
+        "version": "v3.29.0",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.29.0"
+        "version": "v3.29.0",
+        "registry": "quay.io"
       },
       "csi-driver": {
-        "version": "v3.29.0"
+        "version": "v3.29.0",
+        "registry": "quay.io"
       },
       "csi-node-driver-registrar": {
-        "version": "v3.29.0"
+        "version": "v3.29.0",
+        "registry": "quay.io"
       }
     }
   }

--- a/calico_versioned_docs/version-3.30/releases.json
+++ b/calico_versioned_docs/version-3.30/releases.json
@@ -8,70 +8,92 @@
     },
     "components": {
       "calico/typha": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "calico/ctl": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "calico/node-windows": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "calico/cni-windows": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "calico/envoy-gateway": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "calico/envoy-proxy": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "calico/envoy-ratelimit": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.4"
+        "version": "v0.24.4",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "calico/csi": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "calico/node-driver-registrar": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "calico/pod2daemon-flexvol": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "calico/key-cert-provisioner": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "calico/goldmane": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "calico/whisker": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       },
       "calico/whisker-backend": {
-        "version": "v3.30.4"
+        "version": "v3.30.4",
+        "registry": "quay.io"
       }
     }
   },
@@ -84,70 +106,92 @@
     },
     "components": {
       "calico/typha": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "calico/ctl": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "calico/node-windows": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "calico/cni-windows": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "calico/envoy-gateway": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "calico/envoy-proxy": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "calico/envoy-ratelimit": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.4"
+        "version": "v0.24.4",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "calico/csi": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "calico/node-driver-registrar": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "calico/pod2daemon-flexvol": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "calico/key-cert-provisioner": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "calico/goldmane": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "calico/whisker": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       },
       "calico/whisker-backend": {
-        "version": "v3.30.3"
+        "version": "v3.30.3",
+        "registry": "quay.io"
       }
     }
   },
@@ -160,70 +204,92 @@
     },
     "components": {
       "calico/typha": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "calico/ctl": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "calico/node-windows": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "calico/cni-windows": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "calico/envoy-gateway": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "calico/envoy-proxy": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "calico/envoy-ratelimit": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.4"
+        "version": "v0.24.4",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "calico/csi": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "calico/node-driver-registrar": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "calico/pod2daemon-flexvol": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "calico/key-cert-provisioner": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "calico/goldmane": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "calico/whisker": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       },
       "calico/whisker-backend": {
-        "version": "v3.30.2"
+        "version": "v3.30.2",
+        "registry": "quay.io"
       }
     }
   },
@@ -236,70 +302,92 @@
     },
     "components": {
       "calico/typha": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "calico/ctl": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "calico/node-windows": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "calico/cni-windows": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "calico/envoy-gateway": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "calico/envoy-proxy": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "calico/envoy-ratelimit": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.4"
+        "version": "v0.24.4",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "calico/csi": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "calico/node-driver-registrar": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "calico/pod2daemon-flexvol": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "calico/key-cert-provisioner": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "calico/goldmane": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "calico/whisker": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       },
       "calico/whisker-backend": {
-        "version": "v3.30.1"
+        "version": "v3.30.1",
+        "registry": "quay.io"
       }
     }
   },
@@ -312,70 +400,92 @@
     },
     "components": {
       "calico/typha": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "calico/ctl": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "calico/node-windows": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "calico/cni-windows": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "calico/envoy-gateway": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "calico/envoy-proxy": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "calico/envoy-ratelimit": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.4"
+        "version": "v0.24.4",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "calico/csi": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "calico/node-driver-registrar": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "calico/pod2daemon-flexvol": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "calico/key-cert-provisioner": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "calico/goldmane": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "calico/whisker": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       },
       "calico/whisker-backend": {
-        "version": "v3.30.0"
+        "version": "v3.30.0",
+        "registry": "quay.io"
       }
     }
   }

--- a/calico_versioned_docs/version-3.31/releases.json
+++ b/calico_versioned_docs/version-3.31/releases.json
@@ -8,70 +8,92 @@
     },
     "components": {
       "calico/typha": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "calico/ctl": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "calico/node": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "calico/node-windows": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "calico/cni-windows": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "calico/envoy-gateway": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "calico/envoy-proxy": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "calico/envoy-ratelimit": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "flannel": {
-        "version": "v0.24.4"
+        "version": "v0.24.4",
+        "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "flexvol": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "calico/csi": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "calico/node-driver-registrar": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "calico/pod2daemon-flexvol": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "calico/key-cert-provisioner": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "calico/goldmane": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "calico/whisker": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       },
       "calico/whisker-backend": {
-        "version": "v3.31.0"
+        "version": "v3.31.0",
+        "registry": "quay.io"
       }
     }
   }


### PR DESCRIPTION
The alternate registry doc wasn't specifying registries, to it
defaulted to no registry (= Docker). This change makes quay explicit.

GH-2353

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://deploy-preview-2358--tigera.netlify.app/calico/latest/operations/image-options/alternate-registry

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->