### PR TITLE
Restore helm pull changes

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -32,11 +32,15 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 
 ### Download the Helm chart
 
-  <CodeBlock language='bash'>
-     {'$[version]' === 'master'
-       ? `helm repo add tigera gs://tigera-helm-charts`
-       : `curl -O -L https://downloads.tigera.io/ee/charts/tigera-operator-$[chart_version_name].tgz`}
-  </CodeBlock>
+<CodeBlock language='bash'>
+    {'$[version]' === 'master'
+        ? `helm repo add tigera gs://tigera-helm-charts
+helm repo update
+helm pull tigera/tigera-operator --version $[chart_version_name]`
+        : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
+helm repo update
+helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+</CodeBlock>
 
 ### Prepare the Installation Configuration
 

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -32,11 +32,15 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 
 ### Download the Helm chart
 
-  <CodeBlock language='bash'>
-     {'$[version]' === 'master'
-       ? `helm repo add tigera gs://tigera-helm-charts`
-       : `curl -O -L https://downloads.tigera.io/ee/charts/tigera-operator-$[chart_version_name].tgz`}
-  </CodeBlock>
+<CodeBlock language='bash'>
+    {'$[version]' === 'master'
+        ? `helm repo add tigera gs://tigera-helm-charts
+helm repo update
+helm pull tigera/tigera-operator --version $[chart_version_name]`
+        : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
+helm repo update
+helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+</CodeBlock>
 
 ### Prepare the Installation Configuration
 

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -34,11 +34,15 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 
 ### Get the Helm chart
 
-  <CodeBlock language='bash'>
-     {'$[version]' === 'master'
-       ? `helm repo add tigera gs://tigera-helm-charts`
-       : `curl -O -L https://downloads.tigera.io/ee/charts/tigera-operator-$[chart_version_name].tgz`}
-  </CodeBlock>
+<CodeBlock language='bash'>
+    {'$[version]' === 'master'
+        ? `helm repo add tigera gs://tigera-helm-charts
+helm repo update
+helm pull tigera/tigera-operator --version $[chart_version_name]`
+        : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
+helm repo update
+helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+</CodeBlock>
 
 ### Prepare the Installation Configuration
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -32,11 +32,15 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 
 ### Download the Helm chart
 
-  <CodeBlock language='bash'>
-     {'$[version]' === 'master'
-       ? `helm repo add tigera gs://tigera-helm-charts`
-       : `curl -O -L https://downloads.tigera.io/ee/charts/tigera-operator-$[chart_version_name].tgz`}
-  </CodeBlock>
+<CodeBlock language='bash'>
+    {'$[version]' === 'master'
+        ? `helm repo add tigera gs://tigera-helm-charts
+helm repo update
+helm pull tigera/tigera-operator --version $[chart_version_name]`
+        : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
+helm repo update
+helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+</CodeBlock>
 
 ### Prepare the Installation Configuration
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -32,11 +32,15 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 
 ### Download the Helm chart
 
-  <CodeBlock language='bash'>
-     {'$[version]' === 'master'
-       ? `helm repo add tigera gs://tigera-helm-charts`
-       : `curl -O -L https://downloads.tigera.io/ee/charts/tigera-operator-$[chart_version_name].tgz`}
-  </CodeBlock>
+<CodeBlock language='bash'>
+    {'$[version]' === 'master'
+        ? `helm repo add tigera gs://tigera-helm-charts
+helm repo update
+helm pull tigera/tigera-operator --version $[chart_version_name]`
+        : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
+helm repo update
+helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+</CodeBlock>
 
 ### Prepare the Installation Configuration
 

--- a/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -34,11 +34,15 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 
 ### Get the Helm chart
 
-  <CodeBlock language='bash'>
-     {'$[version]' === 'master'
-       ? `helm repo add tigera gs://tigera-helm-charts`
-       : `curl -O -L https://downloads.tigera.io/ee/charts/tigera-operator-$[chart_version_name].tgz`}
-  </CodeBlock>
+<CodeBlock language='bash'>
+    {'$[version]' === 'master'
+        ? `helm repo add tigera gs://tigera-helm-charts
+helm repo update
+helm pull tigera/tigera-operator --version $[chart_version_name]`
+        : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
+helm repo update
+helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+</CodeBlock>
 
 ### Prepare the Installation Configuration
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -32,11 +32,15 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 
 ### Download the Helm chart
 
-  <CodeBlock language='bash'>
-     {'$[version]' === 'master'
-       ? `helm repo add tigera gs://tigera-helm-charts`
-       : `curl -O -L https://downloads.tigera.io/ee/charts/tigera-operator-$[chart_version_name].tgz`}
-  </CodeBlock>
+<CodeBlock language='bash'>
+    {'$[version]' === 'master'
+        ? `helm repo add tigera gs://tigera-helm-charts
+helm repo update
+helm pull tigera/tigera-operator --version $[chart_version_name]`
+        : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
+helm repo update
+helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+</CodeBlock>
 
 ### Prepare the Installation Configuration
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -32,11 +32,15 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 
 ### Download the Helm chart
 
-  <CodeBlock language='bash'>
-     {'$[version]' === 'master'
-       ? `helm repo add tigera gs://tigera-helm-charts`
-       : `curl -O -L https://downloads.tigera.io/ee/charts/tigera-operator-$[chart_version_name].tgz`}
-  </CodeBlock>
+<CodeBlock language='bash'>
+    {'$[version]' === 'master'
+        ? `helm repo add tigera gs://tigera-helm-charts
+helm repo update
+helm pull tigera/tigera-operator --version $[chart_version_name]`
+        : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
+helm repo update
+helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+</CodeBlock>
 
 ### Prepare the Installation Configuration
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -34,11 +34,15 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 
 ### Get the Helm chart
 
-  <CodeBlock language='bash'>
-     {'$[version]' === 'master'
-       ? `helm repo add tigera gs://tigera-helm-charts`
-       : `curl -O -L https://downloads.tigera.io/ee/charts/tigera-operator-$[chart_version_name].tgz`}
-  </CodeBlock>
+<CodeBlock language='bash'>
+    {'$[version]' === 'master'
+        ? `helm repo add tigera gs://tigera-helm-charts
+helm repo update
+helm pull tigera/tigera-operator --version $[chart_version_name]`
+        : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
+helm repo update
+helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+</CodeBlock>
 
 ### Prepare the Installation Configuration
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -32,11 +32,15 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 
 ### Download the Helm chart
 
-  <CodeBlock language='bash'>
-     {'$[version]' === 'master'
-       ? `helm repo add tigera gs://tigera-helm-charts`
-       : `curl -O -L https://downloads.tigera.io/ee/charts/tigera-operator-$[chart_version_name].tgz`}
-  </CodeBlock>
+<CodeBlock language='bash'>
+    {'$[version]' === 'master'
+        ? `helm repo add tigera gs://tigera-helm-charts
+helm repo update
+helm pull tigera/tigera-operator --version $[chart_version_name]`
+        : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
+helm repo update
+helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+</CodeBlock>
 
 ### Prepare the Installation Configuration
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -32,11 +32,15 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 
 ### Download the Helm chart
 
-  <CodeBlock language='bash'>
-     {'$[version]' === 'master'
-       ? `helm repo add tigera gs://tigera-helm-charts`
-       : `curl -O -L https://downloads.tigera.io/ee/charts/tigera-operator-$[chart_version_name].tgz`}
-  </CodeBlock>
+<CodeBlock language='bash'>
+    {'$[version]' === 'master'
+        ? `helm repo add tigera gs://tigera-helm-charts
+helm repo update
+helm pull tigera/tigera-operator --version $[chart_version_name]`
+        : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
+helm repo update
+helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+</CodeBlock>
 
 ### Prepare the Installation Configuration
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -34,11 +34,15 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 
 ### Get the Helm chart
 
-  <CodeBlock language='bash'>
-     {'$[version]' === 'master'
-       ? `helm repo add tigera gs://tigera-helm-charts`
-       : `curl -O -L https://downloads.tigera.io/ee/charts/tigera-operator-$[chart_version_name].tgz`}
-  </CodeBlock>
+<CodeBlock language='bash'>
+    {'$[version]' === 'master'
+        ? `helm repo add tigera gs://tigera-helm-charts
+helm repo update
+helm pull tigera/tigera-operator --version $[chart_version_name]`
+        : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
+helm repo update
+helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+</CodeBlock>
 
 ### Prepare the Installation Configuration
 

--- a/calico-enterprise_versioned_docs/version-3.22-1/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -32,11 +32,15 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 
 ### Download the Helm chart
 
-  <CodeBlock language='bash'>
-     {'$[version]' === 'master'
-       ? `helm repo add tigera gs://tigera-helm-charts`
-       : `curl -O -L https://downloads.tigera.io/ee/charts/tigera-operator-$[chart_version_name].tgz`}
-  </CodeBlock>
+<CodeBlock language='bash'>
+    {'$[version]' === 'master'
+        ? `helm repo add tigera gs://tigera-helm-charts
+helm repo update
+helm pull tigera/tigera-operator --version $[chart_version_name]`
+        : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
+helm repo update
+helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+</CodeBlock>
 
 ### Prepare the Installation Configuration
 

--- a/calico-enterprise_versioned_docs/version-3.22-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -32,11 +32,15 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 
 ### Download the Helm chart
 
-  <CodeBlock language='bash'>
-     {'$[version]' === 'master'
-       ? `helm repo add tigera gs://tigera-helm-charts`
-       : `curl -O -L https://downloads.tigera.io/ee/charts/tigera-operator-$[chart_version_name].tgz`}
-  </CodeBlock>
+<CodeBlock language='bash'>
+    {'$[version]' === 'master'
+        ? `helm repo add tigera gs://tigera-helm-charts
+helm repo update
+helm pull tigera/tigera-operator --version $[chart_version_name]`
+        : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
+helm repo update
+helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+</CodeBlock>
 
 ### Prepare the Installation Configuration
 

--- a/calico-enterprise_versioned_docs/version-3.22-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -34,11 +34,15 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 
 ### Get the Helm chart
 
-  <CodeBlock language='bash'>
-     {'$[version]' === 'master'
-       ? `helm repo add tigera gs://tigera-helm-charts`
-       : `curl -O -L https://downloads.tigera.io/ee/charts/tigera-operator-$[chart_version_name].tgz`}
-  </CodeBlock>
+<CodeBlock language='bash'>
+    {'$[version]' === 'master'
+        ? `helm repo add tigera gs://tigera-helm-charts
+helm repo update
+helm pull tigera/tigera-operator --version $[chart_version_name]`
+        : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
+helm repo update
+helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+</CodeBlock>
 
 ### Prepare the Installation Configuration
 


### PR DESCRIPTION
https://github.com/tigera/docs/pull/2271 changed the download method
from tgz to a Helm index. This change was reverted to fix a problem
with the index file. Now this is fixed, and the index method works.

Added similar changes to MCM Helm docs.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->