### PR TITLE
Add version check command to Free Tier prereqs

### DIFF
--- a/calico-cloud/free/connect-cluster-free.mdx
+++ b/calico-cloud/free/connect-cluster-free.mdx
@@ -21,6 +21,27 @@ Try the [Calico Cloud Free Tier quickstart guide](quickstart.mdx) to create a cl
   * If you upgraded from an earlier version of Calico Open Source, you [enabled the `Goldmane` custom resource](/calico/latest/observability/enable-whisker).
   * Calico Open Source was installed using the operator method.
     Manifest- and Helm-based installations are not supported.
+  <details>
+    <summary>Check Calico compatibility</summary>
+
+    To confirm that you're on a compatible Calico setup, you can run the following command:
+
+    ```bash
+    kubectl get tigerastatus goldmane
+    ```
+
+    If you're running Calico Open Source 3.30+ with the `Goldmane` custom resource is enabled, you should see something like this:
+
+    ```bash title='Example output'
+    NAME       AVAILABLE   PROGRESSING   DEGRADED   SINCE
+    goldmane   True        False         False      21h
+    ```
+    This cluster is ready to connect to Calico Cloud Free Tier.
+
+    If instead you get an error (`Error from server (NotFound): tigerastatuses.operator.tigera.io "goldmane" not found`), then you need to do one of the following:
+    * If you're already on 3.30+ [enable the `Goldmane` custom resource](/calico/latest/observability/enable-whisker).
+    * If you're on 3.29 or earlier, [upgrade your Calico installation to 3.30 or later](/calico/latest/operations/upgrading/kubernetes-upgrade#upgrading-an-installation-that-uses-the-operator) and then [enable the `Goldmane` custom resource](/calico/latest/observability/enable-whisker).
+  </details>
 * You have an active Calico Cloud Free Tier account.
   To create an account, go to the [Calico Cloud Free Tier sign-up page](https://calicocloud.io).
 * You are signed in to the $[prodname] web console.

--- a/calico-cloud_versioned_docs/version-22-1/free/connect-cluster-free.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/free/connect-cluster-free.mdx
@@ -21,6 +21,27 @@ Try the [Calico Cloud Free Tier quickstart guide](quickstart.mdx) to create a cl
   * If you upgraded from an earlier version of Calico Open Source, you [enabled the `Goldmane` custom resource](/calico/latest/observability/enable-whisker).
   * Calico Open Source was installed using the operator method.
     Manifest- and Helm-based installations are not supported.
+  <details>
+    <summary>Check Calico compatibility</summary>
+
+    To confirm that you're on a compatible Calico setup, you can run the following command:
+
+    ```bash
+    kubectl get tigerastatus goldmane
+    ```
+
+    If you're running Calico Open Source 3.30+ with the `Goldmane` custom resource is enabled, you should see something like this:
+
+    ```bash title='Example output'
+    NAME       AVAILABLE   PROGRESSING   DEGRADED   SINCE
+    goldmane   True        False         False      21h
+    ```
+    This cluster is ready to connect to Calico Cloud Free Tier.
+
+    If instead you get an error (`Error from server (NotFound): tigerastatuses.operator.tigera.io "goldmane" not found`), then you need to do one of the following:
+    * If you're already on 3.30+ [enable the `Goldmane` custom resource](/calico/latest/observability/enable-whisker).
+    * If you're on 3.29 or earlier, [upgrade your Calico installation to 3.30 or later](/calico/latest/operations/upgrading/kubernetes-upgrade#upgrading-an-installation-that-uses-the-operator) and then [enable the `Goldmane` custom resource](/calico/latest/observability/enable-whisker).
+  </details>
 * You have an active Calico Cloud Free Tier account.
   To create an account, go to the [Calico Cloud Free Tier sign-up page](https://calicocloud.io).
 * You are signed in to the $[prodname] web console.


### PR DESCRIPTION
This commit adds a quick instruction on how to check what version
of Calico Open Source your cluster is using. A one-line kubectl
command makes checking the version a trivial job for users who
aren't sure whether they have v3.30 or later.
<img width="1039" height="827" alt="image" src="https://github.com/user-attachments/assets/4ea7d656-523b-40b1-9a32-1657691efc4a" />

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->
Calico Cloud 22-1+

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->
N/A

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://deploy-preview-2378--tigera.netlify.app/calico-cloud/free/connect-cluster-free

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->