### PR TITLE
Restore OpenStack Qos changes

### DIFF
--- a/calico/networking/openstack/neutron-api.mdx
+++ b/calico/networking/openstack/neutron-api.mdx
@@ -147,13 +147,33 @@ of packet rate limit rules.  Calico also honours the `direction` field of these
 rules, so these limits can be set independently for both ingress and egress
 directions.
 
-There are also new Calico Neutron driver settings (cluster-wide):
+:::note
+
+There is uncertainty as to whether `max_burst_kbps` is intended to configure
+the burst *rate* or the burst *size*.  Calico interprets it as the burst *rate*
+and honours `neutron.conf` fields for configuring the burst *size*.
+
+:::
+
+There are also new Calico Neutron driver settings (cluster-wide, set in `neutron.conf`):
 
 - `[calico] max_ingress_connections_per_port` for imposing a maximum number of
   ingress connections per Neutron port, and
 
 - `[calico] max_egress_connections_per_port` for imposing a maximum number of
   egress connections per Neutron port.
+
+- `[calico] ingress_burst_kbits`, if non-zero, configures the maximum allowed
+  burst at peakrate, in the ingress direction.
+
+- `[calico] egress_burst_kbits`, if non-zero, configures the maximum allowed
+  burst at peakrate, in the egress direction.
+
+- `[calico] ingress_minburst_bytes`, if non-zero, configures the minimum burst
+  size for peakrate data, in the ingress direction.
+
+- `[calico] egress_minburst_bytes`, if non-zero, configures the minimum burst
+  size for peakrate data, in the egress direction.
 
 ## Load Balancer as a Service
 

--- a/calico_versioned_docs/version-3.30/networking/openstack/neutron-api.mdx
+++ b/calico_versioned_docs/version-3.30/networking/openstack/neutron-api.mdx
@@ -147,13 +147,33 @@ of packet rate limit rules.  Calico also honours the `direction` field of these
 rules, so these limits can be set independently for both ingress and egress
 directions.
 
-There are also new Calico Neutron driver settings (cluster-wide):
+:::note
+
+There is uncertainty as to whether `max_burst_kbps` is intended to configure
+the burst *rate* or the burst *size*.  Calico interprets it as the burst *rate*
+and honours `neutron.conf` fields for configuring the burst *size*.
+
+:::
+
+There are also new Calico Neutron driver settings (cluster-wide, set in `neutron.conf`):
 
 - `[calico] max_ingress_connections_per_port` for imposing a maximum number of
   ingress connections per Neutron port, and
 
 - `[calico] max_egress_connections_per_port` for imposing a maximum number of
   egress connections per Neutron port.
+
+- `[calico] ingress_burst_kbits`, if non-zero, configures the maximum allowed
+  burst at peakrate, in the ingress direction.
+
+- `[calico] egress_burst_kbits`, if non-zero, configures the maximum allowed
+  burst at peakrate, in the egress direction.
+
+- `[calico] ingress_minburst_bytes`, if non-zero, configures the minimum burst
+  size for peakrate data, in the ingress direction.
+
+- `[calico] egress_minburst_bytes`, if non-zero, configures the minimum burst
+  size for peakrate data, in the egress direction.
 
 ## Load Balancer as a Service
 

--- a/calico_versioned_docs/version-3.31/networking/openstack/neutron-api.mdx
+++ b/calico_versioned_docs/version-3.31/networking/openstack/neutron-api.mdx
@@ -147,13 +147,33 @@ of packet rate limit rules.  Calico also honours the `direction` field of these
 rules, so these limits can be set independently for both ingress and egress
 directions.
 
-There are also new Calico Neutron driver settings (cluster-wide):
+:::note
+
+There is uncertainty as to whether `max_burst_kbps` is intended to configure
+the burst *rate* or the burst *size*.  Calico interprets it as the burst *rate*
+and honours `neutron.conf` fields for configuring the burst *size*.
+
+:::
+
+There are also new Calico Neutron driver settings (cluster-wide, set in `neutron.conf`):
 
 - `[calico] max_ingress_connections_per_port` for imposing a maximum number of
   ingress connections per Neutron port, and
 
 - `[calico] max_egress_connections_per_port` for imposing a maximum number of
   egress connections per Neutron port.
+
+- `[calico] ingress_burst_kbits`, if non-zero, configures the maximum allowed
+  burst at peakrate, in the ingress direction.
+
+- `[calico] egress_burst_kbits`, if non-zero, configures the maximum allowed
+  burst at peakrate, in the egress direction.
+
+- `[calico] ingress_minburst_bytes`, if non-zero, configures the minimum burst
+  size for peakrate data, in the ingress direction.
+
+- `[calico] egress_minburst_bytes`, if non-zero, configures the minimum burst
+  size for peakrate data, in the egress direction.
 
 ## Load Balancer as a Service
 


### PR DESCRIPTION
- **[CORE-11449] Doc update for OpenStack peakrate QoS fields**
- **Add qos neutron to 3.31**

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->

[CORE-11449]: https://tigera.atlassian.net/browse/CORE-11449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ