### PR TITLE
For all helm pull commands, replace versions with -0 to just versions

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[version]`}
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+helm pull tigera-ee/tigera-operator --version $[version]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[version]`}
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+helm pull tigera-ee/tigera-operator --version $[version]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -41,7 +41,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[version]`}
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -41,7 +41,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+helm pull tigera-ee/tigera-operator --version $[version]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[version]`}
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+helm pull tigera-ee/tigera-operator --version $[version]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[version]`}
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+helm pull tigera-ee/tigera-operator --version $[version]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -41,7 +41,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[version]`}
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.19-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -41,7 +41,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+helm pull tigera-ee/tigera-operator --version $[version]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[version]`}
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+helm pull tigera-ee/tigera-operator --version $[version]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[version]`}
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+helm pull tigera-ee/tigera-operator --version $[version]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -41,7 +41,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[version]`}
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -41,7 +41,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+helm pull tigera-ee/tigera-operator --version $[version]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[version]`}
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+helm pull tigera-ee/tigera-operator --version $[version]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[version]`}
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+helm pull tigera-ee/tigera-operator --version $[version]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -41,7 +41,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[version]`}
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -41,7 +41,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+helm pull tigera-ee/tigera-operator --version $[version]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[version]`}
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+helm pull tigera-ee/tigera-operator --version $[version]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[version]`}
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -39,7 +39,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+helm pull tigera-ee/tigera-operator --version $[version]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -41,7 +41,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[version]`}
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -41,7 +41,7 @@ helm repo update
 helm pull tigera/tigera-operator --version $[chart_version_name]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[chart_version_name]`}
+helm pull tigera-ee/tigera-operator --version $[version]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration


### PR DESCRIPTION
* so instead of 3.x.0-0 it will be 3.x.0

Product Version(s):
Calico Enterprise

Issue:
Helm pull was failing because --version was looking to match versions including -0 (so instead of looking to match 3.x.0 it was looking to match 3.x.0-0).

When you run helm list -A, the version contains the version of our product which is either in the form of 3.x.0 or 3.x.0-y.0 but never 3.x.0-0. 

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->