### PR TITLE
[RS-2832] Fix broken EnvoyPatchPolicy for WAF

### DIFF
--- a/calico-cloud/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-cloud/threat/deploying-waf-ingress-gateway.mdx
@@ -123,7 +123,7 @@ spec:
       name: <gateway-namespace>/<gateway-name>/http
       operation:
         op: add
-        jsonPath: "default_filter_chain.filters[0].typed_config.http_filters[?match(@.name, '.*tigera-waf-http-filter/.*')]"
+        jsonPath: "default_filter_chain.filters[0].typed_config.http_filters[?match(@.name, '.*tigera-waf-envoy-extension-policy/.*')]"
         path: typed_config/grpc_service/initial_metadata
         value:
           - key: directivesJson

--- a/calico-cloud_versioned_docs/version-22-1/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-cloud_versioned_docs/version-22-1/threat/deploying-waf-ingress-gateway.mdx
@@ -114,7 +114,7 @@ spec:
       name: <gateway-namespace>/<gateway-name>/http
       operation:
         op: add
-        jsonPath: "default_filter_chain.filters[0].typed_config.http_filters[?match(@.name, '.*tigera-waf-http-filter/.*')]"
+        jsonPath: "default_filter_chain.filters[0].typed_config.http_filters[?match(@.name, '.*tigera-waf-envoy-extension-policy/.*')]"
         path: typed_config/grpc_service/initial_metadata
         value:
           - key: directivesJson

--- a/calico-enterprise/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-enterprise/threat/deploying-waf-ingress-gateway.mdx
@@ -123,7 +123,7 @@ spec:
       name: <gateway-namespace>/<gateway-name>/http
       operation:
         op: add
-        jsonPath: "default_filter_chain.filters[0].typed_config.http_filters[?match(@.name, '.*tigera-waf-http-filter/.*')]"
+        jsonPath: "default_filter_chain.filters[0].typed_config.http_filters[?match(@.name, '.*tigera-waf-envoy-extension-policy/.*')]"
         path: typed_config/grpc_service/initial_metadata
         value:
           - key: directivesJson

--- a/calico-enterprise_versioned_docs/version-3.22-2/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/threat/deploying-waf-ingress-gateway.mdx
@@ -123,7 +123,7 @@ spec:
       name: <gateway-namespace>/<gateway-name>/http
       operation:
         op: add
-        jsonPath: "default_filter_chain.filters[0].typed_config.http_filters[?match(@.name, '.*tigera-waf-http-filter/.*')]"
+        jsonPath: "default_filter_chain.filters[0].typed_config.http_filters[?match(@.name, '.*tigera-waf-envoy-extension-policy/.*')]"
         path: typed_config/grpc_service/initial_metadata
         value:
           - key: directivesJson


### PR DESCRIPTION
The name match in the patch policy must match the name of the extension policy for it to work. I believe the extension policy was given a more meaningful name when we did the docs, but we never updated the corresponding part of the patch policy (and later thought this broke with the envoy version update).

Product Version(s):
Anything that uses Enterprise 3.22 or greater

Issue:
https://tigera.atlassian.net/browse/RS-2832

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->