### PR TITLE
Maglev: `kubectl annotate` command syntax is wrong

### DIFF
--- a/calico-enterprise/networking/configuring/add-maglev-load-balancing.mdx
+++ b/calico-enterprise/networking/configuring/add-maglev-load-balancing.mdx
@@ -33,7 +33,7 @@ lb.projectcalico.org/external-traffic-strategy: "maglev"
 Or annotate a pre-existing service with:
 
 ```bash
-kubectl -n <namespace> annotate service <service> 'lb.projectcalico.org/external-traffic-strategy: "maglev"'
+kubectl -n <namespace> annotate service <service> 'lb.projectcalico.org/external-traffic-strategy=maglev'
 ```
 
 Replace the following:

--- a/calico/networking/configuring/add-maglev-load-balancing.mdx
+++ b/calico/networking/configuring/add-maglev-load-balancing.mdx
@@ -33,7 +33,7 @@ lb.projectcalico.org/external-traffic-strategy: "maglev"
 Or annotate a pre-existing service with:
 
 ```bash
-kubectl -n <namespace> annotate service <service> 'lb.projectcalico.org/external-traffic-strategy: "maglev"'
+kubectl -n <namespace> annotate service <service> 'lb.projectcalico.org/external-traffic-strategy=maglev'
 ```
 
 Replace the following:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
unversioned

Issue:
Syntax of a `kubectl` command is wrong

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->