### PR TITLE
For OpenStack, configure EndpointStatusPathPrefix = none

### DIFF
--- a/calico/getting-started/openstack/installation/redhat.mdx
+++ b/calico/getting-started/openstack/installation/redhat.mdx
@@ -285,6 +285,7 @@ On each compute node, perform the following steps:
     [global]
     DatastoreType = etcdv3
     EtcdAddr = <ip>:2379
+    EndpointStatusPathPrefix = none
     ```
 
 1.  Restart the Felix service.

--- a/calico/getting-started/openstack/installation/ubuntu.mdx
+++ b/calico/getting-started/openstack/installation/ubuntu.mdx
@@ -260,6 +260,7 @@ On each compute node, perform the following steps:
     [global]
     DatastoreType = etcdv3
     EtcdAddr = <ip>:2379
+    EndpointStatusPathPrefix = none
     ```
 
 1.  Restart the Felix service.

--- a/calico_versioned_docs/version-3.29/getting-started/openstack/installation/redhat.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/openstack/installation/redhat.mdx
@@ -275,6 +275,7 @@ On each compute node, perform the following steps:
     [global]
     DatastoreType = etcdv3
     EtcdAddr = <ip>:2379
+    EndpointStatusPathPrefix = none
     ```
 
 1.  Restart the Felix service.

--- a/calico_versioned_docs/version-3.29/getting-started/openstack/installation/ubuntu.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/openstack/installation/ubuntu.mdx
@@ -258,6 +258,7 @@ On each compute node, perform the following steps:
     [global]
     DatastoreType = etcdv3
     EtcdAddr = <ip>:2379
+    EndpointStatusPathPrefix = none
     ```
 
 1.  Restart the Felix service.

--- a/calico_versioned_docs/version-3.30/getting-started/openstack/installation/redhat.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/openstack/installation/redhat.mdx
@@ -285,6 +285,7 @@ On each compute node, perform the following steps:
     [global]
     DatastoreType = etcdv3
     EtcdAddr = <ip>:2379
+    EndpointStatusPathPrefix = none
     ```
 
 1.  Restart the Felix service.

--- a/calico_versioned_docs/version-3.30/getting-started/openstack/installation/ubuntu.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/openstack/installation/ubuntu.mdx
@@ -260,6 +260,7 @@ On each compute node, perform the following steps:
     [global]
     DatastoreType = etcdv3
     EtcdAddr = <ip>:2379
+    EndpointStatusPathPrefix = none
     ```
 
 1.  Restart the Felix service.
@@ -291,4 +292,3 @@ symbols for debugging, you can install them with the following steps:
 
 1. You can now install the `calico-felix-dbgsym` package, which contains the debugging symbols
    for the `calico-felix` binary.
-

--- a/calico_versioned_docs/version-3.31/getting-started/openstack/installation/redhat.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/openstack/installation/redhat.mdx
@@ -285,6 +285,7 @@ On each compute node, perform the following steps:
     [global]
     DatastoreType = etcdv3
     EtcdAddr = <ip>:2379
+    EndpointStatusPathPrefix = none
     ```
 
 1.  Restart the Felix service.

--- a/calico_versioned_docs/version-3.31/getting-started/openstack/installation/ubuntu.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/openstack/installation/ubuntu.mdx
@@ -260,6 +260,7 @@ On each compute node, perform the following steps:
     [global]
     DatastoreType = etcdv3
     EtcdAddr = <ip>:2379
+    EndpointStatusPathPrefix = none
     ```
 
 1.  Restart the Felix service.


### PR DESCRIPTION
This avoids a spurious WARNING, as EndpointStatusPathPrefix is not needed with OpenStack.

Note, EndpointStatusPathPrefix first appeared in the v3.28 series.
