### PR TITLE
docs: update Istio integration guide to v1.28.1 with IstioOperator approach

### DIFF
--- a/.github/styles/config/vocabularies/CalicoDocs/accept.txt
+++ b/.github/styles/config/vocabularies/CalicoDocs/accept.txt
@@ -49,3 +49,4 @@ calicoq
 Goldmane
 Tigera Operator
 Maglev
+Dikastes

--- a/calico/network-policy/istio/app-layer-policy.mdx
+++ b/calico/network-policy/istio/app-layer-policy.mdx
@@ -343,35 +343,6 @@ Apply:
 kubectl apply -f <filename>.yaml
 ```
 
-## Architecture
-
-### How it works
-
-When a request flows through an Istio-enabled pod with Dikastes:
-
-1. **Istio Proxy (Envoy)** intercepts the HTTP request
-2. **ext_authz filter** sends an authorization check to Dikastes via Unix socket (`/var/run/dikastes/dikastes.sock`)
-3. **Dikastes** queries Felix for policy decisions via the CSI-mounted socket (`/var/run/felix/nodeagent/socket`)
-4. **Felix** evaluates $[prodname] network policies and returns allow/deny
-5. **Dikastes** responds to Envoy with the authorization decision
-6. **Envoy** allows or blocks the request based on the decision
-
-### Communication paths
-
-```
-HTTP Request → Envoy → ext_authz → Dikastes → Felix Policy Sync API → Policy Decision
-```
-
-### Kubernetes native sidecars
-
-This integration requires Kubernetes 1.29+ native sidecar support with Istio 1.22+. The `istio-proxy` runs as an init container with `restartPolicy: Always`, which provides:
-
-- Guaranteed startup ordering (sidecar starts before application)
-- Automatic restart on failure
-- Proper lifecycle management
-
-When you inspect pods, you'll see the istio-proxy in init containers but the pod status will show 3/3 containers running due to the native sidecar's `restartPolicy: Always`.
-
 ## Create Calico network policies
 
 With Dikastes deployed, you can now create $[prodname] network policies to enforce Layer 7 access control.

--- a/calico/network-policy/istio/app-layer-policy.mdx
+++ b/calico/network-policy/istio/app-layer-policy.mdx
@@ -27,18 +27,17 @@ You can enforce $[prodname] network policy for Istio application layer policy us
 **Supported Istio versions**
 
 - **Istio v1.28.1** (tested and verified - recommended)
-- **Istio v1.18+** (should work with the IstioOperator approach)
-- **Legacy: Istio v1.15.2, v1.10.2** (use ConfigMap patching method - see [Legacy Installation](#legacy-installation-configmap-patching))
+- **Istio v1.22+** (minimum required for Kubernetes native sidecar support)
 
 :::note
 
-Istio v1.9.x and lower are not supported.
+This guide requires Istio 1.22+ with Kubernetes native sidecars. Traditional sidecar injection is not supported. For legacy Istio versions (v1.15.2, v1.10.2), see [Legacy Installation](#legacy-installation-configmap-patching).
 
 :::
 
-**Recommended Kubernetes versions**
+**Required Kubernetes versions**
 
-- **Kubernetes v1.29+**: Required for native sidecar support used by Istio 1.22+
+- **Kubernetes v1.29+**: Required for native sidecar support
 
 ## How to
 
@@ -74,28 +73,16 @@ calicoctl patch FelixConfiguration default --patch \
 kubectl patch installation default --type=merge -p '{"spec": {"flexVolumePath": "None"}}'
 ```
 
-### 2. Install $[prodname] CSI driver
-
-The CSI driver mounts the Felix Policy Sync socket into Dikastes containers.
-
-```bash
-kubectl apply -f $[manifestsUrl]/manifests/csi-driver.yaml
-```
-
-Verify the CSI driver is running:
-
-```bash
-kubectl get pods -n calico-system -l k8s-app=csi-node-driver
-```
-
-### 3. Install Istio
+### 2. Install Istio
 
 Follow the [upstream Istio installation documentation](https://istio.io/latest/docs/setup/getting-started/) to install Istio if not already installed.
 
 For testing, you can use:
 
 ```bash
-curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.1 sh -
+curl -L https://istio.io/downloadIstio -o install-istio.sh
+# Review the script before running it, then install:
+ISTIO_VERSION=1.28.1 sh install-istio.sh
 cd istio-1.28.1
 export PATH=$PWD/bin:$PATH
 ```
@@ -106,7 +93,7 @@ Do not run `istioctl install` yet if you want to configure Dikastes templates du
 
 :::
 
-### 4. Configure Istio with Dikastes injection templates
+### 3. Configure Istio with Dikastes injection templates
 
 #### Option A: IstioOperator Approach (Recommended)
 
@@ -160,8 +147,6 @@ spec:
                 name: dikastes-sock
               - mountPath: /var/run/felix
                 name: felix-sync
-            # Patch istio-proxy to mount dikastes socket
-            # This is REQUIRED for Envoy to access the Dikastes Unix socket
             initContainers:
             - name: istio-proxy
               volumeMounts:
@@ -211,7 +196,6 @@ spec:
                 name: dikastes-sock
               - mountPath: /var/run/felix
                 name: felix-sync
-            # Patch istio-proxy to mount dikastes socket
             initContainers:
             - name: istio-proxy
               volumeMounts:
@@ -254,7 +238,7 @@ istioctl manifest generate -f istio-operator-dikastes.yaml > istio-with-dikastes
 kubectl apply -f istio-with-dikastes.yaml
 ```
 
-### 5. Add Envoy authorization services
+### 4. Add Envoy authorization services
 
 Configure Istio's Envoy proxies to use Dikastes as an external authorization service.
 
@@ -269,7 +253,7 @@ This manifest creates:
 - **DestinationRule**: Disables mTLS for local socket communication
 - **EnvoyFilter**: Configures Envoy's `ext_authz` filter to call Dikastes
 
-### 6. Enable Istio injection for namespaces
+### 5. Enable Istio injection for namespaces
 
 Label the namespace where you want to deploy Istio-enabled workloads:
 
@@ -277,7 +261,7 @@ Label the namespace where you want to deploy Istio-enabled workloads:
 kubectl label namespace <your-namespace> istio-injection=enabled
 ```
 
-### 7. Annotate pods to inject Dikastes
+### 6. Annotate pods to inject Dikastes
 
 To inject the Dikastes sidecar into your pods, add the following annotation to your pod template:
 
@@ -309,7 +293,7 @@ The key difference:
 - `dikastes`: Runs as non-root user (999) - for application workloads
 - `dikastes-gateway`: Runs as root (0) - for ingress/egress gateways
 
-### 8. Verify Dikastes injection
+### 7. Verify Dikastes injection
 
 After deploying a workload with the annotation:
 
@@ -338,7 +322,7 @@ Successfully connected to Policy Sync server
 Starting synchronization with Policy Sync server
 ```
 
-### 9. (Optional) Enable strict mTLS
+### 8. (Optional) Enable strict mTLS
 
 For enhanced security, enable strict mutual TLS between services:
 
@@ -380,13 +364,13 @@ HTTP Request → Envoy → ext_authz → Dikastes → Felix Policy Sync API → 
 
 ### Kubernetes native sidecars
 
-Istio 1.22+ (including 1.28) uses Kubernetes 1.29+ native sidecar support. The `istio-proxy` runs as an init container with `restartPolicy: Always`, which provides:
+This integration requires Kubernetes 1.29+ native sidecar support with Istio 1.22+. The `istio-proxy` runs as an init container with `restartPolicy: Always`, which provides:
 
 - Guaranteed startup ordering (sidecar starts before application)
 - Automatic restart on failure
 - Proper lifecycle management
 
-This is why you'll see the istio-proxy in init containers but the pod shows 3/3 containers running.
+When you inspect pods, you'll see the istio-proxy in init containers but the pod status will show 3/3 containers running due to the native sidecar's `restartPolicy: Always`.
 
 ## Create $[prodname] network policies
 
@@ -429,10 +413,10 @@ Without explicit allow policies, Dikastes enforces a **default-deny** posture fo
 **Check namespace label**:
 
 ```bash
-kubectl get namespace <your-namespace> -o yaml | grep istio-injection
+kubectl get namespace <your-namespace> -o jsonpath='{.metadata.labels.istio-injection}'
 ```
 
-Should show: `istio-injection: enabled`
+Should show: `enabled`
 
 **Check pod annotation**:
 
@@ -445,7 +429,7 @@ Should show: `inject.istio.io/templates: sidecar,dikastes`
 **Verify templates in ConfigMap**:
 
 ```bash
-kubectl get configmap -n istio-system istio-sidecar-injector -o yaml | grep -c "dikastes:"
+kubectl get configmap -n istio-system istio-sidecar-injector -o jsonpath='{.data.values}' | grep -o "dikastes:" | wc -l
 ```
 
 Should return `2` (one for each template).
@@ -464,13 +448,13 @@ kubectl describe pod <pod-name> -n <your-namespace>
 kubectl logs <pod-name> -n <your-namespace> -c dikastes
 ```
 
-**Check CSI driver**:
+**Check CSI driver** (automatically installed with $[prodname]):
 
 ```bash
 kubectl get pods -n calico-system -l k8s-app=csi-node-driver
 ```
 
-All CSI driver pods should be `Running`.
+All CSI driver pods should be `Running`. The CSI driver is required for Dikastes to access the Felix Policy Sync API.
 
 **Verify Felix Policy Sync API**:
 
@@ -505,7 +489,11 @@ detected Calico CNI with 'bpfConnectTimeLoadBalancing=TCP';
 this must be set to 'bpfConnectTimeLoadBalancing=Disabled'
 ```
 
-This may affect connection-level load balancing but does not prevent basic functionality. For production deployments, consider adjusting the $[prodname] configuration as recommended.
+This may affect connection-level load balancing but does not prevent basic functionality. For production deployments, disable BPF connect-time load balancing:
+
+```bash
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"bpfConnectTimeLoadBalancing":"Disabled"}}'
+```
 
 ## Legacy Installation (ConfigMap Patching)
 

--- a/calico/network-policy/istio/app-layer-policy.mdx
+++ b/calico/network-policy/istio/app-layer-policy.mdx
@@ -4,122 +4,345 @@ description: Enforce network policy for Istio service mesh including matching on
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Enforce network policy for Istio
+# Enforce $[prodname] network policy for Istio service mesh
 
-## Big picture
+## Overview
 
-$[prodname] integrates seamlessly with Istio to enforce network policy within the Istio service mesh.
+You can enforce $[prodname] network policy for Istio application layer policy using the Dikastes sidecar. Dikastes enables $[prodname] to integrate with Istio's Envoy proxy to enforce fine-grained Layer 7 (HTTP) policies.
 
-## Value
+### Value
 
-$[prodname] network policy for Istio lets you enforce application layer attributes like HTTP methods or paths, and cryptographically secure identities for Istio-enabled apps.
-
-## Concepts
-
-### Benefits of the Istio integration
-
-The $[prodname] support for Istio service mesh has the following benefits:
-
-- **Pod traffic controls**
-
-  Lets you restrict ingress traffic inside and outside pods and mitigate common threats to Istio-enabled apps.
-
-- **Supports security goals**
-
-  Enables adoption of a zero trust network model for security, including traffic encryption, multiple enforcement points, and multiple identity criteria for authentication.
-
-- **Familiar policy language**
-
-  Kubernetes network policies and $[prodname] network policies work as is; users do not need to learn another network policy model to adopt Istio.
-
-See [Enforce network policy using Istio tutorial](enforce-policy-istio.mdx) to learn how application layer policy provides second-factor authentication for the mythical Yao Bank.
+- **Pod traffic controls for Istio-enabled apps**: Lets you restrict ingress traffic inside and outside pods and mitigate common threats to Istio-enabled apps.
+- **Security alignment with zero trust**: Supports zero-trust network models through traffic encryption, multiple enforcement points, and multiple identity criteria for authentication.
+- **Familiar policy language**: Apply Kubernetes network policies and $[prodname] network policies that you already know.
 
 ## Before you begin
 
 **Required**
 
-- [$[prodname] is installed](../../getting-started/index.mdx)
-- [calicoctl is installed and configured](../../operations/calicoctl/install.mdx)
-- [MutatingAdmissionWebhook](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook) enabled
+- $[prodname] CNI is installed and configured
+- `kubectl` and `istioctl` CLI tools are installed
+- MutatingAdmissionWebhook admission controller is enabled
 
-**Istio support**
+**Supported Istio versions**
 
-Following Istio versions have been verified to work with application layer policies:
+- **Istio v1.28.1** (tested and verified - recommended)
+- **Istio v1.18+** (should work with the IstioOperator approach)
+- **Legacy: Istio v1.15.2, v1.10.2** (use ConfigMap patching method - see [Legacy Installation](#legacy-installation-configmap-patching))
 
-- Istio v1.15.2
-- Istio v1.10.2
+:::note
 
-Istio v1.9.x and lower are **not** supported.
+Istio v1.9.x and lower are not supported.
 
-Although we expect future minor versions to work with the corresponding manifest below (for example, v1.10.2 or v1.15.2), manifest compatibility depends entirely on the upstream changes in the respective Istio release.
+:::
+
+**Recommended Kubernetes versions**
+
+- **Kubernetes v1.29+**: Required for native sidecar support used by Istio 1.22+
 
 ## How to
 
-1. [Enable application layer policy](#enable-application-layer-policy)
-2. [Install Calico CSI Driver](#install-calico-csi-driver)
-3. [Install Istio](#install-istio)
-4. [Update Istio sidecar injector](#update-istio-sidecar-injector)
-5. [Add Calico authorization services to the mesh](#add-calico-authorization-services-to-the-mesh)
-6. [Add namespace labels](#add-namespace-labels)
+This guide covers the **modern IstioOperator approach** which is declarative, version-controllable, and upgrade-safe.
 
-### Enable application layer policy
+For the legacy ConfigMap patching approach, see [Legacy Installation](#legacy-installation-configmap-patching).
 
-To enable the application layer policy, you must enable the **Policy Sync API** on Felix cluster-wide.
+### 1. Enable application layer policy
 
-In the default **FelixConfiguration**, set the field, `policySyncPathPrefix` to `/var/run/nodeagent`:
+Enable the Policy Sync API in Felix to allow Dikastes to query policy decisions.
 
 <Tabs>
-<TabItem label="calicoctl" value="calicoctl-0">
+<TabItem label="kubectl" value="kubectl-0">
 
 ```bash
-calicoctl patch FelixConfiguration default --patch \
-   '{"spec": {"policySyncPathPrefix": "/var/run/nodeagent"}}'
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"policySyncPathPrefix":"/var/run/nodeagent"}}'
 ```
 
 </TabItem>
-<TabItem label="kubectl" value="kubectl-1">
+<TabItem label="calicoctl" value="calicoctl-1">
 
 ```bash
-kubectl patch FelixConfiguration default --type=merge --patch \
-   '{"spec": {"policySyncPathPrefix": "/var/run/nodeagent"}}'
+calicoctl patch FelixConfiguration default --patch \
+  '{"spec": {"policySyncPathPrefix": "/var/run/nodeagent"}}'
 ```
 
 </TabItem>
 </Tabs>
 
-Additionally, if you have installed Calico via the operator, you can optionally disable flexvolumes.
-Flexvolumes were used in earlier implementations and have since been deprecated.
+**Optional**: If using the $[prodname] operator, disable deprecated flexvolumes:
 
 ```bash
 kubectl patch installation default --type=merge -p '{"spec": {"flexVolumePath": "None"}}'
 ```
 
-### Install Calico CSI Driver
+### 2. Install $[prodname] CSI driver
 
-$[prodname] utilizes a Container Storage Interface (CSI) driver to help set up the policy sync API on every node.
-Apply the following to install the Calico CSI driver
+The CSI driver mounts the Felix Policy Sync socket into Dikastes containers.
 
 ```bash
 kubectl apply -f $[manifestsUrl]/manifests/csi-driver.yaml
 ```
 
-### Install Istio
-
-1. Verify [application layer policy requirements](../../getting-started/kubernetes/requirements.mdx#application-layer-policy-requirements).
-2. Install Istio using [installation guide in the project documentation](https://istio.io/v1.15/docs/setup/install/).
+Verify the CSI driver is running:
 
 ```bash
-curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.15.2 sh -
-cd $(ls -d istio-* --color=never)
-./bin/istioctl install
+kubectl get pods -n calico-system -l k8s-app=csi-node-driver
 ```
 
-Next, create the following [PeerAuthentication](https://istio.io/v1.15/docs/reference/config/security/peer_authentication/) policy.
+### 3. Install Istio
 
-Replace `namespace` below by `rootNamespace` value, if it's customized in your environment.
+Follow the [upstream Istio installation documentation](https://istio.io/latest/docs/setup/getting-started/) to install Istio if not already installed.
+
+For testing, you can use:
 
 ```bash
-kubectl create -f - <<EOF
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.28.1 sh -
+cd istio-1.28.1
+export PATH=$PWD/bin:$PATH
+```
+
+:::note
+
+Do not run `istioctl install` yet if you want to configure Dikastes templates during installation. See the next step.
+
+:::
+
+### 4. Configure Istio with Dikastes injection templates
+
+#### Option A: IstioOperator Approach (Recommended)
+
+Create a file named `istio-operator-dikastes.yaml`:
+
+```yaml
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: istio-with-dikastes
+  namespace: istio-system
+spec:
+  profile: minimal  # or 'default' if you need gateways
+
+  values:
+    sidecarInjectorWebhook:
+      templates:
+        # Template for workload pods
+        dikastes: |
+          spec:
+            containers:
+            - name: dikastes
+              image: quay.io/calico/dikastes:$[version]
+              args:
+              - server
+              - -l
+              - /var/run/dikastes/dikastes.sock
+              - -d
+              - /var/run/felix/nodeagent/socket
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsGroup: 999
+                runAsNonRoot: true
+                runAsUser: 999
+              livenessProbe:
+                exec:
+                  command:
+                  - /healthz
+                  - liveness
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              readinessProbe:
+                exec:
+                  command:
+                  - /healthz
+                  - readiness
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              volumeMounts:
+              - mountPath: /var/run/dikastes
+                name: dikastes-sock
+              - mountPath: /var/run/felix
+                name: felix-sync
+            # Patch istio-proxy to mount dikastes socket
+            # This is REQUIRED for Envoy to access the Dikastes Unix socket
+            initContainers:
+            - name: istio-proxy
+              volumeMounts:
+              - mountPath: /var/run/dikastes
+                name: dikastes-sock
+            volumes:
+            - name: dikastes-sock
+              emptyDir:
+                medium: Memory
+            - name: felix-sync
+              csi:
+                driver: csi.tigera.io
+
+        # Template for gateway pods (runs as root)
+        dikastes-gateway: |
+          spec:
+            containers:
+            - name: dikastes
+              image: quay.io/calico/dikastes:$[version]
+              args:
+              - server
+              - -l
+              - /var/run/dikastes/dikastes.sock
+              - -d
+              - /var/run/felix/nodeagent/socket
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsGroup: 0
+                runAsNonRoot: false
+                runAsUser: 0
+              livenessProbe:
+                exec:
+                  command:
+                  - /healthz
+                  - liveness
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              readinessProbe:
+                exec:
+                  command:
+                  - /healthz
+                  - readiness
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              volumeMounts:
+              - mountPath: /var/run/dikastes
+                name: dikastes-sock
+              - mountPath: /var/run/felix
+                name: felix-sync
+            # Patch istio-proxy to mount dikastes socket
+            initContainers:
+            - name: istio-proxy
+              volumeMounts:
+              - mountPath: /var/run/dikastes
+                name: dikastes-sock
+            volumes:
+            - name: dikastes-sock
+              emptyDir:
+                medium: Memory
+            - name: felix-sync
+              csi:
+                driver: csi.tigera.io
+```
+
+**Install or update Istio** with the Dikastes templates:
+
+```bash
+istioctl install -f istio-operator-dikastes.yaml -y
+```
+
+This will:
+- Install Istio (if not already installed)
+- Update the `istio-sidecar-injector` ConfigMap with the Dikastes templates
+- Make the templates available for pod annotation-based injection
+
+**Verify the templates were loaded**:
+
+```bash
+kubectl get configmap -n istio-system istio-sidecar-injector -o yaml | grep "dikastes:" -A 5
+```
+
+You should see both `dikastes` and `dikastes-gateway` templates.
+
+#### Option B: Generate Manifests for GitOps
+
+If you prefer to generate Kubernetes manifests instead of applying directly:
+
+```bash
+istioctl manifest generate -f istio-operator-dikastes.yaml > istio-with-dikastes.yaml
+kubectl apply -f istio-with-dikastes.yaml
+```
+
+### 5. Add Envoy authorization services
+
+Configure Istio's Envoy proxies to use Dikastes as an external authorization service.
+
+```bash
+kubectl apply -f $[manifestsUrl]/manifests/alp/istio-app-layer-policy-envoy-v3.yaml
+```
+
+[View sample manifest]($[manifestsUrl]/manifests/alp/istio-app-layer-policy-envoy-v3.yaml)
+
+This manifest creates:
+- **ServiceEntry**: Defines `dikastes.calico.cluster.local` for Unix socket communication
+- **DestinationRule**: Disables mTLS for local socket communication
+- **EnvoyFilter**: Configures Envoy's `ext_authz` filter to call Dikastes
+
+### 6. Enable Istio injection for namespaces
+
+Label the namespace where you want to deploy Istio-enabled workloads:
+
+```bash
+kubectl label namespace <your-namespace> istio-injection=enabled
+```
+
+### 7. Annotate pods to inject Dikastes
+
+To inject the Dikastes sidecar into your pods, add the following annotation to your pod template:
+
+**For regular workloads**:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: sidecar,dikastes
+    spec:
+      # ... your pod spec
+```
+
+**For gateway workloads**:
+
+```yaml
+metadata:
+  annotations:
+    inject.istio.io/templates: sidecar,dikastes-gateway
+```
+
+The key difference:
+- `dikastes`: Runs as non-root user (999) - for application workloads
+- `dikastes-gateway`: Runs as root (0) - for ingress/egress gateways
+
+### 8. Verify Dikastes injection
+
+After deploying a workload with the annotation:
+
+```bash
+# Check that Dikastes container is present
+kubectl get pod -l app=<your-app> -n <your-namespace> -o jsonpath='{.items[0].spec.containers[*].name}'
+```
+
+You should see: `dikastes <your-app-container> ...`
+
+**Check pod status** (should show all containers ready):
+
+```bash
+kubectl get pods -n <your-namespace>
+```
+
+**Check Dikastes logs**:
+
+```bash
+kubectl logs -n <your-namespace> -l app=<your-app> -c dikastes
+```
+
+You should see:
+```
+Successfully connected to Policy Sync server
+Starting synchronization with Policy Sync server
+```
+
+### 9. (Optional) Enable strict mTLS
+
+For enhanced security, enable strict mutual TLS between services:
+
+```yaml
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
@@ -128,18 +351,173 @@ metadata:
 spec:
   mtls:
     mode: STRICT
-EOF
 ```
 
-### Update Istio sidecar injector
+Apply:
 
-The sidecar injector automatically modifies pods as they are created to work with Istio. This step modifies the injector configuration to add Dikastes (a $[prodname] component), as sidecar containers.
+```bash
+kubectl apply -f <filename>.yaml
+```
 
-1. Follow the [Automatic sidecar injection instructions](https://archive.istio.io/v1.15/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection) to install the sidecar injector and enable it in your chosen namespace(s).
-2. Patch the istio-sidecar-injector `ConfigMap` to enable injection of Dikastes alongside Envoy.
+## Architecture
 
-<Tabs>
-<TabItem label="Istio v1.15.x" value="Istio v1.15.x-2">
+### How it works
+
+When a request flows through an Istio-enabled pod with Dikastes:
+
+1. **Istio Proxy (Envoy)** intercepts the HTTP request
+2. **ext_authz filter** sends an authorization check to Dikastes via Unix socket (`/var/run/dikastes/dikastes.sock`)
+3. **Dikastes** queries Felix for policy decisions via the CSI-mounted socket (`/var/run/felix/nodeagent/socket`)
+4. **Felix** evaluates $[prodname] network policies and returns allow/deny
+5. **Dikastes** responds to Envoy with the authorization decision
+6. **Envoy** allows or blocks the request based on the decision
+
+### Communication paths
+
+```
+HTTP Request → Envoy → ext_authz → Dikastes → Felix Policy Sync API → Policy Decision
+```
+
+### Kubernetes native sidecars
+
+Istio 1.22+ (including 1.28) uses Kubernetes 1.29+ native sidecar support. The `istio-proxy` runs as an init container with `restartPolicy: Always`, which provides:
+
+- Guaranteed startup ordering (sidecar starts before application)
+- Automatic restart on failure
+- Proper lifecycle management
+
+This is why you'll see the istio-proxy in init containers but the pod shows 3/3 containers running.
+
+## Create $[prodname] network policies
+
+With Dikastes deployed, you can now create $[prodname] network policies to enforce Layer 7 access control.
+
+:::note
+
+The specific policy CRDs available depend on your $[prodname] distribution (OSS vs Enterprise). Consult your $[prodname] documentation for policy syntax.
+
+:::
+
+Example conceptual policy (syntax may vary):
+
+```yaml
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: allow-http-get
+  namespace: default
+spec:
+  selector: app == "myapp"
+  types:
+  - Ingress
+  ingress:
+  - action: Allow
+    protocol: TCP
+    destination:
+      ports:
+      - 80
+```
+
+### Default behavior
+
+Without explicit allow policies, Dikastes enforces a **default-deny** posture for security. All HTTP requests will receive a `403 Forbidden` response until you create policies that explicitly allow traffic.
+
+## Troubleshooting
+
+### Dikastes container not injected
+
+**Check namespace label**:
+
+```bash
+kubectl get namespace <your-namespace> -o yaml | grep istio-injection
+```
+
+Should show: `istio-injection: enabled`
+
+**Check pod annotation**:
+
+```bash
+kubectl get pod <pod-name> -n <your-namespace> -o yaml | grep inject.istio.io/templates
+```
+
+Should show: `inject.istio.io/templates: sidecar,dikastes`
+
+**Verify templates in ConfigMap**:
+
+```bash
+kubectl get configmap -n istio-system istio-sidecar-injector -o yaml | grep -c "dikastes:"
+```
+
+Should return `2` (one for each template).
+
+### Pod stuck in PodInitializing or CrashLoopBackOff
+
+**Check pod events**:
+
+```bash
+kubectl describe pod <pod-name> -n <your-namespace>
+```
+
+**Check Dikastes logs**:
+
+```bash
+kubectl logs <pod-name> -n <your-namespace> -c dikastes
+```
+
+**Check CSI driver**:
+
+```bash
+kubectl get pods -n calico-system -l k8s-app=csi-node-driver
+```
+
+All CSI driver pods should be `Running`.
+
+**Verify Felix Policy Sync API**:
+
+```bash
+kubectl get felixconfiguration default -o yaml | grep policySyncPathPrefix
+```
+
+Should show: `policySyncPathPrefix: /var/run/nodeagent`
+
+### All requests returning 403
+
+This is **expected behavior** when no allow policies are configured. Dikastes enforces default-deny for security.
+
+To allow traffic, create $[prodname] network policies that explicitly permit the desired traffic.
+
+### Envoy cannot reach istio-pilot
+
+If you have egress policies applied to your pods, Envoy needs access to the Istio control plane.
+
+Apply the allow policy:
+
+```bash
+kubectl apply -f $[tutorialFilesURL]/allow-istio-pilot.yaml
+```
+
+### Warning about BPF load balancing
+
+If you see this warning during installation:
+
+```
+detected Calico CNI with 'bpfConnectTimeLoadBalancing=TCP';
+this must be set to 'bpfConnectTimeLoadBalancing=Disabled'
+```
+
+This may affect connection-level load balancing but does not prevent basic functionality. For production deployments, consider adjusting the $[prodname] configuration as recommended.
+
+## Legacy Installation (ConfigMap Patching)
+
+:::note
+
+This method is supported but not recommended for new deployments. Use the IstioOperator approach instead.
+
+:::
+
+If you need to use the legacy ConfigMap patching method for Istio 1.15 or 1.10:
+
+### For Istio v1.15.x:
 
 ```bash
 curl $[manifestsUrl]/manifests/alp/istio-inject-configmap-1.15.yaml -o istio-inject-configmap.yaml
@@ -148,8 +526,7 @@ kubectl patch configmap -n istio-system istio-sidecar-injector --patch "$(cat is
 
 [View sample manifest]($[manifestsUrl]/manifests/alp/istio-inject-configmap-1.15.yaml)
 
-</TabItem>
-<TabItem label="Istio v1.10.x" value="Istio v1.10.x-3">
+### For Istio v1.10.x:
 
 ```bash
 curl $[manifestsUrl]/manifests/alp/istio-inject-configmap-1.10.yaml -o istio-inject-configmap.yaml
@@ -158,45 +535,17 @@ kubectl patch configmap -n istio-system istio-sidecar-injector --patch "$(cat is
 
 [View sample manifest]($[manifestsUrl]/manifests/alp/istio-inject-configmap-1.10.yaml)
 
-</TabItem>
-</Tabs>
+**Drawbacks of ConfigMap patching**:
 
-### Add Calico authorization services to the mesh
-
-Apply the following manifest to configure Istio to query $[prodname] for application layer policy authorization decisions.
-
-This applies to Istio v1.15.x and v1.10.x:
-
-```bash
-kubectl apply -f $[manifestsUrl]/manifests/alp/istio-app-layer-policy-envoy-v3.yaml
-```
-
-[View sample manifest]($[manifestsUrl]/manifests/alp/istio-app-layer-policy-envoy-v3.yaml)
-
-### Add namespace labels
-
-You can control enforcement of application layer policy on a per-namespace basis. However, this only works on pods that are started with the Envoy and $[prodname] Dikastes sidecars (as noted in the step, Update Istio sidecar injector). Pods that do not have the $[prodname] sidecars, enforce only standard $[prodname] network policy.
-
-To enable Istio and application layer policy in a namespace, add the label `istio-injection=enabled`.
-
-```bash
-kubectl label namespace <your namespace name> istio-injection=enabled
-```
-
-If the namespace already has pods in it, you must recreate them for this to take effect.
-
-:::note
-
-Envoy must be able to communicate with the `istio-pilot.istio-system service`. If you apply any egress policies to your pods, you _must_ enable access.
-
-```bash
-kubectl apply -f $[tutorialFilesURL]/allow-istio-pilot.yaml
-```
-
-:::
+- Not declarative (imperative command)
+- Not version-controlled
+- Must be re-applied after Istio upgrades
+- Difficult to audit and review
 
 ## Additional resources
 
 - [Enforce network policy using Istio tutorial](enforce-policy-istio.mdx)
 - [Use HTTP methods and paths in policy rules](http-methods.mdx)
-- [Hands-on workshop: Learn how to deploy access control, encryption & auth at the application level](https://www.tigera.io/tutorials/?_sf_s=Deploy%20Service%20Mesh)
+- [Istio Documentation](https://istio.io/latest/docs/)
+- [IstioOperator API Reference](https://istio.io/latest/docs/reference/config/istio.operator.v1alpha1/)
+- [Kubernetes Native Sidecars](https://kubernetes.io/blog/2023/08/25/native-sidecar-containers/)

--- a/calico/network-policy/istio/app-layer-policy.mdx
+++ b/calico/network-policy/istio/app-layer-policy.mdx
@@ -4,7 +4,7 @@ description: Enforce network policy for Istio service mesh including matching on
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Enforce $[prodname] network policy for Istio service mesh
+# Enforce Calico network policy for Istio service mesh
 
 ## Overview
 
@@ -372,7 +372,7 @@ This integration requires Kubernetes 1.29+ native sidecar support with Istio 1.2
 
 When you inspect pods, you'll see the istio-proxy in init containers but the pod status will show 3/3 containers running due to the native sidecar's `restartPolicy: Always`.
 
-## Create $[prodname] network policies
+## Create Calico network policies
 
 With Dikastes deployed, you can now create $[prodname] network policies to enforce Layer 7 access control.
 

--- a/calico/network-policy/istio/app-layer-policy.mdx
+++ b/calico/network-policy/istio/app-layer-policy.mdx
@@ -41,9 +41,9 @@ This guide requires Istio 1.22+ with Kubernetes native sidecars. Traditional sid
 
 ## How to
 
-This guide covers the **modern IstioOperator approach** which is declarative, version-controllable, and upgrade-safe.
+This guide covers the usage of [IstioOperator](https://istio.io/latest/docs/reference/config/istio.operator.v1alpha1/)
 
-For the legacy ConfigMap patching approach, see [Legacy Installation](#legacy-installation-configmap-patching).
+For the ConfigMap patching method, see [Legacy Installation](#legacy-installation-configmap-patching).
 
 ### 1. Enable application layer policy
 
@@ -95,7 +95,7 @@ Do not run `istioctl install` yet if you want to configure Dikastes templates du
 
 ### 3. Configure Istio with Dikastes injection templates
 
-#### Option A: IstioOperator Approach (Recommended)
+#### Option A: use IstioOperator directly
 
 Create a file named `istio-operator-dikastes.yaml`:
 
@@ -499,7 +499,7 @@ kubectl patch felixconfiguration default --type merge -p '{"spec":{"bpfConnectTi
 
 :::note
 
-This method is supported but not recommended for new deployments. Use the IstioOperator approach instead.
+This method is supported but not recommended for new deployments. Use the IstioOperator method instead.
 
 :::
 

--- a/calico/network-policy/istio/app-layer-policy.mdx
+++ b/calico/network-policy/istio/app-layer-policy.mdx
@@ -67,7 +67,7 @@ calicoctl patch FelixConfiguration default --patch \
 </TabItem>
 </Tabs>
 
-**Optional**: If using the $[prodname] operator, disable deprecated flexvolumes:
+**Optional**: If using the $[prodname] operator, disable deprecated Flex Volumes:
 
 ```bash
 kubectl patch installation default --type=merge -p '{"spec": {"flexVolumePath": "None"}}'
@@ -251,7 +251,7 @@ kubectl apply -f $[manifestsUrl]/manifests/alp/istio-app-layer-policy-envoy-v3.y
 This manifest creates:
 - **ServiceEntry**: Defines `dikastes.calico.cluster.local` for Unix socket communication
 - **DestinationRule**: Disables mTLS for local socket communication
-- **EnvoyFilter**: Configures Envoy's `ext_authz` filter to call Dikastes
+- **EnvoyFilter**: Configures Envoy's External Authorization filter to call Dikastes
 
 ### 5. Enable Istio injection for namespaces
 
@@ -349,7 +349,7 @@ With Dikastes deployed, you can now create $[prodname] network policies to enfor
 
 :::note
 
-The specific policy CRDs available depend on your $[prodname] distribution (OSS vs Enterprise). Consult your $[prodname] documentation for policy syntax.
+The specific policy Custom Resource Definitions available depend on your $[prodname] distribution (OSS vs Enterprise). Consult your $[prodname] documentation for policy syntax.
 
 :::
 

--- a/calico/network-policy/istio/app-layer-policy.mdx
+++ b/calico/network-policy/istio/app-layer-policy.mdx
@@ -26,7 +26,7 @@ You can enforce $[prodname] network policy for Istio application layer policy us
 
 **Supported Istio versions**
 
-- **Istio v1.28.1** (tested and verified - recommended)
+- **Istio v1.28.1** (recommended)
 - **Istio v1.22+** (minimum required for Kubernetes native sidecar support)
 
 :::note

--- a/calico_versioned_docs/version-3.29/network-policy/istio/app-layer-policy.mdx
+++ b/calico_versioned_docs/version-3.29/network-policy/istio/app-layer-policy.mdx
@@ -4,122 +4,329 @@ description: Enforce network policy for Istio service mesh including matching on
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Enforce network policy for Istio
+# Enforce Calico network policy for Istio service mesh
 
-## Big picture
+## Overview
 
-$[prodname] integrates seamlessly with Istio to enforce network policy within the Istio service mesh.
+You can enforce $[prodname] network policy for Istio application layer policy using the Dikastes sidecar. Dikastes enables $[prodname] to integrate with Istio's Envoy proxy to enforce fine-grained Layer 7 (HTTP) policies.
 
-## Value
+### Value
 
-$[prodname] network policy for Istio lets you enforce application layer attributes like HTTP methods or paths, and cryptographically secure identities for Istio-enabled apps.
-
-## Concepts
-
-### Benefits of the Istio integration
-
-The $[prodname] support for Istio service mesh has the following benefits:
-
-- **Pod traffic controls**
-
-  Lets you restrict ingress traffic inside and outside pods and mitigate common threats to Istio-enabled apps.
-
-- **Supports security goals**
-
-  Enables adoption of a zero trust network model for security, including traffic encryption, multiple enforcement points, and multiple identity criteria for authentication.
-
-- **Familiar policy language**
-
-  Kubernetes network policies and $[prodname] network policies work as is; users do not need to learn another network policy model to adopt Istio.
-
-See [Enforce network policy using Istio tutorial](enforce-policy-istio.mdx) to learn how application layer policy provides second-factor authentication for the mythical Yao Bank.
+- **Pod traffic controls for Istio-enabled apps**: Lets you restrict ingress traffic inside and outside pods and mitigate common threats to Istio-enabled apps.
+- **Security alignment with zero trust**: Supports zero-trust network models through traffic encryption, multiple enforcement points, and multiple identity criteria for authentication.
+- **Familiar policy language**: Apply Kubernetes network policies and $[prodname] network policies that you already know.
 
 ## Before you begin
 
 **Required**
 
-- [$[prodname] is installed](../../getting-started/index.mdx)
-- [calicoctl is installed and configured](../../operations/calicoctl/install.mdx)
-- [MutatingAdmissionWebhook](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook) enabled
+- $[prodname] CNI is installed and configured
+- `kubectl` and `istioctl` CLI tools are installed
+- MutatingAdmissionWebhook admission controller is enabled
 
-**Istio support**
+**Supported Istio versions**
 
-Following Istio versions have been verified to work with application layer policies:
+- **Istio v1.28.1** (recommended)
+- **Istio v1.22+** (minimum required for Kubernetes native sidecar support)
 
-- Istio v1.15.2
-- Istio v1.10.2
+:::note
 
-Istio v1.9.x and lower are **not** supported.
+This guide requires Istio 1.22+ with Kubernetes native sidecars. Traditional sidecar injection is not supported. For legacy Istio versions (v1.15.2, v1.10.2), see [Legacy Installation](#legacy-installation-configmap-patching).
 
-Although we expect future minor versions to work with the corresponding manifest below (for example, v1.10.2 or v1.15.2), manifest compatibility depends entirely on the upstream changes in the respective Istio release.
+:::
+
+**Required Kubernetes versions**
+
+- **Kubernetes v1.29+**: Required for native sidecar support
 
 ## How to
 
-1. [Enable application layer policy](#enable-application-layer-policy)
-2. [Install Calico CSI Driver](#install-calico-csi-driver)
-3. [Install Istio](#install-istio)
-4. [Update Istio sidecar injector](#update-istio-sidecar-injector)
-5. [Add Calico authorization services to the mesh](#add-calico-authorization-services-to-the-mesh)
-6. [Add namespace labels](#add-namespace-labels)
+This guide covers the usage of [IstioOperator](https://istio.io/latest/docs/reference/config/istio.operator.v1alpha1/)
 
-### Enable application layer policy
+For the ConfigMap patching method, see [Legacy Installation](#legacy-installation-configmap-patching).
 
-To enable the application layer policy, you must enable the **Policy Sync API** on Felix cluster-wide.
+### 1. Enable application layer policy
 
-In the default **FelixConfiguration**, set the field, `policySyncPathPrefix` to `/var/run/nodeagent`:
+Enable the Policy Sync API in Felix to allow Dikastes to query policy decisions.
 
 <Tabs>
-<TabItem label="calicoctl" value="calicoctl-0">
+<TabItem label="kubectl" value="kubectl-0">
 
 ```bash
-calicoctl patch FelixConfiguration default --patch \
-   '{"spec": {"policySyncPathPrefix": "/var/run/nodeagent"}}'
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"policySyncPathPrefix":"/var/run/nodeagent"}}'
 ```
 
 </TabItem>
-<TabItem label="kubectl" value="kubectl-1">
+<TabItem label="calicoctl" value="calicoctl-1">
 
 ```bash
-kubectl patch FelixConfiguration default --type=merge --patch \
-   '{"spec": {"policySyncPathPrefix": "/var/run/nodeagent"}}'
+calicoctl patch FelixConfiguration default --patch \
+  '{"spec": {"policySyncPathPrefix": "/var/run/nodeagent"}}'
 ```
 
 </TabItem>
 </Tabs>
 
-Additionally, if you have installed Calico via the operator, you can optionally disable flexvolumes.
-Flexvolumes were used in earlier implementations and have since been deprecated.
+**Optional**: If using the $[prodname] operator, disable deprecated Flex Volumes:
 
 ```bash
 kubectl patch installation default --type=merge -p '{"spec": {"flexVolumePath": "None"}}'
 ```
 
-### Install Calico CSI Driver
+### 2. Install Istio
 
-$[prodname] utilizes a Container Storage Interface (CSI) driver to help set up the policy sync API on every node.
-Apply the following to install the Calico CSI driver
+Follow the [upstream Istio installation documentation](https://istio.io/latest/docs/setup/getting-started/) to install Istio if not already installed.
+
+For testing, you can use:
 
 ```bash
-kubectl apply -f $[manifestsUrl]/manifests/csi-driver.yaml
+curl -L https://istio.io/downloadIstio -o install-istio.sh
+# Review the script before running it, then install:
+ISTIO_VERSION=1.28.1 sh install-istio.sh
+cd istio-1.28.1
+export PATH=$PWD/bin:$PATH
 ```
 
-### Install Istio
+:::note
 
-1. Verify [application layer policy requirements](../../getting-started/kubernetes/requirements.mdx#application-layer-policy-requirements).
-2. Install Istio using [installation guide in the project documentation](https://istio.io/v1.15/docs/setup/install/).
+Do not run `istioctl install` yet if you want to configure Dikastes templates during installation. See the next step.
 
-```bash
-curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.15.2 sh -
-cd $(ls -d istio-* --color=never)
-./bin/istioctl install
+:::
+
+### 3. Configure Istio with Dikastes injection templates
+
+#### Option A: use IstioOperator directly
+
+Create a file named `istio-operator-dikastes.yaml`:
+
+```yaml
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: istio-with-dikastes
+  namespace: istio-system
+spec:
+  profile: minimal  # or 'default' if you need gateways
+
+  values:
+    sidecarInjectorWebhook:
+      templates:
+        # Template for workload pods
+        dikastes: |
+          spec:
+            containers:
+            - name: dikastes
+              image: quay.io/calico/dikastes:$[version]
+              args:
+              - server
+              - -l
+              - /var/run/dikastes/dikastes.sock
+              - -d
+              - /var/run/felix/nodeagent/socket
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsGroup: 999
+                runAsNonRoot: true
+                runAsUser: 999
+              livenessProbe:
+                exec:
+                  command:
+                  - /healthz
+                  - liveness
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              readinessProbe:
+                exec:
+                  command:
+                  - /healthz
+                  - readiness
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              volumeMounts:
+              - mountPath: /var/run/dikastes
+                name: dikastes-sock
+              - mountPath: /var/run/felix
+                name: felix-sync
+            initContainers:
+            - name: istio-proxy
+              volumeMounts:
+              - mountPath: /var/run/dikastes
+                name: dikastes-sock
+            volumes:
+            - name: dikastes-sock
+              emptyDir:
+                medium: Memory
+            - name: felix-sync
+              csi:
+                driver: csi.tigera.io
+
+        # Template for gateway pods (runs as root)
+        dikastes-gateway: |
+          spec:
+            containers:
+            - name: dikastes
+              image: quay.io/calico/dikastes:$[version]
+              args:
+              - server
+              - -l
+              - /var/run/dikastes/dikastes.sock
+              - -d
+              - /var/run/felix/nodeagent/socket
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsGroup: 0
+                runAsNonRoot: false
+                runAsUser: 0
+              livenessProbe:
+                exec:
+                  command:
+                  - /healthz
+                  - liveness
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              readinessProbe:
+                exec:
+                  command:
+                  - /healthz
+                  - readiness
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              volumeMounts:
+              - mountPath: /var/run/dikastes
+                name: dikastes-sock
+              - mountPath: /var/run/felix
+                name: felix-sync
+            initContainers:
+            - name: istio-proxy
+              volumeMounts:
+              - mountPath: /var/run/dikastes
+                name: dikastes-sock
+            volumes:
+            - name: dikastes-sock
+              emptyDir:
+                medium: Memory
+            - name: felix-sync
+              csi:
+                driver: csi.tigera.io
 ```
 
-Next, create the following [PeerAuthentication](https://istio.io/v1.15/docs/reference/config/security/peer_authentication/) policy.
-
-Replace `namespace` below by `rootNamespace` value, if it's customized in your environment.
+**Install or update Istio** with the Dikastes templates:
 
 ```bash
-kubectl create -f - <<EOF
+istioctl install -f istio-operator-dikastes.yaml -y
+```
+
+This will:
+- Install Istio (if not already installed)
+- Update the `istio-sidecar-injector` ConfigMap with the Dikastes templates
+- Make the templates available for pod annotation-based injection
+
+**Verify the templates were loaded**:
+
+```bash
+kubectl get configmap -n istio-system istio-sidecar-injector -o yaml | grep "dikastes:" -A 5
+```
+
+You should see both `dikastes` and `dikastes-gateway` templates.
+
+#### Option B: Generate Manifests for GitOps
+
+If you prefer to generate Kubernetes manifests instead of applying directly:
+
+```bash
+istioctl manifest generate -f istio-operator-dikastes.yaml > istio-with-dikastes.yaml
+kubectl apply -f istio-with-dikastes.yaml
+```
+
+### 4. Add Envoy authorization services
+
+Configure Istio's Envoy proxies to use Dikastes as an external authorization service.
+
+```bash
+kubectl apply -f $[manifestsUrl]/manifests/alp/istio-app-layer-policy-envoy-v3.yaml
+```
+
+[View sample manifest]($[manifestsUrl]/manifests/alp/istio-app-layer-policy-envoy-v3.yaml)
+
+This manifest creates:
+- **ServiceEntry**: Defines `dikastes.calico.cluster.local` for Unix socket communication
+- **DestinationRule**: Disables mTLS for local socket communication
+- **EnvoyFilter**: Configures Envoy's External Authorization filter to call Dikastes
+
+### 5. Enable Istio injection for namespaces
+
+Label the namespace where you want to deploy Istio-enabled workloads:
+
+```bash
+kubectl label namespace <your-namespace> istio-injection=enabled
+```
+
+### 6. Annotate pods to inject Dikastes
+
+To inject the Dikastes sidecar into your pods, add the following annotation to your pod template:
+
+**For regular workloads**:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: sidecar,dikastes
+    spec:
+      # ... your pod spec
+```
+
+**For gateway workloads**:
+
+```yaml
+metadata:
+  annotations:
+    inject.istio.io/templates: sidecar,dikastes-gateway
+```
+
+The key difference:
+- `dikastes`: Runs as non-root user (999) - for application workloads
+- `dikastes-gateway`: Runs as root (0) - for ingress/egress gateways
+
+### 7. Verify Dikastes injection
+
+After deploying a workload with the annotation:
+
+```bash
+# Check that Dikastes container is present
+kubectl get pod -l app=<your-app> -n <your-namespace> -o jsonpath='{.items[0].spec.containers[*].name}'
+```
+
+You should see: `dikastes <your-app-container> ...`
+
+**Check pod status** (should show all containers ready):
+
+```bash
+kubectl get pods -n <your-namespace>
+```
+
+**Check Dikastes logs**:
+
+```bash
+kubectl logs -n <your-namespace> -l app=<your-app> -c dikastes
+```
+
+You should see:
+```
+Successfully connected to Policy Sync server
+Starting synchronization with Policy Sync server
+```
+
+### 8. (Optional) Enable strict mTLS
+
+For enhanced security, enable strict mutual TLS between services:
+
+```yaml
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
@@ -128,18 +335,148 @@ metadata:
 spec:
   mtls:
     mode: STRICT
-EOF
 ```
 
-### Update Istio sidecar injector
+Apply:
 
-The sidecar injector automatically modifies pods as they are created to work with Istio. This step modifies the injector configuration to add Dikastes (a $[prodname] component), as sidecar containers.
+```bash
+kubectl apply -f <filename>.yaml
+```
 
-1. Follow the [Automatic sidecar injection instructions](https://archive.istio.io/v1.15/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection) to install the sidecar injector and enable it in your chosen namespace(s).
-2. Patch the istio-sidecar-injector `ConfigMap` to enable injection of Dikastes alongside Envoy.
+## Create Calico network policies
 
-<Tabs>
-<TabItem label="Istio v1.15.x" value="Istio v1.15.x-2">
+With Dikastes deployed, you can now create $[prodname] network policies to enforce Layer 7 access control.
+
+:::note
+
+The specific policy Custom Resource Definitions available depend on your $[prodname] distribution (OSS vs Enterprise). Consult your $[prodname] documentation for policy syntax.
+
+:::
+
+Example conceptual policy (syntax may vary):
+
+```yaml
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: allow-http-get
+  namespace: default
+spec:
+  selector: app == "myapp"
+  types:
+  - Ingress
+  ingress:
+  - action: Allow
+    protocol: TCP
+    destination:
+      ports:
+      - 80
+```
+
+### Default behavior
+
+Without explicit allow policies, Dikastes enforces a **default-deny** posture for security. All HTTP requests will receive a `403 Forbidden` response until you create policies that explicitly allow traffic.
+
+## Troubleshooting
+
+### Dikastes container not injected
+
+**Check namespace label**:
+
+```bash
+kubectl get namespace <your-namespace> -o jsonpath='{.metadata.labels.istio-injection}'
+```
+
+Should show: `enabled`
+
+**Check pod annotation**:
+
+```bash
+kubectl get pod <pod-name> -n <your-namespace> -o yaml | grep inject.istio.io/templates
+```
+
+Should show: `inject.istio.io/templates: sidecar,dikastes`
+
+**Verify templates in ConfigMap**:
+
+```bash
+kubectl get configmap -n istio-system istio-sidecar-injector -o jsonpath='{.data.values}' | grep -o "dikastes:" | wc -l
+```
+
+Should return `2` (one for each template).
+
+### Pod stuck in PodInitializing or CrashLoopBackOff
+
+**Check pod events**:
+
+```bash
+kubectl describe pod <pod-name> -n <your-namespace>
+```
+
+**Check Dikastes logs**:
+
+```bash
+kubectl logs <pod-name> -n <your-namespace> -c dikastes
+```
+
+**Check CSI driver** (automatically installed with $[prodname]):
+
+```bash
+kubectl get pods -n calico-system -l k8s-app=csi-node-driver
+```
+
+All CSI driver pods should be `Running`. The CSI driver is required for Dikastes to access the Felix Policy Sync API.
+
+**Verify Felix Policy Sync API**:
+
+```bash
+kubectl get felixconfiguration default -o yaml | grep policySyncPathPrefix
+```
+
+Should show: `policySyncPathPrefix: /var/run/nodeagent`
+
+### All requests returning 403
+
+This is **expected behavior** when no allow policies are configured. Dikastes enforces default-deny for security.
+
+To allow traffic, create $[prodname] network policies that explicitly permit the desired traffic.
+
+### Envoy cannot reach istio-pilot
+
+If you have egress policies applied to your pods, Envoy needs access to the Istio control plane.
+
+Apply the allow policy:
+
+```bash
+kubectl apply -f $[tutorialFilesURL]/allow-istio-pilot.yaml
+```
+
+### Warning about BPF load balancing
+
+If you see this warning during installation:
+
+```
+detected Calico CNI with 'bpfConnectTimeLoadBalancing=TCP';
+this must be set to 'bpfConnectTimeLoadBalancing=Disabled'
+```
+
+This may affect connection-level load balancing but does not prevent basic functionality. For production deployments, disable BPF connect-time load balancing:
+
+```bash
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"bpfConnectTimeLoadBalancing":"Disabled"}}'
+```
+
+## Legacy Installation (ConfigMap Patching)
+
+:::note
+
+This method is supported but not recommended for new deployments. Use the IstioOperator method instead.
+
+:::
+
+If you need to use the legacy ConfigMap patching method for Istio 1.15 or 1.10:
+
+### For Istio v1.15.x:
 
 ```bash
 curl $[manifestsUrl]/manifests/alp/istio-inject-configmap-1.15.yaml -o istio-inject-configmap.yaml
@@ -148,8 +485,7 @@ kubectl patch configmap -n istio-system istio-sidecar-injector --patch "$(cat is
 
 [View sample manifest]($[manifestsUrl]/manifests/alp/istio-inject-configmap-1.15.yaml)
 
-</TabItem>
-<TabItem label="Istio v1.10.x" value="Istio v1.10.x-3">
+### For Istio v1.10.x:
 
 ```bash
 curl $[manifestsUrl]/manifests/alp/istio-inject-configmap-1.10.yaml -o istio-inject-configmap.yaml
@@ -158,45 +494,17 @@ kubectl patch configmap -n istio-system istio-sidecar-injector --patch "$(cat is
 
 [View sample manifest]($[manifestsUrl]/manifests/alp/istio-inject-configmap-1.10.yaml)
 
-</TabItem>
-</Tabs>
+**Drawbacks of ConfigMap patching**:
 
-### Add Calico authorization services to the mesh
-
-Apply the following manifest to configure Istio to query $[prodname] for application layer policy authorization decisions.
-
-This applies to Istio v1.15.x and v1.10.x:
-
-```bash
-kubectl apply -f $[manifestsUrl]/manifests/alp/istio-app-layer-policy-envoy-v3.yaml
-```
-
-[View sample manifest]($[manifestsUrl]/manifests/alp/istio-app-layer-policy-envoy-v3.yaml)
-
-### Add namespace labels
-
-You can control enforcement of application layer policy on a per-namespace basis. However, this only works on pods that are started with the Envoy and $[prodname] Dikastes sidecars (as noted in the step, Update Istio sidecar injector). Pods that do not have the $[prodname] sidecars, enforce only standard $[prodname] network policy.
-
-To enable Istio and application layer policy in a namespace, add the label `istio-injection=enabled`.
-
-```bash
-kubectl label namespace <your namespace name> istio-injection=enabled
-```
-
-If the namespace already has pods in it, you must recreate them for this to take effect.
-
-:::note
-
-Envoy must be able to communicate with the `istio-pilot.istio-system service`. If you apply any egress policies to your pods, you _must_ enable access.
-
-```bash
-kubectl apply -f $[tutorialFilesURL]/allow-istio-pilot.yaml
-```
-
-:::
+- Not declarative (imperative command)
+- Not version-controlled
+- Must be re-applied after Istio upgrades
+- Difficult to audit and review
 
 ## Additional resources
 
 - [Enforce network policy using Istio tutorial](enforce-policy-istio.mdx)
 - [Use HTTP methods and paths in policy rules](http-methods.mdx)
-- [Hands-on workshop: Learn how to deploy access control, encryption & auth at the application level](https://www.tigera.io/tutorials/?_sf_s=Deploy%20Service%20Mesh)
+- [Istio Documentation](https://istio.io/latest/docs/)
+- [IstioOperator API Reference](https://istio.io/latest/docs/reference/config/istio.operator.v1alpha1/)
+- [Kubernetes Native Sidecars](https://kubernetes.io/blog/2023/08/25/native-sidecar-containers/)

--- a/calico_versioned_docs/version-3.30/network-policy/istio/app-layer-policy.mdx
+++ b/calico_versioned_docs/version-3.30/network-policy/istio/app-layer-policy.mdx
@@ -4,122 +4,329 @@ description: Enforce network policy for Istio service mesh including matching on
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Enforce network policy for Istio
+# Enforce Calico network policy for Istio service mesh
 
-## Big picture
+## Overview
 
-$[prodname] integrates seamlessly with Istio to enforce network policy within the Istio service mesh.
+You can enforce $[prodname] network policy for Istio application layer policy using the Dikastes sidecar. Dikastes enables $[prodname] to integrate with Istio's Envoy proxy to enforce fine-grained Layer 7 (HTTP) policies.
 
-## Value
+### Value
 
-$[prodname] network policy for Istio lets you enforce application layer attributes like HTTP methods or paths, and cryptographically secure identities for Istio-enabled apps.
-
-## Concepts
-
-### Benefits of the Istio integration
-
-The $[prodname] support for Istio service mesh has the following benefits:
-
-- **Pod traffic controls**
-
-  Lets you restrict ingress traffic inside and outside pods and mitigate common threats to Istio-enabled apps.
-
-- **Supports security goals**
-
-  Enables adoption of a zero trust network model for security, including traffic encryption, multiple enforcement points, and multiple identity criteria for authentication.
-
-- **Familiar policy language**
-
-  Kubernetes network policies and $[prodname] network policies work as is; users do not need to learn another network policy model to adopt Istio.
-
-See [Enforce network policy using Istio tutorial](enforce-policy-istio.mdx) to learn how application layer policy provides second-factor authentication for the mythical Yao Bank.
+- **Pod traffic controls for Istio-enabled apps**: Lets you restrict ingress traffic inside and outside pods and mitigate common threats to Istio-enabled apps.
+- **Security alignment with zero trust**: Supports zero-trust network models through traffic encryption, multiple enforcement points, and multiple identity criteria for authentication.
+- **Familiar policy language**: Apply Kubernetes network policies and $[prodname] network policies that you already know.
 
 ## Before you begin
 
 **Required**
 
-- [$[prodname] is installed](../../getting-started/index.mdx)
-- [calicoctl is installed and configured](../../operations/calicoctl/install.mdx)
-- [MutatingAdmissionWebhook](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook) enabled
+- $[prodname] CNI is installed and configured
+- `kubectl` and `istioctl` CLI tools are installed
+- MutatingAdmissionWebhook admission controller is enabled
 
-**Istio support**
+**Supported Istio versions**
 
-Following Istio versions have been verified to work with application layer policies:
+- **Istio v1.28.1** (recommended)
+- **Istio v1.22+** (minimum required for Kubernetes native sidecar support)
 
-- Istio v1.15.2
-- Istio v1.10.2
+:::note
 
-Istio v1.9.x and lower are **not** supported.
+This guide requires Istio 1.22+ with Kubernetes native sidecars. Traditional sidecar injection is not supported. For legacy Istio versions (v1.15.2, v1.10.2), see [Legacy Installation](#legacy-installation-configmap-patching).
 
-Although we expect future minor versions to work with the corresponding manifest below (for example, v1.10.2 or v1.15.2), manifest compatibility depends entirely on the upstream changes in the respective Istio release.
+:::
+
+**Required Kubernetes versions**
+
+- **Kubernetes v1.29+**: Required for native sidecar support
 
 ## How to
 
-1. [Enable application layer policy](#enable-application-layer-policy)
-2. [Install Calico CSI Driver](#install-calico-csi-driver)
-3. [Install Istio](#install-istio)
-4. [Update Istio sidecar injector](#update-istio-sidecar-injector)
-5. [Add Calico authorization services to the mesh](#add-calico-authorization-services-to-the-mesh)
-6. [Add namespace labels](#add-namespace-labels)
+This guide covers the usage of [IstioOperator](https://istio.io/latest/docs/reference/config/istio.operator.v1alpha1/)
 
-### Enable application layer policy
+For the ConfigMap patching method, see [Legacy Installation](#legacy-installation-configmap-patching).
 
-To enable the application layer policy, you must enable the **Policy Sync API** on Felix cluster-wide.
+### 1. Enable application layer policy
 
-In the default **FelixConfiguration**, set the field, `policySyncPathPrefix` to `/var/run/nodeagent`:
+Enable the Policy Sync API in Felix to allow Dikastes to query policy decisions.
 
 <Tabs>
-<TabItem label="calicoctl" value="calicoctl-0">
+<TabItem label="kubectl" value="kubectl-0">
 
 ```bash
-calicoctl patch FelixConfiguration default --patch \
-   '{"spec": {"policySyncPathPrefix": "/var/run/nodeagent"}}'
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"policySyncPathPrefix":"/var/run/nodeagent"}}'
 ```
 
 </TabItem>
-<TabItem label="kubectl" value="kubectl-1">
+<TabItem label="calicoctl" value="calicoctl-1">
 
 ```bash
-kubectl patch FelixConfiguration default --type=merge --patch \
-   '{"spec": {"policySyncPathPrefix": "/var/run/nodeagent"}}'
+calicoctl patch FelixConfiguration default --patch \
+  '{"spec": {"policySyncPathPrefix": "/var/run/nodeagent"}}'
 ```
 
 </TabItem>
 </Tabs>
 
-Additionally, if you have installed Calico via the operator, you can optionally disable flexvolumes.
-Flexvolumes were used in earlier implementations and have since been deprecated.
+**Optional**: If using the $[prodname] operator, disable deprecated Flex Volumes:
 
 ```bash
 kubectl patch installation default --type=merge -p '{"spec": {"flexVolumePath": "None"}}'
 ```
 
-### Install Calico CSI Driver
+### 2. Install Istio
 
-$[prodname] utilizes a Container Storage Interface (CSI) driver to help set up the policy sync API on every node.
-Apply the following to install the Calico CSI driver
+Follow the [upstream Istio installation documentation](https://istio.io/latest/docs/setup/getting-started/) to install Istio if not already installed.
+
+For testing, you can use:
 
 ```bash
-kubectl apply -f $[manifestsUrl]/manifests/csi-driver.yaml
+curl -L https://istio.io/downloadIstio -o install-istio.sh
+# Review the script before running it, then install:
+ISTIO_VERSION=1.28.1 sh install-istio.sh
+cd istio-1.28.1
+export PATH=$PWD/bin:$PATH
 ```
 
-### Install Istio
+:::note
 
-1. Verify [application layer policy requirements](../../getting-started/kubernetes/requirements.mdx#application-layer-policy-requirements).
-2. Install Istio using [installation guide in the project documentation](https://istio.io/v1.15/docs/setup/install/).
+Do not run `istioctl install` yet if you want to configure Dikastes templates during installation. See the next step.
 
-```bash
-curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.15.2 sh -
-cd $(ls -d istio-* --color=never)
-./bin/istioctl install
+:::
+
+### 3. Configure Istio with Dikastes injection templates
+
+#### Option A: use IstioOperator directly
+
+Create a file named `istio-operator-dikastes.yaml`:
+
+```yaml
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: istio-with-dikastes
+  namespace: istio-system
+spec:
+  profile: minimal  # or 'default' if you need gateways
+
+  values:
+    sidecarInjectorWebhook:
+      templates:
+        # Template for workload pods
+        dikastes: |
+          spec:
+            containers:
+            - name: dikastes
+              image: quay.io/calico/dikastes:$[version]
+              args:
+              - server
+              - -l
+              - /var/run/dikastes/dikastes.sock
+              - -d
+              - /var/run/felix/nodeagent/socket
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsGroup: 999
+                runAsNonRoot: true
+                runAsUser: 999
+              livenessProbe:
+                exec:
+                  command:
+                  - /healthz
+                  - liveness
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              readinessProbe:
+                exec:
+                  command:
+                  - /healthz
+                  - readiness
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              volumeMounts:
+              - mountPath: /var/run/dikastes
+                name: dikastes-sock
+              - mountPath: /var/run/felix
+                name: felix-sync
+            initContainers:
+            - name: istio-proxy
+              volumeMounts:
+              - mountPath: /var/run/dikastes
+                name: dikastes-sock
+            volumes:
+            - name: dikastes-sock
+              emptyDir:
+                medium: Memory
+            - name: felix-sync
+              csi:
+                driver: csi.tigera.io
+
+        # Template for gateway pods (runs as root)
+        dikastes-gateway: |
+          spec:
+            containers:
+            - name: dikastes
+              image: quay.io/calico/dikastes:$[version]
+              args:
+              - server
+              - -l
+              - /var/run/dikastes/dikastes.sock
+              - -d
+              - /var/run/felix/nodeagent/socket
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsGroup: 0
+                runAsNonRoot: false
+                runAsUser: 0
+              livenessProbe:
+                exec:
+                  command:
+                  - /healthz
+                  - liveness
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              readinessProbe:
+                exec:
+                  command:
+                  - /healthz
+                  - readiness
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              volumeMounts:
+              - mountPath: /var/run/dikastes
+                name: dikastes-sock
+              - mountPath: /var/run/felix
+                name: felix-sync
+            initContainers:
+            - name: istio-proxy
+              volumeMounts:
+              - mountPath: /var/run/dikastes
+                name: dikastes-sock
+            volumes:
+            - name: dikastes-sock
+              emptyDir:
+                medium: Memory
+            - name: felix-sync
+              csi:
+                driver: csi.tigera.io
 ```
 
-Next, create the following [PeerAuthentication](https://istio.io/v1.15/docs/reference/config/security/peer_authentication/) policy.
-
-Replace `namespace` below by `rootNamespace` value, if it's customized in your environment.
+**Install or update Istio** with the Dikastes templates:
 
 ```bash
-kubectl create -f - <<EOF
+istioctl install -f istio-operator-dikastes.yaml -y
+```
+
+This will:
+- Install Istio (if not already installed)
+- Update the `istio-sidecar-injector` ConfigMap with the Dikastes templates
+- Make the templates available for pod annotation-based injection
+
+**Verify the templates were loaded**:
+
+```bash
+kubectl get configmap -n istio-system istio-sidecar-injector -o yaml | grep "dikastes:" -A 5
+```
+
+You should see both `dikastes` and `dikastes-gateway` templates.
+
+#### Option B: Generate Manifests for GitOps
+
+If you prefer to generate Kubernetes manifests instead of applying directly:
+
+```bash
+istioctl manifest generate -f istio-operator-dikastes.yaml > istio-with-dikastes.yaml
+kubectl apply -f istio-with-dikastes.yaml
+```
+
+### 4. Add Envoy authorization services
+
+Configure Istio's Envoy proxies to use Dikastes as an external authorization service.
+
+```bash
+kubectl apply -f $[manifestsUrl]/manifests/alp/istio-app-layer-policy-envoy-v3.yaml
+```
+
+[View sample manifest]($[manifestsUrl]/manifests/alp/istio-app-layer-policy-envoy-v3.yaml)
+
+This manifest creates:
+- **ServiceEntry**: Defines `dikastes.calico.cluster.local` for Unix socket communication
+- **DestinationRule**: Disables mTLS for local socket communication
+- **EnvoyFilter**: Configures Envoy's External Authorization filter to call Dikastes
+
+### 5. Enable Istio injection for namespaces
+
+Label the namespace where you want to deploy Istio-enabled workloads:
+
+```bash
+kubectl label namespace <your-namespace> istio-injection=enabled
+```
+
+### 6. Annotate pods to inject Dikastes
+
+To inject the Dikastes sidecar into your pods, add the following annotation to your pod template:
+
+**For regular workloads**:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: sidecar,dikastes
+    spec:
+      # ... your pod spec
+```
+
+**For gateway workloads**:
+
+```yaml
+metadata:
+  annotations:
+    inject.istio.io/templates: sidecar,dikastes-gateway
+```
+
+The key difference:
+- `dikastes`: Runs as non-root user (999) - for application workloads
+- `dikastes-gateway`: Runs as root (0) - for ingress/egress gateways
+
+### 7. Verify Dikastes injection
+
+After deploying a workload with the annotation:
+
+```bash
+# Check that Dikastes container is present
+kubectl get pod -l app=<your-app> -n <your-namespace> -o jsonpath='{.items[0].spec.containers[*].name}'
+```
+
+You should see: `dikastes <your-app-container> ...`
+
+**Check pod status** (should show all containers ready):
+
+```bash
+kubectl get pods -n <your-namespace>
+```
+
+**Check Dikastes logs**:
+
+```bash
+kubectl logs -n <your-namespace> -l app=<your-app> -c dikastes
+```
+
+You should see:
+```
+Successfully connected to Policy Sync server
+Starting synchronization with Policy Sync server
+```
+
+### 8. (Optional) Enable strict mTLS
+
+For enhanced security, enable strict mutual TLS between services:
+
+```yaml
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
@@ -128,18 +335,148 @@ metadata:
 spec:
   mtls:
     mode: STRICT
-EOF
 ```
 
-### Update Istio sidecar injector
+Apply:
 
-The sidecar injector automatically modifies pods as they are created to work with Istio. This step modifies the injector configuration to add Dikastes (a $[prodname] component), as sidecar containers.
+```bash
+kubectl apply -f <filename>.yaml
+```
 
-1. Follow the [Automatic sidecar injection instructions](https://archive.istio.io/v1.15/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection) to install the sidecar injector and enable it in your chosen namespace(s).
-2. Patch the istio-sidecar-injector `ConfigMap` to enable injection of Dikastes alongside Envoy.
+## Create Calico network policies
 
-<Tabs>
-<TabItem label="Istio v1.15.x" value="Istio v1.15.x-2">
+With Dikastes deployed, you can now create $[prodname] network policies to enforce Layer 7 access control.
+
+:::note
+
+The specific policy Custom Resource Definitions available depend on your $[prodname] distribution (OSS vs Enterprise). Consult your $[prodname] documentation for policy syntax.
+
+:::
+
+Example conceptual policy (syntax may vary):
+
+```yaml
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: allow-http-get
+  namespace: default
+spec:
+  selector: app == "myapp"
+  types:
+  - Ingress
+  ingress:
+  - action: Allow
+    protocol: TCP
+    destination:
+      ports:
+      - 80
+```
+
+### Default behavior
+
+Without explicit allow policies, Dikastes enforces a **default-deny** posture for security. All HTTP requests will receive a `403 Forbidden` response until you create policies that explicitly allow traffic.
+
+## Troubleshooting
+
+### Dikastes container not injected
+
+**Check namespace label**:
+
+```bash
+kubectl get namespace <your-namespace> -o jsonpath='{.metadata.labels.istio-injection}'
+```
+
+Should show: `enabled`
+
+**Check pod annotation**:
+
+```bash
+kubectl get pod <pod-name> -n <your-namespace> -o yaml | grep inject.istio.io/templates
+```
+
+Should show: `inject.istio.io/templates: sidecar,dikastes`
+
+**Verify templates in ConfigMap**:
+
+```bash
+kubectl get configmap -n istio-system istio-sidecar-injector -o jsonpath='{.data.values}' | grep -o "dikastes:" | wc -l
+```
+
+Should return `2` (one for each template).
+
+### Pod stuck in PodInitializing or CrashLoopBackOff
+
+**Check pod events**:
+
+```bash
+kubectl describe pod <pod-name> -n <your-namespace>
+```
+
+**Check Dikastes logs**:
+
+```bash
+kubectl logs <pod-name> -n <your-namespace> -c dikastes
+```
+
+**Check CSI driver** (automatically installed with $[prodname]):
+
+```bash
+kubectl get pods -n calico-system -l k8s-app=csi-node-driver
+```
+
+All CSI driver pods should be `Running`. The CSI driver is required for Dikastes to access the Felix Policy Sync API.
+
+**Verify Felix Policy Sync API**:
+
+```bash
+kubectl get felixconfiguration default -o yaml | grep policySyncPathPrefix
+```
+
+Should show: `policySyncPathPrefix: /var/run/nodeagent`
+
+### All requests returning 403
+
+This is **expected behavior** when no allow policies are configured. Dikastes enforces default-deny for security.
+
+To allow traffic, create $[prodname] network policies that explicitly permit the desired traffic.
+
+### Envoy cannot reach istio-pilot
+
+If you have egress policies applied to your pods, Envoy needs access to the Istio control plane.
+
+Apply the allow policy:
+
+```bash
+kubectl apply -f $[tutorialFilesURL]/allow-istio-pilot.yaml
+```
+
+### Warning about BPF load balancing
+
+If you see this warning during installation:
+
+```
+detected Calico CNI with 'bpfConnectTimeLoadBalancing=TCP';
+this must be set to 'bpfConnectTimeLoadBalancing=Disabled'
+```
+
+This may affect connection-level load balancing but does not prevent basic functionality. For production deployments, disable BPF connect-time load balancing:
+
+```bash
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"bpfConnectTimeLoadBalancing":"Disabled"}}'
+```
+
+## Legacy Installation (ConfigMap Patching)
+
+:::note
+
+This method is supported but not recommended for new deployments. Use the IstioOperator method instead.
+
+:::
+
+If you need to use the legacy ConfigMap patching method for Istio 1.15 or 1.10:
+
+### For Istio v1.15.x:
 
 ```bash
 curl $[manifestsUrl]/manifests/alp/istio-inject-configmap-1.15.yaml -o istio-inject-configmap.yaml
@@ -148,8 +485,7 @@ kubectl patch configmap -n istio-system istio-sidecar-injector --patch "$(cat is
 
 [View sample manifest]($[manifestsUrl]/manifests/alp/istio-inject-configmap-1.15.yaml)
 
-</TabItem>
-<TabItem label="Istio v1.10.x" value="Istio v1.10.x-3">
+### For Istio v1.10.x:
 
 ```bash
 curl $[manifestsUrl]/manifests/alp/istio-inject-configmap-1.10.yaml -o istio-inject-configmap.yaml
@@ -158,45 +494,17 @@ kubectl patch configmap -n istio-system istio-sidecar-injector --patch "$(cat is
 
 [View sample manifest]($[manifestsUrl]/manifests/alp/istio-inject-configmap-1.10.yaml)
 
-</TabItem>
-</Tabs>
+**Drawbacks of ConfigMap patching**:
 
-### Add Calico authorization services to the mesh
-
-Apply the following manifest to configure Istio to query $[prodname] for application layer policy authorization decisions.
-
-This applies to Istio v1.15.x and v1.10.x:
-
-```bash
-kubectl apply -f $[manifestsUrl]/manifests/alp/istio-app-layer-policy-envoy-v3.yaml
-```
-
-[View sample manifest]($[manifestsUrl]/manifests/alp/istio-app-layer-policy-envoy-v3.yaml)
-
-### Add namespace labels
-
-You can control enforcement of application layer policy on a per-namespace basis. However, this only works on pods that are started with the Envoy and $[prodname] Dikastes sidecars (as noted in the step, Update Istio sidecar injector). Pods that do not have the $[prodname] sidecars, enforce only standard $[prodname] network policy.
-
-To enable Istio and application layer policy in a namespace, add the label `istio-injection=enabled`.
-
-```bash
-kubectl label namespace <your namespace name> istio-injection=enabled
-```
-
-If the namespace already has pods in it, you must recreate them for this to take effect.
-
-:::note
-
-Envoy must be able to communicate with the `istio-pilot.istio-system service`. If you apply any egress policies to your pods, you _must_ enable access.
-
-```bash
-kubectl apply -f $[tutorialFilesURL]/allow-istio-pilot.yaml
-```
-
-:::
+- Not declarative (imperative command)
+- Not version-controlled
+- Must be re-applied after Istio upgrades
+- Difficult to audit and review
 
 ## Additional resources
 
 - [Enforce network policy using Istio tutorial](enforce-policy-istio.mdx)
 - [Use HTTP methods and paths in policy rules](http-methods.mdx)
-- [Hands-on workshop: Learn how to deploy access control, encryption & auth at the application level](https://www.tigera.io/tutorials/?_sf_s=Deploy%20Service%20Mesh)
+- [Istio Documentation](https://istio.io/latest/docs/)
+- [IstioOperator API Reference](https://istio.io/latest/docs/reference/config/istio.operator.v1alpha1/)
+- [Kubernetes Native Sidecars](https://kubernetes.io/blog/2023/08/25/native-sidecar-containers/)

--- a/calico_versioned_docs/version-3.31/network-policy/istio/app-layer-policy.mdx
+++ b/calico_versioned_docs/version-3.31/network-policy/istio/app-layer-policy.mdx
@@ -4,122 +4,329 @@ description: Enforce network policy for Istio service mesh including matching on
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Enforce network policy for Istio
+# Enforce Calico network policy for Istio service mesh
 
-## Big picture
+## Overview
 
-$[prodname] integrates seamlessly with Istio to enforce network policy within the Istio service mesh.
+You can enforce $[prodname] network policy for Istio application layer policy using the Dikastes sidecar. Dikastes enables $[prodname] to integrate with Istio's Envoy proxy to enforce fine-grained Layer 7 (HTTP) policies.
 
-## Value
+### Value
 
-$[prodname] network policy for Istio lets you enforce application layer attributes like HTTP methods or paths, and cryptographically secure identities for Istio-enabled apps.
-
-## Concepts
-
-### Benefits of the Istio integration
-
-The $[prodname] support for Istio service mesh has the following benefits:
-
-- **Pod traffic controls**
-
-  Lets you restrict ingress traffic inside and outside pods and mitigate common threats to Istio-enabled apps.
-
-- **Supports security goals**
-
-  Enables adoption of a zero trust network model for security, including traffic encryption, multiple enforcement points, and multiple identity criteria for authentication.
-
-- **Familiar policy language**
-
-  Kubernetes network policies and $[prodname] network policies work as is; users do not need to learn another network policy model to adopt Istio.
-
-See [Enforce network policy using Istio tutorial](enforce-policy-istio.mdx) to learn how application layer policy provides second-factor authentication for the mythical Yao Bank.
+- **Pod traffic controls for Istio-enabled apps**: Lets you restrict ingress traffic inside and outside pods and mitigate common threats to Istio-enabled apps.
+- **Security alignment with zero trust**: Supports zero-trust network models through traffic encryption, multiple enforcement points, and multiple identity criteria for authentication.
+- **Familiar policy language**: Apply Kubernetes network policies and $[prodname] network policies that you already know.
 
 ## Before you begin
 
 **Required**
 
-- [$[prodname] is installed](../../getting-started/index.mdx)
-- [calicoctl is installed and configured](../../operations/calicoctl/install.mdx)
-- [MutatingAdmissionWebhook](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook) enabled
+- $[prodname] CNI is installed and configured
+- `kubectl` and `istioctl` CLI tools are installed
+- MutatingAdmissionWebhook admission controller is enabled
 
-**Istio support**
+**Supported Istio versions**
 
-Following Istio versions have been verified to work with application layer policies:
+- **Istio v1.28.1** (recommended)
+- **Istio v1.22+** (minimum required for Kubernetes native sidecar support)
 
-- Istio v1.15.2
-- Istio v1.10.2
+:::note
 
-Istio v1.9.x and lower are **not** supported.
+This guide requires Istio 1.22+ with Kubernetes native sidecars. Traditional sidecar injection is not supported. For legacy Istio versions (v1.15.2, v1.10.2), see [Legacy Installation](#legacy-installation-configmap-patching).
 
-Although we expect future minor versions to work with the corresponding manifest below (for example, v1.10.2 or v1.15.2), manifest compatibility depends entirely on the upstream changes in the respective Istio release.
+:::
+
+**Required Kubernetes versions**
+
+- **Kubernetes v1.29+**: Required for native sidecar support
 
 ## How to
 
-1. [Enable application layer policy](#enable-application-layer-policy)
-2. [Install Calico CSI Driver](#install-calico-csi-driver)
-3. [Install Istio](#install-istio)
-4. [Update Istio sidecar injector](#update-istio-sidecar-injector)
-5. [Add Calico authorization services to the mesh](#add-calico-authorization-services-to-the-mesh)
-6. [Add namespace labels](#add-namespace-labels)
+This guide covers the usage of [IstioOperator](https://istio.io/latest/docs/reference/config/istio.operator.v1alpha1/)
 
-### Enable application layer policy
+For the ConfigMap patching method, see [Legacy Installation](#legacy-installation-configmap-patching).
 
-To enable the application layer policy, you must enable the **Policy Sync API** on Felix cluster-wide.
+### 1. Enable application layer policy
 
-In the default **FelixConfiguration**, set the field, `policySyncPathPrefix` to `/var/run/nodeagent`:
+Enable the Policy Sync API in Felix to allow Dikastes to query policy decisions.
 
 <Tabs>
-<TabItem label="calicoctl" value="calicoctl-0">
+<TabItem label="kubectl" value="kubectl-0">
 
 ```bash
-calicoctl patch FelixConfiguration default --patch \
-   '{"spec": {"policySyncPathPrefix": "/var/run/nodeagent"}}'
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"policySyncPathPrefix":"/var/run/nodeagent"}}'
 ```
 
 </TabItem>
-<TabItem label="kubectl" value="kubectl-1">
+<TabItem label="calicoctl" value="calicoctl-1">
 
 ```bash
-kubectl patch FelixConfiguration default --type=merge --patch \
-   '{"spec": {"policySyncPathPrefix": "/var/run/nodeagent"}}'
+calicoctl patch FelixConfiguration default --patch \
+  '{"spec": {"policySyncPathPrefix": "/var/run/nodeagent"}}'
 ```
 
 </TabItem>
 </Tabs>
 
-Additionally, if you have installed Calico via the operator, you can optionally disable flexvolumes.
-Flexvolumes were used in earlier implementations and have since been deprecated.
+**Optional**: If using the $[prodname] operator, disable deprecated Flex Volumes:
 
 ```bash
 kubectl patch installation default --type=merge -p '{"spec": {"flexVolumePath": "None"}}'
 ```
 
-### Install Calico CSI Driver
+### 2. Install Istio
 
-$[prodname] utilizes a Container Storage Interface (CSI) driver to help set up the policy sync API on every node.
-Apply the following to install the Calico CSI driver
+Follow the [upstream Istio installation documentation](https://istio.io/latest/docs/setup/getting-started/) to install Istio if not already installed.
+
+For testing, you can use:
 
 ```bash
-kubectl apply -f $[manifestsUrl]/manifests/csi-driver.yaml
+curl -L https://istio.io/downloadIstio -o install-istio.sh
+# Review the script before running it, then install:
+ISTIO_VERSION=1.28.1 sh install-istio.sh
+cd istio-1.28.1
+export PATH=$PWD/bin:$PATH
 ```
 
-### Install Istio
+:::note
 
-1. Verify [application layer policy requirements](../../getting-started/kubernetes/requirements.mdx#application-layer-policy-requirements).
-2. Install Istio using [installation guide in the project documentation](https://istio.io/v1.15/docs/setup/install/).
+Do not run `istioctl install` yet if you want to configure Dikastes templates during installation. See the next step.
 
-```bash
-curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.15.2 sh -
-cd $(ls -d istio-* --color=never)
-./bin/istioctl install
+:::
+
+### 3. Configure Istio with Dikastes injection templates
+
+#### Option A: use IstioOperator directly
+
+Create a file named `istio-operator-dikastes.yaml`:
+
+```yaml
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: istio-with-dikastes
+  namespace: istio-system
+spec:
+  profile: minimal  # or 'default' if you need gateways
+
+  values:
+    sidecarInjectorWebhook:
+      templates:
+        # Template for workload pods
+        dikastes: |
+          spec:
+            containers:
+            - name: dikastes
+              image: quay.io/calico/dikastes:$[version]
+              args:
+              - server
+              - -l
+              - /var/run/dikastes/dikastes.sock
+              - -d
+              - /var/run/felix/nodeagent/socket
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsGroup: 999
+                runAsNonRoot: true
+                runAsUser: 999
+              livenessProbe:
+                exec:
+                  command:
+                  - /healthz
+                  - liveness
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              readinessProbe:
+                exec:
+                  command:
+                  - /healthz
+                  - readiness
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              volumeMounts:
+              - mountPath: /var/run/dikastes
+                name: dikastes-sock
+              - mountPath: /var/run/felix
+                name: felix-sync
+            initContainers:
+            - name: istio-proxy
+              volumeMounts:
+              - mountPath: /var/run/dikastes
+                name: dikastes-sock
+            volumes:
+            - name: dikastes-sock
+              emptyDir:
+                medium: Memory
+            - name: felix-sync
+              csi:
+                driver: csi.tigera.io
+
+        # Template for gateway pods (runs as root)
+        dikastes-gateway: |
+          spec:
+            containers:
+            - name: dikastes
+              image: quay.io/calico/dikastes:$[version]
+              args:
+              - server
+              - -l
+              - /var/run/dikastes/dikastes.sock
+              - -d
+              - /var/run/felix/nodeagent/socket
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsGroup: 0
+                runAsNonRoot: false
+                runAsUser: 0
+              livenessProbe:
+                exec:
+                  command:
+                  - /healthz
+                  - liveness
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              readinessProbe:
+                exec:
+                  command:
+                  - /healthz
+                  - readiness
+                initialDelaySeconds: 3
+                periodSeconds: 3
+              volumeMounts:
+              - mountPath: /var/run/dikastes
+                name: dikastes-sock
+              - mountPath: /var/run/felix
+                name: felix-sync
+            initContainers:
+            - name: istio-proxy
+              volumeMounts:
+              - mountPath: /var/run/dikastes
+                name: dikastes-sock
+            volumes:
+            - name: dikastes-sock
+              emptyDir:
+                medium: Memory
+            - name: felix-sync
+              csi:
+                driver: csi.tigera.io
 ```
 
-Next, create the following [PeerAuthentication](https://istio.io/v1.15/docs/reference/config/security/peer_authentication/) policy.
-
-Replace `namespace` below by `rootNamespace` value, if it's customized in your environment.
+**Install or update Istio** with the Dikastes templates:
 
 ```bash
-kubectl create -f - <<EOF
+istioctl install -f istio-operator-dikastes.yaml -y
+```
+
+This will:
+- Install Istio (if not already installed)
+- Update the `istio-sidecar-injector` ConfigMap with the Dikastes templates
+- Make the templates available for pod annotation-based injection
+
+**Verify the templates were loaded**:
+
+```bash
+kubectl get configmap -n istio-system istio-sidecar-injector -o yaml | grep "dikastes:" -A 5
+```
+
+You should see both `dikastes` and `dikastes-gateway` templates.
+
+#### Option B: Generate Manifests for GitOps
+
+If you prefer to generate Kubernetes manifests instead of applying directly:
+
+```bash
+istioctl manifest generate -f istio-operator-dikastes.yaml > istio-with-dikastes.yaml
+kubectl apply -f istio-with-dikastes.yaml
+```
+
+### 4. Add Envoy authorization services
+
+Configure Istio's Envoy proxies to use Dikastes as an external authorization service.
+
+```bash
+kubectl apply -f $[manifestsUrl]/manifests/alp/istio-app-layer-policy-envoy-v3.yaml
+```
+
+[View sample manifest]($[manifestsUrl]/manifests/alp/istio-app-layer-policy-envoy-v3.yaml)
+
+This manifest creates:
+- **ServiceEntry**: Defines `dikastes.calico.cluster.local` for Unix socket communication
+- **DestinationRule**: Disables mTLS for local socket communication
+- **EnvoyFilter**: Configures Envoy's External Authorization filter to call Dikastes
+
+### 5. Enable Istio injection for namespaces
+
+Label the namespace where you want to deploy Istio-enabled workloads:
+
+```bash
+kubectl label namespace <your-namespace> istio-injection=enabled
+```
+
+### 6. Annotate pods to inject Dikastes
+
+To inject the Dikastes sidecar into your pods, add the following annotation to your pod template:
+
+**For regular workloads**:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: sidecar,dikastes
+    spec:
+      # ... your pod spec
+```
+
+**For gateway workloads**:
+
+```yaml
+metadata:
+  annotations:
+    inject.istio.io/templates: sidecar,dikastes-gateway
+```
+
+The key difference:
+- `dikastes`: Runs as non-root user (999) - for application workloads
+- `dikastes-gateway`: Runs as root (0) - for ingress/egress gateways
+
+### 7. Verify Dikastes injection
+
+After deploying a workload with the annotation:
+
+```bash
+# Check that Dikastes container is present
+kubectl get pod -l app=<your-app> -n <your-namespace> -o jsonpath='{.items[0].spec.containers[*].name}'
+```
+
+You should see: `dikastes <your-app-container> ...`
+
+**Check pod status** (should show all containers ready):
+
+```bash
+kubectl get pods -n <your-namespace>
+```
+
+**Check Dikastes logs**:
+
+```bash
+kubectl logs -n <your-namespace> -l app=<your-app> -c dikastes
+```
+
+You should see:
+```
+Successfully connected to Policy Sync server
+Starting synchronization with Policy Sync server
+```
+
+### 8. (Optional) Enable strict mTLS
+
+For enhanced security, enable strict mutual TLS between services:
+
+```yaml
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
@@ -128,18 +335,148 @@ metadata:
 spec:
   mtls:
     mode: STRICT
-EOF
 ```
 
-### Update Istio sidecar injector
+Apply:
 
-The sidecar injector automatically modifies pods as they are created to work with Istio. This step modifies the injector configuration to add Dikastes (a $[prodname] component), as sidecar containers.
+```bash
+kubectl apply -f <filename>.yaml
+```
 
-1. Follow the [Automatic sidecar injection instructions](https://archive.istio.io/v1.15/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection) to install the sidecar injector and enable it in your chosen namespace(s).
-2. Patch the istio-sidecar-injector `ConfigMap` to enable injection of Dikastes alongside Envoy.
+## Create Calico network policies
 
-<Tabs>
-<TabItem label="Istio v1.15.x" value="Istio v1.15.x-2">
+With Dikastes deployed, you can now create $[prodname] network policies to enforce Layer 7 access control.
+
+:::note
+
+The specific policy Custom Resource Definitions available depend on your $[prodname] distribution (OSS vs Enterprise). Consult your $[prodname] documentation for policy syntax.
+
+:::
+
+Example conceptual policy (syntax may vary):
+
+```yaml
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: allow-http-get
+  namespace: default
+spec:
+  selector: app == "myapp"
+  types:
+  - Ingress
+  ingress:
+  - action: Allow
+    protocol: TCP
+    destination:
+      ports:
+      - 80
+```
+
+### Default behavior
+
+Without explicit allow policies, Dikastes enforces a **default-deny** posture for security. All HTTP requests will receive a `403 Forbidden` response until you create policies that explicitly allow traffic.
+
+## Troubleshooting
+
+### Dikastes container not injected
+
+**Check namespace label**:
+
+```bash
+kubectl get namespace <your-namespace> -o jsonpath='{.metadata.labels.istio-injection}'
+```
+
+Should show: `enabled`
+
+**Check pod annotation**:
+
+```bash
+kubectl get pod <pod-name> -n <your-namespace> -o yaml | grep inject.istio.io/templates
+```
+
+Should show: `inject.istio.io/templates: sidecar,dikastes`
+
+**Verify templates in ConfigMap**:
+
+```bash
+kubectl get configmap -n istio-system istio-sidecar-injector -o jsonpath='{.data.values}' | grep -o "dikastes:" | wc -l
+```
+
+Should return `2` (one for each template).
+
+### Pod stuck in PodInitializing or CrashLoopBackOff
+
+**Check pod events**:
+
+```bash
+kubectl describe pod <pod-name> -n <your-namespace>
+```
+
+**Check Dikastes logs**:
+
+```bash
+kubectl logs <pod-name> -n <your-namespace> -c dikastes
+```
+
+**Check CSI driver** (automatically installed with $[prodname]):
+
+```bash
+kubectl get pods -n calico-system -l k8s-app=csi-node-driver
+```
+
+All CSI driver pods should be `Running`. The CSI driver is required for Dikastes to access the Felix Policy Sync API.
+
+**Verify Felix Policy Sync API**:
+
+```bash
+kubectl get felixconfiguration default -o yaml | grep policySyncPathPrefix
+```
+
+Should show: `policySyncPathPrefix: /var/run/nodeagent`
+
+### All requests returning 403
+
+This is **expected behavior** when no allow policies are configured. Dikastes enforces default-deny for security.
+
+To allow traffic, create $[prodname] network policies that explicitly permit the desired traffic.
+
+### Envoy cannot reach istio-pilot
+
+If you have egress policies applied to your pods, Envoy needs access to the Istio control plane.
+
+Apply the allow policy:
+
+```bash
+kubectl apply -f $[tutorialFilesURL]/allow-istio-pilot.yaml
+```
+
+### Warning about BPF load balancing
+
+If you see this warning during installation:
+
+```
+detected Calico CNI with 'bpfConnectTimeLoadBalancing=TCP';
+this must be set to 'bpfConnectTimeLoadBalancing=Disabled'
+```
+
+This may affect connection-level load balancing but does not prevent basic functionality. For production deployments, disable BPF connect-time load balancing:
+
+```bash
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"bpfConnectTimeLoadBalancing":"Disabled"}}'
+```
+
+## Legacy Installation (ConfigMap Patching)
+
+:::note
+
+This method is supported but not recommended for new deployments. Use the IstioOperator method instead.
+
+:::
+
+If you need to use the legacy ConfigMap patching method for Istio 1.15 or 1.10:
+
+### For Istio v1.15.x:
 
 ```bash
 curl $[manifestsUrl]/manifests/alp/istio-inject-configmap-1.15.yaml -o istio-inject-configmap.yaml
@@ -148,8 +485,7 @@ kubectl patch configmap -n istio-system istio-sidecar-injector --patch "$(cat is
 
 [View sample manifest]($[manifestsUrl]/manifests/alp/istio-inject-configmap-1.15.yaml)
 
-</TabItem>
-<TabItem label="Istio v1.10.x" value="Istio v1.10.x-3">
+### For Istio v1.10.x:
 
 ```bash
 curl $[manifestsUrl]/manifests/alp/istio-inject-configmap-1.10.yaml -o istio-inject-configmap.yaml
@@ -158,45 +494,17 @@ kubectl patch configmap -n istio-system istio-sidecar-injector --patch "$(cat is
 
 [View sample manifest]($[manifestsUrl]/manifests/alp/istio-inject-configmap-1.10.yaml)
 
-</TabItem>
-</Tabs>
+**Drawbacks of ConfigMap patching**:
 
-### Add Calico authorization services to the mesh
-
-Apply the following manifest to configure Istio to query $[prodname] for application layer policy authorization decisions.
-
-This applies to Istio v1.15.x and v1.10.x:
-
-```bash
-kubectl apply -f $[manifestsUrl]/manifests/alp/istio-app-layer-policy-envoy-v3.yaml
-```
-
-[View sample manifest]($[manifestsUrl]/manifests/alp/istio-app-layer-policy-envoy-v3.yaml)
-
-### Add namespace labels
-
-You can control enforcement of application layer policy on a per-namespace basis. However, this only works on pods that are started with the Envoy and $[prodname] Dikastes sidecars (as noted in the step, Update Istio sidecar injector). Pods that do not have the $[prodname] sidecars, enforce only standard $[prodname] network policy.
-
-To enable Istio and application layer policy in a namespace, add the label `istio-injection=enabled`.
-
-```bash
-kubectl label namespace <your namespace name> istio-injection=enabled
-```
-
-If the namespace already has pods in it, you must recreate them for this to take effect.
-
-:::note
-
-Envoy must be able to communicate with the `istio-pilot.istio-system service`. If you apply any egress policies to your pods, you _must_ enable access.
-
-```bash
-kubectl apply -f $[tutorialFilesURL]/allow-istio-pilot.yaml
-```
-
-:::
+- Not declarative (imperative command)
+- Not version-controlled
+- Must be re-applied after Istio upgrades
+- Difficult to audit and review
 
 ## Additional resources
 
 - [Enforce network policy using Istio tutorial](enforce-policy-istio.mdx)
 - [Use HTTP methods and paths in policy rules](http-methods.mdx)
-- [Hands-on workshop: Learn how to deploy access control, encryption & auth at the application level](https://www.tigera.io/tutorials/?_sf_s=Deploy%20Service%20Mesh)
+- [Istio Documentation](https://istio.io/latest/docs/)
+- [IstioOperator API Reference](https://istio.io/latest/docs/reference/config/istio.operator.v1alpha1/)
+- [Kubernetes Native Sidecars](https://kubernetes.io/blog/2023/08/25/native-sidecar-containers/)


### PR DESCRIPTION
Product Version(s):
Calico OSS (latest)

Issue:
N/A

Link to docs preview:
Will be added after preview builds

SME review:
- [ ] An SME has approved this change.

DOCS review:
- [ ] A member of the docs team has approved this change.

Additional information:
Updated the Istio integration documentation to support the latest Istio v1.28.1 using the modern IstioOperator approach. The legacy ConfigMap patching method has been moved to a dedicated section for backwards compatibility.

Merge checklist:
- [ ] Deploy preview inspected wherever changes were made
- [ ] Build completed successfully
- [ ] Test have passed