### PR TITLE
Rename VPP manifest file to match the current configuration

### DIFF
--- a/calico/getting-started/kubernetes/vpp/openshift.mdx
+++ b/calico/getting-started/kubernetes/vpp/openshift.mdx
@@ -93,11 +93,11 @@ cd ..
 cp vpp/* manifests/
 ```
 
-Make sure that `SERVICE_PREFIX` in `manifests/03-configmap-calico-vpp-resources.yaml` matches the service CIDR of the cluster:
+Make sure that `SERVICE_PREFIX` in `manifests/02-configmap-calico-vpp-resources.yaml` matches the service CIDR of the cluster:
 
 ```bash
 SERVICE_CIDR=`grep -A1 serviceNetwork: ./manifests/cluster-config.yaml | tail -n1 | cut -d '-' -f2`
-sed -i "s#SERVICE_PREFIX:.*#SERVICE_PREFIX:$SERVICE_CIDR#" ./manifests/03-configmap-calico-vpp-resources.yaml
+sed -i "s#SERVICE_PREFIX:.*#SERVICE_PREFIX:$SERVICE_CIDR#" ./manifests/02-configmap-calico-vpp-resources.yaml
 ```
 
 ### Optionally provide additional configuration
@@ -108,7 +108,7 @@ If you do not need to provide additional configuration, you can skip this sectio
 
 To include [Calico resources](../../../reference/resources/index.mdx) during installation, edit `manifests/02-configmap-calico-resources.yaml` to add your own configuration.
 
-To customize the configuration of the VPP data plane, edit `manifests/03-configmap-calico-vpp-resources.yaml`. For details refer to the **Configuration options** section of [Getting Started](./getting-started.mdx).
+To customize the configuration of the VPP data plane, edit `manifests/02-configmap-calico-vpp-resources.yaml`. For details refer to the **Configuration options** section of [Getting Started](./getting-started.mdx).
 
 :::note
 

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/vpp/openshift.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/vpp/openshift.mdx
@@ -93,11 +93,11 @@ cd ..
 cp vpp/* manifests/
 ```
 
-Make sure that `SERVICE_PREFIX` in `manifests/03-configmap-calico-vpp-resources.yaml` matches the service CIDR of the cluster:
+Make sure that `SERVICE_PREFIX` in `manifests/02-configmap-calico-vpp-resources.yaml` matches the service CIDR of the cluster:
 
 ```bash
 SERVICE_CIDR=`grep -A1 serviceNetwork: ./manifests/cluster-config.yaml | tail -n1 | cut -d '-' -f2`
-sed -i "s#SERVICE_PREFIX:.*#SERVICE_PREFIX:$SERVICE_CIDR#" ./manifests/03-configmap-calico-vpp-resources.yaml
+sed -i "s#SERVICE_PREFIX:.*#SERVICE_PREFIX:$SERVICE_CIDR#" ./manifests/02-configmap-calico-vpp-resources.yaml
 ```
 
 ### Optionally provide additional configuration
@@ -108,7 +108,7 @@ If you do not need to provide additional configuration, you can skip this sectio
 
 To include [Calico resources](../../../reference/resources/index.mdx) during installation, edit `manifests/02-configmap-calico-resources.yaml` to add your own configuration.
 
-To customize the configuration of the VPP data plane, edit `manifests/03-configmap-calico-vpp-resources.yaml`. For details refer to the **Configuration options** section of [Getting Started](./getting-started.mdx).
+To customize the configuration of the VPP data plane, edit `manifests/02-configmap-calico-vpp-resources.yaml`. For details refer to the **Configuration options** section of [Getting Started](./getting-started.mdx).
 
 :::note
 

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/vpp/openshift.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/vpp/openshift.mdx
@@ -93,11 +93,11 @@ cd ..
 cp vpp/* manifests/
 ```
 
-Make sure that `SERVICE_PREFIX` in `manifests/03-configmap-calico-vpp-resources.yaml` matches the service CIDR of the cluster:
+Make sure that `SERVICE_PREFIX` in `manifests/02-configmap-calico-vpp-resources.yaml` matches the service CIDR of the cluster:
 
 ```bash
 SERVICE_CIDR=`grep -A1 serviceNetwork: ./manifests/cluster-config.yaml | tail -n1 | cut -d '-' -f2`
-sed -i "s#SERVICE_PREFIX:.*#SERVICE_PREFIX:$SERVICE_CIDR#" ./manifests/03-configmap-calico-vpp-resources.yaml
+sed -i "s#SERVICE_PREFIX:.*#SERVICE_PREFIX:$SERVICE_CIDR#" ./manifests/02-configmap-calico-vpp-resources.yaml
 ```
 
 ### Optionally provide additional configuration
@@ -108,7 +108,7 @@ If you do not need to provide additional configuration, you can skip this sectio
 
 To include [Calico resources](../../../reference/resources/index.mdx) during installation, edit `manifests/02-configmap-calico-resources.yaml` to add your own configuration.
 
-To customize the configuration of the VPP data plane, edit `manifests/03-configmap-calico-vpp-resources.yaml`. For details refer to the **Configuration options** section of [Getting Started](./getting-started.mdx).
+To customize the configuration of the VPP data plane, edit `manifests/02-configmap-calico-vpp-resources.yaml`. For details refer to the **Configuration options** section of [Getting Started](./getting-started.mdx).
 
 :::note
 

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/vpp/openshift.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/vpp/openshift.mdx
@@ -93,11 +93,11 @@ cd ..
 cp vpp/* manifests/
 ```
 
-Make sure that `SERVICE_PREFIX` in `manifests/03-configmap-calico-vpp-resources.yaml` matches the service CIDR of the cluster:
+Make sure that `SERVICE_PREFIX` in `manifests/02-configmap-calico-vpp-resources.yaml` matches the service CIDR of the cluster:
 
 ```bash
 SERVICE_CIDR=`grep -A1 serviceNetwork: ./manifests/cluster-config.yaml | tail -n1 | cut -d '-' -f2`
-sed -i "s#SERVICE_PREFIX:.*#SERVICE_PREFIX:$SERVICE_CIDR#" ./manifests/03-configmap-calico-vpp-resources.yaml
+sed -i "s#SERVICE_PREFIX:.*#SERVICE_PREFIX:$SERVICE_CIDR#" ./manifests/02-configmap-calico-vpp-resources.yaml
 ```
 
 ### Optionally provide additional configuration
@@ -108,7 +108,7 @@ If you do not need to provide additional configuration, you can skip this sectio
 
 To include [Calico resources](../../../reference/resources/index.mdx) during installation, edit `manifests/02-configmap-calico-resources.yaml` to add your own configuration.
 
-To customize the configuration of the VPP data plane, edit `manifests/03-configmap-calico-vpp-resources.yaml`. For details refer to the **Configuration options** section of [Getting Started](./getting-started.mdx).
+To customize the configuration of the VPP data plane, edit `manifests/02-configmap-calico-vpp-resources.yaml`. For details refer to the **Configuration options** section of [Getting Started](./getting-started.mdx).
 
 :::note
 


### PR DESCRIPTION
Rename `03-configmap-calico-vpp-resources.yaml` to `02-configmap-calico-vpp-resources.yaml` to match the current configuration.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->