### PR TITLE
Add new doc set selection cards

### DIFF
--- a/src/___new___/components/InnerLayout/innerLayout.js
+++ b/src/___new___/components/InnerLayout/innerLayout.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import SelectDocs from '../SelectDocs';
+import SelectDocSet from '../SelectDocSet';
 import HomepageHeader from '../HomepageHeader';
 import ProductComparison from '../ProductComparison';
 import ProductInfo from '../ProductInfo';
@@ -24,7 +24,7 @@ export default function Home() {
 
       <Grid
         gap={0}
-        templateAreas={'"selectdocs"  "productinfo" "productcomparison" "featuretablecomparison" '}
+        templateAreas={'"selectdocset"  "productinfo" "productcomparison" "featuretablecomparison" '}
         templateColumns={'1fr'}
         // note: just loose heights for now, not based on wireframes, please change!
         //minmax(720px, max-content) for explore
@@ -33,11 +33,11 @@ export default function Home() {
         }
       >
         <GridItem
-          gridArea='selectdocs'
+          gridArea='selectdocset'
           as='section'
           data-testid='selectdocs-section'
         >
-          <SelectDocs isDarkMode={isDarkMode} />
+          <SelectDocSet isDarkMode={isDarkMode} />
         </GridItem>
 
         <GridItem

--- a/src/___new___/components/SelectDocSet/index.tsx
+++ b/src/___new___/components/SelectDocSet/index.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { Box, Flex, Text, SystemStyleObject, Stack, Heading, Button } from '@chakra-ui/react';
+import Link from '@docusaurus/Link';
+
+import { heading2Styles } from '../styles';
+import {
+  sectionOuterStyles,
+  rectangleStyle,
+  stackStyle,
+  headerTextStyle,
+} from './styles';
+
+import { docCardsInfo } from '../../data/docCardsInfo';
+
+interface SelectDocsProps {
+  sx?: SystemStyleObject;
+  isDarkMode: boolean;
+}
+
+const SelectDocs: React.FC<SelectDocsProps> = ({ isDarkMode, ...rest }) => (
+  <Flex
+    sx={sectionOuterStyles(isDarkMode)}
+    {...rest}
+    flexDirection="column"
+  >
+    <Heading
+      as='h2'
+      size='md'
+      sx={{ ...heading2Styles(isDarkMode), ...headerTextStyle }}
+      textAlign="center"
+      mb={10}
+    >
+    Products
+    </Heading>
+
+    <Stack
+      sx={stackStyle}
+      // 'stretch' ensures all cards in a row have the same height
+      direction={['column', 'column', 'column', 'column', 'row', 'row', 'row']}
+      spacing={6}
+      alignItems="stretch"
+      justifyContent="center"
+    >
+      {docCardsInfo.map((info, index) => (
+        <Box
+          key={index}
+          sx={{
+            ...rectangleStyle,
+            maxWidth: '400px',
+            width: '100%',
+            height: 'auto',
+          }}
+          flex="0 1 auto"
+          display="flex"
+          flexDirection="column"
+          justifyContent="center"
+          alignItems="center"
+          textAlign="center"
+          padding="40px 24px"
+          gap="16px"
+        >
+          <Box>
+            <Heading as="h3" size="m" mb={4} color={isDarkMode ? 'white' : 'black'}>
+              {info.heading}
+            </Heading>
+            <Text fontSize="sm" color={isDarkMode ? 'gray.400' : 'gray.600'}>
+              {info.caption}
+            </Text>
+          </Box>
+
+          <Box mt={8}>
+            <Link href={info.link} style={{ textDecoration: 'none' }}>
+              <Button
+                bg="#F89C1D"
+                color="white"
+                px={8}
+                fontWeight="bold"
+                borderRadius="md"
+                transition="background 0.2s ease-in-out"
+                _hover={{
+                  bg: '#E0891A',
+                  textDecoration: 'none'
+                }}
+                _active={{
+                  bg: '#C77916'
+                }}
+              >
+                Go to docs
+              </Button>
+            </Link>
+          </Box>
+        </Box>
+      ))}
+    </Stack>
+  </Flex>
+);
+
+export default SelectDocs;

--- a/src/___new___/components/SelectDocSet/index.tsx
+++ b/src/___new___/components/SelectDocSet/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Box, Flex, Text, SystemStyleObject, Stack, Heading, Button } from '@chakra-ui/react';
+import { ArrowForwardIcon } from '@chakra-ui/icons';
 import Link from '@docusaurus/Link';
 
 import { heading2Styles } from '../styles';
@@ -30,66 +31,74 @@ const SelectDocs: React.FC<SelectDocsProps> = ({ isDarkMode, ...rest }) => (
       textAlign="center"
       mb={10}
     >
-    Products
+      Products
     </Heading>
 
     <Stack
       sx={stackStyle}
-      // 'stretch' ensures all cards in a row have the same height
       direction={['column', 'column', 'column', 'column', 'row', 'row', 'row']}
       spacing={6}
       alignItems="stretch"
       justifyContent="center"
     >
       {docCardsInfo.map((info, index) => (
-        <Box
+        <Link
           key={index}
-          sx={{
-            ...rectangleStyle,
-            maxWidth: '400px',
-            width: '100%',
-            height: 'auto',
-          }}
-          flex="0 1 auto"
-          display="flex"
-          flexDirection="column"
-          justifyContent="center"
-          alignItems="center"
-          textAlign="center"
-          padding="40px 24px"
-          gap="16px"
+          href={info.link}
+          style={{ textDecoration: 'none', display: 'flex' }}
         >
-          <Box>
-            <Heading as="h3" size="m" mb={4} color={isDarkMode ? 'white' : 'black'}>
-              {info.heading}
-            </Heading>
-            <Text fontSize="sm" color={isDarkMode ? 'gray.400' : 'gray.600'}>
-              {info.caption}
-            </Text>
-          </Box>
+          <Box
+            role="group"
+            sx={{
+              ...rectangleStyle,
+              maxWidth: '400px',
+              width: '100%',
+              height: 'auto',
+              backgroundColor: 'white',
+              cursor: 'pointer',
+              transition: 'transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out',
+            }}
+            _hover={{
+              transform: 'translateY(-4px)',
+              boxShadow: 'lg',
+            }}
+            flex="1 1 auto"
+            display="flex"
+            flexDirection="column"
+            justifyContent="center"
+            // Changed from 'center' to 'flex-start' for left alignment
+            alignItems="flex-start"
+            textAlign="left"
+            padding="40px 24px"
+            gap="16px"
+          >
+            <Box width="100%">
+              <Heading as="h3" size="md" mb={4} color="black">
+                {info.heading}
+              </Heading>
+              <Text fontSize="sm" color="gray.700">
+                {info.caption}
+              </Text>
+            </Box>
 
-          <Box mt={8}>
-            <Link href={info.link} style={{ textDecoration: 'none' }}>
+            <Box mt={8}>
               <Button
-                bg="#F89C1D"
-                color="white"
-                px={8}
+                variant="unstyled"
+                display="inline-flex"
+                alignItems="center" // Keeps text and arrow vertically aligned
+                rightIcon={<ArrowForwardIcon />}
+                color="black"
                 fontWeight="bold"
-                borderRadius="md"
-                transition="background 0.2s ease-in-out"
-                _hover={{
-                  bg: '#E0891A',
-                  textDecoration: 'none'
-                }}
-                _active={{
-                  bg: '#C77916'
-                }}
+                fontSize="md"
+                height="auto"
+                p={0}
+                pointerEvents="none"
               >
-                Go to docs
+                Go to documentation
               </Button>
-            </Link>
+            </Box>
           </Box>
-        </Box>
+        </Link>
       ))}
     </Stack>
   </Flex>

--- a/src/___new___/components/SelectDocSet/styles.ts
+++ b/src/___new___/components/SelectDocSet/styles.ts
@@ -1,0 +1,71 @@
+export default {};
+
+export const sectionOuterStyles = (hasDarkBg: boolean) => ({
+  flexDirection: 'column',
+  h: 'auto',
+  w: '100%',
+  bg: hasDarkBg ? 'tigeraBlack' : 'tigeraGrey.100',
+  pb: '60px',
+});
+
+export const stackStyle = {
+  justifyContent: 'center',
+  h: 'auto',
+  alignItems: 'center',
+  mb: -2,
+  px: [4, 0],
+};
+
+export const headerTextStyle = {
+  textAlign: 'center',
+  pt: 14,
+  mb: 4,
+};
+
+export const subHeaderTextStyle = {
+  fontWeight: '600',
+  textAlign: 'center',
+  mt: 7,
+  fontSize: '2xl',
+  lineHeight: 9,
+};
+
+export const innerTextStyle = {
+  textAlign: 'center',
+  fontSize: 'xl',
+  fontWeight: 'normal',
+  color: 'tigeraGrey.800',
+  mx: '44px',
+  mb: 10,
+  mt: 2,
+  lineHeight: 8,
+};
+
+export const iconContainerStyle = {
+  display: 'flex',
+  justifyContent: 'center',
+  pt: '44px',
+};
+
+export const iconStyle = {
+  width: 32,
+  height: 32,
+};
+
+export const rectangleStyle = {
+  minW: ['290px', '371px'],
+  border: '1px',
+  borderColor: 'tigeraCloudGrey',
+  borderRadius: 'lg',
+  bg: 'tigeraWhite',
+  ml: [0, 4],
+  mr: [0, 4],
+  mt: [4, 4, 4, 4, ''],
+  mb: [4, 4, 4, 4, ''],
+  pb: '40px',
+};
+
+export const actionBoxStyles = {
+  mb: 14,
+  justifyContent: 'center',
+};

--- a/src/___new___/data/docCardsInfo.ts
+++ b/src/___new___/data/docCardsInfo.ts
@@ -1,0 +1,19 @@
+// data/docsCardsData.ts
+
+export const docCardsInfo = [
+  {
+    heading: 'Calico Open Source',
+    caption: 'Open source networking and network security for containers and VMs.',
+    link: '/calico/latest/about',
+  },
+  {
+    heading: 'Calico Enterprise',
+    caption: 'Advanced security and observability for multi-cluster deployments.',
+    link: '/calico-enterprise/latest/about',
+  },
+  {
+    heading: 'Calico Cloud',
+    caption: 'A full-stack security service for your cloud-native applications.',
+    link: '/calico-cloud/about',
+  },
+];


### PR DESCRIPTION
This commit adds the SelectDocSet component, which replaces SelectDocs. We're introducing a new Calico icon that does not include versions for different products. Because the old cards were focused on the icons, the cards had to be redesigned.
<img width="1543" height="867" alt="image" src="https://github.com/user-attachments/assets/8895420e-78cc-4079-a40e-7ac4b66f6f4d" />

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->