### PR TITLE
DOCS-2828: Fix error in Istio ambient mode docs

### DIFF
--- a/calico-cloud/compliance/istio/about-istio-ambient.mdx
+++ b/calico-cloud/compliance/istio/about-istio-ambient.mdx
@@ -5,7 +5,7 @@ description: An overview of Calico's bundled version of Istio Ambient Mode
 # Istio Ambient Mode
 
 You can use $[prodname] to deploy and manage an Istio service mesh on your cluster.
-$[prodname] installs Istio in ambient mode, which conserves resources while providing the same robust mTLS encryption for your services.
+$[prodname] installs Istio in ambient mode, which conserves resources while providing the same robust mTLS encryption for your workloads.
 
 :::note
 

--- a/calico-cloud/compliance/istio/deploy-istio-ambient.mdx
+++ b/calico-cloud/compliance/istio/deploy-istio-ambient.mdx
@@ -77,7 +77,7 @@ You can create an Istio service mesh in ambient mode by creating the `Istio` cus
 ## Add a workload to the Istio service mesh
 
 You can add workloads to the mesh by labeling them.
-Communication between labelled namespaces and services goes through the mesh and uses mTLS encryption.
+Communication between labelled namespaces and pods goes through the mesh and uses mTLS encryption.
 
 :::warning
 
@@ -87,30 +87,30 @@ Doing this can cause interruptions and failure to your cluster network.
 If you want to secure $[prodname] components, see [Secure Calico component communications](../../operations/comms/index.mdx).
 :::
 
-1. To add workloads to your Istio service mesh, add the `istio.io/dataplane-mode=ambient` label to a service or namespace resource:
+1. To add workloads to your Istio service mesh, add the `istio.io/dataplane-mode=ambient` label to a pod or namespace resource:
 
    ```bash title='Adding a namespace to the Istio service mesh'
    kubectl label namespace <namespace> istio.io/dataplane-mode=ambient
    ```
    Replace `<namespace>` with the namespace you want to include in the mesh.
 
-   ```bash title='Adding a service to the Istio service mesh'
-   kubectl label service --namespace=<namespace> <service> istio.io/dataplane-mode=ambient
+   ```bash title='Adding a pod to the Istio service mesh'
+   kubectl label pod --namespace=<namespace> <pod> istio.io/dataplane-mode=ambient
    ```
    Replace the following:
-   * `<service>`: The name of the service you want to include in the mesh.
-   * `<namespace>`: The namespace your service is in.
+   * `<pod>`: The name of the pod you want to include in the mesh.
+   * `<namespace>`: The namespace your pod is in.
 
 ## Removing Istio
 
-If you want to remove Istio, first remove the labels you applied to services and namespaces.
+If you want to remove Istio, first remove the labels you applied to pods and namespaces.
 When that's done, you can delete the `Istio` custom resource.
 
-1. Remove the label from namespaces and services by running the following commands:
+1. Remove the label from namespaces and pods by running the following commands:
 
    ```bash
    kubectl label namespaces --all istio.io/dataplane-mode=ambient-
-   kubectl label services --all --all-namespaces istio.io/dataplane-mode=ambient-
+   kubectl label pods --all --all-namespaces istio.io/dataplane-mode=ambient-
    ```
 1. Remove the `Istio` custom resource:
 
@@ -132,7 +132,7 @@ Check whether Istio CRDs are deployed:
 kubectl get crd | grep istio
 ```
 
-Check which services and namespaces are in the mesh:
+Check which pods and namespaces are in the mesh:
 
 * Requires [istioctl](https://istio.io/latest/docs/ops/diagnostic-tools/istioctl/).
 

--- a/calico-enterprise/compliance/istio/about-istio-ambient.mdx
+++ b/calico-enterprise/compliance/istio/about-istio-ambient.mdx
@@ -5,7 +5,7 @@ description: An overview of Calico's bundled version of Istio Ambient Mode
 # Istio Ambient Mode
 
 You can use $[prodname] to deploy and manage an Istio service mesh on your cluster.
-$[prodname] installs Istio in ambient mode, which conserves resources while providing the same robust mTLS encryption for your services.
+$[prodname] installs Istio in ambient mode, which conserves resources while providing the same robust mTLS encryption for your workloads.
 
 :::note
 

--- a/calico-enterprise/compliance/istio/deploy-istio-ambient.mdx
+++ b/calico-enterprise/compliance/istio/deploy-istio-ambient.mdx
@@ -77,7 +77,7 @@ You can create an Istio service mesh in ambient mode by creating the `Istio` cus
 ## Add a workload to the Istio service mesh
 
 You can add workloads to the mesh by labeling them.
-Communication between labelled namespaces and services goes through the mesh and uses mTLS encryption.
+Communication between labelled namespaces and pods goes through the mesh and uses mTLS encryption.
 
 :::warning
 
@@ -87,30 +87,30 @@ Doing this can cause interruptions and failure to your cluster network.
 If you want to secure $[prodname] components, see [Secure Calico component communications](../../operations/comms/index.mdx).
 :::
 
-1. To add workloads to your Istio service mesh, add the `istio.io/dataplane-mode=ambient` label to a service or namespace resource:
+1. To add workloads to your Istio service mesh, add the `istio.io/dataplane-mode=ambient` label to a pod or namespace resource:
 
    ```bash title='Adding a namespace to the Istio service mesh'
    kubectl label namespace <namespace> istio.io/dataplane-mode=ambient
    ```
    Replace `<namespace>` with the namespace you want to include in the mesh.
 
-   ```bash title='Adding a service to the Istio service mesh'
-   kubectl label service --namespace=<namespace> <service> istio.io/dataplane-mode=ambient
+   ```bash title='Adding a pod to the Istio service mesh'
+   kubectl label pod --namespace=<namespace> <pod> istio.io/dataplane-mode=ambient
    ```
    Replace the following:
-   * `<service>`: The name of the service you want to include in the mesh.
-   * `<namespace>`: The namespace your service is in.
+   * `<pod>`: The name of the pod you want to include in the mesh.
+   * `<namespace>`: The namespace your pod is in.
 
 ## Removing Istio
 
-If you want to remove Istio, first remove the labels you applied to services and namespaces.
+If you want to remove Istio, first remove the labels you applied to pods and namespaces.
 When that's done, you can delete the `Istio` custom resource.
 
-1. Remove the label from namespaces and services by running the following commands:
+1. Remove the label from namespaces and pods by running the following commands:
 
    ```bash
    kubectl label namespaces --all istio.io/dataplane-mode=ambient-
-   kubectl label services --all --all-namespaces istio.io/dataplane-mode=ambient-
+   kubectl label pods --all --all-namespaces istio.io/dataplane-mode=ambient-
    ```
 1. Remove the `Istio` custom resource:
 
@@ -132,7 +132,7 @@ Check whether Istio CRDs are deployed:
 kubectl get crd | grep istio
 ```
 
-Check which services and namespaces are in the mesh:
+Check which pods and namespaces are in the mesh:
 
 * Requires [istioctl](https://istio.io/latest/docs/ops/diagnostic-tools/istioctl/).
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/compliance/istio/about-istio-ambient.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/compliance/istio/about-istio-ambient.mdx
@@ -5,7 +5,7 @@ description: An overview of Calico's bundled version of Istio Ambient Mode
 # Istio Ambient Mode
 
 You can use $[prodname] to deploy and manage an Istio service mesh on your cluster.
-$[prodname] installs Istio in ambient mode, which conserves resources while providing the same robust mTLS encryption for your services.
+$[prodname] installs Istio in ambient mode, which conserves resources while providing the same robust mTLS encryption for your workloads.
 
 :::note
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/compliance/istio/deploy-istio-ambient.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/compliance/istio/deploy-istio-ambient.mdx
@@ -77,7 +77,7 @@ You can create an Istio service mesh in ambient mode by creating the `Istio` cus
 ## Add a workload to the Istio service mesh
 
 You can add workloads to the mesh by labeling them.
-Communication between labelled namespaces and services goes through the mesh and uses mTLS encryption.
+Communication between labelled namespaces and pods goes through the mesh and uses mTLS encryption.
 
 :::warning
 
@@ -87,30 +87,30 @@ Doing this can cause interruptions and failure to your cluster network.
 If you want to secure $[prodname] components, see [Secure Calico component communications](../../operations/comms/index.mdx).
 :::
 
-1. To add workloads to your Istio service mesh, add the `istio.io/dataplane-mode=ambient` label to a service or namespace resource:
+1. To add workloads to your Istio service mesh, add the `istio.io/dataplane-mode=ambient` label to a pod or namespace resource:
 
    ```bash title='Adding a namespace to the Istio service mesh'
    kubectl label namespace <namespace> istio.io/dataplane-mode=ambient
    ```
    Replace `<namespace>` with the namespace you want to include in the mesh.
 
-   ```bash title='Adding a service to the Istio service mesh'
-   kubectl label service --namespace=<namespace> <service> istio.io/dataplane-mode=ambient
+   ```bash title='Adding a pod to the Istio service mesh'
+   kubectl label pod --namespace=<namespace> <pod> istio.io/dataplane-mode=ambient
    ```
    Replace the following:
-   * `<service>`: The name of the service you want to include in the mesh.
-   * `<namespace>`: The namespace your service is in.
+   * `<pod>`: The name of the pod you want to include in the mesh.
+   * `<namespace>`: The namespace your pod is in.
 
 ## Removing Istio
 
-If you want to remove Istio, first remove the labels you applied to services and namespaces.
+If you want to remove Istio, first remove the labels you applied to pods and namespaces.
 When that's done, you can delete the `Istio` custom resource.
 
-1. Remove the label from namespaces and services by running the following commands:
+1. Remove the label from namespaces and pods by running the following commands:
 
    ```bash
    kubectl label namespaces --all istio.io/dataplane-mode=ambient-
-   kubectl label services --all --all-namespaces istio.io/dataplane-mode=ambient-
+   kubectl label pods --all --all-namespaces istio.io/dataplane-mode=ambient-
    ```
 1. Remove the `Istio` custom resource:
 
@@ -132,7 +132,7 @@ Check whether Istio CRDs are deployed:
 kubectl get crd | grep istio
 ```
 
-Check which services and namespaces are in the mesh:
+Check which pods and namespaces are in the mesh:
 
 * Requires [istioctl](https://istio.io/latest/docs/ops/diagnostic-tools/istioctl/).
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/compliance/istio/about-istio-ambient.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/compliance/istio/about-istio-ambient.mdx
@@ -5,7 +5,7 @@ description: An overview of Calico's bundled version of Istio Ambient Mode
 # Istio Ambient Mode
 
 You can use $[prodname] to deploy and manage an Istio service mesh on your cluster.
-$[prodname] installs Istio in ambient mode, which conserves resources while providing the same robust mTLS encryption for your services.
+$[prodname] installs Istio in ambient mode, which conserves resources while providing the same robust mTLS encryption for your workloads.
 
 :::note
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/compliance/istio/deploy-istio-ambient.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/compliance/istio/deploy-istio-ambient.mdx
@@ -77,7 +77,7 @@ You can create an Istio service mesh in ambient mode by creating the `Istio` cus
 ## Add a workload to the Istio service mesh
 
 You can add workloads to the mesh by labeling them.
-Communication between labelled namespaces and services goes through the mesh and uses mTLS encryption.
+Communication between labelled namespaces and pods goes through the mesh and uses mTLS encryption.
 
 :::warning
 
@@ -87,30 +87,30 @@ Doing this can cause interruptions and failure to your cluster network.
 If you want to secure $[prodname] components, see [Secure Calico component communications](../../operations/comms/index.mdx).
 :::
 
-1. To add workloads to your Istio service mesh, add the `istio.io/dataplane-mode=ambient` label to a service or namespace resource:
+1. To add workloads to your Istio service mesh, add the `istio.io/dataplane-mode=ambient` label to a pod or namespace resource:
 
    ```bash title='Adding a namespace to the Istio service mesh'
    kubectl label namespace <namespace> istio.io/dataplane-mode=ambient
    ```
    Replace `<namespace>` with the namespace you want to include in the mesh.
 
-   ```bash title='Adding a service to the Istio service mesh'
-   kubectl label service --namespace=<namespace> <service> istio.io/dataplane-mode=ambient
+   ```bash title='Adding a pod to the Istio service mesh'
+   kubectl label pod --namespace=<namespace> <pod> istio.io/dataplane-mode=ambient
    ```
    Replace the following:
-   * `<service>`: The name of the service you want to include in the mesh.
-   * `<namespace>`: The namespace your service is in.
+   * `<pod>`: The name of the pod you want to include in the mesh.
+   * `<namespace>`: The namespace your pod is in.
 
 ## Removing Istio
 
-If you want to remove Istio, first remove the labels you applied to services and namespaces.
+If you want to remove Istio, first remove the labels you applied to pods and namespaces.
 When that's done, you can delete the `Istio` custom resource.
 
-1. Remove the label from namespaces and services by running the following commands:
+1. Remove the label from namespaces and pods by running the following commands:
 
    ```bash
    kubectl label namespaces --all istio.io/dataplane-mode=ambient-
-   kubectl label services --all --all-namespaces istio.io/dataplane-mode=ambient-
+   kubectl label pods --all --all-namespaces istio.io/dataplane-mode=ambient-
    ```
 1. Remove the `Istio` custom resource:
 
@@ -132,7 +132,7 @@ Check whether Istio CRDs are deployed:
 kubectl get crd | grep istio
 ```
 
-Check which services and namespaces are in the mesh:
+Check which pods and namespaces are in the mesh:
 
 * Requires [istioctl](https://istio.io/latest/docs/ops/diagnostic-tools/istioctl/).
 


### PR DESCRIPTION
The docs for Istio ambient mode mistakenly described labelling
namespaces and services to create the mesh. These labels work
only for namespaces and pods, not services.

DOCS-2828

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->