### PR TITLE
fix(windows): add non-cross-subnet requirement to VXLAN encapsulation to Windows docs

### DIFF
--- a/calico-enterprise/_includes/components/CalicoWindowsInstall.js
+++ b/calico-enterprise/_includes/components/CalicoWindowsInstall.js
@@ -9,6 +9,16 @@ import { prodname, prodnameWindows } from '../../variables';
 function CalicoWindowsInstallFirstStep(props) {
   if (props.networkingType === 'vxlan') {
     return (
+      <>
+      <li>
+        Ensure that cross-subnet encapsulation is disabled. You must use <code>VXLAN</code> and NOT <code>VXLANCrossSubnet</code>
+        as the <code>encapsulation:</code> of your IP pool. Use this command to change it if you only have one IP pool configured:
+        <br />
+        <br />
+        <CodeBlock language='bash'>
+          {`kubectl patch installation default --type='json' -p='[{"op": "replace", "path": "/spec/calicoNetwork/ipPools/0/encapsulation", "value": "VXLAN"}]`}
+        </CodeBlock>
+      </li>
       <li>
         Ensure that BGP is disabled.
         <ul>
@@ -20,6 +30,7 @@ function CalicoWindowsInstallFirstStep(props) {
           </CodeBlock>
         </ul>
       </li>
+      </>
     );
   }
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/CalicoWindowsInstall.js
+++ b/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/CalicoWindowsInstall.js
@@ -9,6 +9,16 @@ import { prodname, prodnameWindows } from '../../variables';
 function CalicoWindowsInstallFirstStep(props) {
   if (props.networkingType === 'vxlan') {
     return (
+      <>
+      <li>
+        Ensure that cross-subnet encapsulation is disabled. You must use <code>VXLAN</code> and NOT <code>VXLANCrossSubnet</code>
+        as the <code>encapsulation:</code> of your IP pool. Use this command to change it if you only have one IP pool configured:
+        <br />
+        <br />
+        <CodeBlock language='bash'>
+          {`kubectl patch installation default --type='json' -p='[{"op": "replace", "path": "/spec/calicoNetwork/ipPools/0/encapsulation", "value": "VXLAN"}]`}
+        </CodeBlock>
+      </li>
       <li>
         Ensure that BGP is disabled.
         <ul>
@@ -20,6 +30,7 @@ function CalicoWindowsInstallFirstStep(props) {
           </CodeBlock>
         </ul>
       </li>
+      </>
     );
   }
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/CalicoWindowsInstall.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/CalicoWindowsInstall.js
@@ -9,6 +9,16 @@ import { prodname, prodnameWindows } from '../../variables';
 function CalicoWindowsInstallFirstStep(props) {
   if (props.networkingType === 'vxlan') {
     return (
+      <>
+      <li>
+        Ensure that cross-subnet encapsulation is disabled. You must use <code>VXLAN</code> and NOT <code>VXLANCrossSubnet</code>
+        as the <code>encapsulation:</code> of your IP pool. Use this command to change it if you only have one IP pool configured:
+        <br />
+        <br />
+        <CodeBlock language='bash'>
+          {`kubectl patch installation default --type='json' -p='[{"op": "replace", "path": "/spec/calicoNetwork/ipPools/0/encapsulation", "value": "VXLAN"}]`}
+        </CodeBlock>
+      </li>
       <li>
         Ensure that BGP is disabled.
         <ul>
@@ -20,6 +30,7 @@ function CalicoWindowsInstallFirstStep(props) {
           </CodeBlock>
         </ul>
       </li>
+      </>
     );
   }
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/CalicoWindowsInstall.js
+++ b/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/CalicoWindowsInstall.js
@@ -9,6 +9,16 @@ import { prodname, prodnameWindows } from '../../variables';
 function CalicoWindowsInstallFirstStep(props) {
   if (props.networkingType === 'vxlan') {
     return (
+      <>
+      <li>
+        Ensure that cross-subnet encapsulation is disabled. You must use <code>VXLAN</code> and NOT <code>VXLANCrossSubnet</code>
+        as the <code>encapsulation:</code> of your IP pool. Use this command to change it if you only have one IP pool configured:
+        <br />
+        <br />
+        <CodeBlock language='bash'>
+          {`kubectl patch installation default --type='json' -p='[{"op": "replace", "path": "/spec/calicoNetwork/ipPools/0/encapsulation", "value": "VXLAN"}]`}
+        </CodeBlock>
+      </li>
       <li>
         Ensure that BGP is disabled.
         <ul>
@@ -20,6 +30,7 @@ function CalicoWindowsInstallFirstStep(props) {
           </CodeBlock>
         </ul>
       </li>
+      </>
     );
   }
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/_includes/components/CalicoWindowsInstall.js
+++ b/calico-enterprise_versioned_docs/version-3.23-1/_includes/components/CalicoWindowsInstall.js
@@ -9,6 +9,16 @@ import { prodname, prodnameWindows } from '../../variables';
 function CalicoWindowsInstallFirstStep(props) {
   if (props.networkingType === 'vxlan') {
     return (
+      <>
+      <li>
+        Ensure that cross-subnet encapsulation is disabled. You must use <code>VXLAN</code> and NOT <code>VXLANCrossSubnet</code>
+        as the <code>encapsulation:</code> of your IP pool. Use this command to change it if you only have one IP pool configured:
+        <br />
+        <br />
+        <CodeBlock language='bash'>
+          {`kubectl patch installation default --type='json' -p='[{"op": "replace", "path": "/spec/calicoNetwork/ipPools/0/encapsulation", "value": "VXLAN"}]`}
+        </CodeBlock>
+      </li>
       <li>
         Ensure that BGP is disabled.
         <ul>
@@ -20,6 +30,7 @@ function CalicoWindowsInstallFirstStep(props) {
           </CodeBlock>
         </ul>
       </li>
+      </>
     );
   }
 

--- a/calico/_includes/components/CalicoWindowsInstall.js
+++ b/calico/_includes/components/CalicoWindowsInstall.js
@@ -9,6 +9,16 @@ import { prodname, prodnameWindows } from '../../variables';
 function CalicoWindowsInstallFirstStep(props) {
   if (props.networkingType === 'vxlan') {
     return (
+      <>
+      <li>
+        Ensure that cross-subnet encapsulation is disabled. You must use <code>VXLAN</code> and NOT <code>VXLANCrossSubnet</code>
+        as the <code>encapsulation:</code> of your IP pool. Use this command to change it if you only have one IP pool configured:
+        <br />
+        <br />
+        <CodeBlock language='bash'>
+          {`kubectl patch installation default --type='json' -p='[{"op": "replace", "path": "/spec/calicoNetwork/ipPools/0/encapsulation", "value": "VXLAN"}]`}
+        </CodeBlock>
+      </li>
       <li>
         Ensure that BGP is disabled.
         <ul>
@@ -20,6 +30,7 @@ function CalicoWindowsInstallFirstStep(props) {
           </CodeBlock>
         </ul>
       </li>
+      </>
     );
   }
 

--- a/calico_versioned_docs/version-3.29/_includes/components/CalicoWindowsInstall.js
+++ b/calico_versioned_docs/version-3.29/_includes/components/CalicoWindowsInstall.js
@@ -9,6 +9,16 @@ import { prodname, prodnameWindows } from '../../variables';
 function CalicoWindowsInstallFirstStep(props) {
   if (props.networkingType === 'vxlan') {
     return (
+      <>
+      <li>
+        Ensure that cross-subnet encapsulation is disabled. You must use <code>VXLAN</code> and NOT <code>VXLANCrossSubnet</code>
+        as the <code>encapsulation:</code> of your IP pool. Use this command to change it if you only have one IP pool configured:
+        <br />
+        <br />
+        <CodeBlock language='bash'>
+          {`kubectl patch installation default --type='json' -p='[{"op": "replace", "path": "/spec/calicoNetwork/ipPools/0/encapsulation", "value": "VXLAN"}]`}
+        </CodeBlock>
+      </li>
       <li>
         Ensure that BGP is disabled.
         <ul>
@@ -20,6 +30,7 @@ function CalicoWindowsInstallFirstStep(props) {
           </CodeBlock>
         </ul>
       </li>
+      </>
     );
   }
 

--- a/calico_versioned_docs/version-3.30/_includes/components/CalicoWindowsInstall.js
+++ b/calico_versioned_docs/version-3.30/_includes/components/CalicoWindowsInstall.js
@@ -9,6 +9,16 @@ import { prodname, prodnameWindows } from '../../variables';
 function CalicoWindowsInstallFirstStep(props) {
   if (props.networkingType === 'vxlan') {
     return (
+      <>
+      <li>
+        Ensure that cross-subnet encapsulation is disabled. You must use <code>VXLAN</code> and NOT <code>VXLANCrossSubnet</code>
+        as the <code>encapsulation:</code> of your IP pool. Use this command to change it if you only have one IP pool configured:
+        <br />
+        <br />
+        <CodeBlock language='bash'>
+          {`kubectl patch installation default --type='json' -p='[{"op": "replace", "path": "/spec/calicoNetwork/ipPools/0/encapsulation", "value": "VXLAN"}]`}
+        </CodeBlock>
+      </li>
       <li>
         Ensure that BGP is disabled.
         <ul>
@@ -20,6 +30,7 @@ function CalicoWindowsInstallFirstStep(props) {
           </CodeBlock>
         </ul>
       </li>
+      </>
     );
   }
 

--- a/calico_versioned_docs/version-3.31/_includes/components/CalicoWindowsInstall.js
+++ b/calico_versioned_docs/version-3.31/_includes/components/CalicoWindowsInstall.js
@@ -9,6 +9,16 @@ import { prodname, prodnameWindows } from '../../variables';
 function CalicoWindowsInstallFirstStep(props) {
   if (props.networkingType === 'vxlan') {
     return (
+      <>
+      <li>
+        Ensure that cross-subnet encapsulation is disabled. You must use <code>VXLAN</code> and NOT <code>VXLANCrossSubnet</code>
+        as the <code>encapsulation:</code> of your IP pool. Use this command to change it if you only have one IP pool configured:
+        <br />
+        <br />
+        <CodeBlock language='bash'>
+          {`kubectl patch installation default --type='json' -p='[{"op": "replace", "path": "/spec/calicoNetwork/ipPools/0/encapsulation", "value": "VXLAN"}]`}
+        </CodeBlock>
+      </li>
       <li>
         Ensure that BGP is disabled.
         <ul>
@@ -20,6 +30,7 @@ function CalicoWindowsInstallFirstStep(props) {
           </CodeBlock>
         </ul>
       </li>
+      </>
     );
   }
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue: https://github.com/tigera/docs/issues/1547
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->