### PR TITLE
Change title for Prometheus metrics reference

### DIFF
--- a/calico-cloud/reference/component-resources/kube-controllers/prometheus.mdx
+++ b/calico-cloud/reference/component-resources/kube-controllers/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the kube-controllers component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring kube-controllers with Prometheus
 
 kube-controllers can be configured to report a number of metrics through Prometheus. This reporting is enabled by default on port 9094. See the
 [configuration reference](../../resources/kubecontrollersconfig.mdx) for how to change metrics reporting configuration (or disable it completely).

--- a/calico-cloud/reference/component-resources/node/felix/prometheus.mdx
+++ b/calico-cloud/reference/component-resources/node/felix/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Felix component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Felix with Prometheus
 
 Felix can be configured to report a number of metrics through Prometheus. See the
 [configuration reference](configuration.mdx) for how to enable metrics reporting.

--- a/calico-cloud_versioned_docs/version-22-2/reference/component-resources/kube-controllers/prometheus.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/reference/component-resources/kube-controllers/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the kube-controllers component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring kube-controllers with Prometheus
 
 kube-controllers can be configured to report a number of metrics through Prometheus. This reporting is enabled by default on port 9094. See the
 [configuration reference](../../resources/kubecontrollersconfig.mdx) for how to change metrics reporting configuration (or disable it completely).

--- a/calico-cloud_versioned_docs/version-22-2/reference/component-resources/node/felix/prometheus.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/reference/component-resources/node/felix/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Felix component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Felix with Prometheus
 
 Felix can be configured to report a number of metrics through Prometheus. See the
 [configuration reference](configuration.mdx) for how to enable metrics reporting.

--- a/calico-enterprise/reference/component-resources/kube-controllers/prometheus.mdx
+++ b/calico-enterprise/reference/component-resources/kube-controllers/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the kube-controllers component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring kube-controllers with Prometheus
 
 kube-controllers can be configured to report a number of metrics through Prometheus. This reporting is enabled by default on port 9094. See the
 [configuration reference](../../resources/kubecontrollersconfig.mdx) for how to change metrics reporting configuration (or disable it completely).

--- a/calico-enterprise/reference/component-resources/node/felix/prometheus.mdx
+++ b/calico-enterprise/reference/component-resources/node/felix/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Felix component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Felix with Prometheus
 
 Felix can be configured to report a number of metrics through Prometheus. See the
 [configuration reference](configuration.mdx) for how to enable metrics reporting.

--- a/calico-enterprise/reference/component-resources/typha/prometheus.mdx
+++ b/calico-enterprise/reference/component-resources/typha/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Typha component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Typha with Prometheus
 
 Typha can be configured to report a number of metrics through Prometheus. The Prometheus port can be controlled
 via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#installation).

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/component-resources/kube-controllers/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/component-resources/kube-controllers/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the kube-controllers component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring kube-controllers with Prometheus
 
 kube-controllers can be configured to report a number of metrics through Prometheus. This reporting is enabled by default on port 9094. See the
 [configuration reference](../../resources/kubecontrollersconfig.mdx) for how to change metrics reporting configuration (or disable it completely).

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/component-resources/node/felix/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/component-resources/node/felix/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Felix component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Felix with Prometheus
 
 Felix can be configured to report a number of metrics through Prometheus. See the
 [configuration reference](configuration.mdx) for how to enable metrics reporting.

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/component-resources/typha/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/component-resources/typha/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Typha component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Typha with Prometheus
 
 Typha can be configured to report a number of metrics through Prometheus. The Prometheus port can be controlled
 via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#installation).

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/component-resources/kube-controllers/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/component-resources/kube-controllers/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the kube-controllers component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring kube-controllers with Prometheus
 
 kube-controllers can be configured to report a number of metrics through Prometheus. This reporting is enabled by default on port 9094. See the
 [configuration reference](../../resources/kubecontrollersconfig.mdx) for how to change metrics reporting configuration (or disable it completely).

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/component-resources/node/felix/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/component-resources/node/felix/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Felix component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Felix with Prometheus
 
 Felix can be configured to report a number of metrics through Prometheus. See the
 [configuration reference](configuration.mdx) for how to enable metrics reporting.

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/component-resources/typha/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/component-resources/typha/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Typha component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Typha with Prometheus
 
 Typha can be configured to report a number of metrics through Prometheus. The Prometheus port can be controlled
 via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#installation).

--- a/calico-enterprise_versioned_docs/version-3.22-2/reference/component-resources/kube-controllers/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/reference/component-resources/kube-controllers/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the kube-controllers component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring kube-controllers with Prometheus
 
 kube-controllers can be configured to report a number of metrics through Prometheus. This reporting is enabled by default on port 9094. See the
 [configuration reference](../../resources/kubecontrollersconfig.mdx) for how to change metrics reporting configuration (or disable it completely).

--- a/calico-enterprise_versioned_docs/version-3.22-2/reference/component-resources/node/felix/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/reference/component-resources/node/felix/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Felix component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Felix with Prometheus
 
 Felix can be configured to report a number of metrics through Prometheus. See the
 [configuration reference](configuration.mdx) for how to enable metrics reporting.

--- a/calico-enterprise_versioned_docs/version-3.22-2/reference/component-resources/typha/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/reference/component-resources/typha/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Typha component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Typha with Prometheus
 
 Typha can be configured to report a number of metrics through Prometheus. The Prometheus port can be controlled
 via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#installation).

--- a/calico-enterprise_versioned_docs/version-3.23-1/reference/component-resources/kube-controllers/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/reference/component-resources/kube-controllers/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the kube-controllers component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring kube-controllers with Prometheus
 
 kube-controllers can be configured to report a number of metrics through Prometheus. This reporting is enabled by default on port 9094. See the
 [configuration reference](../../resources/kubecontrollersconfig.mdx) for how to change metrics reporting configuration (or disable it completely).

--- a/calico-enterprise_versioned_docs/version-3.23-1/reference/component-resources/node/felix/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/reference/component-resources/node/felix/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Felix component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Felix with Prometheus
 
 Felix can be configured to report a number of metrics through Prometheus. See the
 [configuration reference](configuration.mdx) for how to enable metrics reporting.

--- a/calico-enterprise_versioned_docs/version-3.23-1/reference/component-resources/typha/prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/reference/component-resources/typha/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Typha component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Typha with Prometheus
 
 Typha can be configured to report a number of metrics through Prometheus. The Prometheus port can be controlled
 via the `typhaPrometheusPort` field in the operator's [`Installation` resource](../../installation/api.mdx#installation).

--- a/calico/reference/felix/prometheus.mdx
+++ b/calico/reference/felix/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Felix component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Felix with Prometheus
 
 Felix can be configured to report a number of metrics through Prometheus. See the
 [configuration reference](configuration.mdx) for how to enable metrics reporting.

--- a/calico/reference/kube-controllers/prometheus.mdx
+++ b/calico/reference/kube-controllers/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the kube-controllers component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring kube-controllers with Prometheus
 
 kube-controllers can be configured to report a number of metrics through Prometheus. This reporting is enabled by default on port 9094. See the
 [configuration reference](../resources/kubecontrollersconfig.mdx) for how to change metrics reporting configuration (or disable it completely).

--- a/calico/reference/typha/prometheus.mdx
+++ b/calico/reference/typha/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Typha component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Typha with Prometheus
 
 Typha can be configured to report a number of metrics through Prometheus. See the
 [configuration reference](configuration.mdx) for how to enable metrics reporting.

--- a/calico_versioned_docs/version-3.29/reference/felix/prometheus.mdx
+++ b/calico_versioned_docs/version-3.29/reference/felix/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Felix component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Felix with Prometheus
 
 Felix can be configured to report a number of metrics through Prometheus. See the
 [configuration reference](configuration.mdx) for how to enable metrics reporting.

--- a/calico_versioned_docs/version-3.29/reference/kube-controllers/prometheus.mdx
+++ b/calico_versioned_docs/version-3.29/reference/kube-controllers/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the kube-controllers component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring kube-controllers with Prometheus
 
 kube-controllers can be configured to report a number of metrics through Prometheus. This reporting is enabled by default on port 9094. See the
 [configuration reference](../resources/kubecontrollersconfig.mdx) for how to change metrics reporting configuration (or disable it completely).

--- a/calico_versioned_docs/version-3.29/reference/typha/prometheus.mdx
+++ b/calico_versioned_docs/version-3.29/reference/typha/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Typha component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Typha with Prometheus
 
 Typha can be configured to report a number of metrics through Prometheus. See the
 [configuration reference](configuration.mdx) for how to enable metrics reporting.

--- a/calico_versioned_docs/version-3.30/reference/felix/prometheus.mdx
+++ b/calico_versioned_docs/version-3.30/reference/felix/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Felix component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Felix with Prometheus
 
 Felix can be configured to report a number of metrics through Prometheus. See the
 [configuration reference](configuration.mdx) for how to enable metrics reporting.

--- a/calico_versioned_docs/version-3.30/reference/kube-controllers/prometheus.mdx
+++ b/calico_versioned_docs/version-3.30/reference/kube-controllers/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the kube-controllers component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring kube-controllers with Prometheus
 
 kube-controllers can be configured to report a number of metrics through Prometheus. This reporting is enabled by default on port 9094. See the
 [configuration reference](../resources/kubecontrollersconfig.mdx) for how to change metrics reporting configuration (or disable it completely).

--- a/calico_versioned_docs/version-3.30/reference/typha/prometheus.mdx
+++ b/calico_versioned_docs/version-3.30/reference/typha/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Typha component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Typha with Prometheus
 
 Typha can be configured to report a number of metrics through Prometheus. See the
 [configuration reference](configuration.mdx) for how to enable metrics reporting.

--- a/calico_versioned_docs/version-3.31/reference/felix/prometheus.mdx
+++ b/calico_versioned_docs/version-3.31/reference/felix/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Felix component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Felix with Prometheus
 
 Felix can be configured to report a number of metrics through Prometheus. See the
 [configuration reference](configuration.mdx) for how to enable metrics reporting.

--- a/calico_versioned_docs/version-3.31/reference/kube-controllers/prometheus.mdx
+++ b/calico_versioned_docs/version-3.31/reference/kube-controllers/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the kube-controllers component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring kube-controllers with Prometheus
 
 kube-controllers can be configured to report a number of metrics through Prometheus. This reporting is enabled by default on port 9094. See the
 [configuration reference](../resources/kubecontrollersconfig.mdx) for how to change metrics reporting configuration (or disable it completely).

--- a/calico_versioned_docs/version-3.31/reference/typha/prometheus.mdx
+++ b/calico_versioned_docs/version-3.31/reference/typha/prometheus.mdx
@@ -2,7 +2,7 @@
 description: Review metrics for the Typha component if you are using Prometheus.
 ---
 
-# Prometheus metrics
+# Monitoring Typha with Prometheus
 
 Typha can be configured to report a number of metrics through Prometheus. See the
 [configuration reference](configuration.mdx) for how to enable metrics reporting.


### PR DESCRIPTION
Pages showing Prometheus metrics for different components -- Felix,
Typha, and kube-controllers -- all had the same title. This commit
differentiates the pages. This makes it easier to people to find
what they need.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->