### PR TITLE
DOCS-2833 Add script that updates Felix config for OSS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,3 +365,13 @@ vale:
 		-v $(CURDIR)/.github/styles:/styles \
 		-v $(CURDIR):/docs \
 		-w /docs/$(PRODUCT) jdkato/vale .
+
+# --------------------------------------------------------------------------- #
+# Felix Configuration Sync                                                    #
+# --------------------------------------------------------------------------- #
+
+.PHONY: update-felix-config
+update-felix-config:
+	$(if $(GITHUB_TOKEN),,$(error GITHUB_TOKEN is not set or empty, but is required))
+	@echo "Updating Felix configurations for OSS and Enterprise..."
+	@./scripts/update-felix-config.sh

--- a/scripts/update-felix-config.sh
+++ b/scripts/update-felix-config.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+
+###############################################################################
+#                                                                             #
+#   felix-update-config-ce.sh                                                 #
+#   Created: 2026-02-05                                                       #
+#                                                                             #
+#   Description: Synchronizes Felix configuration JSON files from GitHub      #
+#   repos (OSS & Enterprise) into local documentation paths.                  #
+#                                                                             #
+###############################################################################
+
+# --- Safety & Environment ---
+set -euo pipefail
+
+# --- Global Constants (No Magic Numbers) ---
+readonly SUCCESS=0
+readonly E_MISSING_TOKEN=1
+readonly E_INVALID_JSON=2
+readonly VERSIONS_FILE_OSS="calico_versions.json"
+readonly VERSIONS_FILE_CE="calico-enterprise_versions.json"
+
+# --- Global Variables ---
+VERSIONS_OSS=($(jq -r '.[]' "$VERSIONS_FILE_OSS"))
+VERSIONS_CE=($(jq -r '.[]' "$VERSIONS_FILE_CE"))
+CLEANUP_FILES=()
+
+# --------------------------------------------------------------------------- #
+# cleanup()                                                                   #
+# Internal function triggered on script exit to remove all temp files.        #
+# --------------------------------------------------------------------------- #
+cleanup() {
+    local file
+    for file in "${CLEANUP_FILES[@]:-}"; do
+        if [[ -f "$file" ]]; then
+            rm -f "$file"
+        fi
+    done
+}
+
+trap cleanup EXIT
+
+# --------------------------------------------------------------------------- #
+# update_felix_config()                                                       #
+# Downloads a remote JSON file and replaces a local target file.              #
+# --------------------------------------------------------------------------- #
+update_felix_config() {
+    local tmpfile
+    tmpfile=$(mktemp -t remote-url-output.XXXXXX)
+    CLEANUP_FILES+=("$tmpfile")
+
+    printf "%s\n\n" "Begin processing $VERSION"
+    printf "%s\n" "Target path: $LOCAL_PATH"
+    printf "%s\n" "Source URL: $REMOTE_URL"
+
+    curl -fsSL \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.v3.raw" \
+          -o "$tmpfile" \
+          "$REMOTE_URL"
+
+    if jq -e . "$tmpfile" >/dev/null 2>&1; then
+        echo "Success: $tmpfile is valid JSON."
+    else
+        echo "Error: $tmpfile contains invalid JSON." >&2
+        exit "$E_INVALID_JSON"
+    fi
+
+    mv "$tmpfile" "$LOCAL_PATH"
+    printf "%s\n\n\n" "Finished processing $VERSION."
+}
+
+# --------------------------------------------------------------------------- #
+# OSS Functions                                                               #
+# --------------------------------------------------------------------------- #
+
+update_master_OSS () {
+    VERSION="master"
+    LOCAL_PATH="calico/_includes/components/FelixConfig/config-params.json"
+    REMOTE_URL="https://raw.githubusercontent.com/projectcalico/calico/refs/heads/master/felix/docs/config-params.json"
+    update_felix_config
+}
+
+update_versions_OSS () {
+    local -n VERSIONS_ARRAY=$1
+    local i
+    for i in "${!VERSIONS_ARRAY[@]}"; do
+        VERSION="${VERSIONS_ARRAY[$i]}"
+        LOCAL_PATH="calico_versioned_docs/version-${VERSION}/_includes/components/FelixConfig/config-params.json"
+        REMOTE_URL="https://raw.githubusercontent.com/projectcalico/calico/refs/heads/release-v${VERSION}/felix/docs/config-params.json"
+
+        if [[ "$VERSION" == "3.29" ]]; then
+            printf "%s\n" "Skipping $VERSION: No action required."
+            continue
+        fi
+
+        update_felix_config
+    done
+}
+
+# --------------------------------------------------------------------------- #
+# Enterprise Functions                                                        #
+# --------------------------------------------------------------------------- #
+
+update_master_CE () {
+    VERSION="master"
+    LOCAL_PATH="calico-enterprise/_includes/components/FelixConfig/config-params.json"
+    REMOTE_URL="https://api.github.com/repos/tigera/calico-private/contents/felix/docs/config-params.json?ref=master"
+    update_felix_config
+}
+
+update_versions_CE() {
+    local -n VERSIONS_ARRAY=$1
+    local i branch base_version
+
+    for i in "${!VERSIONS_ARRAY[@]}"; do
+        VERSION="${VERSIONS_ARRAY[$i]}"
+        base_version="${VERSION%-*}"
+
+        if [[ "$VERSION" == *"-2" ]]; then
+            branch="release-calient-v${base_version}"
+        elif [[ "$VERSION" == *"-1" ]]; then
+            branch="release-calient-v${base_version}-1"
+        else
+            branch="release-v${VERSION}"
+        fi
+
+        LOCAL_PATH="calico-enterprise_versioned_docs/version-${VERSION}/_includes/components/FelixConfig/config-params.json"
+        REMOTE_URL="https://api.github.com/repos/tigera/calico-private/contents/felix/docs/config-params.json?ref=${branch}"
+
+        if [[ "$VERSION" == "3.20-2" ]]; then
+            printf "%s\n" "Skipping $VERSION: No action required."
+            continue
+        fi
+
+        update_felix_config
+    done
+}
+
+# --- Main Logic ---
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+    echo "Error: GITHUB_TOKEN is not set." >&2
+    exit "$E_MISSING_TOKEN"
+fi
+
+printf "OSS Versions: %s\n" "${VERSIONS_OSS[*]}"
+printf "CE Versions:  %s\n\n" "${VERSIONS_CE[*]}"
+
+update_master_OSS
+update_versions_OSS VERSIONS_OSS
+
+update_master_CE
+update_versions_CE VERSIONS_CE
+
+printf "%s\n" "All updates are complete."
+exit "$SUCCESS"

--- a/scripts/update-felix-config.sh
+++ b/scripts/update-felix-config.sh
@@ -29,6 +29,7 @@ CLEANUP_FILES=()
 # cleanup()                                                                   #
 # Internal function triggered on script exit to remove all temp files.        #
 # --------------------------------------------------------------------------- #
+# shellcheck disable=SC2317
 cleanup() {
     local file
     for file in "${CLEANUP_FILES[@]:-}"; do
@@ -49,9 +50,9 @@ update_felix_config() {
     tmpfile=$(mktemp -t remote-url-output.XXXXXX)
     CLEANUP_FILES+=("$tmpfile")
 
-    printf "%s\n\n" "Begin processing $VERSION"
-    printf "%s\n" "Target path: $LOCAL_PATH"
-    printf "%s\n" "Source URL: $REMOTE_URL"
+    echo "Begin processing ${VERSION}"
+    echo "Target path: ${LOCAL_PATH}"
+    echo "Source URL: ${REMOTE_URL}"
 
     curl -fsSL \
           -H "Authorization: token $GITHUB_TOKEN" \
@@ -67,7 +68,7 @@ update_felix_config() {
     fi
 
     mv "$tmpfile" "$LOCAL_PATH"
-    printf "%s\n\n\n" "Finished processing $VERSION."
+    echo -e "Finished processing ${VERSION}.\n\n"
 }
 
 # --------------------------------------------------------------------------- #
@@ -90,7 +91,7 @@ update_versions_OSS () {
         REMOTE_URL="https://raw.githubusercontent.com/projectcalico/calico/refs/heads/release-v${VERSION}/felix/docs/config-params.json"
 
         if [[ "$VERSION" == "3.29" ]]; then
-            printf "%s\n" "Skipping $VERSION: No action required."
+            echo "Skipping ${VERSION}: No action required."
             continue
         fi
 
@@ -129,7 +130,7 @@ update_versions_CE() {
         REMOTE_URL="https://api.github.com/repos/tigera/calico-private/contents/felix/docs/config-params.json?ref=${branch}"
 
         if [[ "$VERSION" == "3.20-2" ]]; then
-            printf "%s\n" "Skipping $VERSION: No action required."
+            echo "Skipping ${VERSION}: No action required."
             continue
         fi
 
@@ -144,8 +145,9 @@ if [[ -z "${GITHUB_TOKEN:-}" ]]; then
     exit "$E_MISSING_TOKEN"
 fi
 
-printf "OSS Versions: %s\n" "${VERSIONS_OSS[*]}"
-printf "CE Versions:  %s\n\n" "${VERSIONS_CE[*]}"
+echo "OSS Versions:" "${VERSIONS_OSS[*]}"
+echo "CE Versions:" "${VERSIONS_CE[*]}"
+echo
 
 update_master_OSS
 update_versions_OSS VERSIONS_OSS
@@ -153,5 +155,5 @@ update_versions_OSS VERSIONS_OSS
 update_master_CE
 update_versions_CE VERSIONS_CE
 
-printf "%s\n" "All updates are complete."
+echo "All updates are complete."
 exit "$SUCCESS"


### PR DESCRIPTION
This script updates the FelixConfiguration component with data the OSS and CE code repositories. A new makefile target makes it easy to run with `make update-felix-config`.

DOCS-2833

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->