### PR TITLE
DOCS-2846: Add instruction for disabling upgrade-ipam

### DIFF
--- a/calico/reference/configure-cni-plugins.mdx
+++ b/calico/reference/configure-cni-plugins.mdx
@@ -398,6 +398,18 @@ When making use of the `usePodCidr` or `usePodCidrIPv6` options, the $[prodname]
 
 When using `host-local` IPAM with the Kubernetes API datastore, you must configure both $[nodecontainer] and the Typha deployment to use the `Node.podCIDR` field by setting the environment variable `USE_POD_CIDR=true` in each.
 
+#### Disabling the `upgrade-ipam` init container
+
+When using `host-local` IPAM on a manifest-based installation of $[prodname], you should remove the `upgrade-ipam` init container from the `calico-node` DaemonSet definition in the manifest before applying it.
+
+If $[prodname] is already installed, you can remove the init container with the following command:
+
+```bash
+kubectl get ds calico-node -n kube-system -o json | \
+jq 'del(.spec.template.spec.initContainers[]? | select(.name == "upgrade-ipam"))' | \
+kubectl apply -f -
+```
+
 </TabItem>
 </Tabs>
 

--- a/calico_versioned_docs/version-3.29/reference/configure-cni-plugins.mdx
+++ b/calico_versioned_docs/version-3.29/reference/configure-cni-plugins.mdx
@@ -398,6 +398,18 @@ When making use of the `usePodCidr` or `usePodCidrIPv6` options, the $[prodname]
 
 When using `host-local` IPAM with the Kubernetes API datastore, you must configure both $[nodecontainer] and the Typha deployment to use the `Node.podCIDR` field by setting the environment variable `USE_POD_CIDR=true` in each.
 
+#### Disabling the `upgrade-ipam` init container
+
+When using `host-local` IPAM on a manifest-based installation of $[prodname], you should remove the `upgrade-ipam` init container from the `calico-node` DaemonSet definition in the manifest before applying it.
+
+If $[prodname] is already installed, you can remove the init container with the following command:
+
+```bash
+kubectl get ds calico-node -n kube-system -o json | \
+jq 'del(.spec.template.spec.initContainers[]? | select(.name == "upgrade-ipam"))' | \
+kubectl apply -f -
+```
+
 </TabItem>
 </Tabs>
 

--- a/calico_versioned_docs/version-3.30/reference/configure-cni-plugins.mdx
+++ b/calico_versioned_docs/version-3.30/reference/configure-cni-plugins.mdx
@@ -398,6 +398,18 @@ When making use of the `usePodCidr` or `usePodCidrIPv6` options, the $[prodname]
 
 When using `host-local` IPAM with the Kubernetes API datastore, you must configure both $[nodecontainer] and the Typha deployment to use the `Node.podCIDR` field by setting the environment variable `USE_POD_CIDR=true` in each.
 
+#### Disabling the `upgrade-ipam` init container
+
+When using `host-local` IPAM on a manifest-based installation of $[prodname], you should remove the `upgrade-ipam` init container from the `calico-node` DaemonSet definition in the manifest before applying it.
+
+If $[prodname] is already installed, you can remove the init container with the following command:
+
+```bash
+kubectl get ds calico-node -n kube-system -o json | \
+jq 'del(.spec.template.spec.initContainers[]? | select(.name == "upgrade-ipam"))' | \
+kubectl apply -f -
+```
+
 </TabItem>
 </Tabs>
 

--- a/calico_versioned_docs/version-3.31/reference/configure-cni-plugins.mdx
+++ b/calico_versioned_docs/version-3.31/reference/configure-cni-plugins.mdx
@@ -398,6 +398,16 @@ When making use of the `usePodCidr` or `usePodCidrIPv6` options, the $[prodname]
 
 When using `host-local` IPAM with the Kubernetes API datastore, you must configure both $[nodecontainer] and the Typha deployment to use the `Node.podCIDR` field by setting the environment variable `USE_POD_CIDR=true` in each.
 
+#### Disabling the `upgrade-ipam` init container
+
+To use host-local IPAM on a manifest-based installation of $[prodname], you should disable the `upgrade-ipam` init container.
+
+```bash
+kubectl get ds calico-node -n kube-system -o json | \
+jq 'del(.spec.template.spec.initContainers[] | select(.name == "upgrade-ipam"))' | \
+kubectl apply -f -
+```
+
 </TabItem>
 </Tabs>
 

--- a/calico_versioned_docs/version-3.31/reference/configure-cni-plugins.mdx
+++ b/calico_versioned_docs/version-3.31/reference/configure-cni-plugins.mdx
@@ -400,11 +400,13 @@ When using `host-local` IPAM with the Kubernetes API datastore, you must configu
 
 #### Disabling the `upgrade-ipam` init container
 
-To use host-local IPAM on a manifest-based installation of $[prodname], you should disable the `upgrade-ipam` init container.
+When using `host-local` IPAM on a manifest-based installation of $[prodname], you should remove the `upgrade-ipam` init container from the `calico-node` DaemonSet definition in the manifest before applying it.
+
+If $[prodname] is already installed, you can remove the init container with the following command:
 
 ```bash
 kubectl get ds calico-node -n kube-system -o json | \
-jq 'del(.spec.template.spec.initContainers[] | select(.name == "upgrade-ipam"))' | \
+jq 'del(.spec.template.spec.initContainers[]? | select(.name == "upgrade-ipam"))' | \
 kubectl apply -f -
 ```
 


### PR DESCRIPTION
For manifest installs, you need to disable upgrade-ipam when
using host-local IPAM.

DOCS-2846

<img width="1095" height="257" alt="image" src="https://github.com/user-attachments/assets/36732f65-8c4b-4c39-abfe-4490c3a0261c" />


<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->
https://github.com/projectcalico/calico/issues/11702

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->