### PR TITLE
Publish Calico Open Source 3.31.5

### DIFF
--- a/calico_versioned_docs/version-3.31/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.31/release-notes/index.mdx
@@ -285,3 +285,19 @@ December 19, 2025
 #### Updating
 
 To update a previous version of Calico, see [our upgrade guides](../operations/upgrading/index.mdx).
+
+### Calico Open Source 3.31.5 bug fix release
+
+February 18, 2026
+
+#### Enhancements
+
+* TBD
+
+#### Bug fixes
+
+* TBD
+
+#### Updating
+
+To update a previous version of Calico, see [our upgrade guides](../operations/upgrading/index.mdx).

--- a/calico_versioned_docs/version-3.31/releases.json
+++ b/calico_versioned_docs/version-3.31/releases.json
@@ -1,5 +1,103 @@
 [
   {
+    "title": "v3.31.5",
+    "tigera-operator": {
+      "image": "tigera/operator",
+      "registry": "quay.io",
+      "version": "v1.40.5"
+    },
+    "components": {
+      "calico/typha": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/ctl": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/node": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/node-windows": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/cni": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/cni-windows": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/apiserver": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/kube-controllers": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/envoy-gateway": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/envoy-proxy": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/envoy-ratelimit": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/flannel-migration-controller": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "flannel": {
+        "version": "v0.24.4",
+        "registry": "docker.io"
+      },
+      "calico/dikastes": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "flexvol": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/csi": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/node-driver-registrar": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/pod2daemon-flexvol": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/key-cert-provisioner": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/goldmane": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/whisker": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/whisker-backend": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      }
+    }
+  },
+  {
     "title": "v3.31.3",
     "tigera-operator": {
       "image": "tigera/operator",

--- a/calico_versioned_docs/version-3.31/variables.js
+++ b/calico_versioned_docs/version-3.31/variables.js
@@ -1,7 +1,7 @@
 const releases = require('./releases.json');
 
 const variables = {
-  releaseTitle: 'v3.31.3',
+  releaseTitle: 'v3.31.5',
   prodname: 'Calico',
   prodnamedash: 'calico',
   version: 'v3.31',
@@ -16,7 +16,7 @@ const variables = {
   noderunning: 'calico-node',
   rootDirWindows: 'C:\\CalicoWindows',
   ppa_repo_name: 'calico-3.31',
-  manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.31.3',
+  manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.31.5',
   releases,
   registry: '',
   vppbranch: 'v3.31.0',


### PR DESCRIPTION
## Summary
- Bump Calico Open Source version to v3.31.5 in `variables.js` (releaseTitle, manifestsUrl)
- Add v3.31.5 component versions to `releases.json` (operator v1.40.5)
- Add 3.31.5 bug fix release section to release notes (TBD placeholders for enhancements and bug fixes)

## Test plan
- [ ] Verify Netlify preview build succeeds
- [ ] Confirm version references render correctly on the docs site
- [ ] Fill in actual release notes (enhancements and bug fixes) before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)