### PR TITLE
DOCS-2845: Disable / shortcut to fix Kapa chat conflict

### DIFF
--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -208,6 +208,21 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
     searchButtonRef,
   });
 
+  // Prevent "/" from opening search when the user is typing in the Kapa AI
+  // chat widget, which uses non-standard input elements that bypass
+  // DocSearch's built-in INPUT/TEXTAREA check (DOCS-2845).
+  React.useEffect(() => {
+    function suppressSlashInKapa(e) {
+      if (e.key !== '/') return;
+      const target = e.composedPath?.()?.[0] || e.target;
+      if (target?.closest?.('[data-kapa-widget-container],.mantine-Modal-root')) {
+        e.stopPropagation();
+      }
+    }
+    window.addEventListener('keydown', suppressSlashInKapa, true);
+    return () => window.removeEventListener('keydown', suppressSlashInKapa, true);
+  }, []);
+
   const isBrowser = useIsBrowser();
   let searchBar;
 


### PR DESCRIPTION
## Summary
- Disables the `/` keyboard shortcut for opening Algolia search, which was intercepting keystrokes inside the Kapa AI chat widget
- The Kapa widget uses a non-standard input element that bypasses DocSearch's built-in INPUT/TEXTAREA check, so `/` opens the search modal when users try to type it in the chat
- Search is still accessible via **Ctrl/Cmd+K** and the search button

I think this will do it, @pasanw? PTAL

## Test plan
- [ ] Open the docs site, click the Kapa AI chat widget, and type a message containing `/` — search should NOT pop up
- [ ] Verify Ctrl/Cmd+K still opens search
- [ ] Verify clicking the search button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)