### PR TITLE
DOCS-2843: Add alt text to images for accessibility

### DIFF
--- a/calico-cloud/networking/configuring/bgp-to-workload.mdx
+++ b/calico-cloud/networking/configuring/bgp-to-workload.mdx
@@ -34,7 +34,7 @@ See [Configure BGP peering](./bgp.mdx) for a general overview of these concepts.
 
 ## Supported BGP topologies
 
-![](/img/calico/nested-bgp.svg)
+![Diagram showing supported BGP topologies for nested clusters running on KubeVirt VMs, with eBGP peering between parent and nested clusters](/img/calico/nested-bgp.svg)
 
 Both parent and nested clusters must be configured to use non-overlay BGP
 networking.

--- a/calico-cloud/reference/architecture/design/l3-interconnect-fabric.mdx
+++ b/calico-cloud/reference/architecture/design/l3-interconnect-fabric.mdx
@@ -184,12 +184,12 @@ set of Ethernet planes interconnecting the ToR switches, and the other
 where the core planes are also routers. The following diagrams may be
 useful for the discussion.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l2-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l2-spine.png)
 
 The diagram above shows the _AS per rack model_ where the ToR switches are
 physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l3-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via discrete BGP spine routers, each in their own AS](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l3-spine.png)
 
 The diagram above shows the _AS per rack model_ where the ToR switches are
 physically meshed via a set of discrete BGP spine routers, each in
@@ -255,12 +255,12 @@ Therefore, if we follow the architecture of the draft, the compute
 server, not the ToR should be the AS boundary. The differences can be
 seen in the following two diagrams.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-server-l2-spine.png)
+![Diagram showing the AS per compute server model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-server-l2-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR
 switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-server-l3-spine.png)
+![Diagram showing the AS per compute server model with ToR switches connected to independent routing planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-server-l3-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR
 switches are physically connected to a set of independent routing
@@ -305,7 +305,7 @@ same AS).
 
 The following diagram will show the AS relationships in this model.
 
-![](/img/calico-enterprise/l3-fabric-downward-default.png)
+![Diagram showing the downward default model where all Calico nodes share one AS and all ToR switches share another, with spine routers announcing default routes downward](/img/calico-enterprise/l3-fabric-downward-default.png)
 
 In the diagram above, we are showing that all $[prodname] nodes share the same
 AS number, as do all ToR switches. However, those ASs are different

--- a/calico-cloud/reference/host-endpoints/overview.mdx
+++ b/calico-cloud/reference/host-endpoints/overview.mdx
@@ -52,6 +52,6 @@ See [GlobalNetworkPolicy spec](../resources/globalnetworkpolicy.mdx#spec).
 Both traffic forwarded between host endpoints and traffic forwarded
 between a host endpoint and a workload endpoint on the same host is regarded as
 `forwarded traffic`.
-![](/img/calico-enterprise/bare-metal-packet-flows.svg)
+![Diagram showing packet flows for forwarded traffic between host endpoints and between host endpoints and workload endpoints](/img/calico-enterprise/bare-metal-packet-flows.svg)
 
 :::

--- a/calico-cloud_versioned_docs/version-22-2/networking/configuring/bgp-to-workload.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/configuring/bgp-to-workload.mdx
@@ -34,7 +34,7 @@ See [Configure BGP peering](./bgp.mdx) for a general overview of these concepts.
 
 ## Supported BGP topologies
 
-![](/img/calico/nested-bgp.svg)
+![Diagram showing supported BGP topologies for nested clusters running on KubeVirt VMs, with eBGP peering between parent and nested clusters](/img/calico/nested-bgp.svg)
 
 Both parent and nested clusters must be configured to use non-overlay BGP
 networking.

--- a/calico-cloud_versioned_docs/version-22-2/reference/architecture/design/l3-interconnect-fabric.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/reference/architecture/design/l3-interconnect-fabric.mdx
@@ -184,12 +184,12 @@ set of Ethernet planes interconnecting the ToR switches, and the other
 where the core planes are also routers. The following diagrams may be
 useful for the discussion.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l2-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l2-spine.png)
 
 The diagram above shows the _AS per rack model_ where the ToR switches are
 physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l3-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via discrete BGP spine routers, each in their own AS](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l3-spine.png)
 
 The diagram above shows the _AS per rack model_ where the ToR switches are
 physically meshed via a set of discrete BGP spine routers, each in
@@ -255,12 +255,12 @@ Therefore, if we follow the architecture of the draft, the compute
 server, not the ToR should be the AS boundary. The differences can be
 seen in the following two diagrams.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-server-l2-spine.png)
+![Diagram showing the AS per compute server model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-server-l2-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR
 switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-server-l3-spine.png)
+![Diagram showing the AS per compute server model with ToR switches connected to independent routing planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-server-l3-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR
 switches are physically connected to a set of independent routing
@@ -305,7 +305,7 @@ same AS).
 
 The following diagram will show the AS relationships in this model.
 
-![](/img/calico-enterprise/l3-fabric-downward-default.png)
+![Diagram showing the downward default model where all Calico nodes share one AS and all ToR switches share another, with spine routers announcing default routes downward](/img/calico-enterprise/l3-fabric-downward-default.png)
 
 In the diagram above, we are showing that all $[prodname] nodes share the same
 AS number, as do all ToR switches. However, those ASs are different

--- a/calico-cloud_versioned_docs/version-22-2/reference/host-endpoints/overview.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/reference/host-endpoints/overview.mdx
@@ -52,6 +52,6 @@ See [GlobalNetworkPolicy spec](../resources/globalnetworkpolicy.mdx#spec).
 Both traffic forwarded between host endpoints and traffic forwarded
 between a host endpoint and a workload endpoint on the same host is regarded as
 `forwarded traffic`.
-![](/img/calico-enterprise/bare-metal-packet-flows.svg)
+![Diagram showing packet flows for forwarded traffic between host endpoints and between host endpoints and workload endpoints](/img/calico-enterprise/bare-metal-packet-flows.svg)
 
 :::

--- a/calico-enterprise/networking/configuring/bgp-to-workload.mdx
+++ b/calico-enterprise/networking/configuring/bgp-to-workload.mdx
@@ -34,7 +34,7 @@ See [Configure BGP peering](./bgp.mdx) for a general overview of these concepts.
 
 ## Supported BGP topologies
 
-![](/img/calico/nested-bgp.svg)
+![Diagram showing supported BGP topologies for nested clusters running on KubeVirt VMs, with eBGP peering between parent and nested clusters](/img/calico/nested-bgp.svg)
 
 Both parent and nested clusters must be configured to use non-overlay BGP
 networking.

--- a/calico-enterprise/reference/architecture/design/l3-interconnect-fabric.mdx
+++ b/calico-enterprise/reference/architecture/design/l3-interconnect-fabric.mdx
@@ -95,11 +95,11 @@ This model is the closest to the model suggested by [IETF RFC 7938](https://data
 
 As mentioned earlier, there are two versions of this model, one with an set of Ethernet planes interconnecting the ToR switches, and the other where the core planes are also routers. The following diagrams may be useful for the discussion.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l2-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l2-spine.png)
 
 The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l3-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via discrete BGP spine routers, each in their own AS](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l3-spine.png)
 
 The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of discrete BGP spine routers, each in their own AS.
 
@@ -126,12 +126,12 @@ This model takes the concept of an AS per rack to its logical conclusion. In the
 
 Therefore, if we follow the architecture of the draft, the compute server, not the ToR should be the AS boundary. The differences can be seen in the following two diagrams.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-server-l2-spine.png)
+![Diagram showing the AS per compute server model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-server-l2-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR
 switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-server-l3-spine.png)
+![Diagram showing the AS per compute server model with ToR switches connected to independent routing planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-server-l3-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR switches are physically connected to a set of independent routing planes.
 
@@ -151,7 +151,7 @@ each stage of the routing path. This is to prevent routes from other nodes in th
 
 The following diagram will show the AS relationships in this model.
 
-![](/img/calico-enterprise/l3-fabric-downward-default.png)
+![Diagram showing the downward default model where all Calico nodes share one AS and all ToR switches share another, with spine routers announcing default routes downward](/img/calico-enterprise/l3-fabric-downward-default.png)
 
 In the diagram above, we are showing that all $[prodname] nodes share the same AS number, as do all ToR switches. However, those ASs are different (_A1_ is not the same network as _A2_, even though the both share the
 same AS number _A_ ).

--- a/calico-enterprise/reference/host-endpoints/overview.mdx
+++ b/calico-enterprise/reference/host-endpoints/overview.mdx
@@ -52,6 +52,6 @@ See [GlobalNetworkPolicy spec](../resources/globalnetworkpolicy.mdx#spec).
 Both traffic forwarded between host endpoints and traffic forwarded
 between a host endpoint and a workload endpoint on the same host is regarded as
 `forwarded traffic`.
-![](/img/calico-enterprise/bare-metal-packet-flows.svg)
+![Diagram showing packet flows for forwarded traffic between host endpoints and between host endpoints and workload endpoints](/img/calico-enterprise/bare-metal-packet-flows.svg)
 
 :::

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/architecture/design/l3-interconnect-fabric.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/architecture/design/l3-interconnect-fabric.mdx
@@ -95,11 +95,11 @@ This model is the closest to the model suggested by [IETF RFC 7938](https://data
 
 As mentioned earlier, there are two versions of this model, one with an set of Ethernet planes interconnecting the ToR switches, and the other where the core planes are also routers. The following diagrams may be useful for the discussion.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l2-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l2-spine.png)
 
 The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l3-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via discrete BGP spine routers, each in their own AS](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l3-spine.png)
 
 The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of discrete BGP spine routers, each in their own AS.
 
@@ -126,12 +126,12 @@ This model takes the concept of an AS per rack to its logical conclusion. In the
 
 Therefore, if we follow the architecture of the draft, the compute server, not the ToR should be the AS boundary. The differences can be seen in the following two diagrams.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-server-l2-spine.png)
+![Diagram showing the AS per compute server model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-server-l2-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR
 switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-server-l3-spine.png)
+![Diagram showing the AS per compute server model with ToR switches connected to independent routing planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-server-l3-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR switches are physically connected to a set of independent routing planes.
 
@@ -151,7 +151,7 @@ each stage of the routing path. This is to prevent routes from other nodes in th
 
 The following diagram will show the AS relationships in this model.
 
-![](/img/calico-enterprise/l3-fabric-downward-default.png)
+![Diagram showing the downward default model where all Calico nodes share one AS and all ToR switches share another, with spine routers announcing default routes downward](/img/calico-enterprise/l3-fabric-downward-default.png)
 
 In the diagram above, we are showing that all $[prodname] nodes share the same AS number, as do all ToR switches. However, those ASs are different (_A1_ is not the same network as _A2_, even though the both share the
 same AS number _A_ ).

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/host-endpoints/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/host-endpoints/overview.mdx
@@ -52,6 +52,6 @@ See [GlobalNetworkPolicy spec](../resources/globalnetworkpolicy.mdx#spec).
 Both traffic forwarded between host endpoints and traffic forwarded
 between a host endpoint and a workload endpoint on the same host is regarded as
 `forwarded traffic`.
-![](/img/calico-enterprise/bare-metal-packet-flows.svg)
+![Diagram showing packet flows for forwarded traffic between host endpoints and between host endpoints and workload endpoints](/img/calico-enterprise/bare-metal-packet-flows.svg)
 
 :::

--- a/calico-enterprise_versioned_docs/version-3.21-2/networking/configuring/bgp-to-workload.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/networking/configuring/bgp-to-workload.mdx
@@ -34,7 +34,7 @@ See [Configure BGP peering](./bgp.mdx) for a general overview of these concepts.
 
 ## Supported BGP topologies
 
-![](/img/calico/nested-bgp.svg)
+![Diagram showing supported BGP topologies for nested clusters running on KubeVirt VMs, with eBGP peering between parent and nested clusters](/img/calico/nested-bgp.svg)
 
 Both parent and nested clusters must be configured to use non-overlay BGP
 networking.

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/architecture/design/l3-interconnect-fabric.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/architecture/design/l3-interconnect-fabric.mdx
@@ -95,11 +95,11 @@ This model is the closest to the model suggested by [IETF RFC 7938](https://data
 
 As mentioned earlier, there are two versions of this model, one with an set of Ethernet planes interconnecting the ToR switches, and the other where the core planes are also routers. The following diagrams may be useful for the discussion.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l2-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l2-spine.png)
 
 The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l3-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via discrete BGP spine routers, each in their own AS](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l3-spine.png)
 
 The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of discrete BGP spine routers, each in their own AS.
 
@@ -126,12 +126,12 @@ This model takes the concept of an AS per rack to its logical conclusion. In the
 
 Therefore, if we follow the architecture of the draft, the compute server, not the ToR should be the AS boundary. The differences can be seen in the following two diagrams.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-server-l2-spine.png)
+![Diagram showing the AS per compute server model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-server-l2-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR
 switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-server-l3-spine.png)
+![Diagram showing the AS per compute server model with ToR switches connected to independent routing planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-server-l3-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR switches are physically connected to a set of independent routing planes.
 
@@ -151,7 +151,7 @@ each stage of the routing path. This is to prevent routes from other nodes in th
 
 The following diagram will show the AS relationships in this model.
 
-![](/img/calico-enterprise/l3-fabric-downward-default.png)
+![Diagram showing the downward default model where all Calico nodes share one AS and all ToR switches share another, with spine routers announcing default routes downward](/img/calico-enterprise/l3-fabric-downward-default.png)
 
 In the diagram above, we are showing that all $[prodname] nodes share the same AS number, as do all ToR switches. However, those ASs are different (_A1_ is not the same network as _A2_, even though the both share the
 same AS number _A_ ).

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/host-endpoints/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/host-endpoints/overview.mdx
@@ -52,6 +52,6 @@ See [GlobalNetworkPolicy spec](../resources/globalnetworkpolicy.mdx#spec).
 Both traffic forwarded between host endpoints and traffic forwarded
 between a host endpoint and a workload endpoint on the same host is regarded as
 `forwarded traffic`.
-![](/img/calico-enterprise/bare-metal-packet-flows.svg)
+![Diagram showing packet flows for forwarded traffic between host endpoints and between host endpoints and workload endpoints](/img/calico-enterprise/bare-metal-packet-flows.svg)
 
 :::

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/bgp-to-workload.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/bgp-to-workload.mdx
@@ -34,7 +34,7 @@ See [Configure BGP peering](./bgp.mdx) for a general overview of these concepts.
 
 ## Supported BGP topologies
 
-![](/img/calico/nested-bgp.svg)
+![Diagram showing supported BGP topologies for nested clusters running on KubeVirt VMs, with eBGP peering between parent and nested clusters](/img/calico/nested-bgp.svg)
 
 Both parent and nested clusters must be configured to use non-overlay BGP
 networking.

--- a/calico-enterprise_versioned_docs/version-3.22-2/reference/architecture/design/l3-interconnect-fabric.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/reference/architecture/design/l3-interconnect-fabric.mdx
@@ -95,11 +95,11 @@ This model is the closest to the model suggested by [IETF RFC 7938](https://data
 
 As mentioned earlier, there are two versions of this model, one with an set of Ethernet planes interconnecting the ToR switches, and the other where the core planes are also routers. The following diagrams may be useful for the discussion.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l2-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l2-spine.png)
 
 The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l3-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via discrete BGP spine routers, each in their own AS](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l3-spine.png)
 
 The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of discrete BGP spine routers, each in their own AS.
 
@@ -126,12 +126,12 @@ This model takes the concept of an AS per rack to its logical conclusion. In the
 
 Therefore, if we follow the architecture of the draft, the compute server, not the ToR should be the AS boundary. The differences can be seen in the following two diagrams.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-server-l2-spine.png)
+![Diagram showing the AS per compute server model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-server-l2-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR
 switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-server-l3-spine.png)
+![Diagram showing the AS per compute server model with ToR switches connected to independent routing planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-server-l3-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR switches are physically connected to a set of independent routing planes.
 
@@ -151,7 +151,7 @@ each stage of the routing path. This is to prevent routes from other nodes in th
 
 The following diagram will show the AS relationships in this model.
 
-![](/img/calico-enterprise/l3-fabric-downward-default.png)
+![Diagram showing the downward default model where all Calico nodes share one AS and all ToR switches share another, with spine routers announcing default routes downward](/img/calico-enterprise/l3-fabric-downward-default.png)
 
 In the diagram above, we are showing that all $[prodname] nodes share the same AS number, as do all ToR switches. However, those ASs are different (_A1_ is not the same network as _A2_, even though the both share the
 same AS number _A_ ).

--- a/calico-enterprise_versioned_docs/version-3.22-2/reference/host-endpoints/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/reference/host-endpoints/overview.mdx
@@ -52,6 +52,6 @@ See [GlobalNetworkPolicy spec](../resources/globalnetworkpolicy.mdx#spec).
 Both traffic forwarded between host endpoints and traffic forwarded
 between a host endpoint and a workload endpoint on the same host is regarded as
 `forwarded traffic`.
-![](/img/calico-enterprise/bare-metal-packet-flows.svg)
+![Diagram showing packet flows for forwarded traffic between host endpoints and between host endpoints and workload endpoints](/img/calico-enterprise/bare-metal-packet-flows.svg)
 
 :::

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/bgp-to-workload.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/bgp-to-workload.mdx
@@ -34,7 +34,7 @@ See [Configure BGP peering](./bgp.mdx) for a general overview of these concepts.
 
 ## Supported BGP topologies
 
-![](/img/calico/nested-bgp.svg)
+![Diagram showing supported BGP topologies for nested clusters running on KubeVirt VMs, with eBGP peering between parent and nested clusters](/img/calico/nested-bgp.svg)
 
 Both parent and nested clusters must be configured to use non-overlay BGP
 networking.

--- a/calico-enterprise_versioned_docs/version-3.23-1/reference/architecture/design/l3-interconnect-fabric.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/reference/architecture/design/l3-interconnect-fabric.mdx
@@ -95,11 +95,11 @@ This model is the closest to the model suggested by [IETF RFC 7938](https://data
 
 As mentioned earlier, there are two versions of this model, one with an set of Ethernet planes interconnecting the ToR switches, and the other where the core planes are also routers. The following diagrams may be useful for the discussion.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l2-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l2-spine.png)
 
 The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l3-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via discrete BGP spine routers, each in their own AS](/img/calico-enterprise/l3-fabric-diagrams-as-rack-l3-spine.png)
 
 The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of discrete BGP spine routers, each in their own AS.
 
@@ -126,12 +126,12 @@ This model takes the concept of an AS per rack to its logical conclusion. In the
 
 Therefore, if we follow the architecture of the draft, the compute server, not the ToR should be the AS boundary. The differences can be seen in the following two diagrams.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-server-l2-spine.png)
+![Diagram showing the AS per compute server model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-server-l2-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR
 switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico-enterprise/l3-fabric-diagrams-as-server-l3-spine.png)
+![Diagram showing the AS per compute server model with ToR switches connected to independent routing planes at the spine layer](/img/calico-enterprise/l3-fabric-diagrams-as-server-l3-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR switches are physically connected to a set of independent routing planes.
 
@@ -151,7 +151,7 @@ each stage of the routing path. This is to prevent routes from other nodes in th
 
 The following diagram will show the AS relationships in this model.
 
-![](/img/calico-enterprise/l3-fabric-downward-default.png)
+![Diagram showing the downward default model where all Calico nodes share one AS and all ToR switches share another, with spine routers announcing default routes downward](/img/calico-enterprise/l3-fabric-downward-default.png)
 
 In the diagram above, we are showing that all $[prodname] nodes share the same AS number, as do all ToR switches. However, those ASs are different (_A1_ is not the same network as _A2_, even though the both share the
 same AS number _A_ ).

--- a/calico-enterprise_versioned_docs/version-3.23-1/reference/host-endpoints/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/reference/host-endpoints/overview.mdx
@@ -52,6 +52,6 @@ See [GlobalNetworkPolicy spec](../resources/globalnetworkpolicy.mdx#spec).
 Both traffic forwarded between host endpoints and traffic forwarded
 between a host endpoint and a workload endpoint on the same host is regarded as
 `forwarded traffic`.
-![](/img/calico-enterprise/bare-metal-packet-flows.svg)
+![Diagram showing packet flows for forwarded traffic between host endpoints and between host endpoints and workload endpoints](/img/calico-enterprise/bare-metal-packet-flows.svg)
 
 :::

--- a/calico/networking/configuring/bgp-to-workload.mdx
+++ b/calico/networking/configuring/bgp-to-workload.mdx
@@ -34,7 +34,7 @@ See [Configure BGP peering](./bgp.mdx) for a general overview of these concepts.
 
 ## Supported BGP topologies
 
-![](/img/calico/nested-bgp.svg)
+![Diagram showing supported BGP topologies for nested clusters running on KubeVirt VMs, with eBGP peering between parent and nested clusters](/img/calico/nested-bgp.svg)
 
 Both parent and nested clusters must be configured to use non-overlay BGP
 networking.

--- a/calico/networking/openstack/semantics.mdx
+++ b/calico/networking/openstack/semantics.mdx
@@ -91,12 +91,12 @@ $[prodname] targets use cases that correspond to two Neutron data model patterns
 
 Firstly, where instances are attached directly to provider networks:
 
-![](/img/calico/networking-calico/calico-provider.png)
+![Diagram showing VMs on compute hosts connected directly to a Calico provider network with access to the physical network](/img/calico/networking-calico/calico-provider.png)
 
 Secondly, where instances are attached to an externally-connected tenant
 network:
 
-![](/img/calico/networking-calico/calico-tenant.png)
+![Diagram showing VMs on compute hosts connected to a Calico tenant network, routed through a Neutron router to a provider network and the physical network](/img/calico/networking-calico/calico-tenant.png)
 
 In the general case those patterns may be combined - so in general there may be
 any number of $[prodname] provider networks, and any number of $[prodname] tenant

--- a/calico/operations/monitor/monitor-component-visual.mdx
+++ b/calico/operations/monitor/monitor-component-visual.mdx
@@ -12,7 +12,7 @@ Use Grafana dashboard to view $[prodname] component metrics.
 
 Using Grafana can be beneficial by providing a means to visualize metrics through graphs that can help you quickly identify unusual activity. The following image shows some of the graphs and metrics that are available for you to leverage to achieve this goal.
 
-![](/img/calico/grafana-dashboard_3.28.png)
+![Screenshot of a Grafana dashboard displaying Calico component metrics including CPU usage, memory usage, client connections, and other performance graphs](/img/calico/grafana-dashboard_3.28.png)
 
 ## Concepts
 

--- a/calico/reference/architecture/design/l3-interconnect-fabric.mdx
+++ b/calico/reference/architecture/design/l3-interconnect-fabric.mdx
@@ -95,11 +95,11 @@ This model is the closest to the model suggested by [IETF RFC 7938](https://data
 
 As mentioned earlier, there are two versions of this model, one with an set of Ethernet planes interconnecting the ToR switches, and the other where the core planes are also routers. The following diagrams may be useful for the discussion.
 
-![](/img/calico/l3-fabric-diagrams-as-rack-l2-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico/l3-fabric-diagrams-as-rack-l2-spine.png)
 
 The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico/l3-fabric-diagrams-as-rack-l3-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via discrete BGP spine routers, each in their own AS](/img/calico/l3-fabric-diagrams-as-rack-l3-spine.png)
 
 The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of discrete BGP spine routers, each in their own AS.
 
@@ -126,12 +126,12 @@ This model takes the concept of an AS per rack to its logical conclusion. In the
 
 Therefore, if we follow the architecture of the draft, the compute server, not the ToR should be the AS boundary. The differences can be seen in the following two diagrams.
 
-![](/img/calico/l3-fabric-diagrams-as-server-l2-spine.png)
+![Diagram showing the AS per compute server model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico/l3-fabric-diagrams-as-server-l2-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR
 switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico/l3-fabric-diagrams-as-server-l3-spine.png)
+![Diagram showing the AS per compute server model with ToR switches connected to independent routing planes at the spine layer](/img/calico/l3-fabric-diagrams-as-server-l3-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR switches are physically connected to a set of independent routing planes.
 
@@ -151,7 +151,7 @@ each stage of the routing path. This is to prevent routes from other nodes in th
 
 The following diagram will show the AS relationships in this model.
 
-![](/img/calico/l3-fabric-downward-default.png)
+![Diagram showing the downward default model where all Calico nodes share one AS and all ToR switches share another, with spine routers announcing default routes downward](/img/calico/l3-fabric-downward-default.png)
 
 In the diagram above, we are showing that all $[prodname] nodes share the same AS number, as do all ToR switches. However, those ASs are different (_A1_ is not the same network as _A2_, even though the both share the
 same AS number _A_ ).

--- a/calico/reference/host-endpoints/overview.mdx
+++ b/calico/reference/host-endpoints/overview.mdx
@@ -52,6 +52,6 @@ See [GlobalNetworkPolicy spec](../resources/globalnetworkpolicy.mdx#spec).
 Both traffic forwarded between host endpoints and traffic forwarded
 between a host endpoint and a workload endpoint on the same host is regarded as
 `forwarded traffic`.
-![](/img/calico/bare-metal-packet-flows.svg)
+![Diagram showing packet flows for forwarded traffic between host endpoints and between host endpoints and workload endpoints](/img/calico/bare-metal-packet-flows.svg)
 
 :::

--- a/calico_versioned_docs/version-3.29/networking/openstack/semantics.mdx
+++ b/calico_versioned_docs/version-3.29/networking/openstack/semantics.mdx
@@ -91,12 +91,12 @@ $[prodname] targets use cases that correspond to two Neutron data model patterns
 
 Firstly, where instances are attached directly to provider networks:
 
-![](/img/calico/networking-calico/calico-provider.png)
+![Diagram showing VMs on compute hosts connected directly to a Calico provider network with access to the physical network](/img/calico/networking-calico/calico-provider.png)
 
 Secondly, where instances are attached to an externally-connected tenant
 network:
 
-![](/img/calico/networking-calico/calico-tenant.png)
+![Diagram showing VMs on compute hosts connected to a Calico tenant network, routed through a Neutron router to a provider network and the physical network](/img/calico/networking-calico/calico-tenant.png)
 
 In the general case those patterns may be combined - so in general there may be
 any number of $[prodname] provider networks, and any number of $[prodname] tenant

--- a/calico_versioned_docs/version-3.29/operations/monitor/monitor-component-visual.mdx
+++ b/calico_versioned_docs/version-3.29/operations/monitor/monitor-component-visual.mdx
@@ -12,7 +12,7 @@ Use Grafana dashboard to view $[prodname] component metrics.
 
 Using Grafana can be beneficial by providing a means to visualize metrics through graphs that can help you quickly identify unusual activity. The following image shows some of the graphs and metrics that are available for you to leverage to achieve this goal.
 
-![](/img/calico/grafana-dashboard_3.28.png)
+![Screenshot of a Grafana dashboard displaying Calico component metrics including CPU usage, memory usage, client connections, and other performance graphs](/img/calico/grafana-dashboard_3.28.png)
 
 ## Concepts
 

--- a/calico_versioned_docs/version-3.29/reference/architecture/design/l3-interconnect-fabric.mdx
+++ b/calico_versioned_docs/version-3.29/reference/architecture/design/l3-interconnect-fabric.mdx
@@ -95,11 +95,11 @@ This model is the closest to the model suggested by [IETF RFC 7938](https://data
 
 As mentioned earlier, there are two versions of this model, one with an set of Ethernet planes interconnecting the ToR switches, and the other where the core planes are also routers. The following diagrams may be useful for the discussion.
 
-![](/img/calico/l3-fabric-diagrams-as-rack-l2-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico/l3-fabric-diagrams-as-rack-l2-spine.png)
 
 The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico/l3-fabric-diagrams-as-rack-l3-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via discrete BGP spine routers, each in their own AS](/img/calico/l3-fabric-diagrams-as-rack-l3-spine.png)
 
 The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of discrete BGP spine routers, each in their own AS.
 
@@ -126,12 +126,12 @@ This model takes the concept of an AS per rack to its logical conclusion. In the
 
 Therefore, if we follow the architecture of the draft, the compute server, not the ToR should be the AS boundary. The differences can be seen in the following two diagrams.
 
-![](/img/calico/l3-fabric-diagrams-as-server-l2-spine.png)
+![Diagram showing the AS per compute server model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico/l3-fabric-diagrams-as-server-l2-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR
 switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico/l3-fabric-diagrams-as-server-l3-spine.png)
+![Diagram showing the AS per compute server model with ToR switches connected to independent routing planes at the spine layer](/img/calico/l3-fabric-diagrams-as-server-l3-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR switches are physically connected to a set of independent routing planes.
 
@@ -151,7 +151,7 @@ each stage of the routing path. This is to prevent routes from other nodes in th
 
 The following diagram will show the AS relationships in this model.
 
-![](/img/calico/l3-fabric-downward-default.png)
+![Diagram showing the downward default model where all Calico nodes share one AS and all ToR switches share another, with spine routers announcing default routes downward](/img/calico/l3-fabric-downward-default.png)
 
 In the diagram above, we are showing that all $[prodname] nodes share the same AS number, as do all ToR switches. However, those ASs are different (_A1_ is not the same network as _A2_, even though the both share the
 same AS number _A_ ).

--- a/calico_versioned_docs/version-3.29/reference/host-endpoints/overview.mdx
+++ b/calico_versioned_docs/version-3.29/reference/host-endpoints/overview.mdx
@@ -52,6 +52,6 @@ See [GlobalNetworkPolicy spec](../resources/globalnetworkpolicy.mdx#spec).
 Both traffic forwarded between host endpoints and traffic forwarded
 between a host endpoint and a workload endpoint on the same host is regarded as
 `forwarded traffic`.
-![](/img/calico/bare-metal-packet-flows.svg)
+![Diagram showing packet flows for forwarded traffic between host endpoints and between host endpoints and workload endpoints](/img/calico/bare-metal-packet-flows.svg)
 
 :::

--- a/calico_versioned_docs/version-3.30/networking/configuring/bgp-to-workload.mdx
+++ b/calico_versioned_docs/version-3.30/networking/configuring/bgp-to-workload.mdx
@@ -34,7 +34,7 @@ See [Configure BGP peering](./bgp.mdx) for a general overview of these concepts.
 
 ## Supported BGP topologies
 
-![](/img/calico/nested-bgp.svg)
+![Diagram showing supported BGP topologies for nested clusters running on KubeVirt VMs, with eBGP peering between parent and nested clusters](/img/calico/nested-bgp.svg)
 
 Both parent and nested clusters must be configured to use non-overlay BGP
 networking.

--- a/calico_versioned_docs/version-3.30/networking/openstack/semantics.mdx
+++ b/calico_versioned_docs/version-3.30/networking/openstack/semantics.mdx
@@ -91,12 +91,12 @@ $[prodname] targets use cases that correspond to two Neutron data model patterns
 
 Firstly, where instances are attached directly to provider networks:
 
-![](/img/calico/networking-calico/calico-provider.png)
+![Diagram showing VMs on compute hosts connected directly to a Calico provider network with access to the physical network](/img/calico/networking-calico/calico-provider.png)
 
 Secondly, where instances are attached to an externally-connected tenant
 network:
 
-![](/img/calico/networking-calico/calico-tenant.png)
+![Diagram showing VMs on compute hosts connected to a Calico tenant network, routed through a Neutron router to a provider network and the physical network](/img/calico/networking-calico/calico-tenant.png)
 
 In the general case those patterns may be combined - so in general there may be
 any number of $[prodname] provider networks, and any number of $[prodname] tenant

--- a/calico_versioned_docs/version-3.30/operations/monitor/monitor-component-visual.mdx
+++ b/calico_versioned_docs/version-3.30/operations/monitor/monitor-component-visual.mdx
@@ -12,7 +12,7 @@ Use Grafana dashboard to view $[prodname] component metrics.
 
 Using Grafana can be beneficial by providing a means to visualize metrics through graphs that can help you quickly identify unusual activity. The following image shows some of the graphs and metrics that are available for you to leverage to achieve this goal.
 
-![](/img/calico/grafana-dashboard_3.28.png)
+![Screenshot of a Grafana dashboard displaying Calico component metrics including CPU usage, memory usage, client connections, and other performance graphs](/img/calico/grafana-dashboard_3.28.png)
 
 ## Concepts
 

--- a/calico_versioned_docs/version-3.30/reference/architecture/design/l3-interconnect-fabric.mdx
+++ b/calico_versioned_docs/version-3.30/reference/architecture/design/l3-interconnect-fabric.mdx
@@ -95,11 +95,11 @@ This model is the closest to the model suggested by [IETF RFC 7938](https://data
 
 As mentioned earlier, there are two versions of this model, one with an set of Ethernet planes interconnecting the ToR switches, and the other where the core planes are also routers. The following diagrams may be useful for the discussion.
 
-![](/img/calico/l3-fabric-diagrams-as-rack-l2-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico/l3-fabric-diagrams-as-rack-l2-spine.png)
 
 The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico/l3-fabric-diagrams-as-rack-l3-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via discrete BGP spine routers, each in their own AS](/img/calico/l3-fabric-diagrams-as-rack-l3-spine.png)
 
 The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of discrete BGP spine routers, each in their own AS.
 
@@ -126,12 +126,12 @@ This model takes the concept of an AS per rack to its logical conclusion. In the
 
 Therefore, if we follow the architecture of the draft, the compute server, not the ToR should be the AS boundary. The differences can be seen in the following two diagrams.
 
-![](/img/calico/l3-fabric-diagrams-as-server-l2-spine.png)
+![Diagram showing the AS per compute server model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico/l3-fabric-diagrams-as-server-l2-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR
 switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico/l3-fabric-diagrams-as-server-l3-spine.png)
+![Diagram showing the AS per compute server model with ToR switches connected to independent routing planes at the spine layer](/img/calico/l3-fabric-diagrams-as-server-l3-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR switches are physically connected to a set of independent routing planes.
 
@@ -151,7 +151,7 @@ each stage of the routing path. This is to prevent routes from other nodes in th
 
 The following diagram will show the AS relationships in this model.
 
-![](/img/calico/l3-fabric-downward-default.png)
+![Diagram showing the downward default model where all Calico nodes share one AS and all ToR switches share another, with spine routers announcing default routes downward](/img/calico/l3-fabric-downward-default.png)
 
 In the diagram above, we are showing that all $[prodname] nodes share the same AS number, as do all ToR switches. However, those ASs are different (_A1_ is not the same network as _A2_, even though the both share the
 same AS number _A_ ).

--- a/calico_versioned_docs/version-3.30/reference/host-endpoints/overview.mdx
+++ b/calico_versioned_docs/version-3.30/reference/host-endpoints/overview.mdx
@@ -52,6 +52,6 @@ See [GlobalNetworkPolicy spec](../resources/globalnetworkpolicy.mdx#spec).
 Both traffic forwarded between host endpoints and traffic forwarded
 between a host endpoint and a workload endpoint on the same host is regarded as
 `forwarded traffic`.
-![](/img/calico/bare-metal-packet-flows.svg)
+![Diagram showing packet flows for forwarded traffic between host endpoints and between host endpoints and workload endpoints](/img/calico/bare-metal-packet-flows.svg)
 
 :::

--- a/calico_versioned_docs/version-3.31/networking/configuring/bgp-to-workload.mdx
+++ b/calico_versioned_docs/version-3.31/networking/configuring/bgp-to-workload.mdx
@@ -34,7 +34,7 @@ See [Configure BGP peering](./bgp.mdx) for a general overview of these concepts.
 
 ## Supported BGP topologies
 
-![](/img/calico/nested-bgp.svg)
+![Diagram showing supported BGP topologies for nested clusters running on KubeVirt VMs, with eBGP peering between parent and nested clusters](/img/calico/nested-bgp.svg)
 
 Both parent and nested clusters must be configured to use non-overlay BGP
 networking.

--- a/calico_versioned_docs/version-3.31/networking/openstack/semantics.mdx
+++ b/calico_versioned_docs/version-3.31/networking/openstack/semantics.mdx
@@ -91,12 +91,12 @@ $[prodname] targets use cases that correspond to two Neutron data model patterns
 
 Firstly, where instances are attached directly to provider networks:
 
-![](/img/calico/networking-calico/calico-provider.png)
+![Diagram showing VMs on compute hosts connected directly to a Calico provider network with access to the physical network](/img/calico/networking-calico/calico-provider.png)
 
 Secondly, where instances are attached to an externally-connected tenant
 network:
 
-![](/img/calico/networking-calico/calico-tenant.png)
+![Diagram showing VMs on compute hosts connected to a Calico tenant network, routed through a Neutron router to a provider network and the physical network](/img/calico/networking-calico/calico-tenant.png)
 
 In the general case those patterns may be combined - so in general there may be
 any number of $[prodname] provider networks, and any number of $[prodname] tenant

--- a/calico_versioned_docs/version-3.31/operations/monitor/monitor-component-visual.mdx
+++ b/calico_versioned_docs/version-3.31/operations/monitor/monitor-component-visual.mdx
@@ -12,7 +12,7 @@ Use Grafana dashboard to view $[prodname] component metrics.
 
 Using Grafana can be beneficial by providing a means to visualize metrics through graphs that can help you quickly identify unusual activity. The following image shows some of the graphs and metrics that are available for you to leverage to achieve this goal.
 
-![](/img/calico/grafana-dashboard_3.28.png)
+![Screenshot of a Grafana dashboard displaying Calico component metrics including CPU usage, memory usage, client connections, and other performance graphs](/img/calico/grafana-dashboard_3.28.png)
 
 ## Concepts
 

--- a/calico_versioned_docs/version-3.31/reference/architecture/design/l3-interconnect-fabric.mdx
+++ b/calico_versioned_docs/version-3.31/reference/architecture/design/l3-interconnect-fabric.mdx
@@ -95,11 +95,11 @@ This model is the closest to the model suggested by [IETF RFC 7938](https://data
 
 As mentioned earlier, there are two versions of this model, one with an set of Ethernet planes interconnecting the ToR switches, and the other where the core planes are also routers. The following diagrams may be useful for the discussion.
 
-![](/img/calico/l3-fabric-diagrams-as-rack-l2-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico/l3-fabric-diagrams-as-rack-l2-spine.png)
 
 The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico/l3-fabric-diagrams-as-rack-l3-spine.png)
+![Diagram showing the AS per rack model with ToR switches meshed via discrete BGP spine routers, each in their own AS](/img/calico/l3-fabric-diagrams-as-rack-l3-spine.png)
 
 The diagram above shows the **AS per rack model** where the ToR switches are physically meshed via a set of discrete BGP spine routers, each in their own AS.
 
@@ -126,12 +126,12 @@ This model takes the concept of an AS per rack to its logical conclusion. In the
 
 Therefore, if we follow the architecture of the draft, the compute server, not the ToR should be the AS boundary. The differences can be seen in the following two diagrams.
 
-![](/img/calico/l3-fabric-diagrams-as-server-l2-spine.png)
+![Diagram showing the AS per compute server model with ToR switches meshed via Ethernet switching planes at the spine layer](/img/calico/l3-fabric-diagrams-as-server-l2-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR
 switches are physically meshed via a set of Ethernet switching planes.
 
-![](/img/calico/l3-fabric-diagrams-as-server-l3-spine.png)
+![Diagram showing the AS per compute server model with ToR switches connected to independent routing planes at the spine layer](/img/calico/l3-fabric-diagrams-as-server-l3-spine.png)
 
 The diagram above shows the _AS per compute server model_ where the ToR switches are physically connected to a set of independent routing planes.
 
@@ -151,7 +151,7 @@ each stage of the routing path. This is to prevent routes from other nodes in th
 
 The following diagram will show the AS relationships in this model.
 
-![](/img/calico/l3-fabric-downward-default.png)
+![Diagram showing the downward default model where all Calico nodes share one AS and all ToR switches share another, with spine routers announcing default routes downward](/img/calico/l3-fabric-downward-default.png)
 
 In the diagram above, we are showing that all $[prodname] nodes share the same AS number, as do all ToR switches. However, those ASs are different (_A1_ is not the same network as _A2_, even though the both share the
 same AS number _A_ ).

--- a/calico_versioned_docs/version-3.31/reference/host-endpoints/overview.mdx
+++ b/calico_versioned_docs/version-3.31/reference/host-endpoints/overview.mdx
@@ -52,6 +52,6 @@ See [GlobalNetworkPolicy spec](../resources/globalnetworkpolicy.mdx#spec).
 Both traffic forwarded between host endpoints and traffic forwarded
 between a host endpoint and a workload endpoint on the same host is regarded as
 `forwarded traffic`.
-![](/img/calico/bare-metal-packet-flows.svg)
+![Diagram showing packet flows for forwarded traffic between host endpoints and between host endpoints and workload endpoints](/img/calico/bare-metal-packet-flows.svg)
 
 :::


### PR DESCRIPTION
## Summary
- Adds descriptive alt text to 10 unique images that previously had empty alt text (`![]()`)
- Covers all 3 products (Calico, Calico Enterprise, Calico Cloud) across both unversioned and versioned directories (39 files total)
- Images include L3 fabric topology diagrams, BGP topology diagrams, host endpoint packet flow diagrams, Grafana dashboard screenshot, and OpenStack network architecture diagrams

## Test plan
- [x] `grep` confirms zero remaining `![]()` patterns in the codebase
- [x] `make build` passes cleanly
- [ ] Spot-check rendered pages in Netlify preview to confirm images display correctly with alt text

Resolves: [DOCS-2843](https://tigera.atlassian.net/browse/DOCS-2843)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-2843]: https://tigera.atlassian.net/browse/DOCS-2843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ