### PR TITLE
Convert headings to sentence case

### DIFF
--- a/calico-cloud/_includes/components/ReqsKernel.js
+++ b/calico-cloud/_includes/components/ReqsKernel.js
@@ -11,7 +11,7 @@ export default function ReqsKernel() {
         as='h2'
         id='kernel-dependencies'
       >
-        Kernel Dependencies
+        Kernel dependencies
       </Heading>
       <Admonition type='tip'>
         <p>If you are using one of the recommended distributions, you will already satisfy these.</p>

--- a/calico-cloud/compliance/overview.mdx
+++ b/calico-cloud/compliance/overview.mdx
@@ -71,7 +71,7 @@ Compliance reports provide the following high-level information:
 
   You must configure audit logs for Kubernetes resources through the Kubernetes API to get a complete view of all resources.
 
-## How To
+## How to
 
 - [Configure report permissions](#configure-report-permissions)
 - [Configure and schedule reports](#configure-and-schedule-reports)

--- a/calico-cloud/image-assurance/understanding-scan-results.mdx
+++ b/calico-cloud/image-assurance/understanding-scan-results.mdx
@@ -49,7 +49,7 @@ Other notes:
 - In the All Scanned Images and Running Images tabs, the **Registry path** field may be blank if $[prodname] cannot access this metadata. For example, images from Docker Hub do not specify the registry in the image metadata.
 - Any exceptions configured for image scanning will be applicable to Runtime View as well. 
 
-## Image assessment: pass, warn, and fail
+## Image assessment: Pass, Warn, and Fail
 
 The Image Assurance image assessment is based on the [Common Vulnerability Scoring System v3 (CVSS Scores)](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator). The following table shows how Image Assurance scores map to CVSS scores.
 

--- a/calico-cloud/image-assurance/understanding-scan-results.mdx
+++ b/calico-cloud/image-assurance/understanding-scan-results.mdx
@@ -49,7 +49,7 @@ Other notes:
 - In the All Scanned Images and Running Images tabs, the **Registry path** field may be blank if $[prodname] cannot access this metadata. For example, images from Docker Hub do not specify the registry in the image metadata.
 - Any exceptions configured for image scanning will be applicable to Runtime View as well. 
 
-## Image assessment: Pass, Warn, and Fail
+## Image assessment: pass, warn, and fail
 
 The Image Assurance image assessment is based on the [Common Vulnerability Scoring System v3 (CVSS Scores)](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator). The following table shows how Image Assurance scores map to CVSS scores.
 

--- a/calico-cloud/network-policy/beginners/simple-policy-cnx.mdx
+++ b/calico-cloud/network-policy/beginners/simple-policy-cnx.mdx
@@ -231,7 +231,7 @@ To view it, go to the policy page and enable **Implicit Drops** from the **Eye**
 
 :::
 
-## Allow Access using a NetworkPolicy
+## Allow access using a NetworkPolicy
 
 Now, let's enable access to the nginx service using a NetworkPolicy. This will allow incoming connections from our `access` pod, but not
 from anywhere else.

--- a/calico-cloud/network-policy/hosts/host-forwarded-traffic.mdx
+++ b/calico-cloud/network-policy/hosts/host-forwarded-traffic.mdx
@@ -54,7 +54,7 @@ When preDNAT is set to false on a global network policy, the policy rules are ev
 
 If you set preDNAT policy to true, you must set applyOnForward to true, and preDNAT policy must only include Ingress policies.
 
-### Host Endpoints with interfaceName: `*`
+### Host endpoints with interfaceName: `*`
 
 HostEndpoint API objects can be created with the name of the host interface (as reported by ip link or similar), or they can be created with interfaceName set to `*`, which means all host interfaces on the given node, including the interfaces between the host to any WEPs on that host.
 

--- a/calico-cloud/networking/configuring/add-maglev-load-balancing.mdx
+++ b/calico-cloud/networking/configuring/add-maglev-load-balancing.mdx
@@ -74,7 +74,7 @@ Check the command output for an entry with your service's IP, and the "maglev" f
 
 ## Additional notes
 
-### BPF Map Sizing for Large Deployments
+### BPF map sizing for large deployments
 
 In order to evenly distribute traffic, consistent-hash-based load balancing algorithms like Maglev must allocate large lookup-tables (LUTs),
 leading to a larger memory footprint than basic algorithms e.g. random-selection, round-robin. For this reason, the feature is enabled on a

--- a/calico-cloud/networking/egress/egress-gateway-maintenance.mdx
+++ b/calico-cloud/networking/egress/egress-gateway-maintenance.mdx
@@ -4,7 +4,7 @@ description: React to egress gateway maintenance windows and minimize the impact
 
 # Optimize egress networking for workloads with long-lived TCP connections
 
-## Big Picture
+## Big picture
 
 React to egress gateway maintenance windows and minimize the impact of egress gateway downtime on sensitive workloads
 

--- a/calico-cloud/networking/egress/external-network.mdx
+++ b/calico-cloud/networking/egress/external-network.mdx
@@ -4,7 +4,7 @@ description: Allows workloads from different namespaces of a Kubernetes cluster 
 
 # Configure egress traffic to multiple external networks
 
-## Big Picture
+## Big picture
 
 Allows workloads from different namespaces of a Kubernetes cluster to egress onto different external networks that (may) have overlapping IPs with each other.
 

--- a/calico-cloud/observability/alerts.mdx
+++ b/calico-cloud/observability/alerts.mdx
@@ -32,7 +32,7 @@ Turning down aggregation levels for flow logs increases the amount of log data g
 
 To turn down aggregation on flow logs, go to [FelixConfiguration](../reference/resources/felixconfig.mdx) and set the field, **flowLogsFileAggregationKindForAllowed** to **1**.
 
-## How To
+## How to
 
 - [Manage alerts in the web console](#manage-alerts-in-manager-ui)
 - [Manage alerts using CLI](#manage-alerts-using-cli)

--- a/calico-cloud/observability/packetcapture.mdx
+++ b/calico-cloud/observability/packetcapture.mdx
@@ -46,7 +46,7 @@ For a simple use case workflow, see [Faster troubleshooting of microservices, co
 - Capturing traffic from pods with multiple interfaces
 - Capturing traffic for pods running on Windows hosts
 
-## How To
+## How to
 
 - [Enable packet capture](#enable-packet-capture)
 - [Packet capture in Service Graph](#packet-capture-in-service-graph)

--- a/calico-cloud/operations/monitor/prometheus/configure-prometheus.mdx
+++ b/calico-cloud/operations/monitor/prometheus/configure-prometheus.mdx
@@ -4,7 +4,7 @@ description: Configure rules for alerts and denied packets, for persistent stora
 
 # Configure Prometheus
 
-## Updating Denied Packets Rules
+## Updating denied packets rules
 
 This is an example of how to modify the sample rule created by the sample manifest.
 The process of updating rules is the same as for user created rules (documented below).
@@ -74,14 +74,14 @@ spec:
             description: '{{$labels.instance}} with calico-node pod {{$labels.pod}} has been denying packets at a fast rate {{$labels.sourceIp}} by policy {{$labels.policy}}.'
 ```
 
-## Creating a New Alerting Rule
+## Creating a new alerting rule
 
 Creating a new alerting rule is straightforward once you figure out what you
 want your rule to look for. Check [alerting rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)
 and [Queries](https://prometheus.io/docs/querying/examples/) for more
 information.
 
-### New Alerting Rule for Monitoring Calico Node
+### New alerting rule for monitoring Calico node
 
 To add the new alerting rule to our Prometheus instance, define a PrometheusRule manifest
 in the `tigera-prometheus` namespace with the labels
@@ -125,7 +125,7 @@ Your changes should be applied in a few seconds by the prometheus-config-reloade
 container inside the prometheus pod launched by the prometheus-operator
 (usually named `prometheus-<your-prometheus-instance-name>`).
 
-### New Alerting Rule for Monitoring BGP Peers
+### New alerting rule for monitoring BGP peers
 
 Let’s look at an example of a new alerting rule to our Prometheus instance with respect to monitoring BGP
 peering health. Define a PrometheusRule manifest in the tigera-prometheus namespace with the labels

--- a/calico-cloud/reference/resources/tier.mdx
+++ b/calico-cloud/reference/resources/tier.mdx
@@ -18,7 +18,7 @@ may be used to specify the resource type on the CLI:
 `tier.projectcalico.org`, `tiers.projectcalico.org` and abbreviations such as
 `tier.p` and `tiers.p`.
 
-## How Policy Is Evaluated
+## How policy is evaluated
 
 When a new connection is processed by $[prodname], each tier that contains a policy that applies to the endpoint processes the packet.
 Tiers are sorted by their `order` - smallest number first.

--- a/calico-cloud/threat/deeppacketinspection.mdx
+++ b/calico-cloud/threat/deeppacketinspection.mdx
@@ -30,7 +30,7 @@ It is commonly used for troubleshooting (like tcpdump and Wireshark), but also f
 - Multi-nic setup
 - $[prodname] nodes running Windows hosts
 
-## How To
+## How to
 
 - [Configure deep packet inspection](#configure-deep-packet-inspection)
 - [Configure resource requirements](#configure-resource-requirements)

--- a/calico-cloud_versioned_docs/version-22-2/_includes/components/ReqsKernel.js
+++ b/calico-cloud_versioned_docs/version-22-2/_includes/components/ReqsKernel.js
@@ -11,7 +11,7 @@ export default function ReqsKernel() {
         as='h2'
         id='kernel-dependencies'
       >
-        Kernel Dependencies
+        Kernel dependencies
       </Heading>
       <Admonition type='tip'>
         <p>If you are using one of the recommended distributions, you will already satisfy these.</p>

--- a/calico-cloud_versioned_docs/version-22-2/compliance/overview.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/compliance/overview.mdx
@@ -71,7 +71,7 @@ Compliance reports provide the following high-level information:
 
   You must configure audit logs for Kubernetes resources through the Kubernetes API to get a complete view of all resources.
 
-## How To
+## How to
 
 - [Configure report permissions](#configure-report-permissions)
 - [Configure and schedule reports](#configure-and-schedule-reports)

--- a/calico-cloud_versioned_docs/version-22-2/image-assurance/understanding-scan-results.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/image-assurance/understanding-scan-results.mdx
@@ -49,7 +49,7 @@ Other notes:
 - In the All Scanned Images and Running Images tabs, the **Registry path** field may be blank if $[prodname] cannot access this metadata. For example, images from Docker Hub do not specify the registry in the image metadata.
 - Any exceptions configured for image scanning will be applicable to Runtime View as well. 
 
-## Image assessment: pass, warn, and fail
+## Image assessment: Pass, Warn, and Fail
 
 The Image Assurance image assessment is based on the [Common Vulnerability Scoring System v3 (CVSS Scores)](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator). The following table shows how Image Assurance scores map to CVSS scores.
 

--- a/calico-cloud_versioned_docs/version-22-2/image-assurance/understanding-scan-results.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/image-assurance/understanding-scan-results.mdx
@@ -49,7 +49,7 @@ Other notes:
 - In the All Scanned Images and Running Images tabs, the **Registry path** field may be blank if $[prodname] cannot access this metadata. For example, images from Docker Hub do not specify the registry in the image metadata.
 - Any exceptions configured for image scanning will be applicable to Runtime View as well. 
 
-## Image assessment: Pass, Warn, and Fail
+## Image assessment: pass, warn, and fail
 
 The Image Assurance image assessment is based on the [Common Vulnerability Scoring System v3 (CVSS Scores)](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator). The following table shows how Image Assurance scores map to CVSS scores.
 

--- a/calico-cloud_versioned_docs/version-22-2/network-policy/beginners/simple-policy-cnx.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/network-policy/beginners/simple-policy-cnx.mdx
@@ -231,7 +231,7 @@ To view it, go to the policy page and enable **Implicit Drops** from the **Eye**
 
 :::
 
-## Allow Access using a NetworkPolicy
+## Allow access using a NetworkPolicy
 
 Now, let's enable access to the nginx service using a NetworkPolicy. This will allow incoming connections from our `access` pod, but not
 from anywhere else.

--- a/calico-cloud_versioned_docs/version-22-2/network-policy/hosts/host-forwarded-traffic.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/network-policy/hosts/host-forwarded-traffic.mdx
@@ -54,7 +54,7 @@ When preDNAT is set to false on a global network policy, the policy rules are ev
 
 If you set preDNAT policy to true, you must set applyOnForward to true, and preDNAT policy must only include Ingress policies.
 
-### Host Endpoints with interfaceName: `*`
+### Host endpoints with interfaceName: `*`
 
 HostEndpoint API objects can be created with the name of the host interface (as reported by ip link or similar), or they can be created with interfaceName set to `*`, which means all host interfaces on the given node, including the interfaces between the host to any WEPs on that host.
 

--- a/calico-cloud_versioned_docs/version-22-2/networking/egress/egress-gateway-maintenance.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/egress/egress-gateway-maintenance.mdx
@@ -4,7 +4,7 @@ description: React to egress gateway maintenance windows and minimize the impact
 
 # Optimize egress networking for workloads with long-lived TCP connections
 
-## Big Picture
+## Big picture
 
 React to egress gateway maintenance windows and minimize the impact of egress gateway downtime on sensitive workloads
 

--- a/calico-cloud_versioned_docs/version-22-2/networking/egress/external-network.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/egress/external-network.mdx
@@ -4,7 +4,7 @@ description: Allows workloads from different namespaces of a Kubernetes cluster 
 
 # Configure egress traffic to multiple external networks
 
-## Big Picture
+## Big picture
 
 Allows workloads from different namespaces of a Kubernetes cluster to egress onto different external networks that (may) have overlapping IPs with each other.
 

--- a/calico-cloud_versioned_docs/version-22-2/observability/alerts.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/alerts.mdx
@@ -32,7 +32,7 @@ Turning down aggregation levels for flow logs increases the amount of log data g
 
 To turn down aggregation on flow logs, go to [FelixConfiguration](../reference/resources/felixconfig.mdx) and set the field, **flowLogsFileAggregationKindForAllowed** to **1**.
 
-## How To
+## How to
 
 - [Manage alerts in the web console](#manage-alerts-in-manager-ui)
 - [Manage alerts using CLI](#manage-alerts-using-cli)

--- a/calico-cloud_versioned_docs/version-22-2/observability/packetcapture.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/packetcapture.mdx
@@ -46,7 +46,7 @@ For a simple use case workflow, see [Faster troubleshooting of microservices, co
 - Capturing traffic from pods with multiple interfaces
 - Capturing traffic for pods running on Windows hosts
 
-## How To
+## How to
 
 - [Enable packet capture](#enable-packet-capture)
 - [Packet capture in Service Graph](#packet-capture-in-service-graph)

--- a/calico-cloud_versioned_docs/version-22-2/operations/monitor/prometheus/configure-prometheus.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/monitor/prometheus/configure-prometheus.mdx
@@ -4,7 +4,7 @@ description: Configure rules for alerts and denied packets, for persistent stora
 
 # Configure Prometheus
 
-## Updating Denied Packets Rules
+## Updating denied packets rules
 
 This is an example of how to modify the sample rule created by the sample manifest.
 The process of updating rules is the same as for user created rules (documented below).
@@ -74,14 +74,14 @@ spec:
             description: '{{$labels.instance}} with calico-node pod {{$labels.pod}} has been denying packets at a fast rate {{$labels.sourceIp}} by policy {{$labels.policy}}.'
 ```
 
-## Creating a New Alerting Rule
+## Creating a new alerting rule
 
 Creating a new alerting rule is straightforward once you figure out what you
 want your rule to look for. Check [alerting rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)
 and [Queries](https://prometheus.io/docs/querying/examples/) for more
 information.
 
-### New Alerting Rule for Monitoring Calico Node
+### New alerting rule for monitoring Calico node
 
 To add the new alerting rule to our Prometheus instance, define a PrometheusRule manifest
 in the `tigera-prometheus` namespace with the labels
@@ -125,7 +125,7 @@ Your changes should be applied in a few seconds by the prometheus-config-reloade
 container inside the prometheus pod launched by the prometheus-operator
 (usually named `prometheus-<your-prometheus-instance-name>`).
 
-### New Alerting Rule for Monitoring BGP Peers
+### New alerting rule for monitoring BGP peers
 
 Let’s look at an example of a new alerting rule to our Prometheus instance with respect to monitoring BGP
 peering health. Define a PrometheusRule manifest in the tigera-prometheus namespace with the labels

--- a/calico-cloud_versioned_docs/version-22-2/reference/resources/tier.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/reference/resources/tier.mdx
@@ -18,7 +18,7 @@ may be used to specify the resource type on the CLI:
 `tier.projectcalico.org`, `tiers.projectcalico.org` and abbreviations such as
 `tier.p` and `tiers.p`.
 
-## How Policy Is Evaluated
+## How policy is evaluated
 
 When a new connection is processed by $[prodname], each tier that contains a policy that applies to the endpoint processes the packet.
 Tiers are sorted by their `order` - smallest number first.

--- a/calico-cloud_versioned_docs/version-22-2/threat/deeppacketinspection.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/threat/deeppacketinspection.mdx
@@ -30,7 +30,7 @@ It is commonly used for troubleshooting (like tcpdump and Wireshark), but also f
 - Multi-nic setup
 - $[prodname] nodes running Windows hosts
 
-## How To
+## How to
 
 - [Configure deep packet inspection](#configure-deep-packet-inspection)
 - [Configure resource requirements](#configure-resource-requirements)

--- a/calico-enterprise/_includes/components/ReqsKernel.js
+++ b/calico-enterprise/_includes/components/ReqsKernel.js
@@ -11,7 +11,7 @@ export default function ReqsKernel() {
         as='h2'
         id='kernel-dependencies'
       >
-        Kernel Dependencies
+        Kernel dependencies
       </Heading>
       <Admonition type='tip'>
         <p>If you are using one of the recommended distributions, you will already satisfy these.</p>

--- a/calico-enterprise/compliance/overview.mdx
+++ b/calico-enterprise/compliance/overview.mdx
@@ -71,7 +71,7 @@ Compliance reports provide the following high-level information:
 
   You must configure audit logs for Kubernetes resources through the Kubernetes API to get a complete view of all resources.
 
-## How To
+## How to
 
 - [Configure report permissions](#configure-report-permissions)
 - [Configure and schedule reports](#configure-and-schedule-reports)

--- a/calico-enterprise/network-policy/beginners/simple-policy-cnx.mdx
+++ b/calico-enterprise/network-policy/beginners/simple-policy-cnx.mdx
@@ -229,7 +229,7 @@ To view it, go to the policy page and enable **Implicit Drops** from the **Eye**
 
 :::
 
-## Allow Access using a NetworkPolicy
+## Allow access using a NetworkPolicy
 
 Now, let's enable access to the nginx service using a NetworkPolicy. This will allow incoming connections from our `access` pod, but not
 from anywhere else.

--- a/calico-enterprise/network-policy/hosts/host-forwarded-traffic.mdx
+++ b/calico-enterprise/network-policy/hosts/host-forwarded-traffic.mdx
@@ -54,7 +54,7 @@ When preDNAT is set to false on a global network policy, the policy rules are ev
 
 If you set preDNAT policy to true, you must set applyOnForward to true, and preDNAT policy must only include Ingress policies.
 
-### Host Endpoints with interfaceName: `*`
+### Host endpoints with interfaceName: `*`
 
 HostEndpoint API objects can be created with the name of the host interface (as reported by ip link or similar), or they can be created with interfaceName set to `*`, which means all host interfaces on the given node, including the interfaces between the host to any WEPs on that host.
 

--- a/calico-enterprise/networking/configuring/add-maglev-load-balancing.mdx
+++ b/calico-enterprise/networking/configuring/add-maglev-load-balancing.mdx
@@ -74,7 +74,7 @@ Check the command output for an entry with your service's IP, and the "maglev" f
 
 ## Additional notes
 
-### BPF Map Sizing for Large Deployments
+### BPF map sizing for large deployments
 
 In order to evenly distribute traffic, consistent-hash-based load balancing algorithms like Maglev must allocate large lookup-tables (LUTs),
 leading to a larger memory footprint than basic algorithms e.g. random-selection, round-robin. For this reason, the feature is enabled on a

--- a/calico-enterprise/networking/determine-best-networking.mdx
+++ b/calico-enterprise/networking/determine-best-networking.mdx
@@ -140,7 +140,7 @@ The Google cloud provider integration uses host-local IPAM CNI plugin to allocat
 
 The host local CNI IPAM plugin is a commonly used IP address management CNI plugin, which allocates a fixed size IP address range (CIDR) to each node, and then allocates pod IP addresses from within that range. The default address range size is 256 IP addresses (a /24), though two of those IP addresses are reserved for special purposes and not assigned to pods. The simplicity of host local CNI IPAM plugin makes it easy to understand, but results in less efficient IP address space usage compared to $[prodname] CNI IPAM plugin.
 
-## Networking Options
+## Networking options
 
 ### On-prem
 

--- a/calico-enterprise/networking/egress/egress-gateway-maintenance.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-maintenance.mdx
@@ -4,7 +4,7 @@ description: React to egress gateway maintenance windows and minimize the impact
 
 # Optimize egress networking for workloads with long-lived TCP connections
 
-## Big Picture
+## Big picture
 
 React to egress gateway maintenance windows and minimize the impact of egress gateway downtime on sensitive workloads
 

--- a/calico-enterprise/networking/egress/external-network.mdx
+++ b/calico-enterprise/networking/egress/external-network.mdx
@@ -4,7 +4,7 @@ description: Allows workloads from different namespaces of a Kubernetes cluster 
 
 # Configure egress traffic to multiple external networks
 
-## Big Picture
+## Big picture
 
 Allows workloads from different namespaces of a Kubernetes cluster to egress onto different external networks that (may) have overlapping IPs with each other.
 

--- a/calico-enterprise/observability/alerts.mdx
+++ b/calico-enterprise/observability/alerts.mdx
@@ -26,7 +26,7 @@ We recommend turning down the aggregation level for flow logs to ensure that you
 
 To turn down aggregation on flow logs, go to [FelixConfiguration](../reference/resources/felixconfig.mdx) and set the field, **flowLogsFileAggregationKindForAllowed** to **1**.
 
-## How To
+## How to
 
 - [Manage alerts in the web console](#manage-alerts-in-manager-ui)
 - [Manage alerts using CLI](#manage-alerts-using-cli)

--- a/calico-enterprise/observability/packetcapture.mdx
+++ b/calico-enterprise/observability/packetcapture.mdx
@@ -46,7 +46,7 @@ For a simple use case workflow, see [Faster troubleshooting of microservices, co
 - Capturing traffic from pods with multiple interfaces
 - Capturing traffic for pods running on Windows hosts
 
-## How To
+## How to
 
 - [Enable packet capture](#enable-packet-capture)
 - [Packet capture in Service Graph](#packet-capture-in-service-graph)

--- a/calico-enterprise/operations/monitor/prometheus/configure-prometheus.mdx
+++ b/calico-enterprise/operations/monitor/prometheus/configure-prometheus.mdx
@@ -4,7 +4,7 @@ description: Configure rules for alerts and denied packets, for persistent stora
 
 # Configure Prometheus
 
-## Updating Denied Packets Rules
+## Updating denied packets rules
 
 This is an example of how to modify the sample rule created by the sample manifest.
 The process of updating rules is the same as for user created rules (documented below).
@@ -74,14 +74,14 @@ spec:
             description: '{{$labels.instance}} with calico-node pod {{$labels.pod}} has been denying packets at a fast rate {{$labels.sourceIp}} by policy {{$labels.policy}}.'
 ```
 
-## Creating a New Alerting Rule
+## Creating a new alerting rule
 
 Creating a new alerting rule is straightforward once you figure out what you
 want your rule to look for. Check [alerting rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)
 and [Queries](https://prometheus.io/docs/querying/examples/) for more
 information.
 
-### New Alerting Rule for Monitoring Calico Node
+### New alerting rule for monitoring Calico node
 
 To add the new alerting rule to our Prometheus instance, define a PrometheusRule manifest
 in the `tigera-prometheus` namespace with the labels
@@ -125,7 +125,7 @@ Your changes should be applied in a few seconds by the prometheus-config-reloade
 container inside the prometheus pod launched by the prometheus-operator
 (usually named `prometheus-<your-prometheus-instance-name>`).
 
-### New Alerting Rule for Monitoring BGP Peers
+### New alerting rule for monitoring BGP peers
 
 Let’s look at an example of a new alerting rule to our Prometheus instance with respect to monitoring BGP
 peering health. Define a PrometheusRule manifest in the tigera-prometheus namespace with the labels

--- a/calico-enterprise/reference/resources/tier.mdx
+++ b/calico-enterprise/reference/resources/tier.mdx
@@ -18,7 +18,7 @@ may be used to specify the resource type on the CLI:
 `tier.projectcalico.org`, `tiers.projectcalico.org` and abbreviations such as
 `tier.p` and `tiers.p`.
 
-## How Policy Is Evaluated
+## How policy is evaluated
 
 When a new connection is processed by $[prodname], each tier that contains a policy that applies to the endpoint processes the packet.
 Tiers are sorted by their `order` - smallest number first.

--- a/calico-enterprise/threat/deeppacketinspection.mdx
+++ b/calico-enterprise/threat/deeppacketinspection.mdx
@@ -30,7 +30,7 @@ It is commonly used for troubleshooting (like tcpdump and Wireshark), but also f
 - Multi-nic setup
 - $[prodname] nodes running Windows hosts
 
-## How To
+## How to
 
 - [Configure deep packet inspection](#configure-deep-packet-inspection)
 - [Configure resource requirements](#configure-resource-requirements)

--- a/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/ReqsKernel.js
+++ b/calico-enterprise_versioned_docs/version-3.20-2/_includes/components/ReqsKernel.js
@@ -11,7 +11,7 @@ export default function ReqsKernel() {
         as='h2'
         id='kernel-dependencies'
       >
-        Kernel Dependencies
+        Kernel dependencies
       </Heading>
       <Admonition type='tip'>
         <p>If you are using one of the recommended distributions, you will already satisfy these.</p>

--- a/calico-enterprise_versioned_docs/version-3.20-2/compliance/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/compliance/overview.mdx
@@ -71,7 +71,7 @@ Compliance reports provide the following high-level information:
 
   You must configure audit logs for Kubernetes resources through the Kubernetes API to get a complete view of all resources.
 
-## How To
+## How to
 
 - [Configure report permissions](#configure-report-permissions)
 - [Configure and schedule reports](#configure-and-schedule-reports)

--- a/calico-enterprise_versioned_docs/version-3.20-2/network-policy/beginners/simple-policy-cnx.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/network-policy/beginners/simple-policy-cnx.mdx
@@ -229,7 +229,7 @@ To view it, go to the policy page and enable **Implicit Drops** from the **Eye**
 
 :::
 
-## Allow Access using a NetworkPolicy
+## Allow access using a NetworkPolicy
 
 Now, let's enable access to the nginx service using a NetworkPolicy. This will allow incoming connections from our `access` pod, but not
 from anywhere else.

--- a/calico-enterprise_versioned_docs/version-3.20-2/network-policy/hosts/host-forwarded-traffic.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/network-policy/hosts/host-forwarded-traffic.mdx
@@ -54,7 +54,7 @@ When preDNAT is set to false on a global network policy, the policy rules are ev
 
 If you set preDNAT policy to true, you must set applyOnForward to true, and preDNAT policy must only include Ingress policies.
 
-### Host Endpoints with interfaceName: `*`
+### Host endpoints with interfaceName: `*`
 
 HostEndpoint API objects can be created with the name of the host interface (as reported by ip link or similar), or they can be created with interfaceName set to `*`, which means all host interfaces on the given node, including the interfaces between the host to any WEPs on that host.
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/networking/determine-best-networking.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/networking/determine-best-networking.mdx
@@ -140,7 +140,7 @@ The Google cloud provider integration uses host-local IPAM CNI plugin to allocat
 
 The host local CNI IPAM plugin is a commonly used IP address management CNI plugin, which allocates a fixed size IP address range (CIDR) to each node, and then allocates pod IP addresses from within that range. The default address range size is 256 IP addresses (a /24), though two of those IP addresses are reserved for special purposes and not assigned to pods. The simplicity of host local CNI IPAM plugin makes it easy to understand, but results in less efficient IP address space usage compared to $[prodname] CNI IPAM plugin.
 
-## Networking Options
+## Networking options
 
 ### On-prem
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/networking/egress/egress-gateway-maintenance.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/networking/egress/egress-gateway-maintenance.mdx
@@ -4,7 +4,7 @@ description: React to egress gateway maintenance windows and minimize the impact
 
 # Optimize egress networking for workloads with long-lived TCP connections
 
-## Big Picture
+## Big picture
 
 React to egress gateway maintenance windows and minimize the impact of egress gateway downtime on sensitive workloads
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/networking/egress/external-network.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/networking/egress/external-network.mdx
@@ -4,7 +4,7 @@ description: Allows workloads from different namespaces of a Kubernetes cluster 
 
 # Configure egress traffic to multiple external networks
 
-## Big Picture
+## Big picture
 
 Allows workloads from different namespaces of a Kubernetes cluster to egress onto different external networks that (may) have overlapping IPs with each other.
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/observability/alerts.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/observability/alerts.mdx
@@ -26,7 +26,7 @@ We recommend turning down the aggregation level for flow logs to ensure that you
 
 To turn down aggregation on flow logs, go to [FelixConfiguration](../reference/resources/felixconfig.mdx) and set the field, **flowLogsFileAggregationKindForAllowed** to **1**.
 
-## How To
+## How to
 
 - [Manage alerts in the web console](#manage-alerts-in-manager-ui)
 - [Manage alerts using CLI](#manage-alerts-using-cli)

--- a/calico-enterprise_versioned_docs/version-3.20-2/observability/packetcapture.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/observability/packetcapture.mdx
@@ -46,7 +46,7 @@ For a simple use case workflow, see [Faster troubleshooting of microservices, co
 - Capturing traffic from pods with multiple interfaces
 - Capturing traffic for pods running on Windows hosts
 
-## How To
+## How to
 
 - [Enable packet capture](#enable-packet-capture)
 - [Packet capture in Service Graph](#packet-capture-in-service-graph)

--- a/calico-enterprise_versioned_docs/version-3.20-2/operations/monitor/prometheus/configure-prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/operations/monitor/prometheus/configure-prometheus.mdx
@@ -4,7 +4,7 @@ description: Configure rules for alerts and denied packets, for persistent stora
 
 # Configure Prometheus
 
-## Updating Denied Packets Rules
+## Updating denied packets rules
 
 This is an example of how to modify the sample rule created by the sample manifest.
 The process of updating rules is the same as for user created rules (documented below).
@@ -74,14 +74,14 @@ spec:
             description: '{{$labels.instance}} with calico-node pod {{$labels.pod}} has been denying packets at a fast rate {{$labels.sourceIp}} by policy {{$labels.policy}}.'
 ```
 
-## Creating a New Alerting Rule
+## Creating a new alerting rule
 
 Creating a new alerting rule is straightforward once you figure out what you
 want your rule to look for. Check [alerting rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)
 and [Queries](https://prometheus.io/docs/querying/examples/) for more
 information.
 
-### New Alerting Rule for Monitoring Calico Node
+### New alerting rule for monitoring Calico node
 
 To add the new alerting rule to our Prometheus instance, define a PrometheusRule manifest
 in the `tigera-prometheus` namespace with the labels
@@ -125,7 +125,7 @@ Your changes should be applied in a few seconds by the prometheus-config-reloade
 container inside the prometheus pod launched by the prometheus-operator
 (usually named `prometheus-<your-prometheus-instance-name>`).
 
-### New Alerting Rule for Monitoring BGP Peers
+### New alerting rule for monitoring BGP peers
 
 Let’s look at an example of a new alerting rule to our Prometheus instance with respect to monitoring BGP
 peering health. Define a PrometheusRule manifest in the tigera-prometheus namespace with the labels

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/resources/tier.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/resources/tier.mdx
@@ -18,7 +18,7 @@ may be used to specify the resource type on the CLI:
 `tier.projectcalico.org`, `tiers.projectcalico.org` and abbreviations such as
 `tier.p` and `tiers.p`.
 
-## How Policy Is Evaluated
+## How policy is evaluated
 
 When a new connection is processed by $[prodname], each tier that contains a policy that applies to the endpoint processes the packet.
 Tiers are sorted by their `order` - smallest number first.

--- a/calico-enterprise_versioned_docs/version-3.20-2/threat/deeppacketinspection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/threat/deeppacketinspection.mdx
@@ -30,7 +30,7 @@ It is commonly used for troubleshooting (like tcpdump and Wireshark), but also f
 - Multi-nic setup
 - $[prodname] nodes running Windows hosts
 
-## How To
+## How to
 
 - [Configure deep packet inspection](#configure-deep-packet-inspection)
 - [Configure resource requirements](#configure-resource-requirements)

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/ReqsKernel.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/ReqsKernel.js
@@ -11,7 +11,7 @@ export default function ReqsKernel() {
         as='h2'
         id='kernel-dependencies'
       >
-        Kernel Dependencies
+        Kernel dependencies
       </Heading>
       <Admonition type='tip'>
         <p>If you are using one of the recommended distributions, you will already satisfy these.</p>

--- a/calico-enterprise_versioned_docs/version-3.21-2/compliance/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/compliance/overview.mdx
@@ -71,7 +71,7 @@ Compliance reports provide the following high-level information:
 
   You must configure audit logs for Kubernetes resources through the Kubernetes API to get a complete view of all resources.
 
-## How To
+## How to
 
 - [Configure report permissions](#configure-report-permissions)
 - [Configure and schedule reports](#configure-and-schedule-reports)

--- a/calico-enterprise_versioned_docs/version-3.21-2/network-policy/beginners/simple-policy-cnx.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/network-policy/beginners/simple-policy-cnx.mdx
@@ -229,7 +229,7 @@ To view it, go to the policy page and enable **Implicit Drops** from the **Eye**
 
 :::
 
-## Allow Access using a NetworkPolicy
+## Allow access using a NetworkPolicy
 
 Now, let's enable access to the nginx service using a NetworkPolicy. This will allow incoming connections from our `access` pod, but not
 from anywhere else.

--- a/calico-enterprise_versioned_docs/version-3.21-2/network-policy/hosts/host-forwarded-traffic.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/network-policy/hosts/host-forwarded-traffic.mdx
@@ -54,7 +54,7 @@ When preDNAT is set to false on a global network policy, the policy rules are ev
 
 If you set preDNAT policy to true, you must set applyOnForward to true, and preDNAT policy must only include Ingress policies.
 
-### Host Endpoints with interfaceName: `*`
+### Host endpoints with interfaceName: `*`
 
 HostEndpoint API objects can be created with the name of the host interface (as reported by ip link or similar), or they can be created with interfaceName set to `*`, which means all host interfaces on the given node, including the interfaces between the host to any WEPs on that host.
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/networking/determine-best-networking.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/networking/determine-best-networking.mdx
@@ -140,7 +140,7 @@ The Google cloud provider integration uses host-local IPAM CNI plugin to allocat
 
 The host local CNI IPAM plugin is a commonly used IP address management CNI plugin, which allocates a fixed size IP address range (CIDR) to each node, and then allocates pod IP addresses from within that range. The default address range size is 256 IP addresses (a /24), though two of those IP addresses are reserved for special purposes and not assigned to pods. The simplicity of host local CNI IPAM plugin makes it easy to understand, but results in less efficient IP address space usage compared to $[prodname] CNI IPAM plugin.
 
-## Networking Options
+## Networking options
 
 ### On-prem
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/networking/egress/egress-gateway-maintenance.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/networking/egress/egress-gateway-maintenance.mdx
@@ -4,7 +4,7 @@ description: React to egress gateway maintenance windows and minimize the impact
 
 # Optimize egress networking for workloads with long-lived TCP connections
 
-## Big Picture
+## Big picture
 
 React to egress gateway maintenance windows and minimize the impact of egress gateway downtime on sensitive workloads
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/networking/egress/external-network.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/networking/egress/external-network.mdx
@@ -4,7 +4,7 @@ description: Allows workloads from different namespaces of a Kubernetes cluster 
 
 # Configure egress traffic to multiple external networks
 
-## Big Picture
+## Big picture
 
 Allows workloads from different namespaces of a Kubernetes cluster to egress onto different external networks that (may) have overlapping IPs with each other.
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/observability/alerts.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/observability/alerts.mdx
@@ -26,7 +26,7 @@ We recommend turning down the aggregation level for flow logs to ensure that you
 
 To turn down aggregation on flow logs, go to [FelixConfiguration](../reference/resources/felixconfig.mdx) and set the field, **flowLogsFileAggregationKindForAllowed** to **1**.
 
-## How To
+## How to
 
 - [Manage alerts in the web console](#manage-alerts-in-manager-ui)
 - [Manage alerts using CLI](#manage-alerts-using-cli)

--- a/calico-enterprise_versioned_docs/version-3.21-2/observability/packetcapture.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/observability/packetcapture.mdx
@@ -46,7 +46,7 @@ For a simple use case workflow, see [Faster troubleshooting of microservices, co
 - Capturing traffic from pods with multiple interfaces
 - Capturing traffic for pods running on Windows hosts
 
-## How To
+## How to
 
 - [Enable packet capture](#enable-packet-capture)
 - [Packet capture in Service Graph](#packet-capture-in-service-graph)

--- a/calico-enterprise_versioned_docs/version-3.21-2/operations/monitor/prometheus/configure-prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/operations/monitor/prometheus/configure-prometheus.mdx
@@ -4,7 +4,7 @@ description: Configure rules for alerts and denied packets, for persistent stora
 
 # Configure Prometheus
 
-## Updating Denied Packets Rules
+## Updating denied packets rules
 
 This is an example of how to modify the sample rule created by the sample manifest.
 The process of updating rules is the same as for user created rules (documented below).
@@ -74,14 +74,14 @@ spec:
             description: '{{$labels.instance}} with calico-node pod {{$labels.pod}} has been denying packets at a fast rate {{$labels.sourceIp}} by policy {{$labels.policy}}.'
 ```
 
-## Creating a New Alerting Rule
+## Creating a new alerting rule
 
 Creating a new alerting rule is straightforward once you figure out what you
 want your rule to look for. Check [alerting rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)
 and [Queries](https://prometheus.io/docs/querying/examples/) for more
 information.
 
-### New Alerting Rule for Monitoring Calico Node
+### New alerting rule for monitoring Calico node
 
 To add the new alerting rule to our Prometheus instance, define a PrometheusRule manifest
 in the `tigera-prometheus` namespace with the labels
@@ -125,7 +125,7 @@ Your changes should be applied in a few seconds by the prometheus-config-reloade
 container inside the prometheus pod launched by the prometheus-operator
 (usually named `prometheus-<your-prometheus-instance-name>`).
 
-### New Alerting Rule for Monitoring BGP Peers
+### New alerting rule for monitoring BGP peers
 
 Let’s look at an example of a new alerting rule to our Prometheus instance with respect to monitoring BGP
 peering health. Define a PrometheusRule manifest in the tigera-prometheus namespace with the labels

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/resources/tier.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/resources/tier.mdx
@@ -18,7 +18,7 @@ may be used to specify the resource type on the CLI:
 `tier.projectcalico.org`, `tiers.projectcalico.org` and abbreviations such as
 `tier.p` and `tiers.p`.
 
-## How Policy Is Evaluated
+## How policy is evaluated
 
 When a new connection is processed by $[prodname], each tier that contains a policy that applies to the endpoint processes the packet.
 Tiers are sorted by their `order` - smallest number first.

--- a/calico-enterprise_versioned_docs/version-3.21-2/threat/deeppacketinspection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/threat/deeppacketinspection.mdx
@@ -30,7 +30,7 @@ It is commonly used for troubleshooting (like tcpdump and Wireshark), but also f
 - Multi-nic setup
 - $[prodname] nodes running Windows hosts
 
-## How To
+## How to
 
 - [Configure deep packet inspection](#configure-deep-packet-inspection)
 - [Configure resource requirements](#configure-resource-requirements)

--- a/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/ReqsKernel.js
+++ b/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/ReqsKernel.js
@@ -11,7 +11,7 @@ export default function ReqsKernel() {
         as='h2'
         id='kernel-dependencies'
       >
-        Kernel Dependencies
+        Kernel dependencies
       </Heading>
       <Admonition type='tip'>
         <p>If you are using one of the recommended distributions, you will already satisfy these.</p>

--- a/calico-enterprise_versioned_docs/version-3.22-2/compliance/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/compliance/overview.mdx
@@ -71,7 +71,7 @@ Compliance reports provide the following high-level information:
 
   You must configure audit logs for Kubernetes resources through the Kubernetes API to get a complete view of all resources.
 
-## How To
+## How to
 
 - [Configure report permissions](#configure-report-permissions)
 - [Configure and schedule reports](#configure-and-schedule-reports)

--- a/calico-enterprise_versioned_docs/version-3.22-2/network-policy/beginners/simple-policy-cnx.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/network-policy/beginners/simple-policy-cnx.mdx
@@ -229,7 +229,7 @@ To view it, go to the policy page and enable **Implicit Drops** from the **Eye**
 
 :::
 
-## Allow Access using a NetworkPolicy
+## Allow access using a NetworkPolicy
 
 Now, let's enable access to the nginx service using a NetworkPolicy. This will allow incoming connections from our `access` pod, but not
 from anywhere else.

--- a/calico-enterprise_versioned_docs/version-3.22-2/network-policy/hosts/host-forwarded-traffic.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/network-policy/hosts/host-forwarded-traffic.mdx
@@ -54,7 +54,7 @@ When preDNAT is set to false on a global network policy, the policy rules are ev
 
 If you set preDNAT policy to true, you must set applyOnForward to true, and preDNAT policy must only include Ingress policies.
 
-### Host Endpoints with interfaceName: `*`
+### Host endpoints with interfaceName: `*`
 
 HostEndpoint API objects can be created with the name of the host interface (as reported by ip link or similar), or they can be created with interfaceName set to `*`, which means all host interfaces on the given node, including the interfaces between the host to any WEPs on that host.
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/determine-best-networking.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/determine-best-networking.mdx
@@ -140,7 +140,7 @@ The Google cloud provider integration uses host-local IPAM CNI plugin to allocat
 
 The host local CNI IPAM plugin is a commonly used IP address management CNI plugin, which allocates a fixed size IP address range (CIDR) to each node, and then allocates pod IP addresses from within that range. The default address range size is 256 IP addresses (a /24), though two of those IP addresses are reserved for special purposes and not assigned to pods. The simplicity of host local CNI IPAM plugin makes it easy to understand, but results in less efficient IP address space usage compared to $[prodname] CNI IPAM plugin.
 
-## Networking Options
+## Networking options
 
 ### On-prem
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/egress-gateway-maintenance.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/egress-gateway-maintenance.mdx
@@ -4,7 +4,7 @@ description: React to egress gateway maintenance windows and minimize the impact
 
 # Optimize egress networking for workloads with long-lived TCP connections
 
-## Big Picture
+## Big picture
 
 React to egress gateway maintenance windows and minimize the impact of egress gateway downtime on sensitive workloads
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/external-network.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/external-network.mdx
@@ -4,7 +4,7 @@ description: Allows workloads from different namespaces of a Kubernetes cluster 
 
 # Configure egress traffic to multiple external networks
 
-## Big Picture
+## Big picture
 
 Allows workloads from different namespaces of a Kubernetes cluster to egress onto different external networks that (may) have overlapping IPs with each other.
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/alerts.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/alerts.mdx
@@ -26,7 +26,7 @@ We recommend turning down the aggregation level for flow logs to ensure that you
 
 To turn down aggregation on flow logs, go to [FelixConfiguration](../reference/resources/felixconfig.mdx) and set the field, **flowLogsFileAggregationKindForAllowed** to **1**.
 
-## How To
+## How to
 
 - [Manage alerts in the web console](#manage-alerts-in-manager-ui)
 - [Manage alerts using CLI](#manage-alerts-using-cli)

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/packetcapture.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/packetcapture.mdx
@@ -46,7 +46,7 @@ For a simple use case workflow, see [Faster troubleshooting of microservices, co
 - Capturing traffic from pods with multiple interfaces
 - Capturing traffic for pods running on Windows hosts
 
-## How To
+## How to
 
 - [Enable packet capture](#enable-packet-capture)
 - [Packet capture in Service Graph](#packet-capture-in-service-graph)

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/prometheus/configure-prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/prometheus/configure-prometheus.mdx
@@ -4,7 +4,7 @@ description: Configure rules for alerts and denied packets, for persistent stora
 
 # Configure Prometheus
 
-## Updating Denied Packets Rules
+## Updating denied packets rules
 
 This is an example of how to modify the sample rule created by the sample manifest.
 The process of updating rules is the same as for user created rules (documented below).
@@ -74,14 +74,14 @@ spec:
             description: '{{$labels.instance}} with calico-node pod {{$labels.pod}} has been denying packets at a fast rate {{$labels.sourceIp}} by policy {{$labels.policy}}.'
 ```
 
-## Creating a New Alerting Rule
+## Creating a new alerting rule
 
 Creating a new alerting rule is straightforward once you figure out what you
 want your rule to look for. Check [alerting rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)
 and [Queries](https://prometheus.io/docs/querying/examples/) for more
 information.
 
-### New Alerting Rule for Monitoring Calico Node
+### New alerting rule for monitoring Calico node
 
 To add the new alerting rule to our Prometheus instance, define a PrometheusRule manifest
 in the `tigera-prometheus` namespace with the labels
@@ -125,7 +125,7 @@ Your changes should be applied in a few seconds by the prometheus-config-reloade
 container inside the prometheus pod launched by the prometheus-operator
 (usually named `prometheus-<your-prometheus-instance-name>`).
 
-### New Alerting Rule for Monitoring BGP Peers
+### New alerting rule for monitoring BGP peers
 
 Let’s look at an example of a new alerting rule to our Prometheus instance with respect to monitoring BGP
 peering health. Define a PrometheusRule manifest in the tigera-prometheus namespace with the labels

--- a/calico-enterprise_versioned_docs/version-3.22-2/reference/resources/tier.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/reference/resources/tier.mdx
@@ -18,7 +18,7 @@ may be used to specify the resource type on the CLI:
 `tier.projectcalico.org`, `tiers.projectcalico.org` and abbreviations such as
 `tier.p` and `tiers.p`.
 
-## How Policy Is Evaluated
+## How policy is evaluated
 
 When a new connection is processed by $[prodname], each tier that contains a policy that applies to the endpoint processes the packet.
 Tiers are sorted by their `order` - smallest number first.

--- a/calico-enterprise_versioned_docs/version-3.22-2/threat/deeppacketinspection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/threat/deeppacketinspection.mdx
@@ -30,7 +30,7 @@ It is commonly used for troubleshooting (like tcpdump and Wireshark), but also f
 - Multi-nic setup
 - $[prodname] nodes running Windows hosts
 
-## How To
+## How to
 
 - [Configure deep packet inspection](#configure-deep-packet-inspection)
 - [Configure resource requirements](#configure-resource-requirements)

--- a/calico-enterprise_versioned_docs/version-3.23-1/_includes/components/ReqsKernel.js
+++ b/calico-enterprise_versioned_docs/version-3.23-1/_includes/components/ReqsKernel.js
@@ -11,7 +11,7 @@ export default function ReqsKernel() {
         as='h2'
         id='kernel-dependencies'
       >
-        Kernel Dependencies
+        Kernel dependencies
       </Heading>
       <Admonition type='tip'>
         <p>If you are using one of the recommended distributions, you will already satisfy these.</p>

--- a/calico-enterprise_versioned_docs/version-3.23-1/compliance/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/compliance/overview.mdx
@@ -71,7 +71,7 @@ Compliance reports provide the following high-level information:
 
   You must configure audit logs for Kubernetes resources through the Kubernetes API to get a complete view of all resources.
 
-## How To
+## How to
 
 - [Configure report permissions](#configure-report-permissions)
 - [Configure and schedule reports](#configure-and-schedule-reports)

--- a/calico-enterprise_versioned_docs/version-3.23-1/network-policy/beginners/simple-policy-cnx.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/network-policy/beginners/simple-policy-cnx.mdx
@@ -229,7 +229,7 @@ To view it, go to the policy page and enable **Implicit Drops** from the **Eye**
 
 :::
 
-## Allow Access using a NetworkPolicy
+## Allow access using a NetworkPolicy
 
 Now, let's enable access to the nginx service using a NetworkPolicy. This will allow incoming connections from our `access` pod, but not
 from anywhere else.

--- a/calico-enterprise_versioned_docs/version-3.23-1/network-policy/hosts/host-forwarded-traffic.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/network-policy/hosts/host-forwarded-traffic.mdx
@@ -54,7 +54,7 @@ When preDNAT is set to false on a global network policy, the policy rules are ev
 
 If you set preDNAT policy to true, you must set applyOnForward to true, and preDNAT policy must only include Ingress policies.
 
-### Host Endpoints with interfaceName: `*`
+### Host endpoints with interfaceName: `*`
 
 HostEndpoint API objects can be created with the name of the host interface (as reported by ip link or similar), or they can be created with interfaceName set to `*`, which means all host interfaces on the given node, including the interfaces between the host to any WEPs on that host.
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/add-maglev-load-balancing.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/add-maglev-load-balancing.mdx
@@ -74,7 +74,7 @@ Check the command output for an entry with your service's IP, and the "maglev" f
 
 ## Additional notes
 
-### BPF Map Sizing for Large Deployments
+### BPF map sizing for large deployments
 
 In order to evenly distribute traffic, consistent-hash-based load balancing algorithms like Maglev must allocate large lookup-tables (LUTs),
 leading to a larger memory footprint than basic algorithms e.g. random-selection, round-robin. For this reason, the feature is enabled on a

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/determine-best-networking.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/determine-best-networking.mdx
@@ -140,7 +140,7 @@ The Google cloud provider integration uses host-local IPAM CNI plugin to allocat
 
 The host local CNI IPAM plugin is a commonly used IP address management CNI plugin, which allocates a fixed size IP address range (CIDR) to each node, and then allocates pod IP addresses from within that range. The default address range size is 256 IP addresses (a /24), though two of those IP addresses are reserved for special purposes and not assigned to pods. The simplicity of host local CNI IPAM plugin makes it easy to understand, but results in less efficient IP address space usage compared to $[prodname] CNI IPAM plugin.
 
-## Networking Options
+## Networking options
 
 ### On-prem
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/egress/egress-gateway-maintenance.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/egress/egress-gateway-maintenance.mdx
@@ -4,7 +4,7 @@ description: React to egress gateway maintenance windows and minimize the impact
 
 # Optimize egress networking for workloads with long-lived TCP connections
 
-## Big Picture
+## Big picture
 
 React to egress gateway maintenance windows and minimize the impact of egress gateway downtime on sensitive workloads
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/egress/external-network.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/egress/external-network.mdx
@@ -4,7 +4,7 @@ description: Allows workloads from different namespaces of a Kubernetes cluster 
 
 # Configure egress traffic to multiple external networks
 
-## Big Picture
+## Big picture
 
 Allows workloads from different namespaces of a Kubernetes cluster to egress onto different external networks that (may) have overlapping IPs with each other.
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/alerts.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/alerts.mdx
@@ -26,7 +26,7 @@ We recommend turning down the aggregation level for flow logs to ensure that you
 
 To turn down aggregation on flow logs, go to [FelixConfiguration](../reference/resources/felixconfig.mdx) and set the field, **flowLogsFileAggregationKindForAllowed** to **1**.
 
-## How To
+## How to
 
 - [Manage alerts in the web console](#manage-alerts-in-manager-ui)
 - [Manage alerts using CLI](#manage-alerts-using-cli)

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/packetcapture.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/packetcapture.mdx
@@ -46,7 +46,7 @@ For a simple use case workflow, see [Faster troubleshooting of microservices, co
 - Capturing traffic from pods with multiple interfaces
 - Capturing traffic for pods running on Windows hosts
 
-## How To
+## How to
 
 - [Enable packet capture](#enable-packet-capture)
 - [Packet capture in Service Graph](#packet-capture-in-service-graph)

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/prometheus/configure-prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/prometheus/configure-prometheus.mdx
@@ -4,7 +4,7 @@ description: Configure rules for alerts and denied packets, for persistent stora
 
 # Configure Prometheus
 
-## Updating Denied Packets Rules
+## Updating denied packets rules
 
 This is an example of how to modify the sample rule created by the sample manifest.
 The process of updating rules is the same as for user created rules (documented below).
@@ -74,14 +74,14 @@ spec:
             description: '{{$labels.instance}} with calico-node pod {{$labels.pod}} has been denying packets at a fast rate {{$labels.sourceIp}} by policy {{$labels.policy}}.'
 ```
 
-## Creating a New Alerting Rule
+## Creating a new alerting rule
 
 Creating a new alerting rule is straightforward once you figure out what you
 want your rule to look for. Check [alerting rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)
 and [Queries](https://prometheus.io/docs/querying/examples/) for more
 information.
 
-### New Alerting Rule for Monitoring Calico Node
+### New alerting rule for monitoring Calico node
 
 To add the new alerting rule to our Prometheus instance, define a PrometheusRule manifest
 in the `tigera-prometheus` namespace with the labels
@@ -125,7 +125,7 @@ Your changes should be applied in a few seconds by the prometheus-config-reloade
 container inside the prometheus pod launched by the prometheus-operator
 (usually named `prometheus-<your-prometheus-instance-name>`).
 
-### New Alerting Rule for Monitoring BGP Peers
+### New alerting rule for monitoring BGP peers
 
 Let’s look at an example of a new alerting rule to our Prometheus instance with respect to monitoring BGP
 peering health. Define a PrometheusRule manifest in the tigera-prometheus namespace with the labels

--- a/calico-enterprise_versioned_docs/version-3.23-1/reference/resources/tier.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/reference/resources/tier.mdx
@@ -18,7 +18,7 @@ may be used to specify the resource type on the CLI:
 `tier.projectcalico.org`, `tiers.projectcalico.org` and abbreviations such as
 `tier.p` and `tiers.p`.
 
-## How Policy Is Evaluated
+## How policy is evaluated
 
 When a new connection is processed by $[prodname], each tier that contains a policy that applies to the endpoint processes the packet.
 Tiers are sorted by their `order` - smallest number first.

--- a/calico-enterprise_versioned_docs/version-3.23-1/threat/deeppacketinspection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/threat/deeppacketinspection.mdx
@@ -30,7 +30,7 @@ It is commonly used for troubleshooting (like tcpdump and Wireshark), but also f
 - Multi-nic setup
 - $[prodname] nodes running Windows hosts
 
-## How To
+## How to
 
 - [Configure deep packet inspection](#configure-deep-packet-inspection)
 - [Configure resource requirements](#configure-resource-requirements)

--- a/calico/_includes/components/HostEndpointsUpgrade.js
+++ b/calico/_includes/components/HostEndpointsUpgrade.js
@@ -12,7 +12,7 @@ export default function HostEndpointsUpgrade(props) {
         as='h2'
         id='host-endpoints'
       >
-        Host Endpoints
+        Host endpoints
       </Heading>
       <Admonition type='caution'>
         If your cluster has host endpoints with <code>interfaceName: *</code> you must prepare your cluster before

--- a/calico/_includes/partials/_system-requirements.mdx
+++ b/calico/_includes/partials/_system-requirements.mdx
@@ -231,7 +231,7 @@ Subject to that, we aim to develop and maintain the Neutron driver for Calico (n
 However, we recommend using OpenStack Caracal or later, and our active support and testing of Calico v3.30 with OpenStack is with Caracal.
 </If>
 
-## Kernel Dependencies
+## Kernel dependencies
 
 :::tip
 

--- a/calico/about/kubernetes-training/about-networking.mdx
+++ b/calico/about/kubernetes-training/about-networking.mdx
@@ -2,7 +2,7 @@
 description: Learn about networking!
 ---
 
-# About Networking
+# About networking
 
 :::note
 

--- a/calico/network-policy/adopt-zero-trust.mdx
+++ b/calico/network-policy/adopt-zero-trust.mdx
@@ -28,7 +28,7 @@ Why assume the network is hostile? In many attack scenarios, it is.
 
 Major breaches typically start as a minor compromise of as little as a single component, but attackers then use the network to move laterally toward high value targets: your company’s or customers’ data. In a zone or perimeter model, attackers can move freely inside the perimeter or zone after they have compromised a single endpoint. A Zero Trust Network is resilient to this threat because it enforces strong, cryptographic authentication and access control on each and every network connection.
 
-### Requirements of a Zero Trust Network
+### Requirements of a zero trust network
 
 Zero Trust Networks rely on network access controls with specific requirements:
 
@@ -42,7 +42,7 @@ Zero Trust Networks rely on network access controls with specific requirements:
 
 **Requirement 5**: Many Zero Trust Networks also rely on encryption of network traffic to prevent disclosure of sensitive data to hostile entities snooping network traffic. This is not an absolute requirement if private data are not exchanged over the network, but to fit the criteria of a Zero Trust Network, encryption must be used on every network connection if it is required at all. A Zero Trust Network does not distinguish between trusted and untrusted network links or paths. Also note that even when not using encryption for data privacy, cryptographic proofs of authenticity are still used to establish identity.
 
-### How $[prodname] and Istio implement Zero Trust Network requirements
+### How $[prodname] and Istio implement zero trust network requirements
 
 $[prodname] works in concert with the Istio service mesh to implement all you need to build a Zero Trust Network in your Kubernetes cluster.
 

--- a/calico/network-policy/adopt-zero-trust.mdx
+++ b/calico/network-policy/adopt-zero-trust.mdx
@@ -28,7 +28,7 @@ Why assume the network is hostile? In many attack scenarios, it is.
 
 Major breaches typically start as a minor compromise of as little as a single component, but attackers then use the network to move laterally toward high value targets: your company’s or customers’ data. In a zone or perimeter model, attackers can move freely inside the perimeter or zone after they have compromised a single endpoint. A Zero Trust Network is resilient to this threat because it enforces strong, cryptographic authentication and access control on each and every network connection.
 
-### Requirements of a zero trust network
+### Requirements of a Zero Trust Network
 
 Zero Trust Networks rely on network access controls with specific requirements:
 
@@ -42,7 +42,7 @@ Zero Trust Networks rely on network access controls with specific requirements:
 
 **Requirement 5**: Many Zero Trust Networks also rely on encryption of network traffic to prevent disclosure of sensitive data to hostile entities snooping network traffic. This is not an absolute requirement if private data are not exchanged over the network, but to fit the criteria of a Zero Trust Network, encryption must be used on every network connection if it is required at all. A Zero Trust Network does not distinguish between trusted and untrusted network links or paths. Also note that even when not using encryption for data privacy, cryptographic proofs of authenticity are still used to establish identity.
 
-### How $[prodname] and Istio implement zero trust network requirements
+### How $[prodname] and Istio implement Zero Trust Network requirements
 
 $[prodname] works in concert with the Istio service mesh to implement all you need to build a Zero Trust Network in your Kubernetes cluster.
 

--- a/calico/network-policy/hosts/host-forwarded-traffic.mdx
+++ b/calico/network-policy/hosts/host-forwarded-traffic.mdx
@@ -54,7 +54,7 @@ When preDNAT is set to false on a global network policy, the policy rules are ev
 
 If you set preDNAT policy to true, you must set applyOnForward to true, and preDNAT policy must only include Ingress policies.
 
-### Host Endpoints with interfaceName: `*`
+### Host endpoints with interfaceName: `*`
 
 HostEndpoint API objects can be created with the name of the host interface (as reported by ip link or similar), or they can be created with interfaceName set to `*`, which means all host interfaces on the given node, including the interfaces between the host to any WEPs on that host.
 

--- a/calico/networking/configuring/add-maglev-load-balancing.mdx
+++ b/calico/networking/configuring/add-maglev-load-balancing.mdx
@@ -74,7 +74,7 @@ Check the command output for an entry with your service's IP, and the "maglev" f
 
 ## Additional notes
 
-### BPF Map Sizing for Large Deployments
+### BPF map sizing for large deployments
 
 In order to evenly distribute traffic, consistent-hash-based load balancing algorithms like Maglev must allocate large lookup-tables (LUTs),
 leading to a larger memory footprint than basic algorithms e.g. random-selection, round-robin. For this reason, the feature is enabled on a

--- a/calico/networking/determine-best-networking.mdx
+++ b/calico/networking/determine-best-networking.mdx
@@ -150,7 +150,7 @@ $[prodname] now has built in support for VXLAN, which we generally recommend for
 
 :::
 
-## Networking Options
+## Networking options
 
 ### On-prem
 

--- a/calico/operations/datastore-migration.mdx
+++ b/calico/operations/datastore-migration.mdx
@@ -32,7 +32,7 @@ documentation.
 
   :::
 
-## How To
+## How to
 
 ### Migrate the datastore
 

--- a/calico/operations/fips.mdx
+++ b/calico/operations/fips.mdx
@@ -44,7 +44,7 @@ The Federal Information Processing Standards (FIPS) are publicly announced stand
   - WireGuard
 - Switching FIPS mode off and then on again is not supported because this can break hashes and other cryptographic settings.
 
-## How To
+## How to
 
 To install $[prodname] in FIPS mode follow these steps.
 

--- a/calico/operations/operator-migration.mdx
+++ b/calico/operations/operator-migration.mdx
@@ -44,7 +44,7 @@ and calculate how to take ownership of them. The operator will maintain existing
 - Ensure that your $[prodname] installation is configured to use the Kubernetes datastore. If your cluster uses etcdv3 directly, you must follow [the datastore migration procedure](datastore-migration.mdx) before following this document.
 - Migration to $[prodname] $[version] operator-managed installation is supported only from $[prodname] $[version] manifest-based installation
 
-## How To
+## How to
 
 ### Migrate a cluster to the operator
 

--- a/calico/reference/resources/tier.mdx
+++ b/calico/reference/resources/tier.mdx
@@ -18,7 +18,7 @@ may be used to specify the resource type on the CLI:
 `tier.projectcalico.org`, `tiers.projectcalico.org` and abbreviations such as
 `tier.p` and `tiers.p`.
 
-## How Policy Is Evaluated
+## How policy is evaluated
 
 When a new connection is processed by $[prodname], each tier that contains a policy that applies to the endpoint processes the packet.
 Tiers are sorted by their `order` - smallest number first.

--- a/calico_versioned_docs/version-3.29/_includes/components/HostEndpointsUpgrade.js
+++ b/calico_versioned_docs/version-3.29/_includes/components/HostEndpointsUpgrade.js
@@ -12,7 +12,7 @@ export default function HostEndpointsUpgrade(props) {
         as='h2'
         id='host-endpoints'
       >
-        Host Endpoints
+        Host endpoints
       </Heading>
       <Admonition type='caution'>
         If your cluster has host endpoints with <code>interfaceName: *</code> you must prepare your cluster before

--- a/calico_versioned_docs/version-3.29/_includes/partials/_system-requirements.mdx
+++ b/calico_versioned_docs/version-3.29/_includes/partials/_system-requirements.mdx
@@ -232,7 +232,7 @@ Subject to that, we aim to develop and maintain the Neutron driver for Calico (n
 However, we recommend using OpenStack Yoga or later, and our active support and testing of Calico v3.29 with OpenStack is with Yoga.
 </If>
 
-## Kernel Dependencies
+## Kernel dependencies
 
 :::tip
 

--- a/calico_versioned_docs/version-3.29/about/kubernetes-training/about-networking.mdx
+++ b/calico_versioned_docs/version-3.29/about/kubernetes-training/about-networking.mdx
@@ -2,7 +2,7 @@
 description: Learn about networking!
 ---
 
-# About Networking
+# About networking
 
 :::note
 

--- a/calico_versioned_docs/version-3.29/network-policy/adopt-zero-trust.mdx
+++ b/calico_versioned_docs/version-3.29/network-policy/adopt-zero-trust.mdx
@@ -28,7 +28,7 @@ Why assume the network is hostile? In many attack scenarios, it is.
 
 Major breaches typically start as a minor compromise of as little as a single component, but attackers then use the network to move laterally toward high value targets: your company’s or customers’ data. In a zone or perimeter model, attackers can move freely inside the perimeter or zone after they have compromised a single endpoint. A Zero Trust Network is resilient to this threat because it enforces strong, cryptographic authentication and access control on each and every network connection.
 
-### Requirements of a Zero Trust Network
+### Requirements of a zero trust network
 
 Zero Trust Networks rely on network access controls with specific requirements:
 
@@ -42,7 +42,7 @@ Zero Trust Networks rely on network access controls with specific requirements:
 
 **Requirement 5**: Many Zero Trust Networks also rely on encryption of network traffic to prevent disclosure of sensitive data to hostile entities snooping network traffic. This is not an absolute requirement if private data are not exchanged over the network, but to fit the criteria of a Zero Trust Network, encryption must be used on every network connection if it is required at all. A Zero Trust Network does not distinguish between trusted and untrusted network links or paths. Also note that even when not using encryption for data privacy, cryptographic proofs of authenticity are still used to establish identity.
 
-### How $[prodname] and Istio implement Zero Trust Network requirements
+### How $[prodname] and Istio implement zero trust network requirements
 
 $[prodname] works in concert with the Istio service mesh to implement all you need to build a Zero Trust Network in your Kubernetes cluster.
 

--- a/calico_versioned_docs/version-3.29/network-policy/adopt-zero-trust.mdx
+++ b/calico_versioned_docs/version-3.29/network-policy/adopt-zero-trust.mdx
@@ -28,7 +28,7 @@ Why assume the network is hostile? In many attack scenarios, it is.
 
 Major breaches typically start as a minor compromise of as little as a single component, but attackers then use the network to move laterally toward high value targets: your company’s or customers’ data. In a zone or perimeter model, attackers can move freely inside the perimeter or zone after they have compromised a single endpoint. A Zero Trust Network is resilient to this threat because it enforces strong, cryptographic authentication and access control on each and every network connection.
 
-### Requirements of a zero trust network
+### Requirements of a Zero Trust Network
 
 Zero Trust Networks rely on network access controls with specific requirements:
 
@@ -42,7 +42,7 @@ Zero Trust Networks rely on network access controls with specific requirements:
 
 **Requirement 5**: Many Zero Trust Networks also rely on encryption of network traffic to prevent disclosure of sensitive data to hostile entities snooping network traffic. This is not an absolute requirement if private data are not exchanged over the network, but to fit the criteria of a Zero Trust Network, encryption must be used on every network connection if it is required at all. A Zero Trust Network does not distinguish between trusted and untrusted network links or paths. Also note that even when not using encryption for data privacy, cryptographic proofs of authenticity are still used to establish identity.
 
-### How $[prodname] and Istio implement zero trust network requirements
+### How $[prodname] and Istio implement Zero Trust Network requirements
 
 $[prodname] works in concert with the Istio service mesh to implement all you need to build a Zero Trust Network in your Kubernetes cluster.
 

--- a/calico_versioned_docs/version-3.29/network-policy/hosts/host-forwarded-traffic.mdx
+++ b/calico_versioned_docs/version-3.29/network-policy/hosts/host-forwarded-traffic.mdx
@@ -54,7 +54,7 @@ When preDNAT is set to false on a global network policy, the policy rules are ev
 
 If you set preDNAT policy to true, you must set applyOnForward to true, and preDNAT policy must only include Ingress policies.
 
-### Host Endpoints with interfaceName: `*`
+### Host endpoints with interfaceName: `*`
 
 HostEndpoint API objects can be created with the name of the host interface (as reported by ip link or similar), or they can be created with interfaceName set to `*`, which means all host interfaces on the given node, including the interfaces between the host to any WEPs on that host.
 

--- a/calico_versioned_docs/version-3.29/networking/determine-best-networking.mdx
+++ b/calico_versioned_docs/version-3.29/networking/determine-best-networking.mdx
@@ -150,7 +150,7 @@ $[prodname] now has built in support for VXLAN, which we generally recommend for
 
 :::
 
-## Networking Options
+## Networking options
 
 ### On-prem
 

--- a/calico_versioned_docs/version-3.29/operations/datastore-migration.mdx
+++ b/calico_versioned_docs/version-3.29/operations/datastore-migration.mdx
@@ -32,7 +32,7 @@ documentation.
 
   :::
 
-## How To
+## How to
 
 ### Migrate the datastore
 

--- a/calico_versioned_docs/version-3.29/operations/fips.mdx
+++ b/calico_versioned_docs/version-3.29/operations/fips.mdx
@@ -38,7 +38,7 @@ The Federal Information Processing Standards (FIPS) are publicly announced stand
   - WireGuard
 - Switching FIPS mode off and then on again is not supported because this can break hashes and other cryptographic settings.
 
-## How To
+## How to
 
 To install $[prodname] in FIPS mode follow these steps.
 

--- a/calico_versioned_docs/version-3.29/operations/operator-migration.mdx
+++ b/calico_versioned_docs/version-3.29/operations/operator-migration.mdx
@@ -44,7 +44,7 @@ and calculate how to take ownership of them. The operator will maintain existing
 - Ensure that your $[prodname] installation is configured to use the Kubernetes datastore. If your cluster uses etcdv3 directly, you must follow [the datastore migration procedure](datastore-migration.mdx) before following this document.
 - Migration to $[prodname] $[version] operator-managed installation is supported only from $[prodname] $[version] manifest-based installation
 
-## How To
+## How to
 
 ### Migrate a cluster to the operator
 

--- a/calico_versioned_docs/version-3.29/reference/resources/tier.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/tier.mdx
@@ -18,7 +18,7 @@ may be used to specify the resource type on the CLI:
 `tier.projectcalico.org`, `tiers.projectcalico.org` and abbreviations such as
 `tier.p` and `tiers.p`.
 
-## How Policy Is Evaluated
+## How policy is evaluated
 
 When a new connection is processed by $[prodname], each tier that contains a policy that applies to the endpoint processes the packet.
 Tiers are sorted by their `order` - smallest number first.

--- a/calico_versioned_docs/version-3.30/_includes/components/HostEndpointsUpgrade.js
+++ b/calico_versioned_docs/version-3.30/_includes/components/HostEndpointsUpgrade.js
@@ -12,7 +12,7 @@ export default function HostEndpointsUpgrade(props) {
         as='h2'
         id='host-endpoints'
       >
-        Host Endpoints
+        Host endpoints
       </Heading>
       <Admonition type='caution'>
         If your cluster has host endpoints with <code>interfaceName: *</code> you must prepare your cluster before

--- a/calico_versioned_docs/version-3.30/_includes/partials/_system-requirements.mdx
+++ b/calico_versioned_docs/version-3.30/_includes/partials/_system-requirements.mdx
@@ -233,7 +233,7 @@ Subject to that, we aim to develop and maintain the Neutron driver for Calico (n
 However, we recommend using OpenStack Caracal or later, and our active support and testing of Calico v3.30 with OpenStack is with Caracal.
 </If>
 
-## Kernel Dependencies
+## Kernel dependencies
 
 :::tip
 

--- a/calico_versioned_docs/version-3.30/about/kubernetes-training/about-networking.mdx
+++ b/calico_versioned_docs/version-3.30/about/kubernetes-training/about-networking.mdx
@@ -2,7 +2,7 @@
 description: Learn about networking!
 ---
 
-# About Networking
+# About networking
 
 :::note
 

--- a/calico_versioned_docs/version-3.30/network-policy/adopt-zero-trust.mdx
+++ b/calico_versioned_docs/version-3.30/network-policy/adopt-zero-trust.mdx
@@ -28,7 +28,7 @@ Why assume the network is hostile? In many attack scenarios, it is.
 
 Major breaches typically start as a minor compromise of as little as a single component, but attackers then use the network to move laterally toward high value targets: your company’s or customers’ data. In a zone or perimeter model, attackers can move freely inside the perimeter or zone after they have compromised a single endpoint. A Zero Trust Network is resilient to this threat because it enforces strong, cryptographic authentication and access control on each and every network connection.
 
-### Requirements of a Zero Trust Network
+### Requirements of a zero trust network
 
 Zero Trust Networks rely on network access controls with specific requirements:
 
@@ -42,7 +42,7 @@ Zero Trust Networks rely on network access controls with specific requirements:
 
 **Requirement 5**: Many Zero Trust Networks also rely on encryption of network traffic to prevent disclosure of sensitive data to hostile entities snooping network traffic. This is not an absolute requirement if private data are not exchanged over the network, but to fit the criteria of a Zero Trust Network, encryption must be used on every network connection if it is required at all. A Zero Trust Network does not distinguish between trusted and untrusted network links or paths. Also note that even when not using encryption for data privacy, cryptographic proofs of authenticity are still used to establish identity.
 
-### How $[prodname] and Istio implement Zero Trust Network requirements
+### How $[prodname] and Istio implement zero trust network requirements
 
 $[prodname] works in concert with the Istio service mesh to implement all you need to build a Zero Trust Network in your Kubernetes cluster.
 

--- a/calico_versioned_docs/version-3.30/network-policy/adopt-zero-trust.mdx
+++ b/calico_versioned_docs/version-3.30/network-policy/adopt-zero-trust.mdx
@@ -28,7 +28,7 @@ Why assume the network is hostile? In many attack scenarios, it is.
 
 Major breaches typically start as a minor compromise of as little as a single component, but attackers then use the network to move laterally toward high value targets: your company’s or customers’ data. In a zone or perimeter model, attackers can move freely inside the perimeter or zone after they have compromised a single endpoint. A Zero Trust Network is resilient to this threat because it enforces strong, cryptographic authentication and access control on each and every network connection.
 
-### Requirements of a zero trust network
+### Requirements of a Zero Trust Network
 
 Zero Trust Networks rely on network access controls with specific requirements:
 
@@ -42,7 +42,7 @@ Zero Trust Networks rely on network access controls with specific requirements:
 
 **Requirement 5**: Many Zero Trust Networks also rely on encryption of network traffic to prevent disclosure of sensitive data to hostile entities snooping network traffic. This is not an absolute requirement if private data are not exchanged over the network, but to fit the criteria of a Zero Trust Network, encryption must be used on every network connection if it is required at all. A Zero Trust Network does not distinguish between trusted and untrusted network links or paths. Also note that even when not using encryption for data privacy, cryptographic proofs of authenticity are still used to establish identity.
 
-### How $[prodname] and Istio implement zero trust network requirements
+### How $[prodname] and Istio implement Zero Trust Network requirements
 
 $[prodname] works in concert with the Istio service mesh to implement all you need to build a Zero Trust Network in your Kubernetes cluster.
 

--- a/calico_versioned_docs/version-3.30/network-policy/hosts/host-forwarded-traffic.mdx
+++ b/calico_versioned_docs/version-3.30/network-policy/hosts/host-forwarded-traffic.mdx
@@ -54,7 +54,7 @@ When preDNAT is set to false on a global network policy, the policy rules are ev
 
 If you set preDNAT policy to true, you must set applyOnForward to true, and preDNAT policy must only include Ingress policies.
 
-### Host Endpoints with interfaceName: `*`
+### Host endpoints with interfaceName: `*`
 
 HostEndpoint API objects can be created with the name of the host interface (as reported by ip link or similar), or they can be created with interfaceName set to `*`, which means all host interfaces on the given node, including the interfaces between the host to any WEPs on that host.
 

--- a/calico_versioned_docs/version-3.30/networking/determine-best-networking.mdx
+++ b/calico_versioned_docs/version-3.30/networking/determine-best-networking.mdx
@@ -150,7 +150,7 @@ $[prodname] now has built in support for VXLAN, which we generally recommend for
 
 :::
 
-## Networking Options
+## Networking options
 
 ### On-prem
 

--- a/calico_versioned_docs/version-3.30/operations/datastore-migration.mdx
+++ b/calico_versioned_docs/version-3.30/operations/datastore-migration.mdx
@@ -32,7 +32,7 @@ documentation.
 
   :::
 
-## How To
+## How to
 
 ### Migrate the datastore
 

--- a/calico_versioned_docs/version-3.30/operations/fips.mdx
+++ b/calico_versioned_docs/version-3.30/operations/fips.mdx
@@ -44,7 +44,7 @@ The Federal Information Processing Standards (FIPS) are publicly announced stand
   - WireGuard
 - Switching FIPS mode off and then on again is not supported because this can break hashes and other cryptographic settings.
 
-## How To
+## How to
 
 To install $[prodname] in FIPS mode follow these steps.
 

--- a/calico_versioned_docs/version-3.30/operations/operator-migration.mdx
+++ b/calico_versioned_docs/version-3.30/operations/operator-migration.mdx
@@ -44,7 +44,7 @@ and calculate how to take ownership of them. The operator will maintain existing
 - Ensure that your $[prodname] installation is configured to use the Kubernetes datastore. If your cluster uses etcdv3 directly, you must follow [the datastore migration procedure](datastore-migration.mdx) before following this document.
 - Migration to $[prodname] $[version] operator-managed installation is supported only from $[prodname] $[version] manifest-based installation
 
-## How To
+## How to
 
 ### Migrate a cluster to the operator
 

--- a/calico_versioned_docs/version-3.30/reference/resources/tier.mdx
+++ b/calico_versioned_docs/version-3.30/reference/resources/tier.mdx
@@ -18,7 +18,7 @@ may be used to specify the resource type on the CLI:
 `tier.projectcalico.org`, `tiers.projectcalico.org` and abbreviations such as
 `tier.p` and `tiers.p`.
 
-## How Policy Is Evaluated
+## How policy is evaluated
 
 When a new connection is processed by $[prodname], each tier that contains a policy that applies to the endpoint processes the packet.
 Tiers are sorted by their `order` - smallest number first.

--- a/calico_versioned_docs/version-3.31/_includes/components/HostEndpointsUpgrade.js
+++ b/calico_versioned_docs/version-3.31/_includes/components/HostEndpointsUpgrade.js
@@ -12,7 +12,7 @@ export default function HostEndpointsUpgrade(props) {
         as='h2'
         id='host-endpoints'
       >
-        Host Endpoints
+        Host endpoints
       </Heading>
       <Admonition type='caution'>
         If your cluster has host endpoints with <code>interfaceName: *</code> you must prepare your cluster before

--- a/calico_versioned_docs/version-3.31/_includes/partials/_system-requirements.mdx
+++ b/calico_versioned_docs/version-3.31/_includes/partials/_system-requirements.mdx
@@ -232,7 +232,7 @@ Subject to that, we aim to develop and maintain the Neutron driver for Calico (n
 However, we recommend using OpenStack Caracal or later, and our active support and testing of Calico v3.30 with OpenStack is with Caracal.
 </If>
 
-## Kernel Dependencies
+## Kernel dependencies
 
 :::tip
 

--- a/calico_versioned_docs/version-3.31/about/kubernetes-training/about-networking.mdx
+++ b/calico_versioned_docs/version-3.31/about/kubernetes-training/about-networking.mdx
@@ -2,7 +2,7 @@
 description: Learn about networking!
 ---
 
-# About Networking
+# About networking
 
 :::note
 

--- a/calico_versioned_docs/version-3.31/network-policy/adopt-zero-trust.mdx
+++ b/calico_versioned_docs/version-3.31/network-policy/adopt-zero-trust.mdx
@@ -28,7 +28,7 @@ Why assume the network is hostile? In many attack scenarios, it is.
 
 Major breaches typically start as a minor compromise of as little as a single component, but attackers then use the network to move laterally toward high value targets: your company’s or customers’ data. In a zone or perimeter model, attackers can move freely inside the perimeter or zone after they have compromised a single endpoint. A Zero Trust Network is resilient to this threat because it enforces strong, cryptographic authentication and access control on each and every network connection.
 
-### Requirements of a Zero Trust Network
+### Requirements of a zero trust network
 
 Zero Trust Networks rely on network access controls with specific requirements:
 
@@ -42,7 +42,7 @@ Zero Trust Networks rely on network access controls with specific requirements:
 
 **Requirement 5**: Many Zero Trust Networks also rely on encryption of network traffic to prevent disclosure of sensitive data to hostile entities snooping network traffic. This is not an absolute requirement if private data are not exchanged over the network, but to fit the criteria of a Zero Trust Network, encryption must be used on every network connection if it is required at all. A Zero Trust Network does not distinguish between trusted and untrusted network links or paths. Also note that even when not using encryption for data privacy, cryptographic proofs of authenticity are still used to establish identity.
 
-### How $[prodname] and Istio implement Zero Trust Network requirements
+### How $[prodname] and Istio implement zero trust network requirements
 
 $[prodname] works in concert with the Istio service mesh to implement all you need to build a Zero Trust Network in your Kubernetes cluster.
 

--- a/calico_versioned_docs/version-3.31/network-policy/adopt-zero-trust.mdx
+++ b/calico_versioned_docs/version-3.31/network-policy/adopt-zero-trust.mdx
@@ -28,7 +28,7 @@ Why assume the network is hostile? In many attack scenarios, it is.
 
 Major breaches typically start as a minor compromise of as little as a single component, but attackers then use the network to move laterally toward high value targets: your company’s or customers’ data. In a zone or perimeter model, attackers can move freely inside the perimeter or zone after they have compromised a single endpoint. A Zero Trust Network is resilient to this threat because it enforces strong, cryptographic authentication and access control on each and every network connection.
 
-### Requirements of a zero trust network
+### Requirements of a Zero Trust Network
 
 Zero Trust Networks rely on network access controls with specific requirements:
 
@@ -42,7 +42,7 @@ Zero Trust Networks rely on network access controls with specific requirements:
 
 **Requirement 5**: Many Zero Trust Networks also rely on encryption of network traffic to prevent disclosure of sensitive data to hostile entities snooping network traffic. This is not an absolute requirement if private data are not exchanged over the network, but to fit the criteria of a Zero Trust Network, encryption must be used on every network connection if it is required at all. A Zero Trust Network does not distinguish between trusted and untrusted network links or paths. Also note that even when not using encryption for data privacy, cryptographic proofs of authenticity are still used to establish identity.
 
-### How $[prodname] and Istio implement zero trust network requirements
+### How $[prodname] and Istio implement Zero Trust Network requirements
 
 $[prodname] works in concert with the Istio service mesh to implement all you need to build a Zero Trust Network in your Kubernetes cluster.
 

--- a/calico_versioned_docs/version-3.31/network-policy/hosts/host-forwarded-traffic.mdx
+++ b/calico_versioned_docs/version-3.31/network-policy/hosts/host-forwarded-traffic.mdx
@@ -54,7 +54,7 @@ When preDNAT is set to false on a global network policy, the policy rules are ev
 
 If you set preDNAT policy to true, you must set applyOnForward to true, and preDNAT policy must only include Ingress policies.
 
-### Host Endpoints with interfaceName: `*`
+### Host endpoints with interfaceName: `*`
 
 HostEndpoint API objects can be created with the name of the host interface (as reported by ip link or similar), or they can be created with interfaceName set to `*`, which means all host interfaces on the given node, including the interfaces between the host to any WEPs on that host.
 

--- a/calico_versioned_docs/version-3.31/networking/determine-best-networking.mdx
+++ b/calico_versioned_docs/version-3.31/networking/determine-best-networking.mdx
@@ -150,7 +150,7 @@ $[prodname] now has built in support for VXLAN, which we generally recommend for
 
 :::
 
-## Networking Options
+## Networking options
 
 ### On-prem
 

--- a/calico_versioned_docs/version-3.31/operations/datastore-migration.mdx
+++ b/calico_versioned_docs/version-3.31/operations/datastore-migration.mdx
@@ -32,7 +32,7 @@ documentation.
 
   :::
 
-## How To
+## How to
 
 ### Migrate the datastore
 

--- a/calico_versioned_docs/version-3.31/operations/fips.mdx
+++ b/calico_versioned_docs/version-3.31/operations/fips.mdx
@@ -44,7 +44,7 @@ The Federal Information Processing Standards (FIPS) are publicly announced stand
   - WireGuard
 - Switching FIPS mode off and then on again is not supported because this can break hashes and other cryptographic settings.
 
-## How To
+## How to
 
 To install $[prodname] in FIPS mode follow these steps.
 

--- a/calico_versioned_docs/version-3.31/operations/operator-migration.mdx
+++ b/calico_versioned_docs/version-3.31/operations/operator-migration.mdx
@@ -44,7 +44,7 @@ and calculate how to take ownership of them. The operator will maintain existing
 - Ensure that your $[prodname] installation is configured to use the Kubernetes datastore. If your cluster uses etcdv3 directly, you must follow [the datastore migration procedure](datastore-migration.mdx) before following this document.
 - Migration to $[prodname] $[version] operator-managed installation is supported only from $[prodname] $[version] manifest-based installation
 
-## How To
+## How to
 
 ### Migrate a cluster to the operator
 

--- a/calico_versioned_docs/version-3.31/reference/resources/tier.mdx
+++ b/calico_versioned_docs/version-3.31/reference/resources/tier.mdx
@@ -18,7 +18,7 @@ may be used to specify the resource type on the CLI:
 `tier.projectcalico.org`, `tiers.projectcalico.org` and abbreviations such as
 `tier.p` and `tiers.p`.
 
-## How Policy Is Evaluated
+## How policy is evaluated
 
 When a new connection is processed by $[prodname], each tier that contains a policy that applies to the endpoint processes the packet.
 Tiers are sorted by their `order` - smallest number first.


### PR DESCRIPTION
## Summary
- Apply sentence case to all doc headings per the Google developer documentation style guide
- Converts Title Case headings (e.g., "## Big Picture", "## How To", "## Networking Options") to sentence case (e.g., "## Big picture", "## How to", "## Networking options")
- PascalCase Kubernetes resource names (HostEndpoints, NetworkPolicy, etc.) and proper nouns are preserved

## Test plan
- [ ] Verify headings render correctly in preview build
- [ ] Spot-check anchor links still resolve (IDs generated from heading text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)