### PR TITLE
CORE-12395: Document KubeVirt IPAM changes

### DIFF
--- a/calico-cloud/reference/resources/ipamconfig.mdx
+++ b/calico-cloud/reference/resources/ipamconfig.mdx
@@ -16,6 +16,7 @@ metadata:
 spec:
   strictAffinity: false
   maxBlocksPerHost: 4
+  kubeVirtVMAddressPersistence: Disabled
 ```
 
 ## IPAM configuration definition
@@ -30,10 +31,11 @@ The resource is a singleton which must have the name `default`.
 
 ### Spec
 
-| Field            | Description                                                         | Accepted Values | Schema | Default   |
-| ---------------- | ------------------------------------------------------------------- | --------------- | ------ | --------- |
-| strictAffinity   | When StrictAffinity is true, borrowing IP addresses is not allowed. | true, false     | bool   | false     |
-| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | 20        |
+| Field                        | Description                                                                                                                          | Accepted Values    | Schema | Default  |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------ | ------ | -------- |
+| strictAffinity               | When StrictAffinity is true, borrowing IP addresses is not allowed.                                                                  | true, false        | bool   | false    |
+| maxBlocksPerHost             | The max number of blocks that can be affine to each host.                                                                            | 0 - max(int32)     | int    | 20       |
+| kubeVirtVMAddressPersistence | Controls whether KubeVirt VMs retain persistent IP addresses across lifecycle events such as restart or migration. Requires KubeVirt. | Enabled, Disabled  | string | Disabled |
 
 ## Supported operations
 

--- a/calico-enterprise/reference/clis/calicoctl/ipam/configure.mdx
+++ b/calico-enterprise/reference/clis/calicoctl/ipam/configure.mdx
@@ -15,15 +15,23 @@ command.
 
 ```
 Usage:
-  calicoctl ipam configure --strictaffinity=<true/false> [--config=<CONFIG>]
+  calicoctl ipam configure --strictaffinity=<true/false>
+                           [--max-blocks-per-host=<number>]
+                           [--kubevirt-ip-persistence=<Enabled|Disabled>]
+                           [--config=<CONFIG>]
 
 Options:
   -h --help                        Show this screen.
-     --strictaffinity=<true/false> Set StrictAffinity to true/false. When StrictAffinity
-                                   is true, borrowing IP addresses is not allowed.
-  -c --config=<CONFIG>             Path to the file containing connection configuration in
-                                   YAML or JSON format.
-                                   [default: /etc/calico/calicoctl.cfg]
+     --strictaffinity=<true/false>  Set StrictAffinity to true/false. When StrictAffinity
+                                    is true, borrowing IP addresses is not allowed.
+     --max-blocks-per-host=<number> Set the maximum number of blocks that can be affine
+                                    to a host.
+     --kubevirt-ip-persistence=<Enabled|Disabled>
+                                    Control whether KubeVirt VMs retain persistent IP
+                                    addresses across lifecycle events.
+  -c --config=<CONFIG>              Path to the file containing connection configuration in
+                                    YAML or JSON format.
+                                    [default: /etc/calico/calicoctl.cfg]
 
 Description:
  Modify configuration for Calico IP address management.
@@ -33,6 +41,10 @@ Description:
 
 ```bash
 calicoctl ipam configure --strictaffinity=true
+```
+
+```bash
+calicoctl ipam configure --kubevirt-ip-persistence=Enabled
 ```
 
 ### General options

--- a/calico-enterprise/reference/clis/calicoctl/ipam/show.mdx
+++ b/calico-enterprise/reference/clis/calicoctl/ipam/show.mdx
@@ -52,14 +52,32 @@ Description:
    calicoctl ipam show --ip=10.244.118.70
    ```
 
-   For a Kubernetes pod IP, attributes indicate the pod name and namespace:
+   For a Kubernetes pod IP, the output shows the handle ID and owner attributes:
 
    ```
    IP 10.244.118.70 is in use
-   Attributes:
+   Handle ID: k8s-pod-network.abc123
+   Active Owner Attributes:
      pod: nano-66d4c99f8b-jm5s9
      namespace: default
      node: ip-172-16-101-160.us-west-2.compute.internal
+   ```
+
+   For a KubeVirt VM IP, alternate owner attributes may also be shown (for example, during a live migration):
+
+   ```
+   IP 10.244.118.80 is in use
+   Handle ID: k8s-pod-network.def456
+   Active Owner Attributes:
+     namespace: default
+     node: worker-node-1
+     vmi: my-vm
+     pod: virt-launcher-my-vm-abc12
+   Alternate Owner Attributes:
+     namespace: default
+     node: worker-node-2
+     vmi: my-vm
+     pod: virt-launcher-my-vm-def34
    ```
 
 1. Print a summary of IP usage.

--- a/calico-enterprise/reference/resources/ipamconfig.mdx
+++ b/calico-enterprise/reference/resources/ipamconfig.mdx
@@ -16,6 +16,7 @@ metadata:
 spec:
   strictAffinity: false
   maxBlocksPerHost: 4
+  kubeVirtVMAddressPersistence: Disabled
 ```
 
 ## IPAM configuration definition
@@ -30,10 +31,11 @@ The resource is a singleton which must have the name `default`.
 
 ### Spec
 
-| Field            | Description                                                         | Accepted Values | Schema | Default   |
-| ---------------- | ------------------------------------------------------------------- | --------------- | ------ | --------- |
-| strictAffinity   | When StrictAffinity is true, borrowing IP addresses is not allowed. | true, false     | bool   | false     |
-| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | 20        |
+| Field                        | Description                                                                                                                          | Accepted Values    | Schema | Default  |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------ | ------ | -------- |
+| strictAffinity               | When StrictAffinity is true, borrowing IP addresses is not allowed.                                                                  | true, false        | bool   | false    |
+| maxBlocksPerHost             | The max number of blocks that can be affine to each host.                                                                            | 0 - max(int32)     | int    | 20       |
+| kubeVirtVMAddressPersistence | Controls whether KubeVirt VMs retain persistent IP addresses across lifecycle events such as restart or migration. Requires KubeVirt. | Enabled, Disabled  | string | Disabled |
 
 ## Supported operations
 

--- a/calico/reference/calicoctl/ipam/configure.mdx
+++ b/calico/reference/calicoctl/ipam/configure.mdx
@@ -15,15 +15,23 @@ command.
 
 ```
 Usage:
-  calicoctl ipam configure --strictaffinity=<true/false> [--config=<CONFIG>]
+  calicoctl ipam configure --strictaffinity=<true/false>
+                           [--max-blocks-per-host=<number>]
+                           [--kubevirt-ip-persistence=<Enabled|Disabled>]
+                           [--config=<CONFIG>]
 
 Options:
   -h --help                        Show this screen.
-     --strictaffinity=<true/false> Set StrictAffinity to true/false. When StrictAffinity
-                                   is true, borrowing IP addresses is not allowed.
-  -c --config=<CONFIG>             Path to the file containing connection configuration in
-                                   YAML or JSON format.
-                                   [default: /etc/calico/calicoctl.cfg]
+     --strictaffinity=<true/false>  Set StrictAffinity to true/false. When StrictAffinity
+                                    is true, borrowing IP addresses is not allowed.
+     --max-blocks-per-host=<number> Set the maximum number of blocks that can be affine
+                                    to a host.
+     --kubevirt-ip-persistence=<Enabled|Disabled>
+                                    Control whether KubeVirt VMs retain persistent IP
+                                    addresses across lifecycle events.
+  -c --config=<CONFIG>              Path to the file containing connection configuration in
+                                    YAML or JSON format.
+                                    [default: /etc/calico/calicoctl.cfg]
 
 Description:
  Modify configuration for Calico IP address management.
@@ -33,6 +41,10 @@ Description:
 
 ```bash
 calicoctl ipam configure --strictaffinity=true
+```
+
+```bash
+calicoctl ipam configure --kubevirt-ip-persistence=Enabled
 ```
 
 ### General options

--- a/calico/reference/calicoctl/ipam/show.mdx
+++ b/calico/reference/calicoctl/ipam/show.mdx
@@ -52,14 +52,32 @@ Description:
    calicoctl ipam show --ip=10.244.118.70
    ```
 
-   For a Kubernetes pod IP, attributes indicate the pod name and namespace:
+   For a Kubernetes pod IP, the output shows the handle ID and owner attributes:
 
    ```
    IP 10.244.118.70 is in use
-   Attributes:
+   Handle ID: k8s-pod-network.abc123
+   Active Owner Attributes:
      pod: nano-66d4c99f8b-jm5s9
      namespace: default
      node: ip-172-16-101-160.us-west-2.compute.internal
+   ```
+
+   For a KubeVirt VM IP, alternate owner attributes may also be shown (for example, during a live migration):
+
+   ```
+   IP 10.244.118.80 is in use
+   Handle ID: k8s-pod-network.def456
+   Active Owner Attributes:
+     namespace: default
+     node: worker-node-1
+     vmi: my-vm
+     pod: virt-launcher-my-vm-abc12
+   Alternate Owner Attributes:
+     namespace: default
+     node: worker-node-2
+     vmi: my-vm
+     pod: virt-launcher-my-vm-def34
    ```
 
 1. Print a summary of IP usage.

--- a/calico/reference/resources/ipamconfig.mdx
+++ b/calico/reference/resources/ipamconfig.mdx
@@ -16,6 +16,7 @@ metadata:
 spec:
   strictAffinity: false
   maxBlocksPerHost: 4
+  kubeVirtVMAddressPersistence: Disabled
 ```
 
 ## IPAM configuration definition
@@ -30,7 +31,8 @@ The resource is a singleton which must have the name `default`.
 
 ### Spec
 
-| Field            | Description                                                         | Accepted Values | Schema | Default   |
-| ---------------- | ------------------------------------------------------------------- | --------------- | ------ | --------- |
-| strictAffinity   | When StrictAffinity is true, borrowing IP addresses is not allowed. | true, false     | bool   | false     |
-| maxBlocksPerHost | The max number of blocks that can be affine to each host.           | 0 - max(int32)  | int    | 20        |
+| Field                        | Description                                                                                                                          | Accepted Values    | Schema | Default  |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------ | ------ | -------- |
+| strictAffinity               | When StrictAffinity is true, borrowing IP addresses is not allowed.                                                                  | true, false        | bool   | false    |
+| maxBlocksPerHost             | The max number of blocks that can be affine to each host.                                                                            | 0 - max(int32)     | int    | 20       |
+| kubeVirtVMAddressPersistence | Controls whether KubeVirt VMs retain persistent IP addresses across lifecycle events such as restart or migration. Requires KubeVirt. | Enabled, Disabled  | string | Disabled |


### PR DESCRIPTION
Document KubeVirt IPAM changes

  - Add `--kubevirt-ip-persistence` and `--max-blocks-per-host` options to
    `calicoctl ipam configure` reference
  - Update `calicoctl ipam show --ip` output to reflect new `Handle ID`,
    `Active Owner Attributes`, and `Alternate Owner Attributes` format
  - Add KubeVirt VM live migration example to `ipam show` output
  - Add `kubeVirtVMAddressPersistence` field to `IPAMConfiguration` resource spec


<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->