### PR TITLE
Add kernel version recommendation warning to eBPF docs

### DIFF
--- a/calico-cloud/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-cloud/operations/ebpf/enabling-ebpf.mdx
@@ -45,6 +45,12 @@ Some eBPF features require a higher kernel version than the base eBPF data plane
 | [QoS bandwidth controls](../../networking/configuring/qos-controls.mdx) | v6.6 | Requires `tcx` support. Established connection limits not supported with eBPF |
 | [DNS policy inline mode](../../network-policy/domain-based-policy.mdx) | v5.17 (RHEL: v5.14) | `BPFDNSPolicyMode: Inline` parses DNS responses in eBPF before they reach the application. Only wildcard prefixes (`*.x.y.z`) supported. Falls back to `NoDelay` on older kernels |
 
+:::warning
+
+While v5.3 is the minimum kernel version required for the eBPF data plane, we strongly recommend using kernel v5.8 or above, which adds support for [CO-RE (Compile Once - Run Everywhere)](https://docs.ebpf.io/concepts/core/). CO-RE significantly improves compatibility and performance across kernel versions. For access to all eBPF features, we recommend kernel v6.6 or above.
+
+:::
+
 - An underlying network fabric that allows VXLAN traffic between hosts. In eBPF mode, VXLAN is used to forward Kubernetes NodePort traffic.
 
 **Unsupported platforms**

--- a/calico-cloud_versioned_docs/version-22-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/ebpf/enabling-ebpf.mdx
@@ -45,6 +45,12 @@ Some eBPF features require a higher kernel version than the base eBPF data plane
 | [QoS bandwidth controls](../../networking/configuring/qos-controls.mdx) | v6.6 | Requires `tcx` support. Established connection limits not supported with eBPF |
 | [DNS policy inline mode](../../network-policy/domain-based-policy.mdx) | v5.17 (RHEL: v5.14) | `BPFDNSPolicyMode: Inline` parses DNS responses in eBPF before they reach the application. Only wildcard prefixes (`*.x.y.z`) supported. Falls back to `NoDelay` on older kernels |
 
+:::warning
+
+While v5.3 is the minimum kernel version required for the eBPF data plane, we strongly recommend using kernel v5.8 or above, which adds support for [CO-RE (Compile Once - Run Everywhere)](https://docs.ebpf.io/concepts/core/). CO-RE significantly improves compatibility and performance across kernel versions. For access to all eBPF features, we recommend kernel v6.6 or above.
+
+:::
+
 - An underlying network fabric that allows VXLAN traffic between hosts. In eBPF mode, VXLAN is used to forward Kubernetes NodePort traffic.
 
 **Unsupported platforms**

--- a/calico-enterprise/operations/ebpf/install.mdx
+++ b/calico-enterprise/operations/ebpf/install.mdx
@@ -52,6 +52,12 @@ Some eBPF features require a higher kernel version than the base eBPF data plane
 | [QoS bandwidth controls](../../networking/configuring/qos-controls.mdx) | v6.6 | Requires `tcx` support. Established connection limits not supported with eBPF |
 | [DNS policy inline mode](../../network-policy/domain-based-policy.mdx) | v5.17 (RHEL: v5.14) | `BPFDNSPolicyMode: Inline` parses DNS responses in eBPF before they reach the application. Only wildcard prefixes (`*.x.y.z`) supported. Falls back to `NoDelay` on older kernels |
 
+:::warning
+
+While v5.3 is the minimum kernel version required for the eBPF data plane, we strongly recommend using kernel v5.8 or above, which adds support for [CO-RE (Compile Once - Run Everywhere)](https://docs.ebpf.io/concepts/core/). CO-RE significantly improves compatibility and performance across kernel versions. For access to all eBPF features, we recommend kernel v6.6 or above.
+
+:::
+
 - An underlying network fabric that allows VXLAN traffic between hosts. In eBPF mode, VXLAN is used to forward Kubernetes NodePort traffic.
 
 **Unsupported platforms**

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/install.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/install.mdx
@@ -52,6 +52,12 @@ Some eBPF features require a higher kernel version than the base eBPF data plane
 | [QoS bandwidth controls](../../networking/configuring/qos-controls.mdx) | v6.6 | Requires `tcx` support. Established connection limits not supported with eBPF |
 | [DNS policy inline mode](../../network-policy/domain-based-policy.mdx) | v5.17 (RHEL: v5.14) | `BPFDNSPolicyMode: Inline` parses DNS responses in eBPF before they reach the application. Only wildcard prefixes (`*.x.y.z`) supported. Falls back to `NoDelay` on older kernels |
 
+:::warning
+
+While v5.3 is the minimum kernel version required for the eBPF data plane, we strongly recommend using kernel v5.8 or above, which adds support for [CO-RE (Compile Once - Run Everywhere)](https://docs.ebpf.io/concepts/core/). CO-RE significantly improves compatibility and performance across kernel versions. For access to all eBPF features, we recommend kernel v6.6 or above.
+
+:::
+
 - An underlying network fabric that allows VXLAN traffic between hosts. In eBPF mode, VXLAN is used to forward Kubernetes NodePort traffic.
 
 **Unsupported platforms**

--- a/calico/operations/ebpf/install.mdx
+++ b/calico/operations/ebpf/install.mdx
@@ -68,6 +68,12 @@ Some eBPF features require a higher kernel version than the base eBPF data plane
 | [Log rules in eBPF mode](../../network-policy/policy-rules/log-rules.mdx) | v5.16 | Logs sent to trace pipe via `bpftool prog tracelog` |
 | [QoS bandwidth controls](../../networking/configuring/qos-controls.mdx) | v6.6 | Requires `tcx` support. Established connection limits not supported with eBPF |
 
+:::warning
+
+While v5.3 is the minimum kernel version required for the eBPF data plane, we strongly recommend using kernel v5.8 or above, which adds support for [CO-RE (Compile Once - Run Everywhere)](https://docs.ebpf.io/concepts/core/). CO-RE significantly improves compatibility and performance across kernel versions. For access to all eBPF features, we recommend kernel v6.6 or above.
+
+:::
+
 - An underlying network fabric that allows VXLAN traffic between hosts. In eBPF mode, VXLAN is used to forward Kubernetes NodePort traffic.
 
 - IPv6

--- a/calico_versioned_docs/version-3.31/operations/ebpf/install.mdx
+++ b/calico_versioned_docs/version-3.31/operations/ebpf/install.mdx
@@ -68,6 +68,12 @@ Some eBPF features require a higher kernel version than the base eBPF data plane
 | [Log rules in eBPF mode](../../network-policy/policy-rules/log-rules.mdx) | v5.16 | Logs sent to trace pipe via `bpftool prog tracelog` |
 | [QoS bandwidth controls](../../networking/configuring/qos-controls.mdx) | v6.6 | Requires `tcx` support. Established connection limits not supported with eBPF |
 
+:::warning
+
+While v5.3 is the minimum kernel version required for the eBPF data plane, we strongly recommend using kernel v5.8 or above, which adds support for [CO-RE (Compile Once - Run Everywhere)](https://docs.ebpf.io/concepts/core/). CO-RE significantly improves compatibility and performance across kernel versions. For access to all eBPF features, we recommend kernel v6.6 or above.
+
+:::
+
 - An underlying network fabric that allows VXLAN traffic between hosts. In eBPF mode, VXLAN is used to forward Kubernetes NodePort traffic.
 
 - IPv6


### PR DESCRIPTION
## Summary
- Adds a warning admonition to all eBPF install/enable pages recommending kernel v5.8+ for CO-RE (Compile Once - Run Everywhere) support and v6.6+ for full eBPF feature access
- While v5.3 is the bare minimum for the base eBPF data plane, many features require newer kernels and CO-RE significantly improves compatibility and performance

## Test plan
- [ ] Verify the warning renders correctly on Calico, Calico Enterprise, and Calico Cloud docs
- [ ] Confirm the CO-RE external link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)