### PR TITLE
Remove unsupported flow log limitations for ApplyOnForward policies

### DIFF
--- a/calico-cloud/observability/elastic/flow/hep.mdx
+++ b/calico-cloud/observability/elastic/flow/hep.mdx
@@ -17,8 +17,6 @@ Get visibility into the network activity at the HostEndpoint level using $[prodn
 **Limitations**
 
 - HostEndpoint reporting is only supported on Kubernetes nodes.
-- Flow logs on ApplyOnForward policies are currently not supported. As a result, a policy blocking traffic at the host level
-from forwarding to a workload endpoint would not result in a flow log from the host endpoint.
 
 ## How to
 

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/hep.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/hep.mdx
@@ -17,8 +17,6 @@ Get visibility into the network activity at the HostEndpoint level using $[prodn
 **Limitations**
 
 - HostEndpoint reporting is only supported on Kubernetes nodes.
-- Flow logs on ApplyOnForward policies are currently not supported. As a result, a policy blocking traffic at the host level
-from forwarding to a workload endpoint would not result in a flow log from the host endpoint.
 
 ## How to
 

--- a/calico-enterprise/observability/elastic/flow/hep.mdx
+++ b/calico-enterprise/observability/elastic/flow/hep.mdx
@@ -17,8 +17,6 @@ Get visibility into the network activity at the HostEndpoint level using $[prodn
 **Limitations**
 
 - HostEndpoint reporting is only supported on Kubernetes nodes.
-- Flow logs on ApplyOnForward policies are currently not supported. As a result, a policy blocking traffic at the host level
-from forwarding to a workload endpoint would not result in a flow log from the host endpoint.
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/flow/hep.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/flow/hep.mdx
@@ -17,8 +17,6 @@ Get visibility into the network activity at the HostEndpoint level using $[prodn
 **Limitations**
 
 - HostEndpoint reporting is only supported on Kubernetes nodes.
-- Flow logs on ApplyOnForward policies are currently not supported. As a result, a policy blocking traffic at the host level
-from forwarding to a workload endpoint would not result in a flow log from the host endpoint.
 
 ## How to
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/hep.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/hep.mdx
@@ -17,8 +17,6 @@ Get visibility into the network activity at the HostEndpoint level using $[prodn
 **Limitations**
 
 - HostEndpoint reporting is only supported on Kubernetes nodes.
-- Flow logs on ApplyOnForward policies are currently not supported. As a result, a policy blocking traffic at the host level
-from forwarding to a workload endpoint would not result in a flow log from the host endpoint.
 
 ## How to
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
Calico Enterprise 3.22+, Calico Cloud 22-2+

Issue:
EV-6372

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
Remove the outdated limitation stating that flow logs on ApplyOnForward policies are not supported. This limitation no longer applies to Calico Enterprise 3.22+ and Calico Cloud.

Affected files:
- calico-cloud/observability/elastic/flow/hep.mdx
- calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/hep.mdx
- calico-enterprise/observability/elastic/flow/hep.mdx
- calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/flow/hep.mdx
- calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/hep.mdx

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->