### PR TITLE
Add separate CRD chart to enterprise Helm install docs

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -36,6 +36,7 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
 helm pull tigera-ee/tigera-operator --version $[releaseTitle]
+helm pull tigera-ee/crd.projectcalico.org.v1 --version $[releaseTitle]
 ```
 
 ### Prepare the Installation Configuration
@@ -95,7 +96,7 @@ To install a standard $[prodname] cluster with Helm:
 1. Create the necessary custom resource definitions.
 
    ```bash
-   helm install calico-crds crd.projectcalico.org.v1-$[chart_version_name] --version $[releaseTitle] --namespace tigera-operator
+   helm install calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz --namespace tigera-operator
    ```
 
 1. Install the Tigera Operator using the Helm 3 chart:

--- a/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -96,7 +96,7 @@ To install a standard $[prodname] cluster with Helm:
 1. Create the necessary custom resource definitions.
 
    ```bash
-   helm install calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz --namespace tigera-operator
+   helm install calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz --namespace tigera-operator --create-namespace
    ```
 
 1. Install the Tigera Operator using the Helm 3 chart:
@@ -105,7 +105,7 @@ To install a standard $[prodname] cluster with Helm:
    helm install $[prodnamedash] tigera-operator-$[chart_version_name].tgz \
    --set-file imagePullSecrets.tigera-pull-secret=<path/to/pull/secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path/to/pull/secret> \
    --set-file licenseKeyContent=<path/to/license/file/yaml> \
-   --namespace tigera-operator --create-namespace
+   --namespace tigera-operator
    ```
 
    or if you created a `values.yaml` above:
@@ -114,7 +114,7 @@ To install a standard $[prodname] cluster with Helm:
    helm install $[prodnamedash] tigera-operator-$[chart_version_name].tgz -f values.yaml \
    --set-file imagePullSecrets.tigera-pull-secret=<path/to/pull/secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path/to/pull/secret> \
    --set-file licenseKeyContent=<path/to/license/file/yaml> \
-   --namespace tigera-operator --create-namespace
+   --namespace tigera-operator
    ```
 1. You can now monitor progress with the following command:
 

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -36,6 +36,7 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
 helm pull tigera-ee/tigera-operator --version $[releaseTitle]
+helm pull tigera-ee/crd.projectcalico.org.v1 --version $[releaseTitle]
 ```
 
 ### Prepare the Installation Configuration
@@ -121,7 +122,13 @@ To install a $[prodname] [managed](../standard-install/create-a-managed-cluster#
         key: $MANAGED_CLUSTER_KEY" >> values.yaml
   ```
 
-1. Install the Tigera Operator and custom resource definitions using the Helm 3 chart:
+1. Create the necessary custom resource definitions.
+
+  ```bash
+  helm install calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz --namespace tigera-operator
+  ```
+
+1. Install the Tigera Operator using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -125,7 +125,7 @@ To install a $[prodname] [managed](../standard-install/create-a-managed-cluster#
 1. Create the necessary custom resource definitions.
 
   ```bash
-  helm install calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz --namespace tigera-operator
+  helm install calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz --namespace tigera-operator --create-namespace
   ```
 
 1. Install the Tigera Operator using the Helm 3 chart:
@@ -136,12 +136,12 @@ To install a $[prodname] [managed](../standard-install/create-a-managed-cluster#
 --set-file imagePullSecrets.tigera-pull-secret=<path/to/pull/secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path/to/pull/secret> \\
 --set-file licenseKeyContent=<path/to/license/file/yaml> \\
 --set logStorage.enabled=false --set manager.enabled=false \\
---namespace tigera-operator --create-namespace`
+--namespace tigera-operator`
        : `helm install $[prodnamedash] tigera-operator-$[chart_version_name].tgz -f values.yaml \\
 --set-file imagePullSecrets.tigera-pull-secret=<path/to/pull/secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path/to/pull/secret> \\
 --set-file licenseKeyContent=<path/to/license/file/yaml> \\
 --set logStorage.enabled=false --set manager.enabled=false \\
---namespace tigera-operator --create-namespace`}
+--namespace tigera-operator`}
   </CodeBlock>
 
 1. You can now monitor progress with the following command:

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -145,7 +145,7 @@ To install a $[prodname] [management](create-a-management-cluster-helm#value) cl
 1. Create the necessary custom resource definitions.
 
   ```bash
-  helm install calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz --namespace tigera-operator
+  helm install calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz --namespace tigera-operator --create-namespace
   ```
 
 1. Install the Tigera Operator using the Helm 3 chart:
@@ -155,11 +155,11 @@ To install a $[prodname] [management](create-a-management-cluster-helm#value) cl
        ? `helm install $[prodnamedash] tigera/tigera-operator --version tigera-operator-v0.0 -f values.yaml \\
 --set-file imagePullSecrets.tigera-pull-secret=<path/to/pull/secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path/to/pull/secret> \\
 --set-file licenseKeyContent=<path/to/license/file/yaml> \\
---namespace tigera-operator --create-namespace`
+--namespace tigera-operator`
        : `helm install $[prodnamedash] tigera-operator-$[chart_version_name].tgz -f values.yaml \\
 --set-file imagePullSecrets.tigera-pull-secret=<path/to/pull/secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path/to/pull/secret> \\
 --set-file licenseKeyContent=<path/to/license/file/yaml> \\
---namespace tigera-operator --create-namespace`}
+--namespace tigera-operator`}
   </CodeBlock>
 
 1. You can now monitor progress with the following command:
@@ -239,7 +239,7 @@ For example, if you are using EKS, you must meet the requirements defined in [cr
 1. Create the necessary custom resource definitions.
 
   ```bash
-  helm install calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz --namespace tigera-operator
+  helm install calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz --namespace tigera-operator --create-namespace
   ```
 
 1. Install the Tigera Operator using the Helm 3 chart:
@@ -249,11 +249,11 @@ For example, if you are using EKS, you must meet the requirements defined in [cr
        ? `helm install $[prodnamedash] tigera/tigera-operator --version tigera-operator-v0.0 -f values.yaml \\
 --set-file imagePullSecrets.tigera-pull-secret=<path/to/pull/secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path/to/pull/secret> \\
 --set-file licenseKeyContent=<path/to/license/file/yaml> \\
---namespace tigera-operator --create-namespace`
+--namespace tigera-operator`
        : `helm install $[prodnamedash] tigera-operator-$[chart_version_name].tgz -f values.yaml \\
 --set-file imagePullSecrets.tigera-pull-secret=<path/to/pull/secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path/to/pull/secret> \\
 --set-file licenseKeyContent=<path/to/license/file/yaml> \\
---namespace tigera-operator --create-namespace`}
+--namespace tigera-operator`}
   </CodeBlock>
 
 1. You can now monitor progress with the following command:

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -38,10 +38,12 @@ In this guide, you install the Tigera Calico operator and custom resource defini
     {'$[version]' === 'master'
         ? `helm repo add tigera gs://tigera-helm-charts
 helm repo update
-helm pull tigera/tigera-operator --version $[releaseTitle]`
+helm pull tigera/tigera-operator --version $[releaseTitle]
+helm pull tigera/crd.projectcalico.org.v1 --version $[releaseTitle]`
         : `helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[releaseTitle]`}
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]
+helm pull tigera-ee/crd.projectcalico.org.v1 --version $[releaseTitle]`}
 </CodeBlock>
 
 ### Prepare the Installation Configuration
@@ -140,7 +142,13 @@ To install a $[prodname] [management](create-a-management-cluster-helm#value) cl
       certificate: $MANAGED_CLUSTER_CERTIFICATE" >> values.yaml
   ```
 
-1. Install the Tigera Operator and custom resource definitions using the Helm 3 chart:
+1. Create the necessary custom resource definitions.
+
+  ```bash
+  helm install calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz --namespace tigera-operator
+  ```
+
+1. Install the Tigera Operator using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'
@@ -228,7 +236,13 @@ For example, if you are using EKS, you must meet the requirements defined in [cr
         value: "internet-facing"
   ```
 
-1. Install the Tigera Operator and custom resource definitions using the Helm 3 chart:
+1. Create the necessary custom resource definitions.
+
+  ```bash
+  helm install calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz --namespace tigera-operator
+  ```
+
+1. Install the Tigera Operator using the Helm 3 chart:
 
   <CodeBlock language='bash'>
      {'$[version]' === 'master'


### PR DESCRIPTION
The `tigera-operator` chart no longer bundles CRDs (see https://github.com/projectcalico/calico/pull/11727) — they're now in a separate `crd.projectcalico.org.v1` chart. The open source Calico install docs already have this, but the enterprise install docs were still missing it in a few places.

This adds the CRD chart download + install step to:
- Standard enterprise Helm install
- Management cluster Helm install (both NodePort and LoadBalancer)
- Managed cluster Helm install

Also fixes the existing CRD install command in the standard enterprise doc (was missing `.tgz` extension and had an unnecessary `--version` flag for a local file).

Fixes https://tigera.atlassian.net/browse/CORE-12418