### PR TITLE
Rename operator-crds.yaml to v1_crd_projectcalico_org.yaml

### DIFF
--- a/calico/getting-started/kubernetes/k3s/multi-node-install.mdx
+++ b/calico/getting-started/kubernetes/k3s/multi-node-install.mdx
@@ -97,7 +97,7 @@ curl -sfL https://get.k3s.io | K3S_URL=https://serverip:6443 K3S_TOKEN=mytoken s
 Install the $[prodname] operator and custom resource definitions.
 
 ```bash
-kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
+kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
 kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
 ```
 

--- a/calico/getting-started/kubernetes/k3s/quickstart.mdx
+++ b/calico/getting-started/kubernetes/k3s/quickstart.mdx
@@ -68,7 +68,7 @@ you are assigning necessary permissions to the file and make it accessible for o
 1. Install the $[prodname] operator and custom resource definitions.
 
 ```bash
-kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
+kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
 kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
 ```
 

--- a/calico/getting-started/kubernetes/k8s-single-node.mdx
+++ b/calico/getting-started/kubernetes/k8s-single-node.mdx
@@ -92,7 +92,7 @@ The geeky details of what you get:
 1. Install the Tigera Operator and custom resource definitions.
 
    ```
-   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
+   kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 

--- a/calico/getting-started/kubernetes/kind.mdx
+++ b/calico/getting-started/kubernetes/kind.mdx
@@ -82,7 +82,7 @@ dev-worker2         NotReady    <none>          4m     v1.25.0   172.18.0.3    <
 1. Install the $[prodname] operator and custom resource definitions.
 
 ```bash
-kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
+kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
 kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
 ```
 

--- a/calico/getting-started/kubernetes/managed-public-cloud/aks.mdx
+++ b/calico/getting-started/kubernetes/managed-public-cloud/aks.mdx
@@ -115,7 +115,7 @@ The geeky details of what you get:
 1. Install the Tigera Operator and custom resource definitions:
 
    ```bash
-   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
+   kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 
@@ -216,7 +216,7 @@ The geeky details of what you get:
 1. Install the Tigera Operator and custom resource definitions.
 
    ```bash
-   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
+   kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 

--- a/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -64,7 +64,7 @@ When using the Amazon VPC CNI plugin, $[prodname] does not support enforcement o
 1. Install the Tigera Operator and custom resource definitions.
 
    ```bash
-   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
+   kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 
@@ -167,7 +167,7 @@ Before you get started, make sure you have downloaded and configured the [necess
 1. Install the Tigera Operator and custom resource definitions.
 
    ```bash
-   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
+   kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 

--- a/calico/getting-started/kubernetes/minikube.mdx
+++ b/calico/getting-started/kubernetes/minikube.mdx
@@ -61,7 +61,7 @@ minikube start --cni=calico
 2. Install the Tigera Operator and custom resource definitions.
 
    ```bash
-   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
+   kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 

--- a/calico/getting-started/kubernetes/nftables.mdx
+++ b/calico/getting-started/kubernetes/nftables.mdx
@@ -102,7 +102,7 @@ mode: nftables
 1. Install the Tigera Operator and custom resource definitions.
 
    ```bash
-   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
+   kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 

--- a/calico/getting-started/kubernetes/rancher.mdx
+++ b/calico/getting-started/kubernetes/rancher.mdx
@@ -46,7 +46,7 @@ The geeky details of what you get:
 1. Install the Tigera Operator and custom resource definitions.
 
    ```
-   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
+   kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 

--- a/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
+++ b/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
@@ -44,7 +44,7 @@ $[prodname] can also be installed using raw manifests as an alternative to the o
 1. Install the Tigera Operator and custom resource definitions.
 
    ```
-   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
+   kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 

--- a/calico/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
+++ b/calico/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
@@ -193,7 +193,7 @@ worker-2     NotReady   <none>   5s      v1.17.2
 1. On the controller, install the Tigera Operator and custom resource definitions:
 
   ```bash
-  kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
+  kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
   kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
   ```
 

--- a/calico/getting-started/kubernetes/vpp/getting-started.mdx
+++ b/calico/getting-started/kubernetes/vpp/getting-started.mdx
@@ -89,7 +89,7 @@ Before you get started, make sure you have downloaded and configured the [necess
 1. Now that you have an empty cluster configured, you can install the Tigera Operator and custom resource definitions.
 
    ```bash
-   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
+   kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 
@@ -158,7 +158,7 @@ DPDK provides better performance compared to the standard install but it require
 1. Now that you have an empty cluster configured, you can install the Tigera Operator and custom resource definitions.
 
    ```bash
-   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
+   kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 
@@ -259,7 +259,7 @@ For some hardware, the following hugepages configuration may enable VPP to use m
 1. Install the Tigera Operator and custom resource definitions.
 
    ```bash
-   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
+   kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 

--- a/calico/getting-started/kubernetes/windows-calico/rancher.mdx
+++ b/calico/getting-started/kubernetes/windows-calico/rancher.mdx
@@ -36,7 +36,7 @@ The following steps will outline the installation of $[prodname] networking on t
 1. Install the Tigera Operator and custom resource definitions.
 
    ```
-   kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
+   kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 

--- a/calico/networking/ingress-gateway/tutorial-ingress-gateway-canary.mdx
+++ b/calico/networking/ingress-gateway/tutorial-ingress-gateway-canary.mdx
@@ -107,7 +107,7 @@ If you've already got a suitable environment, start the tutorial at [Step 2: Cre
 
 1. Install Calico Open Source by adding custom resource definitions, the Tigera Operator, and the custom resources.
    <CodeBlock>
-   {`kubectl create -f ${files}/manifests/operator-crds.yaml
+   {`kubectl create -f ${files}/manifests/v1_crd_projectcalico_org.yaml
    kubectl create -f ${files}/manifests/tigera-operator.yaml
    kubectl create -f ${files}/manifests/custom-resources.yaml`}
    </CodeBlock>

--- a/calico/operations/operator-migration.mdx
+++ b/calico/operations/operator-migration.mdx
@@ -57,7 +57,7 @@ Do not edit or delete any resources in the `kube-system` Namespace during the fo
 1. Install the Tigera Operator and custom resource definitions.
 
    ```bash
-   kubectl apply --server-side --force-conflicts -f $[manifestsUrl]/manifests/operator-crds.yaml
+   kubectl apply --server-side --force-conflicts -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
    kubectl apply --server-side --force-conflicts -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 

--- a/calico/operations/upgrading/kubernetes-upgrade.mdx
+++ b/calico/operations/upgrading/kubernetes-upgrade.mdx
@@ -47,7 +47,7 @@ owned resources being garbage collected by Kubernetes.
 1. Apply the $[version] CRDs:
 
    ```bash
-   kubectl apply --server-side --force-conflicts -f $[manifestsUrl]/manifests/operator-crds.yaml
+   kubectl apply --server-side --force-conflicts -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
    ```
 
 1. Run the helm upgrade:
@@ -61,14 +61,14 @@ owned resources being garbage collected by Kubernetes.
 1. Download the Tigera Operator manifest and custom resource definitions.
 
    ```bash
-   curl $[manifestsUrl]/manifests/operator-crds.yaml -O
+   curl $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml -O
    curl $[manifestsUrl]/manifests/tigera-operator.yaml -O
    ```
 
 1. Use the following command to initiate an upgrade.
 
    ```bash
-   kubectl apply --server-side --force-conflicts -f operator-crds.yaml
+   kubectl apply --server-side --force-conflicts -f v1_crd_projectcalico_org.yaml
    kubectl apply --server-side --force-conflicts -f tigera-operator.yaml
    ```
 


### PR DESCRIPTION
## Summary
- The CRD manifest was renamed upstream from `operator-crds.yaml` to `v1_crd_projectcalico_org.yaml`
- Updates all references across the unversioned calico/ install, upgrade, and getting-started docs (16 files)