### PR TITLE
Add Maglev load balancing release note for CE 3.23 ep1

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.23-1/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/release-notes/index.mdx
@@ -38,6 +38,17 @@ The Ingress Gateway L7 dashboard provides a clear view of how your gateways mana
 
 For more information, see [Dashboards](../observability/dashboards.mdx#ingress-gateway-l7).
 
+### Maglev load balancing for services
+
+Calico Enterprise now supports Maglev consistent-hash load balancing for external traffic to services.
+Maglev enables Calico Enterprise nodes to act as a distributed, horizontally scalable load balancer.
+When a node goes down — for maintenance or otherwise — external connections can fail over to another node.
+This is particularly useful when advertising service IPs as ECMP routes to your broader network.
+
+Maglev is enabled per-service via annotation, keeping the memory footprint contained to only the services that need it.
+
+For more information, see [Add Maglev load balancing to a service](../networking/configuring/add-maglev-load-balancing.mdx).
+
 ### Enhancements
 
 * Improved the deterministic selection logic for flow and L7 logs when multiple NetworkSets have overlapping CIDRs.


### PR DESCRIPTION
## Summary
- Adds a missing release note for Maglev consistent-hash load balancing in the CE 3.23 early preview release notes
- Links to the existing Maglev docs page

## Test plan
- [ ] Verify the release note renders correctly on the 3.23 ep1 release notes page
- [ ] Confirm the link to the Maglev docs page resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)