### PR TITLE
Add GeoIP rules docs and DB-IP attribution to WAF page

### DIFF
--- a/calico-enterprise/threat/web-application-firewall.mdx
+++ b/calico-enterprise/threat/web-application-firewall.mdx
@@ -339,10 +339,10 @@ SecRule GEO:COUNTRY_CODE "@streq RU" "phase:1,id:157,deny,msg:'Access from this 
 **Example: Deny traffic from IPs not found in the GeoIP database (e.g. private IPs)**
 
 ```bash
-SecRule REMOTE_ADDR "@geoLookup" "phase:1,id:155,nolog,pass"
+SecRule REMOTE_ADDR "@geoLookup" "phase:1,id:158,nolog,pass"
 
 # &GEO equals 0 when the IP was not found in the database
-SecRule &GEO "@eq 0" "phase:1,id:156,deny,msg:'Failed to lookup IP'"
+SecRule &GEO "@eq 0" "phase:1,id:159,deny,msg:'Failed to look up IP'"
 ```
 
 :::note

--- a/calico-enterprise/threat/web-application-firewall.mdx
+++ b/calico-enterprise/threat/web-application-firewall.mdx
@@ -320,6 +320,41 @@ kubectl replace -f ruleset.configmap.yaml
 
 Read more about the order of execution for plugins here: https://coreruleset.org/docs/4-about-plugins/4-1-plugins/
 
+#### GeoIP-based rules
+
+WAF includes an embedded city-level geolocation database, enabling you to write rules that filter traffic
+based on geographic origin. You can use the `@geoLookup` operator along with `GEO` variables like
+`GEO:COUNTRY_CODE` in your custom rules.
+
+**Example: Block traffic from a specific country**
+
+```bash
+# Look up the geographic location of the client IP
+SecRule REMOTE_ADDR "@geoLookup" "phase:1,id:155,nolog,pass"
+
+# Deny the request if the country code matches
+SecRule GEO:COUNTRY_CODE "@streq RU" "phase:1,id:157,deny,msg:'Access from this country is not allowed'"
+```
+
+**Example: Deny traffic from IPs not found in the GeoIP database (e.g. private IPs)**
+
+```bash
+SecRule REMOTE_ADDR "@geoLookup" "phase:1,id:155,nolog,pass"
+
+# &GEO equals 0 when the IP was not found in the database
+SecRule &GEO "@eq 0" "phase:1,id:156,deny,msg:'Failed to lookup IP'"
+```
+
+:::note
+
+You can combine both rules to deny unknown IPs while also blocking specific countries. If you only want to
+block certain countries but allow private/unknown IPs through, omit the `&GEO "@eq 0"` rule.
+
+:::
+
+GeoIP data provided by [DB-IP](https://db-ip.com), available under the
+[Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
+
 ## View WAF events
 
 ### Security Events

--- a/calico-enterprise/threat/web-application-firewall.mdx
+++ b/calico-enterprise/threat/web-application-firewall.mdx
@@ -352,9 +352,6 @@ block certain countries but allow private/unknown IPs through, omit the `&GEO "@
 
 :::
 
-GeoIP data provided by [DB-IP](https://db-ip.com), available under the
-[Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
-
 ## View WAF events
 
 ### Security Events


### PR DESCRIPTION
## Summary

- Adds a new **GeoIP-based rules** subsection under WAF customization options, documenting how to use `@geoLookup` and `GEO:COUNTRY_CODE` in custom rules
- Includes two practical examples: blocking traffic by country, and denying IPs not found in the GeoIP database
- Adds the required [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/) notice for the embedded [DB-IP](https://db-ip.com) Lite database

## Context

WAF ships with an embedded DB-IP Lite city-level geolocation database (bundled in the dikastes image), but this capability was previously undocumented. The DB-IP Lite license (CC BY 4.0) also requires attribution with a link back to db-ip.com, which was missing.

## Test plan

- [ ] Verify the page renders correctly on the docs site
- [ ] Confirm the new section appears under "Customization options" in the WAF page
- [ ] Verify links to DB-IP and CC BY 4.0 license resolve correctly