### PR TITLE
Skip dead OpenStack review link in link checker

### DIFF
--- a/__tests__/crawler.test.js
+++ b/__tests__/crawler.test.js
@@ -201,7 +201,8 @@ test('Crawl the docs and execute tests', async () => {
     'https://calico-docs.mcp.kapa.ai',
     'https://docs.tigera.io/img/calico-logo-2026-badge.png',
     'http://www.w3.org/2000/svg', // Appears in SVG file 'xmlns', doesn't need checking
-    'https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html' // TEMP
+    'https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html', // TEMP
+    'https://review.openstack.org/#/c/344008/' // TEMP: dead link (503)
   ];
 
   const lc = linkChecker();


### PR DESCRIPTION
## Summary
- Add `https://review.openstack.org/#/c/344008/` to the crawler skip list as a temporary exception
- This link returns 503 and is failing Netlify CI builds on the `/calico/latest/networking/openstack/semantics` page

## Test plan
- [ ] Verify Netlify CI build passes with the exception in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)