### PR TITLE
DOCS-2861: Update hackathon banner to mid-way encouragement

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -116,12 +116,20 @@ export default async function createAsyncConfig() {
           searchPagePath: '/search',
         },
         announcementBar: {
-          id: "calico_hackathon",
-          content: '🚀 The <a href="https://www.tigera.io/lp/project-calico-hackathon?utm_source=website&utm_medium=Docs_site&utm_campaign=Hackathon2026">Calico 3.30+ Hackathon</a> is live! Leverage Calico 3.30+ to solve networking challenges and win up to $1,000.',
+          id: "calico_hackathon_midway",
+          content: '🛡️ Hack the latest features: Leverage Calico 3.30+ to solve networking challenges and win up to $1,000. <a href="https://www.tigera.io/lp/project-calico-hackathon?utm_source=website&utm_medium=Docs_site&utm_campaign=Hackathon2026">Enter the Calico 3.30+ Hackathon</a>',
           backgroundColor: "#FCE181",
           textColor: "#000",
-          isCloseable: true
+          isCloseable: true,
         },
+        // DOCS-2862: Hackathon deadline approaching (go-live March 24)
+        // announcementBar: {
+        //   id: "calico_hackathon_deadline",
+        //   content: '🏃 Only one week left (Ends March 31, 2026!) Finalize your GitHub repo and demo video to enter the <a href="https://www.tigera.io/lp/project-calico-hackathon?utm_source=website&utm_medium=Docs_site&utm_campaign=Hackathon2026">Calico 3.30+ Hackathon</a>',
+        //   backgroundColor: "#FCE181",
+        //   textColor: "#000",
+        //   isCloseable: true,
+        // },
         navbar: {
           logo: {
             src: 'img/tigera-logo-2026-black-text.svg',


### PR DESCRIPTION
## Summary
- Replace the launch banner with the mid-way encouragement message for the Calico 3.30+ Hackathon
- Add commented-out DOCS-2862 deadline banner (March 24 milestone) for easy activation later

## Go-live
**Do not merge before March 9, 2026**

## Test plan
- [ ] Verify the mid-way banner renders correctly with the shield emoji and link
- [ ] Verify the commented-out DOCS-2862 banner doesn't affect the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)