### PR TITLE
Limit Vale CI to PR diff only

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -7,22 +7,41 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed
+        run: |
+          FILES=$(git diff --name-only --diff-filter=d ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -- '*.md' '*.mdx' | tr '\n' ' ')
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
+          if [ -z "$FILES" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Enable Corepack
+        if: steps.changed.outputs.skip == 'false'
         run: corepack enable
       - name: Setup Node.js with Yarn
+        if: steps.changed.outputs.skip == 'false'
         uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: yarn
       - name: Install dependencies
+        if: steps.changed.outputs.skip == 'false'
         run: yarn install --immutable
       - name: Install mdx2vast globally
+        if: steps.changed.outputs.skip == 'false'
         run: npm install -g mdx2vast
       - name: Swap stuff
+        if: steps.changed.outputs.skip == 'false'
         run: |
           sudo apt-get install ripgrep
           rg -l0 '\$\[[^\]]*\]' -g '*.mdx' -g '*.md' . | xargs -0 perl -i -pe 's/\$\[[^\]]*\]/PICKLEVAR/g'
       - name: Run Vale with Reviewdog
+        if: steps.changed.outputs.skip == 'false'
         uses: errata-ai/vale-action@reviewdog
         with:
+          files: ${{ steps.changed.outputs.files }}
           fail_on_error: false

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Get changed files
         id: changed
         run: |
-          FILES=$(git diff --name-only --diff-filter=d ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -- '*.md' '*.mdx' | tr '\n' ' ')
+          FILES=$(git diff --name-only --diff-filter=d ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} -- '*.md' '*.mdx' | tr '\n' ' ')
           echo "files=$FILES" >> "$GITHUB_OUTPUT"
           if [ -z "$FILES" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -38,7 +38,10 @@ jobs:
         if: steps.changed.outputs.skip == 'false'
         run: |
           sudo apt-get install ripgrep
-          rg -l0 '\$\[[^\]]*\]' -g '*.mdx' -g '*.md' . | xargs -0 perl -i -pe 's/\$\[[^\]]*\]/PICKLEVAR/g'
+          FILES="${{ steps.changed.outputs.files }}"
+          if [ -n "$FILES" ]; then
+            rg -l0 '\$\[[^\]]*\]' -- $FILES | xargs -0 perl -i -pe 's/\$\[[^\]]*\]/PICKLEVAR/g' || true
+          fi
       - name: Run Vale with Reviewdog
         if: steps.changed.outputs.skip == 'false'
         uses: errata-ai/vale-action@reviewdog


### PR DESCRIPTION
## Summary
- Vale was scanning the entire repo on every PR, taking ~10 minutes
- Now computes changed `.md`/`.mdx` files from the PR diff and passes only those to Vale
- Skips all steps entirely if no markdown files changed

## Test plan
- [ ] Open a PR that changes a few markdown files — verify Vale runs quickly and only reports on those files
- [ ] Open a PR with no markdown changes — verify the job skips gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)