### PR TITLE
DOCS-2844: Clarify k8s/OpenStack QoS pages

### DIFF
--- a/calico/networking/configuring/qos-controls.mdx
+++ b/calico/networking/configuring/qos-controls.mdx
@@ -9,9 +9,17 @@ description: Configure QoS (Quality of Service) Controls to limit ingress and/or
 Configure QoS (Quality of Service) Controls to limit ingress and/or egress bandwidth, packet rate and number of connections used by $[prodname] workloads in order to prevent them from overusing or overloading network resources.
 Additionally, it allows configuring Differentiated Services (DiffServ) on egress traffic of $[prodname] workloads and hosts.
 
+:::note
+
+This page covers QoS controls for **Kubernetes** workloads using pod annotations.
+If you are using $[prodname] with OpenStack, QoS is configured through Neutron policies and is an entirely separate mechanism.
+See [QoS controls on OpenStack](../openstack/neutron-api.mdx#qos).
+
+:::
+
 ## Value
 
-With QoS controls, $[prodname] enforces network resource limits (bandwidth, packet rate, connections) for Kubernetes pods and OpenStack VMs, ensuring fair resource allocation and preventing performance degradation for other workloads.
+With QoS controls, $[prodname] enforces network resource limits (bandwidth, packet rate, connections) for Kubernetes pods, ensuring fair resource allocation and preventing performance degradation for other workloads.
 $[prodname] can also apply DiffServ on egress traffic to allow upstream devices to prioritise forwarding accordingly.
 
 ## Prerequisites

--- a/calico_versioned_docs/version-3.30/networking/configuring/qos-controls.mdx
+++ b/calico_versioned_docs/version-3.30/networking/configuring/qos-controls.mdx
@@ -8,9 +8,17 @@ description: Configure QoS (Quality of Service) Controls to limit ingress and/or
 
 Configure QoS (Quality of Service) Controls to limit ingress and/or egress bandwidth, packet rate and number of connections used by Calico workloads in order to prevent them from overusing or overloading network resources.
 
+:::note
+
+This page covers QoS controls for **Kubernetes** workloads using pod annotations.
+If you are using $[prodname] with OpenStack, QoS is configured through Neutron policies and is an entirely separate mechanism.
+See [QoS controls on OpenStack](../openstack/neutron-api.mdx#qos).
+
+:::
+
 ## Value
 
-With QoS controls, $[prodname] enforces network resource limits (bandwidth, packet rate, connections) for Kubernetes pods and OpenStack VMs, ensuring fair resource allocation and preventing performance degradation for other workloads.
+With QoS controls, $[prodname] enforces network resource limits (bandwidth, packet rate, connections) for Kubernetes pods, ensuring fair resource allocation and preventing performance degradation for other workloads.
 
 ## Limitations
 


### PR DESCRIPTION
## Summary

- Adds a `:::note` admonition near the top of the QoS controls page clarifying that it covers **Kubernetes** workloads only, and directing OpenStack users to the separate Neutron QoS documentation
- Removes misleading "and OpenStack VMs" from the Value section (the two mechanisms are entirely separate)
- Changes applied to calico next and versioned 3.30 docs (enterprise/cloud files already correct)

Resolves: https://tigera.atlassian.net/browse/DOCS-2844

## Test plan

- [ ] Verify the note renders correctly on the QoS controls page
- [ ] Verify the cross-link to the OpenStack Neutron API QoS section works

🤖 Generated with [Claude Code](https://claude.com/claude-code)