### PR TITLE
Document MKE VXLAN port conflict for eBPF dataplane

### DIFF
--- a/calico-enterprise/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise/operations/ebpf/enabling-ebpf.mdx
@@ -190,7 +190,7 @@ If both `kube-proxy` and `BPFKubeProxyIptablesCleanupEnabled` is enabled then `k
 :::caution
 
 MKE uses Docker Swarm overlay networking, which creates VXLAN devices on UDP port 4789 inside Docker network namespaces.
-When $[prodname] switches to eBPF mode on kernels with BTF support (v5.8+), Felix creates the `vxlan.calico` device in
+When $[prodname] switches to eBPF mode on kernels where BTF is available (typically v5.8+), Felix creates the `vxlan.calico` device in
 flow mode, which acts as a catch-all on its UDP port. The kernel rejects this when another VXLAN device (Docker Swarm's)
 already holds the same port, causing `vxlan.calico` to stay DOWN with `address already in use` errors.
 

--- a/calico-enterprise/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise/operations/ebpf/enabling-ebpf.mdx
@@ -185,6 +185,32 @@ kubectl patch felixconfiguration default --patch='{"spec": {"bpfKubeProxyIptable
 
 If both `kube-proxy` and `BPFKubeProxyIptablesCleanupEnabled` is enabled then `kube-proxy` will write its iptables rules and Felix will try to clean them up resulting in iptables flapping between the two.
 
+### MKE: Change the VXLAN port before enabling eBPF
+
+:::caution
+
+MKE uses Docker Swarm overlay networking, which creates VXLAN devices on UDP port 4789 inside Docker network namespaces.
+When $[prodname] switches to eBPF mode on kernels with BTF support (v5.8+), Felix creates the `vxlan.calico` device in
+flow mode, which acts as a catch-all on its UDP port. The kernel rejects this when another VXLAN device (Docker Swarm's)
+already holds the same port, causing `vxlan.calico` to stay DOWN with `address already in use` errors.
+
+**You must change the VXLAN port before enabling eBPF on MKE clusters:**
+
+```bash
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"vxlanPort":4790}}'
+```
+
+Wait for all calico-node pods to recreate the VXLAN device on the new port, then verify on each node:
+
+```bash
+kubectl exec -n calico-system <calico-node-pod> -- ip -d link show vxlan.calico
+```
+
+Confirm the device shows `dstport 4790` (or your chosen port) and is UP before proceeding.
+Ensure that the chosen UDP port is allowed by your underlying network between all nodes.
+
+:::
+
 ### Enable eBPF mode
 
 To enable eBPF mode, change the `spec.calicoNetwork.linuxDataplane` parameter in the operator's `Installation`

--- a/calico-enterprise/operations/ebpf/install.mdx
+++ b/calico-enterprise/operations/ebpf/install.mdx
@@ -175,6 +175,21 @@ can do that by setting `--kube-proxy-mode=disabled` and `--kube-default-drop-mas
 
 More details can be found in [the MKE documentation](https://docs.mirantis.com/mke/current/install/predeployment/configure-networking/cluster-service-networking-options.html)
 
+:::caution VXLAN port conflict
+
+MKE's Docker Swarm overlay networking uses UDP port 4789 for its own VXLAN devices. In eBPF mode with BTF support (kernel v5.8+),
+$[prodname] creates the `vxlan.calico` device in flow mode, which conflicts with Docker Swarm's use of the same port.
+You must change the VXLAN port before enabling eBPF:
+
+```bash
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"vxlanPort":4790}}'
+```
+
+Ensure the chosen UDP port is allowed by your underlying network between all nodes.
+See [Troubleshoot eBPF mode](troubleshoot-ebpf.mdx#mke-vxlan-device-down) for more details.
+
+:::
+
 </TabItem>
 
 </Tabs>

--- a/calico-enterprise/operations/ebpf/install.mdx
+++ b/calico-enterprise/operations/ebpf/install.mdx
@@ -177,7 +177,7 @@ More details can be found in [the MKE documentation](https://docs.mirantis.com/m
 
 :::caution VXLAN port conflict
 
-MKE's Docker Swarm overlay networking uses UDP port 4789 for its own VXLAN devices. In eBPF mode with BTF support (kernel v5.8+),
+MKE's Docker Swarm overlay networking uses UDP port 4789 for its own VXLAN devices. In eBPF mode, when BTF is available on the node (typically kernel v5.8+),
 $[prodname] creates the `vxlan.calico` device in flow mode, which conflicts with Docker Swarm's use of the same port.
 You must change the VXLAN port before enabling eBPF:
 

--- a/calico-enterprise/operations/ebpf/troubleshoot-ebpf.mdx
+++ b/calico-enterprise/operations/ebpf/troubleshoot-ebpf.mdx
@@ -396,7 +396,7 @@ e2e` command. The command resets the profiling data after dumping it.
 
 ```
 
-## MKE: VXLAN device DOWN {#mke-vxlan-device-down}
+## MKE: VXLAN device DOWN
 
 On MKE clusters, after enabling eBPF mode, the `vxlan.calico` device may stay DOWN with Felix logs showing:
 
@@ -404,7 +404,7 @@ On MKE clusters, after enabling eBPF mode, the `vxlan.calico` device may stay DO
 Failed to set tunnel device up error=address already in use
 ```
 
-This happens because MKE's Docker Swarm overlay networking creates VXLAN devices on UDP port 4789 inside Docker network namespaces (`/run/docker/netns/`). In eBPF mode with BTF support (kernel v5.8+), Felix creates `vxlan.calico` in flow mode (`external`), which acts as a catch-all on its UDP port. The kernel rejects this because Docker Swarm's VXLAN device already holds port 4789.
+This happens because MKE's Docker Swarm overlay networking creates VXLAN devices on UDP port 4789 inside Docker network namespaces (`/run/docker/netns/`). In eBPF mode, when BTF is available on the node (typically kernel v5.8+), Felix creates `vxlan.calico` in flow mode (`external`), which acts as a catch-all on its UDP port. The kernel rejects this because Docker Swarm's VXLAN device already holds port 4789.
 
 In iptables mode this conflict doesn't occur because Calico's VXLAN device binds with a specific VNI (4096), which can coexist with Docker Swarm's VXLAN on the same port.
 
@@ -417,9 +417,9 @@ kubectl exec -n calico-system <calico-node-pod> -- ip -d link show vxlan.calico
 # Check what holds port 4789 (shows a kernel-owned socket with no process name)
 kubectl exec -n calico-system <calico-node-pod> -- ss -ulnp sport = :4789
 
-# Find Docker Swarm VXLAN devices in Docker network namespaces
+# Find Docker Swarm VXLAN devices in Docker network namespaces (run on the node via SSH)
 for ns in /run/docker/netns/*; do
-  echo "=== $(basename $ns) ==="
+  echo "=== $(basename "$ns") ==="
   nsenter --net="$ns" ip -d link show type vxlan 2>/dev/null
 done
 ```

--- a/calico-enterprise/operations/ebpf/troubleshoot-ebpf.mdx
+++ b/calico-enterprise/operations/ebpf/troubleshoot-ebpf.mdx
@@ -396,6 +396,55 @@ e2e` command. The command resets the profiling data after dumping it.
 
 ```
 
+## MKE: VXLAN device DOWN {#mke-vxlan-device-down}
+
+On MKE clusters, after enabling eBPF mode, the `vxlan.calico` device may stay DOWN with Felix logs showing:
+
+```
+Failed to set tunnel device up error=address already in use
+```
+
+This happens because MKE's Docker Swarm overlay networking creates VXLAN devices on UDP port 4789 inside Docker network namespaces (`/run/docker/netns/`). In eBPF mode with BTF support (kernel v5.8+), Felix creates `vxlan.calico` in flow mode (`external`), which acts as a catch-all on its UDP port. The kernel rejects this because Docker Swarm's VXLAN device already holds port 4789.
+
+In iptables mode this conflict doesn't occur because Calico's VXLAN device binds with a specific VNI (4096), which can coexist with Docker Swarm's VXLAN on the same port.
+
+**Diagnosis:**
+
+```bash
+# Confirm the VXLAN device is DOWN
+kubectl exec -n calico-system <calico-node-pod> -- ip -d link show vxlan.calico
+
+# Check what holds port 4789 (shows a kernel-owned socket with no process name)
+kubectl exec -n calico-system <calico-node-pod> -- ss -ulnp sport = :4789
+
+# Find Docker Swarm VXLAN devices in Docker network namespaces
+for ns in /run/docker/netns/*; do
+  echo "=== $(basename $ns) ==="
+  nsenter --net="$ns" ip -d link show type vxlan 2>/dev/null
+done
+```
+
+**Fix:** Change Calico's VXLAN port to avoid the conflict:
+
+```bash
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"vxlanPort":4790}}'
+```
+
+Felix will recreate `vxlan.calico` on the new port within seconds. Verify on each node:
+
+```bash
+kubectl exec -n calico-system <calico-node-pod> -- ip -d link show vxlan.calico
+# Should show: vxlan external ... dstport 4790 ... state UP
+```
+
+Ensure the chosen UDP port is allowed by your underlying network between all nodes.
+
+:::tip
+
+For MKE clusters, set the VXLAN port **before** enabling eBPF mode to avoid any disruption.
+
+:::
+
 ## Debug high CPU usage
 
 If you notice `$[noderunning]` using high CPU:

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/enabling-ebpf.mdx
@@ -190,7 +190,7 @@ If both `kube-proxy` and `BPFKubeProxyIptablesCleanupEnabled` is enabled then `k
 :::caution
 
 MKE uses Docker Swarm overlay networking, which creates VXLAN devices on UDP port 4789 inside Docker network namespaces.
-When $[prodname] switches to eBPF mode on kernels with BTF support (v5.8+), Felix creates the `vxlan.calico` device in
+When $[prodname] switches to eBPF mode on kernels where BTF is available (typically v5.8+), Felix creates the `vxlan.calico` device in
 flow mode, which acts as a catch-all on its UDP port. The kernel rejects this when another VXLAN device (Docker Swarm's)
 already holds the same port, causing `vxlan.calico` to stay DOWN with `address already in use` errors.
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/enabling-ebpf.mdx
@@ -185,6 +185,32 @@ kubectl patch felixconfiguration default --patch='{"spec": {"bpfKubeProxyIptable
 
 If both `kube-proxy` and `BPFKubeProxyIptablesCleanupEnabled` is enabled then `kube-proxy` will write its iptables rules and Felix will try to clean them up resulting in iptables flapping between the two.
 
+### MKE: Change the VXLAN port before enabling eBPF
+
+:::caution
+
+MKE uses Docker Swarm overlay networking, which creates VXLAN devices on UDP port 4789 inside Docker network namespaces.
+When $[prodname] switches to eBPF mode on kernels with BTF support (v5.8+), Felix creates the `vxlan.calico` device in
+flow mode, which acts as a catch-all on its UDP port. The kernel rejects this when another VXLAN device (Docker Swarm's)
+already holds the same port, causing `vxlan.calico` to stay DOWN with `address already in use` errors.
+
+**You must change the VXLAN port before enabling eBPF on MKE clusters:**
+
+```bash
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"vxlanPort":4790}}'
+```
+
+Wait for all calico-node pods to recreate the VXLAN device on the new port, then verify on each node:
+
+```bash
+kubectl exec -n calico-system <calico-node-pod> -- ip -d link show vxlan.calico
+```
+
+Confirm the device shows `dstport 4790` (or your chosen port) and is UP before proceeding.
+Ensure that the chosen UDP port is allowed by your underlying network between all nodes.
+
+:::
+
 ### Enable eBPF mode
 
 To enable eBPF mode, change the `spec.calicoNetwork.linuxDataplane` parameter in the operator's `Installation`

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/install.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/install.mdx
@@ -175,6 +175,21 @@ can do that by setting `--kube-proxy-mode=disabled` and `--kube-default-drop-mas
 
 More details can be found in [the MKE documentation](https://docs.mirantis.com/mke/current/install/predeployment/configure-networking/cluster-service-networking-options.html)
 
+:::caution VXLAN port conflict
+
+MKE's Docker Swarm overlay networking uses UDP port 4789 for its own VXLAN devices. In eBPF mode with BTF support (kernel v5.8+),
+$[prodname] creates the `vxlan.calico` device in flow mode, which conflicts with Docker Swarm's use of the same port.
+You must change the VXLAN port before enabling eBPF:
+
+```bash
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"vxlanPort":4790}}'
+```
+
+Ensure the chosen UDP port is allowed by your underlying network between all nodes.
+See [Troubleshoot eBPF mode](troubleshoot-ebpf.mdx#mke-vxlan-device-down) for more details.
+
+:::
+
 </TabItem>
 
 </Tabs>

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/install.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/install.mdx
@@ -177,7 +177,7 @@ More details can be found in [the MKE documentation](https://docs.mirantis.com/m
 
 :::caution VXLAN port conflict
 
-MKE's Docker Swarm overlay networking uses UDP port 4789 for its own VXLAN devices. In eBPF mode with BTF support (kernel v5.8+),
+MKE's Docker Swarm overlay networking uses UDP port 4789 for its own VXLAN devices. In eBPF mode, when BTF is available on the node (typically kernel v5.8+),
 $[prodname] creates the `vxlan.calico` device in flow mode, which conflicts with Docker Swarm's use of the same port.
 You must change the VXLAN port before enabling eBPF:
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/troubleshoot-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/troubleshoot-ebpf.mdx
@@ -396,7 +396,7 @@ e2e` command. The command resets the profiling data after dumping it.
 
 ```
 
-## MKE: VXLAN device DOWN {#mke-vxlan-device-down}
+## MKE: VXLAN device DOWN
 
 On MKE clusters, after enabling eBPF mode, the `vxlan.calico` device may stay DOWN with Felix logs showing:
 
@@ -404,7 +404,7 @@ On MKE clusters, after enabling eBPF mode, the `vxlan.calico` device may stay DO
 Failed to set tunnel device up error=address already in use
 ```
 
-This happens because MKE's Docker Swarm overlay networking creates VXLAN devices on UDP port 4789 inside Docker network namespaces (`/run/docker/netns/`). In eBPF mode with BTF support (kernel v5.8+), Felix creates `vxlan.calico` in flow mode (`external`), which acts as a catch-all on its UDP port. The kernel rejects this because Docker Swarm's VXLAN device already holds port 4789.
+This happens because MKE's Docker Swarm overlay networking creates VXLAN devices on UDP port 4789 inside Docker network namespaces (`/run/docker/netns/`). In eBPF mode, when BTF is available on the node (typically kernel v5.8+), Felix creates `vxlan.calico` in flow mode (`external`), which acts as a catch-all on its UDP port. The kernel rejects this because Docker Swarm's VXLAN device already holds port 4789.
 
 In iptables mode this conflict doesn't occur because Calico's VXLAN device binds with a specific VNI (4096), which can coexist with Docker Swarm's VXLAN on the same port.
 
@@ -417,9 +417,9 @@ kubectl exec -n calico-system <calico-node-pod> -- ip -d link show vxlan.calico
 # Check what holds port 4789 (shows a kernel-owned socket with no process name)
 kubectl exec -n calico-system <calico-node-pod> -- ss -ulnp sport = :4789
 
-# Find Docker Swarm VXLAN devices in Docker network namespaces
+# Find Docker Swarm VXLAN devices in Docker network namespaces (run on the node via SSH)
 for ns in /run/docker/netns/*; do
-  echo "=== $(basename $ns) ==="
+  echo "=== $(basename "$ns") ==="
   nsenter --net="$ns" ip -d link show type vxlan 2>/dev/null
 done
 ```

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/troubleshoot-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/troubleshoot-ebpf.mdx
@@ -396,6 +396,55 @@ e2e` command. The command resets the profiling data after dumping it.
 
 ```
 
+## MKE: VXLAN device DOWN {#mke-vxlan-device-down}
+
+On MKE clusters, after enabling eBPF mode, the `vxlan.calico` device may stay DOWN with Felix logs showing:
+
+```
+Failed to set tunnel device up error=address already in use
+```
+
+This happens because MKE's Docker Swarm overlay networking creates VXLAN devices on UDP port 4789 inside Docker network namespaces (`/run/docker/netns/`). In eBPF mode with BTF support (kernel v5.8+), Felix creates `vxlan.calico` in flow mode (`external`), which acts as a catch-all on its UDP port. The kernel rejects this because Docker Swarm's VXLAN device already holds port 4789.
+
+In iptables mode this conflict doesn't occur because Calico's VXLAN device binds with a specific VNI (4096), which can coexist with Docker Swarm's VXLAN on the same port.
+
+**Diagnosis:**
+
+```bash
+# Confirm the VXLAN device is DOWN
+kubectl exec -n calico-system <calico-node-pod> -- ip -d link show vxlan.calico
+
+# Check what holds port 4789 (shows a kernel-owned socket with no process name)
+kubectl exec -n calico-system <calico-node-pod> -- ss -ulnp sport = :4789
+
+# Find Docker Swarm VXLAN devices in Docker network namespaces
+for ns in /run/docker/netns/*; do
+  echo "=== $(basename $ns) ==="
+  nsenter --net="$ns" ip -d link show type vxlan 2>/dev/null
+done
+```
+
+**Fix:** Change Calico's VXLAN port to avoid the conflict:
+
+```bash
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"vxlanPort":4790}}'
+```
+
+Felix will recreate `vxlan.calico` on the new port within seconds. Verify on each node:
+
+```bash
+kubectl exec -n calico-system <calico-node-pod> -- ip -d link show vxlan.calico
+# Should show: vxlan external ... dstport 4790 ... state UP
+```
+
+Ensure the chosen UDP port is allowed by your underlying network between all nodes.
+
+:::tip
+
+For MKE clusters, set the VXLAN port **before** enabling eBPF mode to avoid any disruption.
+
+:::
+
 ## Debug high CPU usage
 
 If you notice `$[noderunning]` using high CPU:

--- a/calico/operations/ebpf/enabling-ebpf.mdx
+++ b/calico/operations/ebpf/enabling-ebpf.mdx
@@ -326,6 +326,32 @@ kubectl patch felixconfiguration default --patch='{"spec": {"bpfKubeProxyIptable
 
 If both `kube-proxy` and `BPFKubeProxyIptablesCleanupEnabled` is enabled then `kube-proxy` will write its iptables rules and Felix will try to clean them up resulting in iptables flapping between the two.
 
+### MKE: Change the VXLAN port before enabling eBPF
+
+:::caution
+
+MKE uses Docker Swarm overlay networking, which creates VXLAN devices on UDP port 4789 inside Docker network namespaces.
+When $[prodname] switches to eBPF mode on kernels with BTF support (v5.8+), Felix creates the `vxlan.calico` device in
+flow mode, which acts as a catch-all on its UDP port. The kernel rejects this when another VXLAN device (Docker Swarm's)
+already holds the same port, causing `vxlan.calico` to stay DOWN with `address already in use` errors.
+
+**You must change the VXLAN port before enabling eBPF on MKE clusters:**
+
+```bash
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"vxlanPort":4790}}'
+```
+
+Wait for all calico-node pods to recreate the VXLAN device on the new port, then verify on each node:
+
+```bash
+kubectl exec -n calico-system <calico-node-pod> -- ip -d link show vxlan.calico
+```
+
+Confirm the device shows `dstport 4790` (or your chosen port) and is UP before proceeding.
+Ensure that the chosen UDP port is allowed by your underlying network between all nodes.
+
+:::
+
 ### Enable eBPF mode
 
 **The next step depends on whether you installed $[prodname] using the operator, or a manifest:**

--- a/calico/operations/ebpf/enabling-ebpf.mdx
+++ b/calico/operations/ebpf/enabling-ebpf.mdx
@@ -331,7 +331,7 @@ If both `kube-proxy` and `BPFKubeProxyIptablesCleanupEnabled` is enabled then `k
 :::caution
 
 MKE uses Docker Swarm overlay networking, which creates VXLAN devices on UDP port 4789 inside Docker network namespaces.
-When $[prodname] switches to eBPF mode on kernels with BTF support (v5.8+), Felix creates the `vxlan.calico` device in
+When $[prodname] switches to eBPF mode on kernels where BTF is available (typically v5.8+), Felix creates the `vxlan.calico` device in
 flow mode, which acts as a catch-all on its UDP port. The kernel rejects this when another VXLAN device (Docker Swarm's)
 already holds the same port, causing `vxlan.calico` to stay DOWN with `address already in use` errors.
 

--- a/calico/operations/ebpf/install.mdx
+++ b/calico/operations/ebpf/install.mdx
@@ -203,6 +203,21 @@ can do that by setting `--kube-proxy-mode=disabled` and `--kube-default-drop-mas
 
 More details can be found in [the MKE documentation](https://docs.mirantis.com/mke/current/install/predeployment/configure-networking/cluster-service-networking-options.html)
 
+:::caution VXLAN port conflict
+
+MKE's Docker Swarm overlay networking uses UDP port 4789 for its own VXLAN devices. In eBPF mode with BTF support (kernel v5.8+),
+$[prodname] creates the `vxlan.calico` device in flow mode, which conflicts with Docker Swarm's use of the same port.
+You must change the VXLAN port before enabling eBPF:
+
+```bash
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"vxlanPort":4790}}'
+```
+
+Ensure the chosen UDP port is allowed by your underlying network between all nodes.
+See [Troubleshoot eBPF mode](troubleshoot-ebpf.mdx#mke-vxlan-device-down) for more details.
+
+:::
+
 </TabItem>
 
 </Tabs>

--- a/calico/operations/ebpf/install.mdx
+++ b/calico/operations/ebpf/install.mdx
@@ -205,7 +205,7 @@ More details can be found in [the MKE documentation](https://docs.mirantis.com/m
 
 :::caution VXLAN port conflict
 
-MKE's Docker Swarm overlay networking uses UDP port 4789 for its own VXLAN devices. In eBPF mode with BTF support (kernel v5.8+),
+MKE's Docker Swarm overlay networking uses UDP port 4789 for its own VXLAN devices. In eBPF mode, when BTF is available on the node (typically kernel v5.8+),
 $[prodname] creates the `vxlan.calico` device in flow mode, which conflicts with Docker Swarm's use of the same port.
 You must change the VXLAN port before enabling eBPF:
 

--- a/calico/operations/ebpf/troubleshoot-ebpf.mdx
+++ b/calico/operations/ebpf/troubleshoot-ebpf.mdx
@@ -396,7 +396,7 @@ e2e` command. The command resets the profiling data after dumping it.
 
 ```
 
-## MKE: VXLAN device DOWN {#mke-vxlan-device-down}
+## MKE: VXLAN device DOWN
 
 On MKE clusters, after enabling eBPF mode, the `vxlan.calico` device may stay DOWN with Felix logs showing:
 
@@ -404,7 +404,7 @@ On MKE clusters, after enabling eBPF mode, the `vxlan.calico` device may stay DO
 Failed to set tunnel device up error=address already in use
 ```
 
-This happens because MKE's Docker Swarm overlay networking creates VXLAN devices on UDP port 4789 inside Docker network namespaces (`/run/docker/netns/`). In eBPF mode with BTF support (kernel v5.8+), Felix creates `vxlan.calico` in flow mode (`external`), which acts as a catch-all on its UDP port. The kernel rejects this because Docker Swarm's VXLAN device already holds port 4789.
+This happens because MKE's Docker Swarm overlay networking creates VXLAN devices on UDP port 4789 inside Docker network namespaces (`/run/docker/netns/`). In eBPF mode, when BTF is available on the node (typically kernel v5.8+), Felix creates `vxlan.calico` in flow mode (`external`), which acts as a catch-all on its UDP port. The kernel rejects this because Docker Swarm's VXLAN device already holds port 4789.
 
 In iptables mode this conflict doesn't occur because Calico's VXLAN device binds with a specific VNI (4096), which can coexist with Docker Swarm's VXLAN on the same port.
 
@@ -417,9 +417,9 @@ kubectl exec -n calico-system <calico-node-pod> -- ip -d link show vxlan.calico
 # Check what holds port 4789 (shows a kernel-owned socket with no process name)
 kubectl exec -n calico-system <calico-node-pod> -- ss -ulnp sport = :4789
 
-# Find Docker Swarm VXLAN devices in Docker network namespaces
+# Find Docker Swarm VXLAN devices in Docker network namespaces (run on the node via SSH)
 for ns in /run/docker/netns/*; do
-  echo "=== $(basename $ns) ==="
+  echo "=== $(basename "$ns") ==="
   nsenter --net="$ns" ip -d link show type vxlan 2>/dev/null
 done
 ```

--- a/calico/operations/ebpf/troubleshoot-ebpf.mdx
+++ b/calico/operations/ebpf/troubleshoot-ebpf.mdx
@@ -396,6 +396,55 @@ e2e` command. The command resets the profiling data after dumping it.
 
 ```
 
+## MKE: VXLAN device DOWN {#mke-vxlan-device-down}
+
+On MKE clusters, after enabling eBPF mode, the `vxlan.calico` device may stay DOWN with Felix logs showing:
+
+```
+Failed to set tunnel device up error=address already in use
+```
+
+This happens because MKE's Docker Swarm overlay networking creates VXLAN devices on UDP port 4789 inside Docker network namespaces (`/run/docker/netns/`). In eBPF mode with BTF support (kernel v5.8+), Felix creates `vxlan.calico` in flow mode (`external`), which acts as a catch-all on its UDP port. The kernel rejects this because Docker Swarm's VXLAN device already holds port 4789.
+
+In iptables mode this conflict doesn't occur because Calico's VXLAN device binds with a specific VNI (4096), which can coexist with Docker Swarm's VXLAN on the same port.
+
+**Diagnosis:**
+
+```bash
+# Confirm the VXLAN device is DOWN
+kubectl exec -n calico-system <calico-node-pod> -- ip -d link show vxlan.calico
+
+# Check what holds port 4789 (shows a kernel-owned socket with no process name)
+kubectl exec -n calico-system <calico-node-pod> -- ss -ulnp sport = :4789
+
+# Find Docker Swarm VXLAN devices in Docker network namespaces
+for ns in /run/docker/netns/*; do
+  echo "=== $(basename $ns) ==="
+  nsenter --net="$ns" ip -d link show type vxlan 2>/dev/null
+done
+```
+
+**Fix:** Change Calico's VXLAN port to avoid the conflict:
+
+```bash
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"vxlanPort":4790}}'
+```
+
+Felix will recreate `vxlan.calico` on the new port within seconds. Verify on each node:
+
+```bash
+kubectl exec -n calico-system <calico-node-pod> -- ip -d link show vxlan.calico
+# Should show: vxlan external ... dstport 4790 ... state UP
+```
+
+Ensure the chosen UDP port is allowed by your underlying network between all nodes.
+
+:::tip
+
+For MKE clusters, set the VXLAN port **before** enabling eBPF mode to avoid any disruption.
+
+:::
+
 ## Debug high CPU usage
 
 If you notice `$[noderunning]` using high CPU:

--- a/calico_versioned_docs/version-3.31/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.31/operations/ebpf/enabling-ebpf.mdx
@@ -326,6 +326,32 @@ kubectl patch felixconfiguration default --patch='{"spec": {"bpfKubeProxyIptable
 
 If both `kube-proxy` and `BPFKubeProxyIptablesCleanupEnabled` is enabled then `kube-proxy` will write its iptables rules and Felix will try to clean them up resulting in iptables flapping between the two.
 
+### MKE: Change the VXLAN port before enabling eBPF
+
+:::caution
+
+MKE uses Docker Swarm overlay networking, which creates VXLAN devices on UDP port 4789 inside Docker network namespaces.
+When $[prodname] switches to eBPF mode on kernels with BTF support (v5.8+), Felix creates the `vxlan.calico` device in
+flow mode, which acts as a catch-all on its UDP port. The kernel rejects this when another VXLAN device (Docker Swarm's)
+already holds the same port, causing `vxlan.calico` to stay DOWN with `address already in use` errors.
+
+**You must change the VXLAN port before enabling eBPF on MKE clusters:**
+
+```bash
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"vxlanPort":4790}}'
+```
+
+Wait for all calico-node pods to recreate the VXLAN device on the new port, then verify on each node:
+
+```bash
+kubectl exec -n calico-system <calico-node-pod> -- ip -d link show vxlan.calico
+```
+
+Confirm the device shows `dstport 4790` (or your chosen port) and is UP before proceeding.
+Ensure that the chosen UDP port is allowed by your underlying network between all nodes.
+
+:::
+
 ### Enable eBPF mode
 
 **The next step depends on whether you installed $[prodname] using the operator, or a manifest:**

--- a/calico_versioned_docs/version-3.31/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.31/operations/ebpf/enabling-ebpf.mdx
@@ -331,7 +331,7 @@ If both `kube-proxy` and `BPFKubeProxyIptablesCleanupEnabled` is enabled then `k
 :::caution
 
 MKE uses Docker Swarm overlay networking, which creates VXLAN devices on UDP port 4789 inside Docker network namespaces.
-When $[prodname] switches to eBPF mode on kernels with BTF support (v5.8+), Felix creates the `vxlan.calico` device in
+When $[prodname] switches to eBPF mode on kernels where BTF is available (typically v5.8+), Felix creates the `vxlan.calico` device in
 flow mode, which acts as a catch-all on its UDP port. The kernel rejects this when another VXLAN device (Docker Swarm's)
 already holds the same port, causing `vxlan.calico` to stay DOWN with `address already in use` errors.
 

--- a/calico_versioned_docs/version-3.31/operations/ebpf/install.mdx
+++ b/calico_versioned_docs/version-3.31/operations/ebpf/install.mdx
@@ -203,6 +203,21 @@ can do that by setting `--kube-proxy-mode=disabled` and `--kube-default-drop-mas
 
 More details can be found in [the MKE documentation](https://docs.mirantis.com/mke/current/install/predeployment/configure-networking/cluster-service-networking-options.html)
 
+:::caution VXLAN port conflict
+
+MKE's Docker Swarm overlay networking uses UDP port 4789 for its own VXLAN devices. In eBPF mode with BTF support (kernel v5.8+),
+$[prodname] creates the `vxlan.calico` device in flow mode, which conflicts with Docker Swarm's use of the same port.
+You must change the VXLAN port before enabling eBPF:
+
+```bash
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"vxlanPort":4790}}'
+```
+
+Ensure the chosen UDP port is allowed by your underlying network between all nodes.
+See [Troubleshoot eBPF mode](troubleshoot-ebpf.mdx#mke-vxlan-device-down) for more details.
+
+:::
+
 </TabItem>
 
 </Tabs>

--- a/calico_versioned_docs/version-3.31/operations/ebpf/install.mdx
+++ b/calico_versioned_docs/version-3.31/operations/ebpf/install.mdx
@@ -205,7 +205,7 @@ More details can be found in [the MKE documentation](https://docs.mirantis.com/m
 
 :::caution VXLAN port conflict
 
-MKE's Docker Swarm overlay networking uses UDP port 4789 for its own VXLAN devices. In eBPF mode with BTF support (kernel v5.8+),
+MKE's Docker Swarm overlay networking uses UDP port 4789 for its own VXLAN devices. In eBPF mode, when BTF is available on the node (typically kernel v5.8+),
 $[prodname] creates the `vxlan.calico` device in flow mode, which conflicts with Docker Swarm's use of the same port.
 You must change the VXLAN port before enabling eBPF:
 

--- a/calico_versioned_docs/version-3.31/operations/ebpf/troubleshoot-ebpf.mdx
+++ b/calico_versioned_docs/version-3.31/operations/ebpf/troubleshoot-ebpf.mdx
@@ -396,7 +396,7 @@ e2e` command. The command resets the profiling data after dumping it.
 
 ```
 
-## MKE: VXLAN device DOWN {#mke-vxlan-device-down}
+## MKE: VXLAN device DOWN
 
 On MKE clusters, after enabling eBPF mode, the `vxlan.calico` device may stay DOWN with Felix logs showing:
 
@@ -404,7 +404,7 @@ On MKE clusters, after enabling eBPF mode, the `vxlan.calico` device may stay DO
 Failed to set tunnel device up error=address already in use
 ```
 
-This happens because MKE's Docker Swarm overlay networking creates VXLAN devices on UDP port 4789 inside Docker network namespaces (`/run/docker/netns/`). In eBPF mode with BTF support (kernel v5.8+), Felix creates `vxlan.calico` in flow mode (`external`), which acts as a catch-all on its UDP port. The kernel rejects this because Docker Swarm's VXLAN device already holds port 4789.
+This happens because MKE's Docker Swarm overlay networking creates VXLAN devices on UDP port 4789 inside Docker network namespaces (`/run/docker/netns/`). In eBPF mode, when BTF is available on the node (typically kernel v5.8+), Felix creates `vxlan.calico` in flow mode (`external`), which acts as a catch-all on its UDP port. The kernel rejects this because Docker Swarm's VXLAN device already holds port 4789.
 
 In iptables mode this conflict doesn't occur because Calico's VXLAN device binds with a specific VNI (4096), which can coexist with Docker Swarm's VXLAN on the same port.
 
@@ -417,9 +417,9 @@ kubectl exec -n calico-system <calico-node-pod> -- ip -d link show vxlan.calico
 # Check what holds port 4789 (shows a kernel-owned socket with no process name)
 kubectl exec -n calico-system <calico-node-pod> -- ss -ulnp sport = :4789
 
-# Find Docker Swarm VXLAN devices in Docker network namespaces
+# Find Docker Swarm VXLAN devices in Docker network namespaces (run on the node via SSH)
 for ns in /run/docker/netns/*; do
-  echo "=== $(basename $ns) ==="
+  echo "=== $(basename "$ns") ==="
   nsenter --net="$ns" ip -d link show type vxlan 2>/dev/null
 done
 ```

--- a/calico_versioned_docs/version-3.31/operations/ebpf/troubleshoot-ebpf.mdx
+++ b/calico_versioned_docs/version-3.31/operations/ebpf/troubleshoot-ebpf.mdx
@@ -396,6 +396,55 @@ e2e` command. The command resets the profiling data after dumping it.
 
 ```
 
+## MKE: VXLAN device DOWN {#mke-vxlan-device-down}
+
+On MKE clusters, after enabling eBPF mode, the `vxlan.calico` device may stay DOWN with Felix logs showing:
+
+```
+Failed to set tunnel device up error=address already in use
+```
+
+This happens because MKE's Docker Swarm overlay networking creates VXLAN devices on UDP port 4789 inside Docker network namespaces (`/run/docker/netns/`). In eBPF mode with BTF support (kernel v5.8+), Felix creates `vxlan.calico` in flow mode (`external`), which acts as a catch-all on its UDP port. The kernel rejects this because Docker Swarm's VXLAN device already holds port 4789.
+
+In iptables mode this conflict doesn't occur because Calico's VXLAN device binds with a specific VNI (4096), which can coexist with Docker Swarm's VXLAN on the same port.
+
+**Diagnosis:**
+
+```bash
+# Confirm the VXLAN device is DOWN
+kubectl exec -n calico-system <calico-node-pod> -- ip -d link show vxlan.calico
+
+# Check what holds port 4789 (shows a kernel-owned socket with no process name)
+kubectl exec -n calico-system <calico-node-pod> -- ss -ulnp sport = :4789
+
+# Find Docker Swarm VXLAN devices in Docker network namespaces
+for ns in /run/docker/netns/*; do
+  echo "=== $(basename $ns) ==="
+  nsenter --net="$ns" ip -d link show type vxlan 2>/dev/null
+done
+```
+
+**Fix:** Change Calico's VXLAN port to avoid the conflict:
+
+```bash
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"vxlanPort":4790}}'
+```
+
+Felix will recreate `vxlan.calico` on the new port within seconds. Verify on each node:
+
+```bash
+kubectl exec -n calico-system <calico-node-pod> -- ip -d link show vxlan.calico
+# Should show: vxlan external ... dstport 4790 ... state UP
+```
+
+Ensure the chosen UDP port is allowed by your underlying network between all nodes.
+
+:::tip
+
+For MKE clusters, set the VXLAN port **before** enabling eBPF mode to avoid any disruption.
+
+:::
+
 ## Debug high CPU usage
 
 If you notice `$[noderunning]` using high CPU:


### PR DESCRIPTION
## Summary

- MKE's Docker Swarm overlay networking creates VXLAN devices on UDP port 4789, which conflicts with Calico's VXLAN in eBPF flow mode (BTF/kernel v5.8+). The flow-mode device acts as a catch-all and the kernel rejects it with `EADDRINUSE`.
- Documents the prerequisite to change the VXLAN port (e.g. to 4790) before enabling eBPF on MKE clusters.
- Adds a troubleshooting section with diagnosis commands and fix for when `vxlan.calico` stays DOWN.

### Files changed (12 total)

Across Calico OSS (next + 3.31) and Enterprise (next + 3.23-1):
- **enabling-ebpf.mdx**: New "MKE: Change the VXLAN port before enabling eBPF" prerequisite section with caution admonition
- **install.mdx**: Caution admonition in the MKE tab about VXLAN port conflict
- **troubleshoot-ebpf.mdx**: New "MKE: VXLAN device DOWN" section with symptom, root cause, diagnosis, and fix

Calico Cloud skipped — MKE is listed as unsupported for eBPF on that product.

## Test plan

- [ ] Verify docs build successfully
- [ ] Check enabling-ebpf pages render the caution admonition correctly for MKE
- [ ] Check install pages render the caution in the MKE tab
- [ ] Check troubleshoot pages render the new section with anchor link `#mke-vxlan-device-down`
- [ ] Verify cross-links from install.mdx to troubleshoot-ebpf.mdx#mke-vxlan-device-down resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)