### PR TITLE
Fix llms.txt workflow to use PR instead of direct push

### DIFF
--- a/.github/workflows/generate-llms-txt.yml
+++ b/.github/workflows/generate-llms-txt.yml
@@ -57,14 +57,16 @@ jobs:
           BRANCH="chore/update-llms-txt-$(date +%Y-%m-%d)"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
+          git checkout -B "$BRANCH"
           git add static/llms.txt \
             static/calico/llms.txt static/calico/llms-full.txt \
             static/calico-enterprise/llms.txt static/calico-enterprise/llms-full.txt \
             static/calico-cloud/llms.txt static/calico-cloud/llms-full.txt
           git commit -m "chore: update generated llms.txt files"
-          git push -u origin "$BRANCH"
-          gh pr create \
-            --title "chore: update generated llms.txt files" \
-            --body "Automated weekly update of llms.txt and llms-full.txt files." \
-            --base main
+          git push --force-with-lease -u origin "$BRANCH"
+          if ! gh pr list --head "$BRANCH" --json number --jq '.[0].number' | grep -q .; then
+            gh pr create \
+              --title "chore: update generated llms.txt files" \
+              --body "Automated weekly update of llms.txt and llms-full.txt files." \
+              --base main
+          fi

--- a/.github/workflows/generate-llms-txt.yml
+++ b/.github/workflows/generate-llms-txt.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   generate:
@@ -48,14 +49,22 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Commit and push
+      - name: Create PR with updates
         if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          BRANCH="chore/update-llms-txt-$(date +%Y-%m-%d)"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add static/llms.txt \
             static/calico/llms.txt static/calico/llms-full.txt \
             static/calico-enterprise/llms.txt static/calico-enterprise/llms-full.txt \
             static/calico-cloud/llms.txt static/calico-cloud/llms-full.txt
           git commit -m "chore: update generated llms.txt files"
-          git push
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "chore: update generated llms.txt files" \
+            --body "Automated weekly update of llms.txt and llms-full.txt files." \
+            --base main


### PR DESCRIPTION
## Summary
- The weekly `generate-llms-txt` workflow was failing because it tried to push directly to `main`, which is a protected branch
- Changed the workflow to create a dated branch (`chore/update-llms-txt-YYYY-MM-DD`) and open a PR against `main` instead
- Added `pull-requests: write` permission so the workflow can create PRs

## Test plan
- [ ] Trigger the workflow manually via `workflow_dispatch` and verify it creates a PR instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)