### PR TITLE
Fix Vale CI file scoping and remove dead eBPF tutorial link

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -12,12 +12,14 @@ jobs:
       - name: Get changed files
         id: changed
         run: |
-          FILES=$(git diff --name-only --diff-filter=d ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} -- '*.md' '*.mdx' | tr '\n' ' ')
-          echo "files=$FILES" >> "$GITHUB_OUTPUT"
+          FILES=$(git diff --name-only --diff-filter=d ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} -- '*.md' '*.mdx')
           if [ -z "$FILES" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo 'files=all' >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
+            JSON=$(echo "$FILES" | jq -R -s -c 'split("\n") | map(select(. != ""))')
+            echo "files=$JSON" >> "$GITHUB_OUTPUT"
           fi
       - name: Enable Corepack
         if: steps.changed.outputs.skip == 'false'
@@ -38,7 +40,7 @@ jobs:
         if: steps.changed.outputs.skip == 'false'
         run: |
           sudo apt-get install ripgrep
-          FILES="${{ steps.changed.outputs.files }}"
+          FILES=$(echo '${{ steps.changed.outputs.files }}' | jq -r '.[]' | tr '\n' ' ')
           if [ -n "$FILES" ]; then
             rg -l0 '\$\[[^\]]*\]' -- $FILES | xargs -0 perl -i -pe 's/\$\[[^\]]*\]/PICKLEVAR/g' || true
           fi

--- a/calico/network-policy/extreme-traffic/high-connection-workloads.mdx
+++ b/calico/network-policy/extreme-traffic/high-connection-workloads.mdx
@@ -87,4 +87,3 @@ spec:
 ## Additional resources
 
 - [Global network policy](../../reference/resources/globalnetworkpolicy.mdx)
-- [Hands-on workshop: Learn how to implement eBPF security policies and XDP](https://www.tigera.io/tutorials/?_sf_s=%27calico%20ebpf%20and%20xdp%27)

--- a/calico_versioned_docs/version-3.29/network-policy/extreme-traffic/high-connection-workloads.mdx
+++ b/calico_versioned_docs/version-3.29/network-policy/extreme-traffic/high-connection-workloads.mdx
@@ -87,4 +87,3 @@ spec:
 ## Additional resources
 
 - [Global network policy](../../reference/resources/globalnetworkpolicy.mdx)
-- [Hands-on workshop: Learn how to implement eBPF security policies and XDP](https://www.tigera.io/tutorials/?_sf_s=%27calico%20ebpf%20and%20xdp%27)

--- a/calico_versioned_docs/version-3.30/network-policy/extreme-traffic/high-connection-workloads.mdx
+++ b/calico_versioned_docs/version-3.30/network-policy/extreme-traffic/high-connection-workloads.mdx
@@ -87,4 +87,3 @@ spec:
 ## Additional resources
 
 - [Global network policy](../../reference/resources/globalnetworkpolicy.mdx)
-- [Hands-on workshop: Learn how to implement eBPF security policies and XDP](https://www.tigera.io/tutorials/?_sf_s=%27calico%20ebpf%20and%20xdp%27)

--- a/calico_versioned_docs/version-3.31/network-policy/extreme-traffic/high-connection-workloads.mdx
+++ b/calico_versioned_docs/version-3.31/network-policy/extreme-traffic/high-connection-workloads.mdx
@@ -87,4 +87,3 @@ spec:
 ## Additional resources
 
 - [Global network policy](../../reference/resources/globalnetworkpolicy.mdx)
-- [Hands-on workshop: Learn how to implement eBPF security policies and XDP](https://www.tigera.io/tutorials/?_sf_s=%27calico%20ebpf%20and%20xdp%27)


### PR DESCRIPTION
## Summary
- Fix Vale CI workflow to pass changed files as a JSON array, avoiding `getInput().trim()` stripping the separator
- Scope all Vale workflow steps to only run when changed files exist
- Remove dead tigera.io/tutorials eBPF link from high-connection-workloads pages (4 files)

## Test plan
- [ ] Verify Vale CI runs only on changed `.md`/`.mdx` files, not the entire repo
- [ ] Confirm the workflow skips cleanly when no markdown files are changed
- [ ] Check high-connection-workloads pages render without the removed link

🤖 Generated with [Claude Code](https://claude.com/claude-code)