### PR TITLE
Update announcement banner to AI Agent Governance Workshop

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -116,8 +116,8 @@ export default async function createAsyncConfig() {
           searchPagePath: '/search',
         },
         announcementBar: {
-          id: "calico_hackathon_midway",
-          content: '🛡️ Hack the latest features: Leverage Calico 3.30+ to solve networking challenges and win up to $1,000. <a href="https://www.tigera.io/lp/project-calico-hackathon?utm_source=website&utm_medium=Docs_site&utm_campaign=Hackathon2026">Enter the Calico 3.30+ Hackathon</a>',
+          id: "ai_agent_governance_kubecon",
+          content: '🛠️ How do you govern autonomous AI agents? Register for the AI Agent Governance Workshop @ KubeCon EU (March 23, 2026) <a href="https://link.tigera.io/umnHe">Learn more →</a>',
           backgroundColor: "#FCE181",
           textColor: "#000",
           isCloseable: true,


### PR DESCRIPTION
## Summary
- Replace hackathon announcement banner with AI Agent Governance Workshop @ KubeCon EU (Mar 23)
- New banner ID ensures it displays for users who dismissed the previous banner

## Test plan
- [ ] Verify banner renders correctly on local dev server
- [ ] Confirm "Learn more →" link resolves to https://link.tigera.io/umnHe

🤖 Generated with [Claude Code](https://claude.com/claude-code)