### PR TITLE
DOCS-2817: Update license expiration warning language

### DIFF
--- a/calico-enterprise/_includes/content/_license.mdx
+++ b/calico-enterprise/_includes/content/_license.mdx
@@ -16,7 +16,7 @@ Yes. The license indicator in the web console (top right banner) turns red when 
 
 :::caution
 
-Although users can still log in to the web console, your deployment is no longer operational. All policy enforcement stops, except for policies in the default tier. In most cases, you will experience broken connectivity (depending on your policies in the default tier). $[prodname] stops reporting flow logs, DNS logs, and $[prodname] metrics, which affects other UI elements like Service Graph and dashboards. Although some elements may appear to work, actions are not saved, and you should regard your deployment as non-functional. We recommend that you proactively manage your license to avoid disruption.
+$[prodname] stops reporting flow logs, DNS logs, and $[prodname] metrics, which affects other UI elements like Service Graph and dashboards. Although some elements in the UI may appear to work, actions are not saved. We recommend that you proactively manage your license to avoid disruption.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/_includes/content/_license.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/_includes/content/_license.mdx
@@ -16,7 +16,7 @@ Yes. The license indicator in the web console (top right banner) turns red when 
 
 :::caution
 
-Although users can still log in to the web console, your deployment is no longer operational. All policy enforcement stops, except for policies in the default tier. In most cases, you will experience broken connectivity (depending on your policies in the default tier). $[prodname] stops reporting flow logs, DNS logs, and $[prodname] metrics, which affects other UI elements like Service Graph and dashboards. Although some elements may appear to work, actions are not saved, and you should regard your deployment as non-functional. We recommend that you proactively manage your license to avoid disruption.
+$[prodname] stops reporting flow logs, DNS logs, and $[prodname] metrics, which affects other UI elements like Service Graph and dashboards. Although some elements in the UI may appear to work, actions are not saved. We recommend that you proactively manage your license to avoid disruption.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/content/_license.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/content/_license.mdx
@@ -16,7 +16,7 @@ Yes. The license indicator in the web console (top right banner) turns red when 
 
 :::caution
 
-Although users can still log in to the web console, your deployment is no longer operational. All policy enforcement stops, except for policies in the default tier. In most cases, you will experience broken connectivity (depending on your policies in the default tier). $[prodname] stops reporting flow logs, DNS logs, and $[prodname] metrics, which affects other UI elements like Service Graph and dashboards. Although some elements may appear to work, actions are not saved, and you should regard your deployment as non-functional. We recommend that you proactively manage your license to avoid disruption.
+$[prodname] stops reporting flow logs, DNS logs, and $[prodname] metrics, which affects other UI elements like Service Graph and dashboards. Although some elements in the UI may appear to work, actions are not saved. We recommend that you proactively manage your license to avoid disruption.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/_includes/content/_license.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/_includes/content/_license.mdx
@@ -16,7 +16,7 @@ Yes. The license indicator in the web console (top right banner) turns red when 
 
 :::caution
 
-Although users can still log in to the web console, your deployment is no longer operational. All policy enforcement stops, except for policies in the default tier. In most cases, you will experience broken connectivity (depending on your policies in the default tier). $[prodname] stops reporting flow logs, DNS logs, and $[prodname] metrics, which affects other UI elements like Service Graph and dashboards. Although some elements may appear to work, actions are not saved, and you should regard your deployment as non-functional. We recommend that you proactively manage your license to avoid disruption.
+$[prodname] stops reporting flow logs, DNS logs, and $[prodname] metrics, which affects other UI elements like Service Graph and dashboards. Although some elements in the UI may appear to work, actions are not saved. We recommend that you proactively manage your license to avoid disruption.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/_includes/content/_license.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/_includes/content/_license.mdx
@@ -16,7 +16,7 @@ Yes. The license indicator in the web console (top right banner) turns red when 
 
 :::caution
 
-Although users can still log in to the web console, your deployment is no longer operational. All policy enforcement stops, except for policies in the default tier. In most cases, you will experience broken connectivity (depending on your policies in the default tier). $[prodname] stops reporting flow logs, DNS logs, and $[prodname] metrics, which affects other UI elements like Service Graph and dashboards. Although some elements may appear to work, actions are not saved, and you should regard your deployment as non-functional. We recommend that you proactively manage your license to avoid disruption.
+$[prodname] stops reporting flow logs, DNS logs, and $[prodname] metrics, which affects other UI elements like Service Graph and dashboards. Although some elements in the UI may appear to work, actions are not saved. We recommend that you proactively manage your license to avoid disruption.
 
 :::
 


### PR DESCRIPTION
## Summary

- Replaces alarming license expiration warning with matter-of-fact language across all Calico Enterprise versioned docs (3.20-2, 3.21-2, 3.22-2, 3.23-1, and next)
- Removes claims about policy enforcement stopping and broken connectivity
- New text focuses on observable effects: logs/metrics stop reporting, UI actions not saved

## Test plan

- [ ] Verify the caution box renders correctly on the [license-options page](https://docs.tigera.io/calico-enterprise/latest/operations/license-options#what-happens-when-a-license-expires-or-is-invalid)
- [ ] Spot-check at least one versioned doc page to confirm the change is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)