### PR TITLE
Raise eBPF dataplane minimum kernel to v5.10

### DIFF
--- a/calico-cloud/observability/elastic/flow/tcpstats.mdx
+++ b/calico-cloud/observability/elastic/flow/tcpstats.mdx
@@ -6,7 +6,7 @@ description: Enabling TCP socket stats information in flow logs
 
 ## Big picture
 
-Configure $[prodname] to collect additional TCP socket statistics. While this feature is available in both iptables and eBPF data plane modes, it uses eBPF to collect the statistics. Therefore it requires a recent Linux kernel (at least v5.3.0/v4.18.0-193 for RHEL).
+Configure $[prodname] to collect additional TCP socket statistics. While this feature is available in both iptables and eBPF data plane modes, it uses eBPF to collect the statistics. Therefore it requires a recent Linux kernel (at least v5.10.0/v4.18.0-305 for RHEL).
 
 ## Value
 
@@ -21,7 +21,7 @@ eBPF is a Linux kernel technology that allows safe mini-programs to be attached 
 ## Before you begin
 
 Ensure that your kernel contains support for eBPF that $[prodname] uses. The minimum supported
-kernel for tcp socket stats is: `v5.3.0`. For distros based on RHEL, the minimum kernel version is `v4.18.0-193`.
+kernel for tcp socket stats is: `v5.10.0`. For distros based on RHEL, the minimum kernel version is `v4.18.0-305`.
 
 # How to
 

--- a/calico-cloud/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-cloud/operations/ebpf/enabling-ebpf.mdx
@@ -28,9 +28,9 @@ eBPF (or "extended Berkeley Packet Filter"), is a technology that allows safe mi
 - arm64 (little-endian)
 - Linux distribution/kernel:
 
-  - Ubuntu 20.04 or above.
-  - Red Hat v8.2 with Linux kernel v4.18.0-193 or above (Red Hat have backported the required features to that build).
-  - Another supported distribution with Linux kernel v5.3 or above.  {/*TODO-XREFS-CC */}
+  - Ubuntu 22.04 or above.
+  - Red Hat v8.4 with Linux kernel v4.18.0-305 or above (Red Hat have backported the required features to that build).
+  - Another supported distribution with Linux kernel v5.10 or above.  {/*TODO-XREFS-CC */}
   - Immutable operating systems (e.g., Talos Linux): Ensure the `CgroupV2Path` in the `FelixConfiguration` CRD is set to a writable path.
 
 #### Kernel version requirements for eBPF features
@@ -39,15 +39,14 @@ Some eBPF features require a higher kernel version than the base eBPF data plane
 
 | Feature | Minimum kernel version | Details |
 |---|---|---|
-| Base eBPF data plane | v5.3 (RHEL: v4.18.0-193) | v5.8+ with CO-RE recommended for better performance |
-| [XDP acceleration](../../network-policy/extreme-traffic/defend-dos-attack.mdx) | v4.16 | Used for DoS mitigation; when `bpfEnabled` is `true`, policy is always accelerated using best available BPF technology |
+| Base eBPF data plane | v5.10 (RHEL: v4.18.0-305) | CO-RE supported at this version for better performance |
 | Log rules in eBPF mode | v5.16 | Logs sent to trace pipe via `bpftool prog tracelog` |
 | [QoS bandwidth controls](../../networking/configuring/qos-controls.mdx) | v6.6 | Requires `tcx` support. Established connection limits not supported with eBPF |
 | [DNS policy inline mode](../../network-policy/domain-based-policy.mdx) | v5.17 (RHEL: v5.14) | `BPFDNSPolicyMode: Inline` parses DNS responses in eBPF before they reach the application. Only wildcard prefixes (`*.x.y.z`) supported. Falls back to `NoDelay` on older kernels |
 
 :::warning
 
-While v5.3 is the minimum kernel version required for the eBPF data plane, we strongly recommend using kernel v5.8 or above, which adds support for [CO-RE (Compile Once - Run Everywhere)](https://docs.ebpf.io/concepts/core/). CO-RE significantly improves compatibility and performance across kernel versions. For access to all eBPF features, we recommend kernel v6.6 or above.
+The minimum kernel version required for the eBPF data plane is v5.10, which includes support for [CO-RE (Compile Once - Run Everywhere)](https://docs.ebpf.io/concepts/core/). CO-RE significantly improves compatibility and performance across kernel versions. For access to all eBPF features, we recommend kernel v6.6 or above.
 
 :::
 
@@ -113,15 +112,15 @@ The output should look like this:
 5.4.0-42-generic #46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020
 ```
 
-In this case the kernel version is v5.4, which is suitable.
+In this case the kernel version is v5.4, which is not suitable (minimum is v5.10).
 
 On Red Hat-derived distributions, you may see something like this:
 
 ```
-4.18.0-193.el8.x86_64 (mockbuild@x86-vm-08.build.eng.bos.redhat.com)
+4.18.0-305.el8.x86_64 (mockbuild@x86-vm-08.build.eng.bos.redhat.com)
 ```
 
-Since the Red Hat kernel is v4.18 with at least build number 193, this kernel is suitable.
+Since the Red Hat kernel is v4.18 with at least build number 305 (RHEL 8.4), this kernel is suitable.
 
 ### Configure $[prodname] to talk directly to the API server
 

--- a/calico-cloud/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-cloud/operations/ebpf/enabling-ebpf.mdx
@@ -109,10 +109,10 @@ uname -rv
 The output should look like this:
 
 ```
-5.4.0-42-generic #46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020
+5.10.0-26-generic #28~20.04.1-Ubuntu SMP Fri Jan 27 14:30:10 UTC 2023
 ```
 
-In this case the kernel version is v5.4, which is not suitable (minimum is v5.10).
+In this case the kernel version is v5.10, which is suitable.
 
 On Red Hat-derived distributions, you may see something like this:
 

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/tcpstats.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/tcpstats.mdx
@@ -6,7 +6,7 @@ description: Enabling TCP socket stats information in flow logs
 
 ## Big picture
 
-Configure $[prodname] to collect additional TCP socket statistics. While this feature is available in both iptables and eBPF data plane modes, it uses eBPF to collect the statistics. Therefore it requires a recent Linux kernel (at least v5.3.0/v4.18.0-193 for RHEL).
+Configure $[prodname] to collect additional TCP socket statistics. While this feature is available in both iptables and eBPF data plane modes, it uses eBPF to collect the statistics. Therefore it requires a recent Linux kernel (at least v5.10.0/v4.18.0-305 for RHEL).
 
 ## Value
 
@@ -21,7 +21,7 @@ eBPF is a Linux kernel technology that allows safe mini-programs to be attached 
 ## Before you begin
 
 Ensure that your kernel contains support for eBPF that $[prodname] uses. The minimum supported
-kernel for tcp socket stats is: `v5.3.0`. For distros based on RHEL, the minimum kernel version is `v4.18.0-193`.
+kernel for tcp socket stats is: `v5.10.0`. For distros based on RHEL, the minimum kernel version is `v4.18.0-305`.
 
 # How to
 

--- a/calico-cloud_versioned_docs/version-22-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/ebpf/enabling-ebpf.mdx
@@ -28,9 +28,9 @@ eBPF (or "extended Berkeley Packet Filter"), is a technology that allows safe mi
 - arm64 (little-endian)
 - Linux distribution/kernel:
 
-  - Ubuntu 20.04 or above.
-  - Red Hat v8.2 with Linux kernel v4.18.0-193 or above (Red Hat have backported the required features to that build).
-  - Another supported distribution with Linux kernel v5.3 or above.  {/*TODO-XREFS-CC */}
+  - Ubuntu 22.04 or above.
+  - Red Hat v8.4 with Linux kernel v4.18.0-305 or above (Red Hat have backported the required features to that build).
+  - Another supported distribution with Linux kernel v5.10 or above.  {/*TODO-XREFS-CC */}
   - Immutable operating systems (e.g., Talos Linux): Ensure the `CgroupV2Path` in the `FelixConfiguration` CRD is set to a writable path.
 
 #### Kernel version requirements for eBPF features
@@ -39,15 +39,14 @@ Some eBPF features require a higher kernel version than the base eBPF data plane
 
 | Feature | Minimum kernel version | Details |
 |---|---|---|
-| Base eBPF data plane | v5.3 (RHEL: v4.18.0-193) | v5.8+ with CO-RE recommended for better performance |
-| [XDP acceleration](../../network-policy/extreme-traffic/defend-dos-attack.mdx) | v4.16 | Used for DoS mitigation; when `bpfEnabled` is `true`, policy is always accelerated using best available BPF technology |
+| Base eBPF data plane | v5.10 (RHEL: v4.18.0-305) | CO-RE supported at this version for better performance |
 | Log rules in eBPF mode | v5.16 | Logs sent to trace pipe via `bpftool prog tracelog` |
 | [QoS bandwidth controls](../../networking/configuring/qos-controls.mdx) | v6.6 | Requires `tcx` support. Established connection limits not supported with eBPF |
 | [DNS policy inline mode](../../network-policy/domain-based-policy.mdx) | v5.17 (RHEL: v5.14) | `BPFDNSPolicyMode: Inline` parses DNS responses in eBPF before they reach the application. Only wildcard prefixes (`*.x.y.z`) supported. Falls back to `NoDelay` on older kernels |
 
 :::warning
 
-While v5.3 is the minimum kernel version required for the eBPF data plane, we strongly recommend using kernel v5.8 or above, which adds support for [CO-RE (Compile Once - Run Everywhere)](https://docs.ebpf.io/concepts/core/). CO-RE significantly improves compatibility and performance across kernel versions. For access to all eBPF features, we recommend kernel v6.6 or above.
+The minimum kernel version required for the eBPF data plane is v5.10, which includes support for [CO-RE (Compile Once - Run Everywhere)](https://docs.ebpf.io/concepts/core/). CO-RE significantly improves compatibility and performance across kernel versions. For access to all eBPF features, we recommend kernel v6.6 or above.
 
 :::
 
@@ -113,15 +112,15 @@ The output should look like this:
 5.4.0-42-generic #46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020
 ```
 
-In this case the kernel version is v5.4, which is suitable.
+In this case the kernel version is v5.4, which is not suitable (minimum is v5.10).
 
 On Red Hat-derived distributions, you may see something like this:
 
 ```
-4.18.0-193.el8.x86_64 (mockbuild@x86-vm-08.build.eng.bos.redhat.com)
+4.18.0-305.el8.x86_64 (mockbuild@x86-vm-08.build.eng.bos.redhat.com)
 ```
 
-Since the Red Hat kernel is v4.18 with at least build number 193, this kernel is suitable.
+Since the Red Hat kernel is v4.18 with at least build number 305 (RHEL 8.4), this kernel is suitable.
 
 ### Configure $[prodname] to talk directly to the API server
 

--- a/calico-cloud_versioned_docs/version-22-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/ebpf/enabling-ebpf.mdx
@@ -109,10 +109,10 @@ uname -rv
 The output should look like this:
 
 ```
-5.4.0-42-generic #46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020
+5.10.0-26-generic #28~20.04.1-Ubuntu SMP Fri Jan 27 14:30:10 UTC 2023
 ```
 
-In this case the kernel version is v5.4, which is not suitable (minimum is v5.10).
+In this case the kernel version is v5.10, which is suitable.
 
 On Red Hat-derived distributions, you may see something like this:
 

--- a/calico-enterprise/observability/elastic/flow/tcpstats.mdx
+++ b/calico-enterprise/observability/elastic/flow/tcpstats.mdx
@@ -6,7 +6,7 @@ description: Enabling TCP socket stats information in flow logs
 
 ## Big picture
 
-Configure $[prodname] to collect additional TCP socket statistics. While this feature is available in both iptables and eBPF data plane modes, it uses eBPF to collect the statistics. Therefore it requires a recent Linux kernel (at least v5.3.0/v4.18.0-193 for RHEL).
+Configure $[prodname] to collect additional TCP socket statistics. While this feature is available in both iptables and eBPF data plane modes, it uses eBPF to collect the statistics. Therefore it requires a recent Linux kernel (at least v5.10.0/v4.18.0-305 for RHEL).
 
 ## Value
 
@@ -21,7 +21,7 @@ eBPF is a Linux kernel technology that allows safe mini-programs to be attached 
 ## Before you begin
 
 Ensure that your kernel contains support for eBPF that $[prodname] uses. The minimum supported
-kernel for tcp socket stats is: `v5.3.0`. For distros based on RHEL, the minimum kernel version is `v4.18.0-193`.
+kernel for tcp socket stats is: `v5.10.0`. For distros based on RHEL, the minimum kernel version is `v4.18.0-305`.
 
 # How to
 

--- a/calico-enterprise/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise/operations/ebpf/enabling-ebpf.mdx
@@ -48,18 +48,18 @@ uname -rv
 The output should look like this:
 
 ```
-5.4.0-42-generic #46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020
+5.10.0-26-generic #28~20.04.1-Ubuntu SMP Fri Jan 27 14:30:10 UTC 2023
 ```
 
-In this case the kernel version is v5.4, which is suitable.
+In this case the kernel version is v5.10, which is suitable.
 
 On Red Hat-derived distributions, you may see something like this:
 
 ```
-4.18.0-193.el8.x86_64 (mockbuild@x86-vm-08.build.eng.bos.redhat.com)
+4.18.0-305.el8.x86_64 (mockbuild@x86-vm-08.build.eng.bos.redhat.com)
 ```
 
-Since the Red Hat kernel is v4.18 with at least build number 193, this kernel is suitable.
+Since the Red Hat kernel is v4.18 with at least build number 305 (RHEL 8.4), this kernel is suitable.
 
 ### Configure $[prodname] to talk directly to the API server
 

--- a/calico-enterprise/operations/ebpf/install.mdx
+++ b/calico-enterprise/operations/ebpf/install.mdx
@@ -35,9 +35,9 @@ and in particular, pushing the networking capabilities of the latest Linux kerne
 
 - Linux distribution/kernel:
 
-  - Ubuntu 20.04 or above.
-  - Red Hat v8.2 with Linux kernel v4.18.0-193 or above (Red Hat have backported the required features to that build).
-  - Another [supported distribution](../../getting-started/install-on-clusters/requirements.mdx) with Linux kernel v5.3 or above.
+  - Ubuntu 22.04 or above.
+  - Red Hat v8.4 with Linux kernel v4.18.0-305 or above (Red Hat have backported the required features to that build).
+  - Another [supported distribution](../../getting-started/install-on-clusters/requirements.mdx) with Linux kernel v5.10 or above.
   - Immutable operating systems (e.g., Talos Linux): Ensure the `CgroupV2Path` in the `FelixConfiguration` CRD is set to a writable path.
 
 #### Kernel version requirements for eBPF features
@@ -46,15 +46,14 @@ Some eBPF features require a higher kernel version than the base eBPF data plane
 
 | Feature | Minimum kernel version | Details |
 |---|---|---|
-| Base eBPF data plane | v5.3 (RHEL: v4.18.0-193) | v5.8+ with CO-RE recommended for better performance |
-| [XDP acceleration](../../network-policy/extreme-traffic/defend-dos-attack.mdx) | v4.16 | Used for DoS mitigation; when `bpfEnabled` is `true`, policy is always accelerated using best available BPF technology |
+| Base eBPF data plane | v5.10 (RHEL: v4.18.0-305) | CO-RE supported at this version for better performance |
 | Log rules in eBPF mode | v5.16 | Logs sent to trace pipe via `bpftool prog tracelog` |
 | [QoS bandwidth controls](../../networking/configuring/qos-controls.mdx) | v6.6 | Requires `tcx` support. Established connection limits not supported with eBPF |
 | [DNS policy inline mode](../../network-policy/domain-based-policy.mdx) | v5.17 (RHEL: v5.14) | `BPFDNSPolicyMode: Inline` parses DNS responses in eBPF before they reach the application. Only wildcard prefixes (`*.x.y.z`) supported. Falls back to `NoDelay` on older kernels |
 
 :::warning
 
-While v5.3 is the minimum kernel version required for the eBPF data plane, we strongly recommend using kernel v5.8 or above, which adds support for [CO-RE (Compile Once - Run Everywhere)](https://docs.ebpf.io/concepts/core/). CO-RE significantly improves compatibility and performance across kernel versions. For access to all eBPF features, we recommend kernel v6.6 or above.
+The minimum kernel version required for the eBPF data plane is v5.10, which includes support for [CO-RE (Compile Once - Run Everywhere)](https://docs.ebpf.io/concepts/core/). CO-RE significantly improves compatibility and performance across kernel versions. For access to all eBPF features, we recommend kernel v6.6 or above.
 
 :::
 
@@ -124,7 +123,7 @@ Select the appropriate tab below for distribution-specific instructions:
 <Tabs groupId="k8s-distro">
 <TabItem label="Generic or kubeadm" value="Generic or kubeadm-0">
 
-`kubeadm` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 20.04) meets the kernel
+`kubeadm` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 22.04) meets the kernel
 requirements, `kubeadm`-provisioned clusters are supported.
 
 Since `kube-proxy` is not required in eBPF mode, you must disable `kube-proxy` at install time. With `kubeadm`
@@ -137,7 +136,7 @@ kubeadm init --skip-phases=addon/kube-proxy
 </TabItem>
 <TabItem label="kOps" value="kOps-1">
 
-`kops` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 20.04 or RHEL 8.2) meets the kernel
+`kops` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 22.04 or RHEL 8.4) meets the kernel
 requirements, `kops`-provisioned clusters are supported.
 
 Since `kube-proxy` is not required in eBPF mode, you must disable `kube-proxy` at install time. With `kops` you
@@ -153,7 +152,7 @@ kubeProxy:
 
 OpenShift supports a number of base OSes; as long as the base OS chosen has a recent enough kernel, OpenShift clusters are
 fully supported. Since Red Hat have backported the eBPF features required by $[prodname] the Red Hat kernel
-version required is lower than the mainline: v4.18.0-193 or above.
+version required is lower than the mainline: v4.18.0-305 or above.
 
 </TabItem>
 <TabItem label="AKS" value="AKS-3">

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/tcpstats.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/tcpstats.mdx
@@ -6,7 +6,7 @@ description: Enabling TCP socket stats information in flow logs
 
 ## Big picture
 
-Configure $[prodname] to collect additional TCP socket statistics. While this feature is available in both iptables and eBPF data plane modes, it uses eBPF to collect the statistics. Therefore it requires a recent Linux kernel (at least v5.3.0/v4.18.0-193 for RHEL).
+Configure $[prodname] to collect additional TCP socket statistics. While this feature is available in both iptables and eBPF data plane modes, it uses eBPF to collect the statistics. Therefore it requires a recent Linux kernel (at least v5.10.0/v4.18.0-305 for RHEL).
 
 ## Value
 
@@ -21,7 +21,7 @@ eBPF is a Linux kernel technology that allows safe mini-programs to be attached 
 ## Before you begin
 
 Ensure that your kernel contains support for eBPF that $[prodname] uses. The minimum supported
-kernel for tcp socket stats is: `v5.3.0`. For distros based on RHEL, the minimum kernel version is `v4.18.0-193`.
+kernel for tcp socket stats is: `v5.10.0`. For distros based on RHEL, the minimum kernel version is `v4.18.0-305`.
 
 # How to
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/enabling-ebpf.mdx
@@ -48,18 +48,18 @@ uname -rv
 The output should look like this:
 
 ```
-5.4.0-42-generic #46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020
+5.10.0-26-generic #28~20.04.1-Ubuntu SMP Fri Jan 27 14:30:10 UTC 2023
 ```
 
-In this case the kernel version is v5.4, which is suitable.
+In this case the kernel version is v5.10, which is suitable.
 
 On Red Hat-derived distributions, you may see something like this:
 
 ```
-4.18.0-193.el8.x86_64 (mockbuild@x86-vm-08.build.eng.bos.redhat.com)
+4.18.0-305.el8.x86_64 (mockbuild@x86-vm-08.build.eng.bos.redhat.com)
 ```
 
-Since the Red Hat kernel is v4.18 with at least build number 193, this kernel is suitable.
+Since the Red Hat kernel is v4.18 with at least build number 305 (RHEL 8.4), this kernel is suitable.
 
 ### Configure $[prodname] to talk directly to the API server
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/install.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/install.mdx
@@ -35,9 +35,9 @@ and in particular, pushing the networking capabilities of the latest Linux kerne
 
 - Linux distribution/kernel:
 
-  - Ubuntu 20.04 or above.
-  - Red Hat v8.2 with Linux kernel v4.18.0-193 or above (Red Hat have backported the required features to that build).
-  - Another [supported distribution](../../getting-started/install-on-clusters/requirements.mdx) with Linux kernel v5.3 or above.
+  - Ubuntu 22.04 or above.
+  - Red Hat v8.4 with Linux kernel v4.18.0-305 or above (Red Hat have backported the required features to that build).
+  - Another [supported distribution](../../getting-started/install-on-clusters/requirements.mdx) with Linux kernel v5.10 or above.
   - Immutable operating systems (e.g., Talos Linux): Ensure the `CgroupV2Path` in the `FelixConfiguration` CRD is set to a writable path.
 
 #### Kernel version requirements for eBPF features
@@ -46,15 +46,14 @@ Some eBPF features require a higher kernel version than the base eBPF data plane
 
 | Feature | Minimum kernel version | Details |
 |---|---|---|
-| Base eBPF data plane | v5.3 (RHEL: v4.18.0-193) | v5.8+ with CO-RE recommended for better performance |
-| [XDP acceleration](../../network-policy/extreme-traffic/defend-dos-attack.mdx) | v4.16 | Used for DoS mitigation; when `bpfEnabled` is `true`, policy is always accelerated using best available BPF technology |
+| Base eBPF data plane | v5.10 (RHEL: v4.18.0-305) | CO-RE supported at this version for better performance |
 | Log rules in eBPF mode | v5.16 | Logs sent to trace pipe via `bpftool prog tracelog` |
 | [QoS bandwidth controls](../../networking/configuring/qos-controls.mdx) | v6.6 | Requires `tcx` support. Established connection limits not supported with eBPF |
 | [DNS policy inline mode](../../network-policy/domain-based-policy.mdx) | v5.17 (RHEL: v5.14) | `BPFDNSPolicyMode: Inline` parses DNS responses in eBPF before they reach the application. Only wildcard prefixes (`*.x.y.z`) supported. Falls back to `NoDelay` on older kernels |
 
 :::warning
 
-While v5.3 is the minimum kernel version required for the eBPF data plane, we strongly recommend using kernel v5.8 or above, which adds support for [CO-RE (Compile Once - Run Everywhere)](https://docs.ebpf.io/concepts/core/). CO-RE significantly improves compatibility and performance across kernel versions. For access to all eBPF features, we recommend kernel v6.6 or above.
+The minimum kernel version required for the eBPF data plane is v5.10, which includes support for [CO-RE (Compile Once - Run Everywhere)](https://docs.ebpf.io/concepts/core/). CO-RE significantly improves compatibility and performance across kernel versions. For access to all eBPF features, we recommend kernel v6.6 or above.
 
 :::
 
@@ -124,7 +123,7 @@ Select the appropriate tab below for distribution-specific instructions:
 <Tabs groupId="k8s-distro">
 <TabItem label="Generic or kubeadm" value="Generic or kubeadm-0">
 
-`kubeadm` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 20.04) meets the kernel
+`kubeadm` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 22.04) meets the kernel
 requirements, `kubeadm`-provisioned clusters are supported.
 
 Since `kube-proxy` is not required in eBPF mode, you must disable `kube-proxy` at install time. With `kubeadm`
@@ -137,7 +136,7 @@ kubeadm init --skip-phases=addon/kube-proxy
 </TabItem>
 <TabItem label="kOps" value="kOps-1">
 
-`kops` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 20.04 or RHEL 8.2) meets the kernel
+`kops` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 22.04 or RHEL 8.4) meets the kernel
 requirements, `kops`-provisioned clusters are supported.
 
 Since `kube-proxy` is not required in eBPF mode, you must disable `kube-proxy` at install time. With `kops` you
@@ -153,7 +152,7 @@ kubeProxy:
 
 OpenShift supports a number of base OSes; as long as the base OS chosen has a recent enough kernel, OpenShift clusters are
 fully supported. Since Red Hat have backported the eBPF features required by $[prodname] the Red Hat kernel
-version required is lower than the mainline: v4.18.0-193 or above.
+version required is lower than the mainline: v4.18.0-305 or above.
 
 </TabItem>
 <TabItem label="AKS" value="AKS-3">

--- a/calico/operations/ebpf/enabling-ebpf.mdx
+++ b/calico/operations/ebpf/enabling-ebpf.mdx
@@ -69,9 +69,9 @@ This section explains how to enable the eBPF data plane on all compatible cluste
   - RKE (RKE2 recommended because it supports disabling `kube-proxy`)
   - MKE
 - Linux distribution/kernel:
-  - Ubuntu 20.04.
-  - Red Hat v8.2 with Linux kernel v4.18.0-193 or above (Red Hat have backported the required features to that build).
-  - Another [supported distribution](../../getting-started/kubernetes/requirements.mdx) with Linux kernel v5.3 or above. Kernel v5.8 or above with CO-RE enabled is recommended for better performance.
+  - Ubuntu 22.04.
+  - Red Hat v8.4 with Linux kernel v4.18.0-305 or above (Red Hat have backported the required features to that build).
+  - Another [supported distribution](../../getting-started/kubernetes/requirements.mdx) with Linux kernel v5.10 or above.
 - An underlying network fabric that allows VXLAN traffic between hosts. In eBPF mode, VXLAN is used to forward Kubernetes NodePort traffic.
 - IPv6
 

--- a/calico/operations/ebpf/enabling-ebpf.mdx
+++ b/calico/operations/ebpf/enabling-ebpf.mdx
@@ -108,18 +108,18 @@ uname -rv
 The output should look like this:
 
 ```
-5.4.0-42-generic #46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020
+5.10.0-26-generic #28~20.04.1-Ubuntu SMP Fri Jan 27 14:30:10 UTC 2023
 ```
 
-In this case the kernel version is v5.4, which is suitable.
+In this case the kernel version is v5.10, which is suitable.
 
 On Red Hat-derived distributions, you may see something like this:
 
 ```
-4.18.0-193.el8.x86_64 (mockbuild@x86-vm-08.build.eng.bos.redhat.com)
+4.18.0-305.el8.x86_64 (mockbuild@x86-vm-08.build.eng.bos.redhat.com)
 ```
 
-Since the Red Hat kernel is v4.18 with at least build number 193, this kernel is suitable.
+Since the Red Hat kernel is v4.18 with at least build number 305 (RHEL 8.4), this kernel is suitable.
 
 #### Performance
 

--- a/calico/operations/ebpf/install.mdx
+++ b/calico/operations/ebpf/install.mdx
@@ -52,9 +52,9 @@ and in particular, pushing the networking capabilities of the latest Linux kerne
 
 - Linux distribution/kernel:
 
-  - Ubuntu 20.04 or above.
-  - Red Hat v8.2 with Linux kernel v4.18.0-193 or above (Red Hat have backported the required features to that build).
-  - Another [supported distribution](../../getting-started/kubernetes/requirements.mdx) with Linux kernel v5.3 or above.
+  - Ubuntu 22.04 or above.
+  - Red Hat v8.4 with Linux kernel v4.18.0-305 or above (Red Hat have backported the required features to that build).
+  - Another [supported distribution](../../getting-started/kubernetes/requirements.mdx) with Linux kernel v5.10 or above.
   - Immutable operating systems (e.g., Talos Linux): Ensure the `CgroupV2Path` in the `FelixConfiguration` CRD is set to a writable path.
 
 #### Kernel version requirements for eBPF features
@@ -63,14 +63,13 @@ Some eBPF features require a higher kernel version than the base eBPF data plane
 
 | Feature | Minimum kernel version | Details |
 |---|---|---|
-| Base eBPF data plane | v5.3 (RHEL: v4.18.0-193) | v5.8+ with CO-RE recommended for better performance |
-| [XDP acceleration](../../network-policy/extreme-traffic/defend-dos-attack.mdx) | v4.16 | Used for DoS mitigation; when `bpfEnabled` is `true`, policy is always accelerated using best available BPF technology |
+| Base eBPF data plane | v5.10 (RHEL: v4.18.0-305) | CO-RE supported at this version for better performance |
 | [Log rules in eBPF mode](../../network-policy/policy-rules/log-rules.mdx) | v5.16 | Logs sent to trace pipe via `bpftool prog tracelog` |
 | [QoS bandwidth controls](../../networking/configuring/qos-controls.mdx) | v6.6 | Requires `tcx` support. Established connection limits not supported with eBPF |
 
 :::warning
 
-While v5.3 is the minimum kernel version required for the eBPF data plane, we strongly recommend using kernel v5.8 or above, which adds support for [CO-RE (Compile Once - Run Everywhere)](https://docs.ebpf.io/concepts/core/). CO-RE significantly improves compatibility and performance across kernel versions. For access to all eBPF features, we recommend kernel v6.6 or above.
+The minimum kernel version required for the eBPF data plane is v5.10, which includes support for [CO-RE (Compile Once - Run Everywhere)](https://docs.ebpf.io/concepts/core/). CO-RE significantly improves compatibility and performance across kernel versions. For access to all eBPF features, we recommend kernel v6.6 or above.
 
 :::
 
@@ -153,7 +152,7 @@ Select the appropriate tab below for distribution-specific instructions:
   If you're installing $[prodname] on a self-managed kubeadm cluster, you can enable eBPF mode automatically following the operator installation method in [Install Calico for on-premises deployments](../../getting-started/kubernetes/self-managed-onprem/onpremises.mdx). For this category of clusters, eBPF mode is the default data plane, and you don't need to follow the steps in this guide.
 
   :::
-`kubeadm` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 20.04) meets the kernel
+`kubeadm` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 22.04) meets the kernel
 requirements, `kubeadm`-provisioned clusters are supported.
 
 Since `kube-proxy` is not required in eBPF mode, you must disable `kube-proxy` at install time. With `kubeadm`
@@ -167,7 +166,7 @@ kubeadm init --skip-phases=addon/kube-proxy
 
 <TabItem label="kOps" value="kOps-1">
 
-`kops` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 20.04 or RHEL 8.2) meets the kernel
+`kops` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 22.04 or RHEL 8.4) meets the kernel
 requirements, `kops`-provisioned clusters are supported.
 
 Since `kube-proxy` is not required in eBPF mode, you must disable `kube-proxy` at install time. With `kops` you

--- a/calico_versioned_docs/version-3.31/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.31/operations/ebpf/enabling-ebpf.mdx
@@ -69,9 +69,9 @@ This section explains how to enable the eBPF data plane on all compatible cluste
   - RKE (RKE2 recommended because it supports disabling `kube-proxy`)
   - MKE
 - Linux distribution/kernel:
-  - Ubuntu 20.04.
-  - Red Hat v8.2 with Linux kernel v4.18.0-193 or above (Red Hat have backported the required features to that build).
-  - Another [supported distribution](../../getting-started/kubernetes/requirements.mdx) with Linux kernel v5.3 or above. Kernel v5.8 or above with CO-RE enabled is recommended for better performance.
+  - Ubuntu 22.04.
+  - Red Hat v8.4 with Linux kernel v4.18.0-305 or above (Red Hat have backported the required features to that build).
+  - Another [supported distribution](../../getting-started/kubernetes/requirements.mdx) with Linux kernel v5.10 or above.
 - An underlying network fabric that allows VXLAN traffic between hosts. In eBPF mode, VXLAN is used to forward Kubernetes NodePort traffic.
 - IPv6
 

--- a/calico_versioned_docs/version-3.31/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.31/operations/ebpf/enabling-ebpf.mdx
@@ -108,18 +108,18 @@ uname -rv
 The output should look like this:
 
 ```
-5.4.0-42-generic #46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020
+5.10.0-26-generic #28~20.04.1-Ubuntu SMP Fri Jan 27 14:30:10 UTC 2023
 ```
 
-In this case the kernel version is v5.4, which is suitable.
+In this case the kernel version is v5.10, which is suitable.
 
 On Red Hat-derived distributions, you may see something like this:
 
 ```
-4.18.0-193.el8.x86_64 (mockbuild@x86-vm-08.build.eng.bos.redhat.com)
+4.18.0-305.el8.x86_64 (mockbuild@x86-vm-08.build.eng.bos.redhat.com)
 ```
 
-Since the Red Hat kernel is v4.18 with at least build number 193, this kernel is suitable.
+Since the Red Hat kernel is v4.18 with at least build number 305 (RHEL 8.4), this kernel is suitable.
 
 #### Performance
 

--- a/calico_versioned_docs/version-3.31/operations/ebpf/install.mdx
+++ b/calico_versioned_docs/version-3.31/operations/ebpf/install.mdx
@@ -52,9 +52,9 @@ and in particular, pushing the networking capabilities of the latest Linux kerne
 
 - Linux distribution/kernel:
 
-  - Ubuntu 20.04 or above.
-  - Red Hat v8.2 with Linux kernel v4.18.0-193 or above (Red Hat have backported the required features to that build).
-  - Another [supported distribution](../../getting-started/kubernetes/requirements.mdx) with Linux kernel v5.3 or above.
+  - Ubuntu 22.04 or above.
+  - Red Hat v8.4 with Linux kernel v4.18.0-305 or above (Red Hat have backported the required features to that build).
+  - Another [supported distribution](../../getting-started/kubernetes/requirements.mdx) with Linux kernel v5.10 or above.
   - Immutable operating systems (e.g., Talos Linux): Ensure the `CgroupV2Path` in the `FelixConfiguration` CRD is set to a writable path.
 
 #### Kernel version requirements for eBPF features
@@ -63,14 +63,13 @@ Some eBPF features require a higher kernel version than the base eBPF data plane
 
 | Feature | Minimum kernel version | Details |
 |---|---|---|
-| Base eBPF data plane | v5.3 (RHEL: v4.18.0-193) | v5.8+ with CO-RE recommended for better performance |
-| [XDP acceleration](../../network-policy/extreme-traffic/defend-dos-attack.mdx) | v4.16 | Used for DoS mitigation; when `bpfEnabled` is `true`, policy is always accelerated using best available BPF technology |
+| Base eBPF data plane | v5.10 (RHEL: v4.18.0-305) | CO-RE supported at this version for better performance |
 | [Log rules in eBPF mode](../../network-policy/policy-rules/log-rules.mdx) | v5.16 | Logs sent to trace pipe via `bpftool prog tracelog` |
 | [QoS bandwidth controls](../../networking/configuring/qos-controls.mdx) | v6.6 | Requires `tcx` support. Established connection limits not supported with eBPF |
 
 :::warning
 
-While v5.3 is the minimum kernel version required for the eBPF data plane, we strongly recommend using kernel v5.8 or above, which adds support for [CO-RE (Compile Once - Run Everywhere)](https://docs.ebpf.io/concepts/core/). CO-RE significantly improves compatibility and performance across kernel versions. For access to all eBPF features, we recommend kernel v6.6 or above.
+The minimum kernel version required for the eBPF data plane is v5.10, which includes support for [CO-RE (Compile Once - Run Everywhere)](https://docs.ebpf.io/concepts/core/). CO-RE significantly improves compatibility and performance across kernel versions. For access to all eBPF features, we recommend kernel v6.6 or above.
 
 :::
 
@@ -153,7 +152,7 @@ Select the appropriate tab below for distribution-specific instructions:
   If you're installing $[prodname] on a self-managed kubeadm cluster, you can enable eBPF mode automatically following the operator installation method in [Install Calico for on-premises deployments](../../getting-started/kubernetes/self-managed-onprem/onpremises.mdx). For this category of clusters, eBPF mode is the default data plane, and you don't need to follow the steps in this guide.
 
   :::
-`kubeadm` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 20.04) meets the kernel
+`kubeadm` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 22.04) meets the kernel
 requirements, `kubeadm`-provisioned clusters are supported.
 
 Since `kube-proxy` is not required in eBPF mode, you must disable `kube-proxy` at install time. With `kubeadm`
@@ -167,7 +166,7 @@ kubeadm init --skip-phases=addon/kube-proxy
 
 <TabItem label="kOps" value="kOps-1">
 
-`kops` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 20.04 or RHEL 8.2) meets the kernel
+`kops` supports a number of base OSes; as long as the base OS chosen (such as Ubuntu 22.04 or RHEL 8.4) meets the kernel
 requirements, `kops`-provisioned clusters are supported.
 
 Since `kube-proxy` is not required in eBPF mode, you must disable `kube-proxy` at install time. With `kops` you


### PR DESCRIPTION
## Summary
- Raise eBPF dataplane minimum kernel from v5.3 to **v5.10** (RHEL: v4.18.0-193 → **v4.18.0-305** / RHEL 8.4)
- Update minimum Ubuntu from 20.04 to **22.04** (first LTS shipping kernel 5.10+)
- Remove XDP acceleration row from feature table (v4.16 is below new minimum)
- Simplify CO-RE warning since v5.10 already includes CO-RE support (v5.8+)

## Test plan
- [ ] Verify eBPF install pages render correctly for Calico, Calico Enterprise, and Calico Cloud
- [ ] Confirm kernel version table no longer lists XDP (v4.16) row
- [ ] Confirm all references to v5.3, v4.18.0-193, RHEL 8.2, and Ubuntu 20.04 are updated in latest + latest versioned docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)