### PR TITLE
Standardize kube-dns policy examples to use service match syntax

### DIFF
--- a/calico_versioned_docs/version-3.29/network-policy/get-started/kubernetes-default-deny.mdx
+++ b/calico_versioned_docs/version-3.29/network-policy/get-started/kubernetes-default-deny.mdx
@@ -111,6 +111,8 @@ spec:
       services:
         name: kube-dns
         namespace: kube-system
+      ports:
+      - 53
 ```
 
 Note the following:

--- a/calico_versioned_docs/version-3.29/network-policy/get-started/kubernetes-default-deny.mdx
+++ b/calico_versioned_docs/version-3.29/network-policy/get-started/kubernetes-default-deny.mdx
@@ -107,17 +107,10 @@ spec:
   egress:
    # allow all namespaces to communicate to DNS pods
   - action: Allow
-    protocol: UDP
     destination:
-      selector: 'k8s-app == "kube-dns"'
-      ports:
-      - 53
-  - action: Allow
-    protocol: TCP
-    destination:
-      selector: 'k8s-app == "kube-dns"'
-      ports:
-      - 53
+      services:
+        name: kube-dns
+        namespace: kube-system
 ```
 
 Note the following:

--- a/calico_versioned_docs/version-3.29/network-policy/policy-rules/service-policy.mdx
+++ b/calico_versioned_docs/version-3.29/network-policy/policy-rules/service-policy.mdx
@@ -70,6 +70,12 @@ This policy also enacts a default-deny behavior for all pods, so make sure any o
 
 :::
 
+:::tip
+
+You may see examples elsewhere that use a label selector (for example, `selector: 'k8s-app == "kube-dns"'`) with explicit protocol and port rules to allow DNS traffic. That approach can be useful when you need to target pods directly without a backing Kubernetes Service, but the service match syntax shown above is preferred because it is simpler and automatically resolves the correct endpoints and ports.
+
+:::
+
 ## Allow access from a specified service
 
 In the following example, ingress traffic is allowed from the `frontend-service` service in the `frontend` namespace for all pods in the namespace `backend`.

--- a/calico_versioned_docs/version-3.29/network-policy/policy-rules/service-policy.mdx
+++ b/calico_versioned_docs/version-3.29/network-policy/policy-rules/service-policy.mdx
@@ -72,7 +72,7 @@ This policy also enacts a default-deny behavior for all pods, so make sure any o
 
 :::tip
 
-You may see examples elsewhere that use a label selector (for example, `selector: 'k8s-app == "kube-dns"'`) with explicit protocol and port rules to allow DNS traffic. That approach can be useful when you need to target pods directly without a backing Kubernetes Service, but the service match syntax shown above is preferred because it is simpler and automatically resolves the correct endpoints and ports.
+You may see examples elsewhere that use a label selector (for example, `selector: 'k8s-app == "kube-dns"'`) with explicit protocol and port rules to allow DNS traffic. That approach can be useful when you need to target pods directly without a backing Kubernetes Service, or when you need to restrict traffic to only a subset of a Service's ports or protocols. The service match syntax shown above is preferred in the common case because it is simpler and automatically resolves the correct endpoints and ports.
 
 :::
 

--- a/calico_versioned_docs/version-3.30/network-policy/get-started/kubernetes-default-deny.mdx
+++ b/calico_versioned_docs/version-3.30/network-policy/get-started/kubernetes-default-deny.mdx
@@ -111,6 +111,8 @@ spec:
       services:
         name: kube-dns
         namespace: kube-system
+      ports:
+      - 53
 ```
 
 Note the following:

--- a/calico_versioned_docs/version-3.30/network-policy/get-started/kubernetes-default-deny.mdx
+++ b/calico_versioned_docs/version-3.30/network-policy/get-started/kubernetes-default-deny.mdx
@@ -107,17 +107,10 @@ spec:
   egress:
    # allow all namespaces to communicate to DNS pods
   - action: Allow
-    protocol: UDP
     destination:
-      selector: 'k8s-app == "kube-dns"'
-      ports:
-      - 53
-  - action: Allow
-    protocol: TCP
-    destination:
-      selector: 'k8s-app == "kube-dns"'
-      ports:
-      - 53
+      services:
+        name: kube-dns
+        namespace: kube-system
 ```
 
 Note the following:

--- a/calico_versioned_docs/version-3.30/network-policy/policy-rules/service-policy.mdx
+++ b/calico_versioned_docs/version-3.30/network-policy/policy-rules/service-policy.mdx
@@ -70,6 +70,12 @@ This policy also enacts a default-deny behavior for all pods, so make sure any o
 
 :::
 
+:::tip
+
+You may see examples elsewhere that use a label selector (for example, `selector: 'k8s-app == "kube-dns"'`) with explicit protocol and port rules to allow DNS traffic. That approach can be useful when you need to target pods directly without a backing Kubernetes Service, but the service match syntax shown above is preferred because it is simpler and automatically resolves the correct endpoints and ports.
+
+:::
+
 ## Allow access from a specified service
 
 In the following example, ingress traffic is allowed from the `frontend-service` service in the `frontend` namespace for all pods in the namespace `backend`.

--- a/calico_versioned_docs/version-3.30/network-policy/policy-rules/service-policy.mdx
+++ b/calico_versioned_docs/version-3.30/network-policy/policy-rules/service-policy.mdx
@@ -72,7 +72,7 @@ This policy also enacts a default-deny behavior for all pods, so make sure any o
 
 :::tip
 
-You may see examples elsewhere that use a label selector (for example, `selector: 'k8s-app == "kube-dns"'`) with explicit protocol and port rules to allow DNS traffic. That approach can be useful when you need to target pods directly without a backing Kubernetes Service, but the service match syntax shown above is preferred because it is simpler and automatically resolves the correct endpoints and ports.
+You may see examples elsewhere that use a label selector (for example, `selector: 'k8s-app == "kube-dns"'`) with explicit protocol and port rules to allow DNS traffic. That approach can be useful when you need to target pods directly without a backing Kubernetes Service, or when you need to restrict traffic to only a subset of a Service's ports or protocols. The service match syntax shown above is preferred in the common case because it is simpler and automatically resolves the correct endpoints and ports.
 
 :::
 

--- a/calico_versioned_docs/version-3.31/network-policy/get-started/kubernetes-default-deny.mdx
+++ b/calico_versioned_docs/version-3.31/network-policy/get-started/kubernetes-default-deny.mdx
@@ -111,6 +111,8 @@ spec:
       services:
         name: kube-dns
         namespace: kube-system
+      ports:
+      - 53
 ```
 
 Note the following:

--- a/calico_versioned_docs/version-3.31/network-policy/get-started/kubernetes-default-deny.mdx
+++ b/calico_versioned_docs/version-3.31/network-policy/get-started/kubernetes-default-deny.mdx
@@ -107,17 +107,10 @@ spec:
   egress:
    # allow all namespaces to communicate to DNS pods
   - action: Allow
-    protocol: UDP
     destination:
-      selector: 'k8s-app == "kube-dns"'
-      ports:
-      - 53
-  - action: Allow
-    protocol: TCP
-    destination:
-      selector: 'k8s-app == "kube-dns"'
-      ports:
-      - 53
+      services:
+        name: kube-dns
+        namespace: kube-system
 ```
 
 Note the following:

--- a/calico_versioned_docs/version-3.31/network-policy/policy-rules/service-policy.mdx
+++ b/calico_versioned_docs/version-3.31/network-policy/policy-rules/service-policy.mdx
@@ -70,6 +70,12 @@ This policy also enacts a default-deny behavior for all pods, so make sure any o
 
 :::
 
+:::tip
+
+You may see examples elsewhere that use a label selector (for example, `selector: 'k8s-app == "kube-dns"'`) with explicit protocol and port rules to allow DNS traffic. That approach can be useful when you need to target pods directly without a backing Kubernetes Service, but the service match syntax shown above is preferred because it is simpler and automatically resolves the correct endpoints and ports.
+
+:::
+
 ## Allow access from a specified service
 
 In the following example, ingress traffic is allowed from the `frontend-service` service in the `frontend` namespace for all pods in the namespace `backend`.

--- a/calico_versioned_docs/version-3.31/network-policy/policy-rules/service-policy.mdx
+++ b/calico_versioned_docs/version-3.31/network-policy/policy-rules/service-policy.mdx
@@ -72,7 +72,7 @@ This policy also enacts a default-deny behavior for all pods, so make sure any o
 
 :::tip
 
-You may see examples elsewhere that use a label selector (for example, `selector: 'k8s-app == "kube-dns"'`) with explicit protocol and port rules to allow DNS traffic. That approach can be useful when you need to target pods directly without a backing Kubernetes Service, but the service match syntax shown above is preferred because it is simpler and automatically resolves the correct endpoints and ports.
+You may see examples elsewhere that use a label selector (for example, `selector: 'k8s-app == "kube-dns"'`) with explicit protocol and port rules to allow DNS traffic. That approach can be useful when you need to target pods directly without a backing Kubernetes Service, or when you need to restrict traffic to only a subset of a Service's ports or protocols. The service match syntax shown above is preferred in the common case because it is simpler and automatically resolves the correct endpoints and ports.
 
 :::
 


### PR DESCRIPTION
## Summary

- Replace verbose label selector kube-dns examples in `kubernetes-default-deny.mdx` with the preferred service match syntax (`services: name/namespace`) across versions 3.29, 3.30, and 3.31
- Add a tip to `service-policy.mdx` (all three versions) explaining when the label selector approach may still be appropriate
- No change to policy meaning or scope — only syntax standardization and a brief cross-reference

Closes #2251

## Test plan

- [ ] Verify the YAML examples in `kubernetes-default-deny.mdx` render correctly for each version
- [ ] Verify the new `:::tip` block in `service-policy.mdx` renders correctly for each version
- [ ] Confirm no broken links or formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)