### PR TITLE
Add tip: set --allocate-node-cidrs=false with Calico IPAM

### DIFF
--- a/calico-cloud/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico-cloud/networking/ipam/get-started-ip-addresses.mdx
@@ -24,6 +24,16 @@ The **calico-ipam** plugin uses $[prodname]’s IP pool resource to control how 
 
 By default, $[prodname] uses a single IP pool for the entire Kubernetes pod CIDR, but you can divide the pod CIDR into several pools. You can assign separate IP pools to particular selections of **nodes**, or to teams, users, or applications within a cluster using **namespaces**.
 
+:::tip
+
+Because Calico IPAM does not use the Kubernetes node CIDR allocations (`Node.spec.podCIDR`), you can set `--allocate-node-cidrs=false` on the kube-controller-manager.
+This prevents Kubernetes from allocating unused node CIDRs and avoids `CIDRNotAvailable` events on nodes.
+
+If you bootstrapped your cluster with kubeadm and passed `--pod-network-cidr`, kubeadm enables node CIDR allocation automatically.
+See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure/) for instructions on reconfiguring the controller manager after cluster creation.
+
+:::
+
 You can control which pools $[prodname] uses for each pod using
 
 - node selectors

--- a/calico-cloud_versioned_docs/version-22-2/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/ipam/get-started-ip-addresses.mdx
@@ -24,6 +24,16 @@ The **calico-ipam** plugin uses $[prodname]’s IP pool resource to control how 
 
 By default, $[prodname] uses a single IP pool for the entire Kubernetes pod CIDR, but you can divide the pod CIDR into several pools. You can assign separate IP pools to particular selections of **nodes**, or to teams, users, or applications within a cluster using **namespaces**.
 
+:::tip
+
+Because Calico IPAM does not use the Kubernetes node CIDR allocations (`Node.spec.podCIDR`), you can set `--allocate-node-cidrs=false` on the kube-controller-manager.
+This prevents Kubernetes from allocating unused node CIDRs and avoids `CIDRNotAvailable` events on nodes.
+
+If you bootstrapped your cluster with kubeadm and passed `--pod-network-cidr`, kubeadm enables node CIDR allocation automatically.
+See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure/) for instructions on reconfiguring the controller manager after cluster creation.
+
+:::
+
 You can control which pools $[prodname] uses for each pod using
 
 - node selectors

--- a/calico-enterprise/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico-enterprise/networking/ipam/get-started-ip-addresses.mdx
@@ -24,6 +24,16 @@ The **calico-ipam** plugin uses $[prodname]’s IP pool resource to control how 
 
 By default, $[prodname] uses a single IP pool for the entire Kubernetes pod CIDR, but you can divide the pod CIDR into several pools. You can assign separate IP pools to particular selections of **nodes**, or to teams, users, or applications within a cluster using **namespaces**.
 
+:::tip
+
+Because Calico IPAM does not use the Kubernetes node CIDR allocations (`Node.spec.podCIDR`), you can set `--allocate-node-cidrs=false` on the kube-controller-manager.
+This prevents Kubernetes from allocating unused node CIDRs and avoids `CIDRNotAvailable` events on nodes.
+
+If you bootstrapped your cluster with kubeadm and passed `--pod-network-cidr`, kubeadm enables node CIDR allocation automatically.
+See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure/) for instructions on reconfiguring the controller manager after cluster creation.
+
+:::
+
 You can control which pools $[prodname] uses for each pod using
 
 - node selectors

--- a/calico-enterprise_versioned_docs/version-3.20-2/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/networking/ipam/get-started-ip-addresses.mdx
@@ -24,6 +24,16 @@ The **calico-ipam** plugin uses $[prodname]’s IP pool resource to control how 
 
 By default, $[prodname] uses a single IP pool for the entire Kubernetes pod CIDR, but you can divide the pod CIDR into several pools. You can assign separate IP pools to particular selections of **nodes**, or to teams, users, or applications within a cluster using **namespaces**.
 
+:::tip
+
+Because Calico IPAM does not use the Kubernetes node CIDR allocations (`Node.spec.podCIDR`), you can set `--allocate-node-cidrs=false` on the kube-controller-manager.
+This prevents Kubernetes from allocating unused node CIDRs and avoids `CIDRNotAvailable` events on nodes.
+
+If you bootstrapped your cluster with kubeadm and passed `--pod-network-cidr`, kubeadm enables node CIDR allocation automatically.
+See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure/) for instructions on reconfiguring the controller manager after cluster creation.
+
+:::
+
 You can control which pools $[prodname] uses for each pod using
 
 - node selectors

--- a/calico-enterprise_versioned_docs/version-3.21-2/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/networking/ipam/get-started-ip-addresses.mdx
@@ -24,6 +24,16 @@ The **calico-ipam** plugin uses $[prodname]’s IP pool resource to control how 
 
 By default, $[prodname] uses a single IP pool for the entire Kubernetes pod CIDR, but you can divide the pod CIDR into several pools. You can assign separate IP pools to particular selections of **nodes**, or to teams, users, or applications within a cluster using **namespaces**.
 
+:::tip
+
+Because Calico IPAM does not use the Kubernetes node CIDR allocations (`Node.spec.podCIDR`), you can set `--allocate-node-cidrs=false` on the kube-controller-manager.
+This prevents Kubernetes from allocating unused node CIDRs and avoids `CIDRNotAvailable` events on nodes.
+
+If you bootstrapped your cluster with kubeadm and passed `--pod-network-cidr`, kubeadm enables node CIDR allocation automatically.
+See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure/) for instructions on reconfiguring the controller manager after cluster creation.
+
+:::
+
 You can control which pools $[prodname] uses for each pod using
 
 - node selectors

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/get-started-ip-addresses.mdx
@@ -24,6 +24,16 @@ The **calico-ipam** plugin uses $[prodname]’s IP pool resource to control how 
 
 By default, $[prodname] uses a single IP pool for the entire Kubernetes pod CIDR, but you can divide the pod CIDR into several pools. You can assign separate IP pools to particular selections of **nodes**, or to teams, users, or applications within a cluster using **namespaces**.
 
+:::tip
+
+Because Calico IPAM does not use the Kubernetes node CIDR allocations (`Node.spec.podCIDR`), you can set `--allocate-node-cidrs=false` on the kube-controller-manager.
+This prevents Kubernetes from allocating unused node CIDRs and avoids `CIDRNotAvailable` events on nodes.
+
+If you bootstrapped your cluster with kubeadm and passed `--pod-network-cidr`, kubeadm enables node CIDR allocation automatically.
+See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure/) for instructions on reconfiguring the controller manager after cluster creation.
+
+:::
+
 You can control which pools $[prodname] uses for each pod using
 
 - node selectors

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/get-started-ip-addresses.mdx
@@ -24,6 +24,16 @@ The **calico-ipam** plugin uses $[prodname]’s IP pool resource to control how 
 
 By default, $[prodname] uses a single IP pool for the entire Kubernetes pod CIDR, but you can divide the pod CIDR into several pools. You can assign separate IP pools to particular selections of **nodes**, or to teams, users, or applications within a cluster using **namespaces**.
 
+:::tip
+
+Because Calico IPAM does not use the Kubernetes node CIDR allocations (`Node.spec.podCIDR`), you can set `--allocate-node-cidrs=false` on the kube-controller-manager.
+This prevents Kubernetes from allocating unused node CIDRs and avoids `CIDRNotAvailable` events on nodes.
+
+If you bootstrapped your cluster with kubeadm and passed `--pod-network-cidr`, kubeadm enables node CIDR allocation automatically.
+See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure/) for instructions on reconfiguring the controller manager after cluster creation.
+
+:::
+
 You can control which pools $[prodname] uses for each pod using
 
 - node selectors

--- a/calico/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico/networking/ipam/get-started-ip-addresses.mdx
@@ -24,6 +24,16 @@ The **calico-ipam** plugin uses Calico’s IP pool resource to control how IP ad
 
 By default, Calico uses a single IP pool for the entire Kubernetes pod CIDR, but you can divide the pod CIDR into several pools. You can assign separate IP pools to particular selections of **nodes**, or to teams, users, or applications within a cluster using **namespaces**.
 
+:::tip
+
+Because Calico IPAM does not use the Kubernetes node CIDR allocations (`Node.spec.podCIDR`), you can set `--allocate-node-cidrs=false` on the kube-controller-manager.
+This prevents Kubernetes from allocating unused node CIDRs and avoids `CIDRNotAvailable` events on nodes.
+
+If you bootstrapped your cluster with kubeadm and passed `--pod-network-cidr`, kubeadm enables node CIDR allocation automatically.
+See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure/) for instructions on reconfiguring the controller manager after cluster creation.
+
+:::
+
 You can control which pools Calico uses for each pod using
 
 - node selectors

--- a/calico_versioned_docs/version-3.29/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico_versioned_docs/version-3.29/networking/ipam/get-started-ip-addresses.mdx
@@ -24,6 +24,16 @@ The **calico-ipam** plugin uses Calico’s IP pool resource to control how IP ad
 
 By default, Calico uses a single IP pool for the entire Kubernetes pod CIDR, but you can divide the pod CIDR into several pools. You can assign separate IP pools to particular selections of **nodes**, or to teams, users, or applications within a cluster using **namespaces**.
 
+:::tip
+
+Because Calico IPAM does not use the Kubernetes node CIDR allocations (`Node.spec.podCIDR`), you can set `--allocate-node-cidrs=false` on the kube-controller-manager.
+This prevents Kubernetes from allocating unused node CIDRs and avoids `CIDRNotAvailable` events on nodes.
+
+If you bootstrapped your cluster with kubeadm and passed `--pod-network-cidr`, kubeadm enables node CIDR allocation automatically.
+See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure/) for instructions on reconfiguring the controller manager after cluster creation.
+
+:::
+
 You can control which pools Calico uses for each pod using
 
 - node selectors

--- a/calico_versioned_docs/version-3.30/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico_versioned_docs/version-3.30/networking/ipam/get-started-ip-addresses.mdx
@@ -24,6 +24,16 @@ The **calico-ipam** plugin uses Calico’s IP pool resource to control how IP ad
 
 By default, Calico uses a single IP pool for the entire Kubernetes pod CIDR, but you can divide the pod CIDR into several pools. You can assign separate IP pools to particular selections of **nodes**, or to teams, users, or applications within a cluster using **namespaces**.
 
+:::tip
+
+Because Calico IPAM does not use the Kubernetes node CIDR allocations (`Node.spec.podCIDR`), you can set `--allocate-node-cidrs=false` on the kube-controller-manager.
+This prevents Kubernetes from allocating unused node CIDRs and avoids `CIDRNotAvailable` events on nodes.
+
+If you bootstrapped your cluster with kubeadm and passed `--pod-network-cidr`, kubeadm enables node CIDR allocation automatically.
+See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure/) for instructions on reconfiguring the controller manager after cluster creation.
+
+:::
+
 You can control which pools Calico uses for each pod using
 
 - node selectors

--- a/calico_versioned_docs/version-3.31/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico_versioned_docs/version-3.31/networking/ipam/get-started-ip-addresses.mdx
@@ -24,6 +24,16 @@ The **calico-ipam** plugin uses Calico’s IP pool resource to control how IP ad
 
 By default, Calico uses a single IP pool for the entire Kubernetes pod CIDR, but you can divide the pod CIDR into several pools. You can assign separate IP pools to particular selections of **nodes**, or to teams, users, or applications within a cluster using **namespaces**.
 
+:::tip
+
+Because Calico IPAM does not use the Kubernetes node CIDR allocations (`Node.spec.podCIDR`), you can set `--allocate-node-cidrs=false` on the kube-controller-manager.
+This prevents Kubernetes from allocating unused node CIDRs and avoids `CIDRNotAvailable` events on nodes.
+
+If you bootstrapped your cluster with kubeadm and passed `--pod-network-cidr`, kubeadm enables node CIDR allocation automatically.
+See the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-reconfigure/) for instructions on reconfiguring the controller manager after cluster creation.
+
+:::
+
 You can control which pools Calico uses for each pod using
 
 - node selectors


### PR DESCRIPTION
## Summary

- Adds a tip to the Calico IPAM getting-started page explaining that `--allocate-node-cidrs=false` should be set on the kube-controller-manager when using Calico IPAM
- Calico IPAM ignores `Node.spec.podCIDR`, so Kubernetes node CIDR allocation is unnecessary and can produce confusing `CIDRNotAvailable` events
- Includes guidance for kubeadm users who need to reconfigure after cluster creation

Applied across all products (Calico, Calico Enterprise, Calico Cloud) and all versions.

Closes #1885

## Test plan

- [ ] Verify tip renders correctly on the IPAM getting-started page
- [ ] Confirm the Kubernetes documentation link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)