### PR TITLE
DOCS-2867: Replace Poppins font with DM Sans

### DIFF
--- a/__tests__/crawler.test.js
+++ b/__tests__/crawler.test.js
@@ -87,6 +87,7 @@ test('Crawl the docs and execute tests', async () => {
     //`https://installer.calicocloud.io/manifests/v3.17.1-3/manifests`,
     //`https://installer.calicocloud.io/manifests/v3.17.1-4/manifests`,
     `https://d881b853ae312e00302a84f1e346a77.gr7.us-west-2.eks.amazonaws.com`,
+    /^https:\/\/fonts\.googleapis\.com\/css2/, // Google Fonts URLs with semicolons confuse the link checker
     `https://www.googletagmanager.com`,
     'https://www.googletagmanager.com/gtm.js?id=',
     'https://twitter.com/tigeraio',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -56,7 +56,7 @@ export default async function createAsyncConfig() {
           "The Calico Docs AI answers questions based on what it finds in our product documentation. As with all AI solutions, it's a good idea to verify answers in the source material. ",
         //"data-modal-example-questions": "Docs Calico use eBPF?,Get started with egress gateways",
         'data-modal-ask-ai-input-placeholder': 'Ask me a question about Calico',
-        'data-font-family': 'Poppins,Helvetica Neue,Helvetica,Arial,sans-serif',
+        'data-font-family': 'DM Sans,Helvetica Neue,Helvetica,Arial,sans-serif',
         'data-modal-border-radius': '6px',
         'data-button-box-shadow': '2px 2px 8px rgba(0, 0, 0, 0.2)',
         'data-modal-header-bg-color': '#FFFFFF',
@@ -90,6 +90,13 @@ export default async function createAsyncConfig() {
           },
         }),
       ],
+    ],
+
+    stylesheets: [
+      {
+        href: 'https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap',
+        type: 'text/css',
+      },
     ],
 
     themeConfig:

--- a/src/___new___/theme/components/Heading.ts
+++ b/src/___new___/theme/components/Heading.ts
@@ -1,6 +1,6 @@
 export default {
     baseStyle: {
         fontFamily:
-            '"Poppins", "Helvetica Neue", "Helvetica", "Arial", sans-serif',
+            '"DM Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif',
     },
 };

--- a/src/___new___/theme/global.ts
+++ b/src/___new___/theme/global.ts
@@ -2,7 +2,7 @@
 
 export default {
   'html, body': {
-    fontFamily: '"Poppins", "Helvetica Neue", "Helvetica", "Arial", sans-serif',
+    fontFamily: '"DM Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif',
   },
   img: {
     verticalAlign: 'unset',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -4,7 +4,6 @@
  * work well for content-centric websites.
  */
 
- @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700&display=swap');
 
 /* You can override the default Infima variables here and define our custom global variables. */
 :root {
@@ -31,8 +30,8 @@
   --ifm-link-color: #273981;
   --ifm-link-hover-color: #273981;
   --ifm-menu-color-active: #273981;
-  --ifm-heading-font-family: Poppins;
-  --ifm-font-family-base: Poppins;
+  --ifm-heading-font-family: 'DM Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --ifm-font-family-base: 'DM Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   --ifm-navbar-link-color: #000000;
   --ifm-font-color-base: #141414;
   --ifm-menu-color-active: #141414;
@@ -148,6 +147,10 @@ img {
 */
 .theme-doc-markdown.markdown > h1:first-of-type + h2 {
   margin-top: 0;
+}
+
+.theme-doc-markdown.markdown {
+  font-size: 18px;
 }
 
 /* Overrides for the logo in the header */
@@ -499,7 +502,7 @@ th {
 }
 
 .DocSearch.DocSearch-Button {
-  font-family: 'Poppins';
+  font-family: 'DM Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   border-radius: 6px;
   border: 1px solid #dcdde0;
 }


### PR DESCRIPTION
## Summary
- Replaces Poppins with DM Sans (Google Fonts) across all CSS and theme config as part of rebranding
- Loads font via `<link>` in `<head>` instead of CSS `@import` for better render performance
- Bumps doc content font size to 18px (scoped to markdown content to avoid navbar layout issues)
- Adds Google Fonts URLs to link checker skip list to prevent false positives
- SVG images with embedded Poppins need to be re-exported separately (tracked in DOCS-2880)

## Test plan
- [ ] Verify DM Sans loads correctly on all pages
- [ ] Check heading and body text rendering
- [ ] Confirm DocSearch button font
- [ ] Confirm Kapa AI widget font
- [ ] Spot-check dark mode
- [ ] Verify navbar spacing looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)