### PR TITLE
Fix broken Juju install link in Charmed K8s docs

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/charmed-k8s.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/charmed-k8s.mdx
@@ -30,7 +30,7 @@ This guide describes how to install $[prodname] on a Charmed Kubernetes cluster.
 - A [compatible Charmed Kubernetes bundle](https://github.com/charmed-kubernetes/bundle/tree/main/releases) configured without a CNI
 - A [Tigera license key and credentials](calico-enterprise.mdx)
 - [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) on your workstation
-- [Install juju](https://juju.is/docs/juju/install-juju) on your workstation (if managing the cluster directly)
+- [Install juju](https://documentation.ubuntu.com/juju/latest/howto/manage-juju/) on your workstation (if managing the cluster directly)
 
 ## Prepare a compatible cluster for $[prodname] using a modified bundle file
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/charmed-k8s.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/charmed-k8s.mdx
@@ -30,7 +30,7 @@ This guide describes how to install $[prodname] on a Charmed Kubernetes cluster.
 - A [compatible Charmed Kubernetes bundle](https://github.com/charmed-kubernetes/bundle/tree/main/releases) configured without a CNI
 - A [Tigera license key and credentials](calico-enterprise.mdx)
 - [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) on your workstation
-- [Install juju](https://juju.is/docs/juju/install-juju) on your workstation (if managing the cluster directly)
+- [Install juju](https://documentation.ubuntu.com/juju/latest/howto/manage-juju/) on your workstation (if managing the cluster directly)
 
 ## Prepare a compatible cluster for $[prodname] using a modified bundle file
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/charmed-k8s.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/charmed-k8s.mdx
@@ -30,7 +30,7 @@ This guide describes how to install $[prodname] on a Charmed Kubernetes cluster.
 - A [compatible Charmed Kubernetes bundle](https://github.com/charmed-kubernetes/bundle/tree/main/releases) configured without a CNI
 - A [Tigera license key and credentials](calico-enterprise.mdx)
 - [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) on your workstation
-- [Install juju](https://juju.is/docs/juju/install-juju) on your workstation (if managing the cluster directly)
+- [Install juju](https://documentation.ubuntu.com/juju/latest/howto/manage-juju/) on your workstation (if managing the cluster directly)
 
 ## Prepare a compatible cluster for $[prodname] using a modified bundle file
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/charmed-k8s.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/charmed-k8s.mdx
@@ -30,7 +30,7 @@ This guide describes how to install $[prodname] on a Charmed Kubernetes cluster.
 - A [compatible Charmed Kubernetes bundle](https://github.com/charmed-kubernetes/bundle/tree/main/releases) configured without a CNI
 - A [Tigera license key and credentials](calico-enterprise.mdx)
 - [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) on your workstation
-- [Install juju](https://juju.is/docs/juju/install-juju) on your workstation (if managing the cluster directly)
+- [Install juju](https://documentation.ubuntu.com/juju/latest/howto/manage-juju/) on your workstation (if managing the cluster directly)
 
 ## Prepare a compatible cluster for $[prodname] using a modified bundle file
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/getting-started/install-on-clusters/charmed-k8s.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/getting-started/install-on-clusters/charmed-k8s.mdx
@@ -30,7 +30,7 @@ This guide describes how to install $[prodname] on a Charmed Kubernetes cluster.
 - A [compatible Charmed Kubernetes bundle](https://github.com/charmed-kubernetes/bundle/tree/main/releases) configured without a CNI
 - A [Tigera license key and credentials](calico-enterprise.mdx)
 - [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) on your workstation
-- [Install juju](https://juju.is/docs/juju/install-juju) on your workstation (if managing the cluster directly)
+- [Install juju](https://documentation.ubuntu.com/juju/latest/howto/manage-juju/) on your workstation (if managing the cluster directly)
 
 ## Prepare a compatible cluster for $[prodname] using a modified bundle file
 


### PR DESCRIPTION
## Summary
- The old `juju.is/docs/juju/install-juju` URL returns a 301 → 302 redirect chain and is no longer reliable
- Updated to the canonical Ubuntu documentation URL (`documentation.ubuntu.com/juju/latest/howto/manage-juju/`) across all versioned Charmed Kubernetes install docs

## Test plan
- [ ] Verify the new link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)