### PR TITLE
Add upstream-istio to component versions for CE v3.22+

### DIFF
--- a/calico-enterprise/releases.json
+++ b/calico-enterprise/releases.json
@@ -170,6 +170,9 @@
         "image": "tigera/prometheus",
         "version": "master"
       },
+      "coreos-istio": {
+        "version": "1.28.1"
+      },
       "coreos-prometheus": {
         "version": "v2.48.1"
       },

--- a/calico-enterprise/releases.json
+++ b/calico-enterprise/releases.json
@@ -170,7 +170,7 @@
         "image": "tigera/prometheus",
         "version": "master"
       },
-      "coreos-istio": {
+      "upstream-istio": {
         "version": "1.28.1"
       },
       "coreos-prometheus": {

--- a/calico-enterprise_versioned_docs/version-3.22-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.22-2/releases.json
@@ -607,9 +607,6 @@
       "coreos-fluentd": {
         "version": "1.18.0"
       },
-      "upstream-istio": {
-        "version": "1.28.1"
-      },
       "coreos-prometheus": {
         "version": "v3.4.1"
       },
@@ -874,9 +871,6 @@
       },
       "coreos-fluentd": {
         "version": "1.18.0"
-      },
-      "upstream-istio": {
-        "version": "1.28.1"
       },
       "coreos-prometheus": {
         "version": "v3.4.1"
@@ -1146,9 +1140,6 @@
       },
       "coreos-fluentd": {
         "version": "1.18.0"
-      },
-      "upstream-istio": {
-        "version": "1.28.1"
       },
       "coreos-prometheus": {
         "version": "v3.4.1"

--- a/calico-enterprise_versioned_docs/version-3.22-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.22-2/releases.json
@@ -79,7 +79,7 @@
       "coreos-fluentd": {
         "version": "1.18.0"
       },
-      "coreos-istio": {
+      "upstream-istio": {
         "version": "1.28.1"
       },
       "coreos-prometheus": {
@@ -343,7 +343,7 @@
       "coreos-fluentd": {
         "version": "1.18.0"
       },
-      "coreos-istio": {
+      "upstream-istio": {
         "version": "1.28.1"
       },
       "coreos-prometheus": {
@@ -607,7 +607,7 @@
       "coreos-fluentd": {
         "version": "1.18.0"
       },
-      "coreos-istio": {
+      "upstream-istio": {
         "version": "1.28.1"
       },
       "coreos-prometheus": {
@@ -875,7 +875,7 @@
       "coreos-fluentd": {
         "version": "1.18.0"
       },
-      "coreos-istio": {
+      "upstream-istio": {
         "version": "1.28.1"
       },
       "coreos-prometheus": {
@@ -1147,7 +1147,7 @@
       "coreos-fluentd": {
         "version": "1.18.0"
       },
-      "coreos-istio": {
+      "upstream-istio": {
         "version": "1.28.1"
       },
       "coreos-prometheus": {

--- a/calico-enterprise_versioned_docs/version-3.22-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.22-2/releases.json
@@ -79,6 +79,9 @@
       "coreos-fluentd": {
         "version": "1.18.0"
       },
+      "coreos-istio": {
+        "version": "1.28.1"
+      },
       "coreos-prometheus": {
         "version": "v3.4.1"
       },
@@ -340,6 +343,9 @@
       "coreos-fluentd": {
         "version": "1.18.0"
       },
+      "coreos-istio": {
+        "version": "1.28.1"
+      },
       "coreos-prometheus": {
         "version": "v3.4.1"
       },
@@ -600,6 +606,9 @@
       },
       "coreos-fluentd": {
         "version": "1.18.0"
+      },
+      "coreos-istio": {
+        "version": "1.28.1"
       },
       "coreos-prometheus": {
         "version": "v3.4.1"
@@ -865,6 +874,9 @@
       },
       "coreos-fluentd": {
         "version": "1.18.0"
+      },
+      "coreos-istio": {
+        "version": "1.28.1"
       },
       "coreos-prometheus": {
         "version": "v3.4.1"
@@ -1134,6 +1146,9 @@
       },
       "coreos-fluentd": {
         "version": "1.18.0"
+      },
+      "coreos-istio": {
+        "version": "1.28.1"
       },
       "coreos-prometheus": {
         "version": "v3.4.1"

--- a/calico-enterprise_versioned_docs/version-3.23-1/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.23-1/releases.json
@@ -79,6 +79,9 @@
       "coreos-fluentd": {
         "version": "1.18.0"
       },
+      "coreos-istio": {
+        "version": "1.28.1"
+      },
       "coreos-prometheus": {
         "version": "v3.4.1"
       },

--- a/calico-enterprise_versioned_docs/version-3.23-1/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.23-1/releases.json
@@ -79,7 +79,7 @@
       "coreos-fluentd": {
         "version": "1.18.0"
       },
-      "coreos-istio": {
+      "upstream-istio": {
         "version": "1.28.1"
       },
       "coreos-prometheus": {

--- a/scripts/versions/main.go
+++ b/scripts/versions/main.go
@@ -35,12 +35,12 @@ var componentsToPrune = []string{
 // Components where the key in the upstream yaml file is different from what's present in docs
 var componentsToRename = map[string]string{
 	"upstream-fluentd": "coreos-fluentd",
-	"upstream-istio":   "coreos-istio",
 }
 
 // Components that we leave as-is without updating
 var componentsToIgnore = []string{
 	"upstream-dex",
+	"upstream-istio",
 }
 
 // TigeraOperator represents the tigera-operator configuration

--- a/scripts/versions/main.go
+++ b/scripts/versions/main.go
@@ -35,6 +35,7 @@ var componentsToPrune = []string{
 // Components where the key in the upstream yaml file is different from what's present in docs
 var componentsToRename = map[string]string{
 	"upstream-fluentd": "coreos-fluentd",
+	"upstream-istio":   "coreos-istio",
 }
 
 // Components that we leave as-is without updating


### PR DESCRIPTION
## Summary
- Add `coreos-istio` (version 1.28.1) to component-versions page for Calico Enterprise v3.22, v3.23, and next/master
- Add `upstream-istio` → `coreos-istio` rename mapping in `scripts/versions/main.go`, following the same pattern as `upstream-fluentd` → `coreos-fluentd`
- Companion to calico-private PRs: https://github.com/tigera/calico-private/pull/11183 and https://github.com/tigera/calico-private/pull/11181

## Test plan
- [ ] Verify component-versions page renders correctly for CE v3.22, v3.23, and next
- [ ] Verify `coreos-istio` appears in the component table with version `1.28.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)