### PR TITLE
Add missing release note from v3.30.7

### DIFF
--- a/calico_versioned_docs/version-3.30/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.30/release-notes/index.mdx
@@ -422,7 +422,7 @@ March 18, 2026
 
 #### Deprecations
 
-- Support for non-privileged mode has been removed from Operator installations. The `Installation.spec.nonPrivileged` field is deprecated, and setting it to Enabled will mark Calico as Degraded. [calico 12091](https://github.com/projectcalico/calico/pull/12091) (@MichalFupso)
+- Support for non-privileged mode has been removed from Operator installations. The `Installation.spec.nonPrivileged` field is deprecated, and setting it to `Enabled` will mark Calico as `Degraded`. [calico 12091](https://github.com/projectcalico/calico/pull/12091) (@MichalFupso)
 - We continue testing Calico against OpenStack Caracal, but have stopped testing Calico against OpenStack Yoga. This is because Yoga has now been "unmaintained" for over a year, and is not compatible with current CI platforms based on Ubuntu 22.04. [calico 11746](https://github.com/projectcalico/calico/pull/11746) (@nelljerram)
 
 #### Bug fixes

--- a/calico_versioned_docs/version-3.30/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.30/release-notes/index.mdx
@@ -422,6 +422,7 @@ March 18, 2026
 
 #### Deprecations
 
+- Support for non-privileged mode has been removed from Operator installations. The `Installation.spec.nonPrivileged` field is deprecated, and setting it to Enabled will mark Calico as Degraded. [calico 12091](https://github.com/projectcalico/calico/pull/12091) (@MichalFupso)
 - We continue testing Calico against OpenStack Caracal, but have stopped testing Calico against OpenStack Yoga. This is because Yoga has now been "unmaintained" for over a year, and is not compatible with current CI platforms based on Ubuntu 22.04. [calico 11746](https://github.com/projectcalico/calico/pull/11746) (@nelljerram)
 
 #### Bug fixes


### PR DESCRIPTION
One release note didn't make it into the published release notes; it's been added to the calico repository and I'm adding it here as well.