### PR TITLE
Correct release date for Calico Enterprise 3.22.2

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -271,7 +271,7 @@ To update an existing installation of Calico Enterprise 3.22, see [Install a pat
 
 ### Calico Enterprise 3.22.2 hotfix release
 
-February 20, 2025
+February 20, 2026
 
 #### Bug fixes
 


### PR DESCRIPTION
Updated release date for Calico Enterprise 3.22.2 hotfix release from February 20, 2025 to February 20, 2026.

DOCS review:
- [x] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->


<!--- After you open your PR, ask for review from docs team:
@ctauchen 