### PR TITLE
Add edge function for /tag/* password auth

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -115,6 +115,12 @@ command = "[[ $PREVIEW_TYPE == cloudpreview ]] && echo Building deploy preview f
 #to = "/index.html"
 #status = 200
 
+[[redirects]]
+  from = "/tag"
+  to = "/tag/"
+  status = 301
+  force = true
+
 # Redirects for old Calico Open Source docs
 # proxy redirect for Helm chart repo
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -115,12 +115,6 @@ command = "[[ $PREVIEW_TYPE == cloudpreview ]] && echo Building deploy preview f
 #to = "/index.html"
 #status = 200
 
-[[redirects]]
-  from = "/tag/*"
-  to = "https://tag-docs-tigera.netlify.app/tag/:splat"
-  status = 200
-  force = true
-
 # Redirects for old Calico Open Source docs
 # proxy redirect for Helm chart repo
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -350,6 +350,10 @@ for = "/*"
 # This feature may not be available on all plans.
 #Basic-Auth = "someuser:somepassword anotheruser:anotherpassword"
 
+[[edge_functions]]
+  function = "tag-auth"
+  path = "/tag/*"
+
 [functions]
 # Directory with serverless functions, including background
 # functions, to deploy. This is relative to the base directory

--- a/netlify.toml
+++ b/netlify.toml
@@ -115,6 +115,12 @@ command = "[[ $PREVIEW_TYPE == cloudpreview ]] && echo Building deploy preview f
 #to = "/index.html"
 #status = 200
 
+[[redirects]]
+  from = "/tag/*"
+  to = "https://tag-docs-tigera.netlify.app/tag/:splat"
+  status = 200
+  force = true
+
 # Redirects for old Calico Open Source docs
 # proxy redirect for Helm chart repo
 

--- a/netlify/edge-functions/tag-auth.js
+++ b/netlify/edge-functions/tag-auth.js
@@ -1,0 +1,49 @@
+const PASSWORD = Netlify.env.get('TAG_PASSWORD');
+
+export default async (request, context) => {
+  const cookie = request.headers.get('cookie') || '';
+
+  if (cookie.includes('tag_auth=authorized')) {
+    return context.next();
+  }
+
+  if (request.method === 'POST') {
+    const body = await request.formData();
+    if (body.get('password') === PASSWORD) {
+      const url = new URL(request.url);
+      return new Response(null, {
+        status: 302,
+        headers: {
+          'Location': url.pathname,
+          'Set-Cookie': 'tag_auth=authorized; Path=/tag; HttpOnly; Secure; SameSite=Lax; Max-Age=86400',
+        },
+      });
+    }
+  }
+
+  return new Response(`
+    <!DOCTYPE html>
+    <html>
+    <head><title>Authentication Required</title>
+    <style>
+      body { font-family: system-ui; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; background: #f5f5f5; }
+      form { background: white; padding: 2rem; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); }
+      input { display: block; width: 100%; padding: 0.5rem; margin: 0.5rem 0 1rem; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box; }
+      button { background: #2563eb; color: white; border: none; padding: 0.5rem 1.5rem; border-radius: 4px; cursor: pointer; }
+    </style>
+    </head>
+    <body>
+      <form method="POST">
+        <h3>Enter password to continue</h3>
+        <input type="password" name="password" placeholder="Password" autofocus />
+        <button type="submit">Submit</button>
+      </form>
+    </body>
+    </html>
+  `, {
+    status: 401,
+    headers: { 'Content-Type': 'text/html' },
+  });
+};
+
+export const config = { path: '/tag/*' };

--- a/netlify/edge-functions/tag-auth.js
+++ b/netlify/edge-functions/tag-auth.js
@@ -1,6 +1,13 @@
 const PASSWORD = Netlify.env.get('TAG_PASSWORD');
 
 export default async (request, context) => {
+  if (!PASSWORD) {
+    return new Response('Server configuration error: TAG_PASSWORD is not set.', {
+      status: 500,
+      headers: { 'Content-Type': 'text/plain' },
+    });
+  }
+
   const cookie = request.headers.get('cookie') || '';
 
   // Already authenticated — proxy to the private site
@@ -21,7 +28,7 @@ export default async (request, context) => {
       return new Response(null, {
         status: 302,
         headers: {
-          'Location': url.pathname,
+          'Location': url.pathname + url.search,
           'Set-Cookie': 'tag_auth=authorized; Path=/tag; HttpOnly; Secure; SameSite=Lax; Max-Age=86400',
         },
       });
@@ -43,7 +50,8 @@ export default async (request, context) => {
     <body>
       <form method="POST">
         <h3>Enter password to continue</h3>
-        <input type="password" name="password" placeholder="Password" autofocus />
+        <label for="password">Password</label>
+        <input id="password" type="password" name="password" placeholder="Password" autofocus />
         <button type="submit">Submit</button>
       </form>
     </body>

--- a/netlify/edge-functions/tag-auth.js
+++ b/netlify/edge-functions/tag-auth.js
@@ -3,10 +3,17 @@ const PASSWORD = Netlify.env.get('TAG_PASSWORD');
 export default async (request, context) => {
   const cookie = request.headers.get('cookie') || '';
 
+  // Already authenticated — proxy to the private site
   if (cookie.includes('tag_auth=authorized')) {
-    return context.next();
+    const url = new URL(request.url);
+    const path = url.pathname.replace(/^\/tag/, '') || '/';
+    const target = `https://tag-docs-tigera.netlify.app/tag${path}${url.search}`;
+    return fetch(target, {
+      headers: request.headers,
+    });
   }
 
+  // Handle form submission
   if (request.method === 'POST') {
     const body = await request.formData();
     if (body.get('password') === PASSWORD) {
@@ -21,6 +28,7 @@ export default async (request, context) => {
     }
   }
 
+  // Show login page
   return new Response(`
     <!DOCTYPE html>
     <html>


### PR DESCRIPTION
## Summary
- Adds a Netlify edge function (`netlify/edge-functions/tag-auth.js`) that password-protects all `/tag/*` routes
- Password is read from the `TAG_PASSWORD` environment variable (must be set in Netlify site settings)
- Authorized users get a cookie (`tag_auth=authorized`) valid for 24 hours

## Test plan
- [ ] Set `TAG_PASSWORD` env var in Netlify site settings
- [ ] Deploy and verify `/tag/*` routes show the password form
- [ ] Verify correct password grants access and sets the cookie
- [ ] Verify incorrect password keeps showing the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)