### PR TITLE
docs(ing2gw): add NGINX-to-Gateway migration guide

### DIFF
--- a/.github/styles/config/vocabularies/CalicoBrands/accept.txt
+++ b/.github/styles/config/vocabularies/CalicoBrands/accept.txt
@@ -34,7 +34,9 @@ Kibana
 Kubernetes
 Kubespray
 Kuryr
+kgateway
 Linux
+Lua
 Maglev
 Mellanox
 MetalLB

--- a/.github/styles/config/vocabularies/CalicoTerminology/accept.txt
+++ b/.github/styles/config/vocabularies/CalicoTerminology/accept.txt
@@ -11,9 +11,11 @@ adjacencies
 [cC]luster[Rr]ole[s]?
 [cC]ommandlet[s]?
 [cC]onfig[s]?
+[cC]onformant
 [cC]onntrack
 [cC]ronjob[s]?
 [cC]rontab[s]?
+[cC]utover[s]?
 [cC]ybersecurity
 [dD]atacenter[s]?
 [dD]atapath
@@ -87,6 +89,7 @@ quantile[s]?
 [rR]eachability
 [rR]ebalanc(e|ed|ing)
 [rR]egex(es)?
+[rR]eimplement(ed|ing|s)?
 [rR]einstall(s|ed|ing)?
 [rR]eplica[Ss]et[s]?
 [rR]epurpos(e|ed|ing)

--- a/calico/networking/ingress-gateway/migrate-from-nginx.mdx
+++ b/calico/networking/ingress-gateway/migrate-from-nginx.mdx
@@ -46,7 +46,7 @@ kubectl get ingress,service,secret -A -o yaml > pre-migration.yaml
 
 Translate your `Ingress` resources into `Gateway`, `HTTPRoute`, `ReferenceGrant`, and any matching `SecurityPolicy`, `BackendTrafficPolicy`, or `ClientTrafficPolicy` resources. Compare each generated resource against the original `Ingress`.
 
-:::note
+:::info
 We have a [conversion tool](#conversion-tool) provided to help you generate Gateway API resources from your existing `Ingress` YAML files.
 :::
 
@@ -100,7 +100,9 @@ The [conversion tool](https://tigera.github.io/ing2gw/) drafts Gateway API resou
 
 It auto-detects the annotation prefix (community NGINX vs NGINX Inc / F5) and supports both controllers. Everything runs in your browser — no YAML leaves your machine. The full annotation reference (which annotations convert cleanly and which need human judgment) lives [on the tool's site](https://tigera.github.io/ing2gw/#/reference).
 
-:::warning[The output is a starting draft, not a finished migration]
+:::caution[Important]
+The output is a starting draft, not a finished migration.
+
 Every generated resource must be reviewed, validated with `egctl`, tested in a non-production cluster, and proven at parity with your existing NGINX setup before switching production traffic over. The tool may emit incorrect or incomplete output for edge cases — verify each resource against your live config and exercise it with representative traffic before taking it to production.
 :::
 

--- a/calico/networking/ingress-gateway/migrate-from-nginx.mdx
+++ b/calico/networking/ingress-gateway/migrate-from-nginx.mdx
@@ -9,7 +9,7 @@ Calico Ingress Gateway, powered by Envoy Gateway, is a replacement for NGINX Ing
 
 This page covers the conceptual mapping from NGINX Ingress to Calico Ingress Gateway, a step-by-step migration workflow, and common problems to watch for.
 
-:::tip Ready to migrate?
+:::tip[Ready to migrate?]
 If you already understand how Gateway API differs from NGINX Ingress, jump ahead to the [migration workflow](#migration-workflow). We also provide an optional [conversion tool](#conversion-tool) for your convenience.
 :::
 
@@ -100,7 +100,7 @@ The [conversion tool](https://tigera.github.io/ing2gw/) drafts Gateway API resou
 
 It auto-detects the annotation prefix (community NGINX vs NGINX Inc / F5) and supports both controllers. Everything runs in your browser — no YAML leaves your machine. The full annotation reference (which annotations convert cleanly and which need human judgment) lives [on the tool's site](https://tigera.github.io/ing2gw/#/reference).
 
-:::warning The output is a starting draft, not a finished migration
+:::warning[The output is a starting draft, not a finished migration]
 Every generated resource must be reviewed, validated with `egctl`, tested in a non-production cluster, and proven at parity with your existing NGINX setup before switching production traffic over. The tool may emit incorrect or incomplete output for edge cases — verify each resource against your live config and exercise it with representative traffic before taking it to production.
 :::
 

--- a/calico/networking/ingress-gateway/migrate-from-nginx.mdx
+++ b/calico/networking/ingress-gateway/migrate-from-nginx.mdx
@@ -1,0 +1,109 @@
+---
+description: Migrate NGINX Ingress resources to Calico Ingress Gateway with a step-by-step workflow and an optional conversion tool.
+title: Migrating from NGINX
+---
+
+# Migrating from NGINX Ingress
+
+Calico Ingress Gateway, powered by Envoy Gateway, is a replacement for NGINX Ingress on Kubernetes clusters. NGINX Ingress Controller [retired in March 2026](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/) and no longer receives releases, bug fixes, or security patches.
+
+This page covers the conceptual mapping from NGINX Ingress to Calico Ingress Gateway, a step-by-step migration workflow, and common problems to watch for.
+
+:::tip Ready to migrate?
+If you already understand how Gateway API differs from NGINX Ingress, jump ahead to the [migration workflow](#migration-workflow). We also provide an optional [conversion tool](#conversion-tool) for your convenience.
+:::
+
+## Why Gateway API
+
+NGINX Ingress encodes behavior in vendor-specific annotation strings on `Ingress` objects. Gateway API encodes the same behavior in typed CRDs that any conformant controller (such as Envoy Gateway, Istio, Cilium, and kgateway) can read. The mental shift:
+
+| NGINX Ingress | Gateway API + Calico Ingress Gateway |
+| --- | --- |
+| Annotation strings on `Ingress` | Typed fields on `HTTPRoute`, `SecurityPolicy`, `BackendTrafficPolicy`, `ClientTrafficPolicy` |
+| Behavior depends on which controller reads the annotation | Behavior depends on a policy's `targetRef` to a route or gateway |
+| Controller-specific snippets for advanced cases | `EnvoyPatchPolicy` or Lua filters for advanced cases |
+| Single resource owns routing, TLS, security, traffic shaping | Concerns split across `Gateway`, `HTTPRoute`, and policy CRDs |
+
+## Migration workflow
+
+### Step 1: Create an inventory
+
+Catalogue every `Ingress` resource and the annotations it uses. Note the annotation prefix (community NGINX uses `nginx.ingress.kubernetes.io/`; NGINX Inc / F5 uses `nginx.org/` and `nginx.com/`):
+
+```bash
+kubectl get ingress -A -o yaml
+```
+
+### Step 2: Back up your resources
+
+Export current `Ingress`, `Service`, and TLS `Secret` state to a file before changing anything:
+
+```bash
+kubectl get ingress,service,secret -A -o yaml > pre-migration.yaml
+```
+
+### Step 3: Author Gateway API resources
+
+Translate your `Ingress` resources into `Gateway`, `HTTPRoute`, `ReferenceGrant`, and any matching `SecurityPolicy`, `BackendTrafficPolicy`, or `ClientTrafficPolicy` resources. Compare each generated resource against the original `Ingress`.
+
+:::note
+We have a [conversion tool](#conversion-tool) provided to help you generate Gateway API resources from your existing `Ingress` YAML files.
+:::
+
+### Step 4: Validate the generated config
+
+Use `egctl` to translate the generated config and surface schema or semantic errors:
+
+```bash
+egctl experimental translate --type gateway-api --file generated.yaml --output yaml
+```
+
+### Step 5: Apply to a non-production cluster and test
+
+Apply to a non-production cluster running Calico Ingress Gateway. Exercise:
+
+- **TLS** — cert chain, SNI selection, redirect-to-HTTPS, HSTS
+- **Auth** — every protected route with valid and invalid credentials/tokens
+- **Rate limit** — confirm thresholds match expected behavior (note: NGINX uses leaky bucket, Envoy uses token bucket — same numeric limits, different burst semantics)
+- **Timeouts and retries** — under intentional upstream slowness or failures
+- **Session affinity** — repeated requests from the same client land on the same backend
+- **CORS** — preflight responses match NGINX's behavior on every protected origin
+
+### Step 6: Run in parallel in production
+
+Deploy Calico Ingress Gateway alongside the existing NGINX Ingress controller. Shift traffic gradually using one of:
+
+- DNS weighting between two LoadBalancer addresses
+- Header-based or query-param-based routing in front of both
+- Percentage canary at the edge load balancer
+
+Keep NGINX live and serving traffic until parity is proven under representative load. This is also your rollback path: if Calico Ingress Gateway misbehaves, shift traffic back to NGINX with a DNS change or by reversing the percentage shift.
+
+### Step 7: Remove NGINX
+
+Once parity is proven and traffic is fully on Calico Ingress Gateway, retire the NGINX Ingress controller and delete the `Ingress` resources.
+
+## Common problems
+
+- **Snippet annotations silently dropped.** ingress-nginx 1.15+ silently drops Ingresses that contain SSL variables in `configuration-snippet` or `server-snippet`. If your migration notes a bunch of "missing" routes after the switchover, check whether they relied on snippets.
+- **Annotation prefix detection.** The converter auto-detects `nginx.ingress.kubernetes.io/` vs `nginx.org/`/`nginx.com/`. Double-check on a representative sample before bulk-converting.
+- **Envoy Gateway version skew.** Some fields (e.g. `SecurityPolicy.spec.tls` vs `ClientTrafficPolicy.spec.tls`) moved between EG releases. Calico Ingress Gateway currently ships EG 1.5.x; verify the generated YAML against the version actually deployed in your cluster, not against EG documentation.
+- **Rate-limit semantics differ.** NGINX uses leaky bucket; Envoy uses token bucket. Same numeric limits will behave differently under burst traffic.
+- **`ReferenceGrant` is not optional.** Cross-namespace references (`HTTPRoute` → `Service`, `Gateway` → TLS `Secret`) require an explicit `ReferenceGrant`. The converter generates these, but if you hand-edit the output it's easy to drop one and end up with silently broken routing.
+
+## Conversion tool
+
+The [conversion tool](https://tigera.github.io/ing2gw/) drafts Gateway API resources from existing `Ingress` YAML files. Paste one or more `Ingress` objects into the input pane and the tool returns:
+
+- A multi-document YAML with `Gateway`, `HTTPRoute`, `ReferenceGrant`, and any matching `SecurityPolicy`, `BackendTrafficPolicy`, or `ClientTrafficPolicy` resources for the supported NGINX annotations.
+- A migration playbook in markdown describing what was converted, what was skipped, and any unsupported annotations alongside workarounds in Envoy terms.
+
+It auto-detects the annotation prefix (community NGINX vs NGINX Inc / F5) and supports both controllers. Everything runs in your browser — no YAML leaves your machine. The full annotation reference (which annotations convert cleanly and which need human judgment) lives [on the tool's site](https://tigera.github.io/ing2gw/#/reference).
+
+:::warning The output is a starting draft, not a finished migration
+Every generated resource must be reviewed, validated with `egctl`, tested in a non-production cluster, and proven at parity with your existing NGINX setup before switching production traffic over. The tool may emit incorrect or incomplete output for edge cases — verify each resource against your live config and exercise it with representative traffic before taking it to production.
+:::
+
+## Need help?
+
+Ask on the [Calico Users Slack](https://calicousers.slack.com/) for community help. For complex migrations (hundreds of `Ingress` resources, custom NGINX snippets, mTLS, NGINX Plus features), [talk to a Tigera engineer](https://www.tigera.io/contact/).

--- a/calico/networking/ingress-gateway/migrate-from-nginx.mdx
+++ b/calico/networking/ingress-gateway/migrate-from-nginx.mdx
@@ -50,13 +50,15 @@ Translate your `Ingress` resources into `Gateway`, `HTTPRoute`, `ReferenceGrant`
 We have a [conversion tool](#conversion-tool) provided to help you generate Gateway API resources from your existing `Ingress` YAML files.
 :::
 
-### Step 4: Validate the generated config
+### Step 4: Validate the resources
 
-Use `egctl` to translate the generated config and surface schema or semantic errors:
+Run `egctl experimental translate` on the resources you authored in Step 3 to surface schema or semantic errors before applying anything to a cluster:
 
 ```bash
-egctl experimental translate --type gateway-api --file generated.yaml --output yaml
+egctl experimental translate --type gateway-api --file gateway-api.yaml --output yaml
 ```
+
+Replace `gateway-api.yaml` with the path to your authored (or generated) Gateway API manifest.
 
 ### Step 5: Apply to a non-production cluster and test
 

--- a/calico_versioned_docs/version-3.31/networking/ingress-gateway/migrate-from-nginx.mdx
+++ b/calico_versioned_docs/version-3.31/networking/ingress-gateway/migrate-from-nginx.mdx
@@ -46,7 +46,7 @@ kubectl get ingress,service,secret -A -o yaml > pre-migration.yaml
 
 Translate your `Ingress` resources into `Gateway`, `HTTPRoute`, `ReferenceGrant`, and any matching `SecurityPolicy`, `BackendTrafficPolicy`, or `ClientTrafficPolicy` resources. Compare each generated resource against the original `Ingress`.
 
-:::note
+:::info
 We have a [conversion tool](#conversion-tool) provided to help you generate Gateway API resources from your existing `Ingress` YAML files.
 :::
 
@@ -100,7 +100,9 @@ The [conversion tool](https://tigera.github.io/ing2gw/) drafts Gateway API resou
 
 It auto-detects the annotation prefix (community NGINX vs NGINX Inc / F5) and supports both controllers. Everything runs in your browser — no YAML leaves your machine. The full annotation reference (which annotations convert cleanly and which need human judgment) lives [on the tool's site](https://tigera.github.io/ing2gw/#/reference).
 
-:::warning[The output is a starting draft, not a finished migration]
+:::caution[Important]
+The output is a starting draft, not a finished migration.
+
 Every generated resource must be reviewed, validated with `egctl`, tested in a non-production cluster, and proven at parity with your existing NGINX setup before switching production traffic over. The tool may emit incorrect or incomplete output for edge cases — verify each resource against your live config and exercise it with representative traffic before taking it to production.
 :::
 

--- a/calico_versioned_docs/version-3.31/networking/ingress-gateway/migrate-from-nginx.mdx
+++ b/calico_versioned_docs/version-3.31/networking/ingress-gateway/migrate-from-nginx.mdx
@@ -9,7 +9,7 @@ Calico Ingress Gateway, powered by Envoy Gateway, is a replacement for NGINX Ing
 
 This page covers the conceptual mapping from NGINX Ingress to Calico Ingress Gateway, a step-by-step migration workflow, and common problems to watch for.
 
-:::tip Ready to migrate?
+:::tip[Ready to migrate?]
 If you already understand how Gateway API differs from NGINX Ingress, jump ahead to the [migration workflow](#migration-workflow). We also provide an optional [conversion tool](#conversion-tool) for your convenience.
 :::
 
@@ -100,7 +100,7 @@ The [conversion tool](https://tigera.github.io/ing2gw/) drafts Gateway API resou
 
 It auto-detects the annotation prefix (community NGINX vs NGINX Inc / F5) and supports both controllers. Everything runs in your browser — no YAML leaves your machine. The full annotation reference (which annotations convert cleanly and which need human judgment) lives [on the tool's site](https://tigera.github.io/ing2gw/#/reference).
 
-:::warning The output is a starting draft, not a finished migration
+:::warning[The output is a starting draft, not a finished migration]
 Every generated resource must be reviewed, validated with `egctl`, tested in a non-production cluster, and proven at parity with your existing NGINX setup before switching production traffic over. The tool may emit incorrect or incomplete output for edge cases — verify each resource against your live config and exercise it with representative traffic before taking it to production.
 :::
 

--- a/calico_versioned_docs/version-3.31/networking/ingress-gateway/migrate-from-nginx.mdx
+++ b/calico_versioned_docs/version-3.31/networking/ingress-gateway/migrate-from-nginx.mdx
@@ -1,0 +1,109 @@
+---
+description: Migrate NGINX Ingress resources to Calico Ingress Gateway with a step-by-step workflow and an optional conversion tool.
+title: Migrating from NGINX
+---
+
+# Migrating from NGINX Ingress
+
+Calico Ingress Gateway, powered by Envoy Gateway, is a replacement for NGINX Ingress on Kubernetes clusters. NGINX Ingress Controller [retired in March 2026](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/) and no longer receives releases, bug fixes, or security patches.
+
+This page covers the conceptual mapping from NGINX Ingress to Calico Ingress Gateway, a step-by-step migration workflow, and common problems to watch for.
+
+:::tip Ready to migrate?
+If you already understand how Gateway API differs from NGINX Ingress, jump ahead to the [migration workflow](#migration-workflow). We also provide an optional [conversion tool](#conversion-tool) for your convenience.
+:::
+
+## Why Gateway API
+
+NGINX Ingress encodes behavior in vendor-specific annotation strings on `Ingress` objects. Gateway API encodes the same behavior in typed CRDs that any conformant controller (such as Envoy Gateway, Istio, Cilium, and kgateway) can read. The mental shift:
+
+| NGINX Ingress | Gateway API + Calico Ingress Gateway |
+| --- | --- |
+| Annotation strings on `Ingress` | Typed fields on `HTTPRoute`, `SecurityPolicy`, `BackendTrafficPolicy`, `ClientTrafficPolicy` |
+| Behavior depends on which controller reads the annotation | Behavior depends on a policy's `targetRef` to a route or gateway |
+| Controller-specific snippets for advanced cases | `EnvoyPatchPolicy` or Lua filters for advanced cases |
+| Single resource owns routing, TLS, security, traffic shaping | Concerns split across `Gateway`, `HTTPRoute`, and policy CRDs |
+
+## Migration workflow
+
+### Step 1: Create an inventory
+
+Catalogue every `Ingress` resource and the annotations it uses. Note the annotation prefix (community NGINX uses `nginx.ingress.kubernetes.io/`; NGINX Inc / F5 uses `nginx.org/` and `nginx.com/`):
+
+```bash
+kubectl get ingress -A -o yaml
+```
+
+### Step 2: Back up your resources
+
+Export current `Ingress`, `Service`, and TLS `Secret` state to a file before changing anything:
+
+```bash
+kubectl get ingress,service,secret -A -o yaml > pre-migration.yaml
+```
+
+### Step 3: Author Gateway API resources
+
+Translate your `Ingress` resources into `Gateway`, `HTTPRoute`, `ReferenceGrant`, and any matching `SecurityPolicy`, `BackendTrafficPolicy`, or `ClientTrafficPolicy` resources. Compare each generated resource against the original `Ingress`.
+
+:::note
+We have a [conversion tool](#conversion-tool) provided to help you generate Gateway API resources from your existing `Ingress` YAML files.
+:::
+
+### Step 4: Validate the generated config
+
+Use `egctl` to translate the generated config and surface schema or semantic errors:
+
+```bash
+egctl experimental translate --type gateway-api --file generated.yaml --output yaml
+```
+
+### Step 5: Apply to a non-production cluster and test
+
+Apply to a non-production cluster running Calico Ingress Gateway. Exercise:
+
+- **TLS** — cert chain, SNI selection, redirect-to-HTTPS, HSTS
+- **Auth** — every protected route with valid and invalid credentials/tokens
+- **Rate limit** — confirm thresholds match expected behavior (note: NGINX uses leaky bucket, Envoy uses token bucket — same numeric limits, different burst semantics)
+- **Timeouts and retries** — under intentional upstream slowness or failures
+- **Session affinity** — repeated requests from the same client land on the same backend
+- **CORS** — preflight responses match NGINX's behavior on every protected origin
+
+### Step 6: Run in parallel in production
+
+Deploy Calico Ingress Gateway alongside the existing NGINX Ingress controller. Shift traffic gradually using one of:
+
+- DNS weighting between two LoadBalancer addresses
+- Header-based or query-param-based routing in front of both
+- Percentage canary at the edge load balancer
+
+Keep NGINX live and serving traffic until parity is proven under representative load. This is also your rollback path: if Calico Ingress Gateway misbehaves, shift traffic back to NGINX with a DNS change or by reversing the percentage shift.
+
+### Step 7: Remove NGINX
+
+Once parity is proven and traffic is fully on Calico Ingress Gateway, retire the NGINX Ingress controller and delete the `Ingress` resources.
+
+## Common problems
+
+- **Snippet annotations silently dropped.** ingress-nginx 1.15+ silently drops Ingresses that contain SSL variables in `configuration-snippet` or `server-snippet`. If your migration notes a bunch of "missing" routes after the switchover, check whether they relied on snippets.
+- **Annotation prefix detection.** The converter auto-detects `nginx.ingress.kubernetes.io/` vs `nginx.org/`/`nginx.com/`. Double-check on a representative sample before bulk-converting.
+- **Envoy Gateway version skew.** Some fields (e.g. `SecurityPolicy.spec.tls` vs `ClientTrafficPolicy.spec.tls`) moved between EG releases. Calico Ingress Gateway currently ships EG 1.5.x; verify the generated YAML against the version actually deployed in your cluster, not against EG documentation.
+- **Rate-limit semantics differ.** NGINX uses leaky bucket; Envoy uses token bucket. Same numeric limits will behave differently under burst traffic.
+- **`ReferenceGrant` is not optional.** Cross-namespace references (`HTTPRoute` → `Service`, `Gateway` → TLS `Secret`) require an explicit `ReferenceGrant`. The converter generates these, but if you hand-edit the output it's easy to drop one and end up with silently broken routing.
+
+## Conversion tool
+
+The [conversion tool](https://tigera.github.io/ing2gw/) drafts Gateway API resources from existing `Ingress` YAML files. Paste one or more `Ingress` objects into the input pane and the tool returns:
+
+- A multi-document YAML with `Gateway`, `HTTPRoute`, `ReferenceGrant`, and any matching `SecurityPolicy`, `BackendTrafficPolicy`, or `ClientTrafficPolicy` resources for the supported NGINX annotations.
+- A migration playbook in markdown describing what was converted, what was skipped, and any unsupported annotations alongside workarounds in Envoy terms.
+
+It auto-detects the annotation prefix (community NGINX vs NGINX Inc / F5) and supports both controllers. Everything runs in your browser — no YAML leaves your machine. The full annotation reference (which annotations convert cleanly and which need human judgment) lives [on the tool's site](https://tigera.github.io/ing2gw/#/reference).
+
+:::warning The output is a starting draft, not a finished migration
+Every generated resource must be reviewed, validated with `egctl`, tested in a non-production cluster, and proven at parity with your existing NGINX setup before switching production traffic over. The tool may emit incorrect or incomplete output for edge cases — verify each resource against your live config and exercise it with representative traffic before taking it to production.
+:::
+
+## Need help?
+
+Ask on the [Calico Users Slack](https://calicousers.slack.com/) for community help. For complex migrations (hundreds of `Ingress` resources, custom NGINX snippets, mTLS, NGINX Plus features), [talk to a Tigera engineer](https://www.tigera.io/contact/).

--- a/calico_versioned_docs/version-3.31/networking/ingress-gateway/migrate-from-nginx.mdx
+++ b/calico_versioned_docs/version-3.31/networking/ingress-gateway/migrate-from-nginx.mdx
@@ -50,13 +50,15 @@ Translate your `Ingress` resources into `Gateway`, `HTTPRoute`, `ReferenceGrant`
 We have a [conversion tool](#conversion-tool) provided to help you generate Gateway API resources from your existing `Ingress` YAML files.
 :::
 
-### Step 4: Validate the generated config
+### Step 4: Validate the resources
 
-Use `egctl` to translate the generated config and surface schema or semantic errors:
+Run `egctl experimental translate` on the resources you authored in Step 3 to surface schema or semantic errors before applying anything to a cluster:
 
 ```bash
-egctl experimental translate --type gateway-api --file generated.yaml --output yaml
+egctl experimental translate --type gateway-api --file gateway-api.yaml --output yaml
 ```
+
+Replace `gateway-api.yaml` with the path to your authored (or generated) Gateway API manifest.
 
 ### Step 5: Apply to a non-production cluster and test
 

--- a/calico_versioned_sidebars/version-3.31-sidebars.json
+++ b/calico_versioned_sidebars/version-3.31-sidebars.json
@@ -253,7 +253,8 @@
             "networking/ingress-gateway/about-calico-ingress-gateway",
             "networking/ingress-gateway/create-ingress-gateway",
             "networking/ingress-gateway/customize-ingress-gateway",
-            "networking/ingress-gateway/tutorial-ingress-gateway-canary"
+            "networking/ingress-gateway/tutorial-ingress-gateway-canary",
+            "networking/ingress-gateway/migrate-from-nginx"
           ]
         },
         {

--- a/sidebars-calico.js
+++ b/sidebars-calico.js
@@ -260,7 +260,8 @@ module.exports = {
             'networking/ingress-gateway/about-calico-ingress-gateway',
             'networking/ingress-gateway/create-ingress-gateway',
             'networking/ingress-gateway/customize-ingress-gateway',
-            'networking/ingress-gateway/tutorial-ingress-gateway-canary'
+            'networking/ingress-gateway/tutorial-ingress-gateway-canary',
+            'networking/ingress-gateway/migrate-from-nginx'
           ],
         },
         {

--- a/src/utils/linkChecker.js
+++ b/src/utils/linkChecker.js
@@ -22,6 +22,7 @@ const defaultSkipList = [
   /\/manifests\/alp\/istio-inject-configmap-$/,
   /^https?:\/\/auth\.calicocloud\.io/,
   /^https?:\/\/www\.calicocloud\.io/,
+  /^https?:\/\/hypershift-docs\.netlify\.app/,
   'https://en.wikipedia.org/wiki/Autonomous_System_(Internet',
   'https://github.com/dims/etcd3-gateway.git@5a3157a122368c2314c7a961f61722e47355f981',
   'https://installer.calicocloud.io:443/',


### PR DESCRIPTION
## Summary

Adds a step-by-step guide for migrating NGINX Ingress resources to Calico Ingress Gateway (Envoy Gateway).

The migration tool is **not embedded** in the docs anymore — it still runs entirely in the browser (no YAML leaves the user's machine), but now lives on its own site at [tigera.github.io/ing2gw](https://tigera.github.io/ing2gw/) and is linked from the guide.

## Why split the tool from the guide

The tool is a **draft generator**, not an authoritative migration. Embedding it directly in the docs gave readers the impression that paste-in / paste-out was a complete migration. Splitting the two keeps the docs as the source of truth on the *process* (review, validate with `egctl`, stage, parallel run, switchover) and lets the tool iterate on its own cadence without docs PRs.

## Changes

- **New:** `calico/networking/ingress-gateway/migrate-from-nginx.mdx` (current + v3.31)
- **Modified:** Sidebar configs add the "Migrating from NGINX" entry under Ingress gateway
- **Removed:** Earlier embedded `<IngressConverter />` wrapper, vendored `@tigera/ingress-to-gateway-web` bundle, `marked` dep, and the GitHub Packages auth step in `vale.yml` (no longer needed)
- **Vocab:** Add `cutover`, `conformant`, `reimplement` to `CalicoTerminology`; add `Lua`, `kgateway` to `CalicoBrands`

## Test plan

- [ ] CI passes (vale, build, deploy previews)
- [ ] Page renders at `/calico/latest/networking/ingress-gateway/migrate-from-nginx`
- [ ] Versioned page renders at `/calico/3.31/...`
- [ ] All external links resolve (tigera.github.io/ing2gw, kubernetes.io retirement post, calicousers.slack.com, tigera.io/contact)
- [ ] Top admonition renders as a tip; bottom one as a warning