### PR TITLE
Fix dead RKE1 cluster config link in Rancher docs

### DIFF
--- a/calico/getting-started/kubernetes/rancher.mdx
+++ b/calico/getting-started/kubernetes/rancher.mdx
@@ -26,7 +26,7 @@ The geeky details of what you get:
 
 - A compatible [Rancher Kubernetes Engine cluster](https://rancher.com/docs/rke/latest/en/) with version 1.3
 
-  - Configure your cluster with a [Cluster Config File](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#rke-cluster-config-file-reference) and specify [no network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) by setting `plugin: none` under `network` in your configuration file.
+  - Configure your cluster with a [Cluster Config File](https://ranchermanager.docs.rancher.com/v2.10/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#rke-cluster-config-file-reference) and specify [no network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) by setting `plugin: none` under `network` in your configuration file.
 
 - RKE cluster meets the [$[prodname] requirements](requirements.mdx)
 

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/rancher.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/rancher.mdx
@@ -26,7 +26,7 @@ The geeky details of what you get:
 
 - A compatible [Rancher Kubernetes Engine cluster](https://rancher.com/docs/rke/latest/en/) with version 1.3
 
-  - Configure your cluster with a [Cluster Config File](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#rke-cluster-config-file-reference) and specify [no network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) by setting `plugin: none` under `network` in your configuration file.
+  - Configure your cluster with a [Cluster Config File](https://ranchermanager.docs.rancher.com/v2.10/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#rke-cluster-config-file-reference) and specify [no network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) by setting `plugin: none` under `network` in your configuration file.
 
 - RKE cluster meets the [$[prodname] requirements](requirements.mdx)
 

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/rancher.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/rancher.mdx
@@ -26,7 +26,7 @@ The geeky details of what you get:
 
 - A compatible [Rancher Kubernetes Engine cluster](https://rancher.com/docs/rke/latest/en/) with version 1.3
 
-  - Configure your cluster with a [Cluster Config File](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#rke-cluster-config-file-reference) and specify [no network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) by setting `plugin: none` under `network` in your configuration file.
+  - Configure your cluster with a [Cluster Config File](https://ranchermanager.docs.rancher.com/v2.10/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#rke-cluster-config-file-reference) and specify [no network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) by setting `plugin: none` under `network` in your configuration file.
 
 - RKE cluster meets the [$[prodname] requirements](requirements.mdx)
 

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/rancher.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/rancher.mdx
@@ -26,7 +26,7 @@ The geeky details of what you get:
 
 - A compatible [Rancher Kubernetes Engine cluster](https://rancher.com/docs/rke/latest/en/) with version 1.3
 
-  - Configure your cluster with a [Cluster Config File](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#rke-cluster-config-file-reference) and specify [no network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) by setting `plugin: none` under `network` in your configuration file.
+  - Configure your cluster with a [Cluster Config File](https://ranchermanager.docs.rancher.com/v2.10/reference-guides/cluster-configuration/rancher-server-configuration/rke1-cluster-configuration#rke-cluster-config-file-reference) and specify [no network plugin](https://rancher.com/docs/rke/latest/en/config-options/add-ons/network-plugins/) by setting `plugin: none` under `network` in your configuration file.
 
 - RKE cluster meets the [$[prodname] requirements](requirements.mdx)
 


### PR DESCRIPTION
The Rancher docs removed RKE1 content from their latest version after RKE1 hit EOL in July 2025. This pins the link to the v2.10 versioned URL, which is the last version that still has the RKE1 cluster config file reference.

Fixes the dead link that's failing the Netlify build link checker.