### PR TITLE
Inject x-proxy-secret header when proxying to tag site

### DIFF
--- a/netlify/edge-functions/tag-auth.js
+++ b/netlify/edge-functions/tag-auth.js
@@ -10,13 +10,15 @@ export default async (request, context) => {
 
   const cookie = request.headers.get('cookie') || '';
 
-  // Already authenticated — proxy to the private site
+  // Already authenticated — proxy to the private site with shared secret
   if (cookie.includes('tag_auth=authorized')) {
     const url = new URL(request.url);
     const path = url.pathname.replace(/^\/tag/, '') || '/';
     const target = `https://tag-docs-tigera.netlify.app/tag${path}${url.search}`;
+    const proxyHeaders = new Headers(request.headers);
+    proxyHeaders.set('x-proxy-secret', Netlify.env.get('PROXY_SECRET'));
     return fetch(target, {
-      headers: request.headers,
+      headers: proxyHeaders,
     });
   }
 


### PR DESCRIPTION
## Summary

- After the existing password challenge passes, the main site's edge function now injects an `x-proxy-secret` header (from the `PROXY_SECRET` env var) when proxying requests to the tag site.
- This allows the tag site to verify that traffic arrived through the main site's auth layer, enabling it to reject direct access to its own URL.

## Netlify setup required

Set `PROXY_SECRET` on **both** Netlify sites to the same value (generate with `openssl rand -hex 32`). The tag site changes (gate function) will be submitted separately.

## Test plan

- [ ] Set `PROXY_SECRET` on both Netlify sites (same value)
- [ ] Verify `docs.tigera.io/tag/` still works end-to-end through the password challenge
- [ ] Verify the `x-proxy-secret` header is forwarded correctly to the tag site

🤖 Generated with [Claude Code](https://claude.com/claude-code)