### PR TITLE
Use helm template + kubectl apply for CRD charts

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -93,10 +93,10 @@ To install a standard $[prodname] cluster with Helm:
         }
     </CodeBlock>
 
-1. Create the necessary custom resource definitions.
+1. Install the necessary custom resource definitions.
 
    ```bash
-   helm install calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz --namespace tigera-operator --create-namespace
+   helm template calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz | kubectl apply --server-side -f -
    ```
 
 1. Install the Tigera Operator using the Helm 3 chart:
@@ -105,7 +105,8 @@ To install a standard $[prodname] cluster with Helm:
    helm install $[prodnamedash] tigera-operator-$[chart_version_name].tgz \
    --set-file imagePullSecrets.tigera-pull-secret=<path/to/pull/secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path/to/pull/secret> \
    --set-file licenseKeyContent=<path/to/license/file/yaml> \
-   --namespace tigera-operator
+   --namespace tigera-operator \
+   --create-namespace
    ```
 
    or if you created a `values.yaml` above:
@@ -114,7 +115,8 @@ To install a standard $[prodname] cluster with Helm:
    helm install $[prodnamedash] tigera-operator-$[chart_version_name].tgz -f values.yaml \
    --set-file imagePullSecrets.tigera-pull-secret=<path/to/pull/secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path/to/pull/secret> \
    --set-file licenseKeyContent=<path/to/license/file/yaml> \
-   --namespace tigera-operator
+   --namespace tigera-operator \
+   --create-namespace
    ```
 1. You can now monitor progress with the following command:
 

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -122,10 +122,10 @@ To install a $[prodname] [managed](../standard-install/create-a-managed-cluster#
         key: $MANAGED_CLUSTER_KEY" >> values.yaml
   ```
 
-1. Create the necessary custom resource definitions.
+1. Install the necessary custom resource definitions.
 
   ```bash
-  helm install calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz --namespace tigera-operator --create-namespace
+  helm template calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz | kubectl apply --server-side -f -
   ```
 
 1. Install the Tigera Operator using the Helm 3 chart:
@@ -136,12 +136,14 @@ To install a $[prodname] [managed](../standard-install/create-a-managed-cluster#
 --set-file imagePullSecrets.tigera-pull-secret=<path/to/pull/secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path/to/pull/secret> \\
 --set-file licenseKeyContent=<path/to/license/file/yaml> \\
 --set logStorage.enabled=false --set manager.enabled=false \\
---namespace tigera-operator`
+--namespace tigera-operator \\
+--create-namespace`
        : `helm install $[prodnamedash] tigera-operator-$[chart_version_name].tgz -f values.yaml \\
 --set-file imagePullSecrets.tigera-pull-secret=<path/to/pull/secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path/to/pull/secret> \\
 --set-file licenseKeyContent=<path/to/license/file/yaml> \\
 --set logStorage.enabled=false --set manager.enabled=false \\
---namespace tigera-operator`}
+--namespace tigera-operator \\
+--create-namespace`}
   </CodeBlock>
 
 1. You can now monitor progress with the following command:

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -142,10 +142,10 @@ To install a $[prodname] [management](create-a-management-cluster-helm#value) cl
       certificate: $MANAGED_CLUSTER_CERTIFICATE" >> values.yaml
   ```
 
-1. Create the necessary custom resource definitions.
+1. Install the necessary custom resource definitions.
 
   ```bash
-  helm install calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz --namespace tigera-operator --create-namespace
+  helm template calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz | kubectl apply --server-side -f -
   ```
 
 1. Install the Tigera Operator using the Helm 3 chart:
@@ -155,11 +155,13 @@ To install a $[prodname] [management](create-a-management-cluster-helm#value) cl
        ? `helm install $[prodnamedash] tigera/tigera-operator --version tigera-operator-v0.0 -f values.yaml \\
 --set-file imagePullSecrets.tigera-pull-secret=<path/to/pull/secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path/to/pull/secret> \\
 --set-file licenseKeyContent=<path/to/license/file/yaml> \\
---namespace tigera-operator`
+--namespace tigera-operator \\
+--create-namespace`
        : `helm install $[prodnamedash] tigera-operator-$[chart_version_name].tgz -f values.yaml \\
 --set-file imagePullSecrets.tigera-pull-secret=<path/to/pull/secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path/to/pull/secret> \\
 --set-file licenseKeyContent=<path/to/license/file/yaml> \\
---namespace tigera-operator`}
+--namespace tigera-operator \\
+--create-namespace`}
   </CodeBlock>
 
 1. You can now monitor progress with the following command:
@@ -236,10 +238,10 @@ For example, if you are using EKS, you must meet the requirements defined in [cr
         value: "internet-facing"
   ```
 
-1. Create the necessary custom resource definitions.
+1. Install the necessary custom resource definitions.
 
   ```bash
-  helm install calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz --namespace tigera-operator --create-namespace
+  helm template calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz | kubectl apply --server-side -f -
   ```
 
 1. Install the Tigera Operator using the Helm 3 chart:
@@ -249,11 +251,13 @@ For example, if you are using EKS, you must meet the requirements defined in [cr
        ? `helm install $[prodnamedash] tigera/tigera-operator --version tigera-operator-v0.0 -f values.yaml \\
 --set-file imagePullSecrets.tigera-pull-secret=<path/to/pull/secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path/to/pull/secret> \\
 --set-file licenseKeyContent=<path/to/license/file/yaml> \\
---namespace tigera-operator`
+--namespace tigera-operator \\
+--create-namespace`
        : `helm install $[prodnamedash] tigera-operator-$[chart_version_name].tgz -f values.yaml \\
 --set-file imagePullSecrets.tigera-pull-secret=<path/to/pull/secret>,tigera-prometheus-operator.imagePullSecrets.tigera-pull-secret=<path/to/pull/secret> \\
 --set-file licenseKeyContent=<path/to/license/file/yaml> \\
---namespace tigera-operator`}
+--namespace tigera-operator \\
+--create-namespace`}
   </CodeBlock>
 
 1. You can now monitor progress with the following command:

--- a/calico-enterprise/operations/native-v3-crds.mdx
+++ b/calico-enterprise/operations/native-v3-crds.mdx
@@ -70,7 +70,7 @@ Select the method below based on your preferred installation method.
 1. Install the v3 CRD chart instead of the default v1 CRD chart:
 
    ```bash
-   helm install calico-crds projectcalico/projectcalico.org.v3 --version $[releaseTitle] --namespace tigera-operator
+   helm template calico-crds projectcalico/projectcalico.org.v3 --version $[releaseTitle] | kubectl apply --server-side -f -
    ```
 
    :::note

--- a/calico/getting-started/kubernetes/helm.mdx
+++ b/calico/getting-started/kubernetes/helm.mdx
@@ -79,10 +79,10 @@ For more information about configurable options via `values.yaml` please see [He
    kubectl create namespace tigera-operator
    ```
 
-1. Create the necessary custom resource definitions.
+1. Install the necessary custom resource definitions.
 
    ```bash
-   helm install calico-crds projectcalico/crd.projectcalico.org.v1 --version $[releaseTitle] --namespace tigera-operator
+   helm template calico-crds projectcalico/crd.projectcalico.org.v1 --version $[releaseTitle] | kubectl apply --server-side -f -
    ```
 
    :::tip
@@ -90,7 +90,7 @@ For more information about configurable options via `values.yaml` please see [He
    To install with [native v3 CRDs](../../operations/native-v3-crds.mdx) (tech preview) instead, use the v3 CRD chart:
 
    ```bash
-   helm install calico-crds projectcalico/projectcalico.org.v3 --version $[releaseTitle] --namespace tigera-operator
+   helm template calico-crds projectcalico/projectcalico.org.v3 --version $[releaseTitle] | kubectl apply --server-side -f -
    ```
 
    Native v3 CRDs eliminate the need for the aggregation API server and allows `kubectl` to manage `projectcalico.org/v3` resources directly.

--- a/calico/operations/native-v3-crds.mdx
+++ b/calico/operations/native-v3-crds.mdx
@@ -70,7 +70,7 @@ Select the method below based on your preferred installation method.
 1. Install the v3 CRD chart instead of the default v1 CRD chart:
 
    ```bash
-   helm install calico-crds projectcalico/projectcalico.org.v3 --version $[releaseTitle] --namespace tigera-operator
+   helm template calico-crds projectcalico/projectcalico.org.v3 --version $[releaseTitle] | kubectl apply --server-side -f -
    ```
 
    :::note


### PR DESCRIPTION
The CRD Helm charts have grown large enough to exceed the 1MB Kubernetes Secret size limit that Helm uses for release tracking. Since CRDs don't actually need Helm release management, this switches to `helm template` piped to `kubectl apply --server-side` instead.

Also moves `--create-namespace` to the operator `helm install` step in the enterprise docs, since the CRD step no longer needs a namespace.

Fixes CORE-12633