### PR TITLE
Fix broken link in license-options.mdx

### DIFF
--- a/calico-enterprise/operations/license-options.mdx
+++ b/calico-enterprise/operations/license-options.mdx
@@ -42,6 +42,6 @@ To route these alerts, see [Configure Alertmanager](monitor/prometheus/alertmana
 
 ## Additional resources
 
-- [LicenseKey resource](../../reference/resources/licensekey.mdx)
+- [LicenseKey resource](../reference/resources/licensekey.mdx)
 - [Configure Alertmanager](monitor/prometheus/alertmanager.mdx)
 - [Configure Prometheus](monitor/prometheus/configure-prometheus.mdx)


### PR DESCRIPTION
## Summary
- Fixes the Netlify production build failure on `main@f97d764`
- The link `../../reference/resources/licensekey.mdx` in `calico-enterprise/operations/license-options.mdx` resolved outside the `calico-enterprise/` plugin, causing the MDX compiler to fail. Corrected to `../reference/resources/licensekey.mdx`.

## Test plan
- [ ] Netlify deploy preview succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)