### PR TITLE
Cloud: Add IdP group limitations for org-level permissions

### DIFF
--- a/calico-cloud/users/create-custom-role-for-entra-id-group.mdx
+++ b/calico-cloud/users/create-custom-role-for-entra-id-group.mdx
@@ -10,6 +10,15 @@ import IconUser from '/img/icons/user-icon.svg';
 If you have Microsoft Entra&nbsp;ID configured as your identity provider, you can define role-based access in Calico Cloud and assign roles to an Entra&nbsp;ID (formerly Azure AD) security group.
 By managing membership in that security group, you can manage role-based access to Calico Cloud directly from your identity provider portal.
 
+## Limitations
+
+The following organization-level permissions cannot be assigned through IdP groups:
+
+- Manage Team
+- Usage Metrics
+
+To grant these permissions, assign them directly to individual users in the Calico Cloud web console.
+
 ## Prerequisites
 
 * You are signed in to the web console with owner or administrator permissions.

--- a/calico-cloud_versioned_docs/version-22-2/users/create-custom-role-for-entra-id-group.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/users/create-custom-role-for-entra-id-group.mdx
@@ -10,6 +10,15 @@ import IconUser from '/img/icons/user-icon.svg';
 If you have Microsoft Entra&nbsp;ID configured as your identity provider, you can define role-based access in Calico Cloud and assign roles to an Entra&nbsp;ID (formerly Azure AD) security group.
 By managing membership in that security group, you can manage role-based access to Calico Cloud directly from your identity provider portal.
 
+## Limitations
+
+The following organization-level permissions cannot be assigned through IdP groups:
+
+- Manage Team
+- Usage Metrics
+
+To grant these permissions, assign them directly to individual users in the Calico Cloud web console.
+
 ## Prerequisites
 
 * You are signed in to the web console with owner or administrator permissions.


### PR DESCRIPTION
Product Version(s):
Calico Cloud

Issue:
Picks up stale work from #2576. Users need to know that certain organization-level permissions (Manage Team, Usage Metrics) cannot be assigned through IdP groups.

## Summary
- Adds a **Limitations** section before Prerequisites documenting which org-level permissions cannot be assigned through IdP groups
- Includes workaround: assign permissions directly to individual users in the web console
- Applied to both vNext and v22-2

Closes #2576

🤖 Generated with [Claude Code](https://claude.com/claude-code)