### PR TITLE
fix: add section on allowing encapsulated traffic for HCP clusters

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/openshift/hostedcontrolplanes.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/openshift/hostedcontrolplanes.mdx
@@ -156,6 +156,13 @@ If you have provided a `calico-resources` configmap and the tigera-operator pod 
 check the output of the init-container with `oc logs -n tigera-operator -l k8s-app=tigera-operator -c create-initial-resources`.
 :::
 
+### Ensure encapsulated traffic is allowed on the hosting cluster
+
+By default, Calico drops encapsulated packets (IP-in-IP or VXLAN) originating from workloads. This can prevent communication between KubeVirt pods across nodes.
+If your hosted cluster uses encapsulation, you must allow this traffic on the hosting cluster.
+
+Set `allowIPIPPacketsFromWorkloads: true` or `allowVXLANPacketsFromWorkloads: true` in the [FelixConfiguration](../../../reference/resources/felixconfig.mdx) on the hosting cluster, depending on the encapsulation mode used by your hosted cluster.
+
 ### Apply the $[prodname] install manifests
 
 Apply the install manifests paying attention to the required order. First apply all necessary manifests to install the Tigera Operator:

--- a/calico/getting-started/kubernetes/openshift/hostedcontrolplanes.mdx
+++ b/calico/getting-started/kubernetes/openshift/hostedcontrolplanes.mdx
@@ -139,6 +139,13 @@ If you have provided a `calico-resources` configmap and the tigera-operator pod 
 check the output of the init-container with `oc logs -n tigera-operator -l k8s-app=tigera-operator -c create-initial-resources`.
 :::
 
+### Ensure encapsulated traffic is allowed on the hosting cluster
+
+By default, Calico drops encapsulated packets (IP-in-IP or VXLAN) originating from workloads. This can prevent communication between KubeVirt pods across nodes.
+If your hosted cluster uses encapsulation, you must allow this traffic on the hosting cluster.
+
+Set `allowIPIPPacketsFromWorkloads: true` or `allowVXLANPacketsFromWorkloads: true` in the [FelixConfiguration](../../../reference/resources/felixconfig.mdx) on the hosting cluster, depending on the encapsulation mode used by your hosted cluster.
+
 ### Apply the $[prodname] install manifests
 
 Apply the install manifests paying attention to the required order. First apply all necessary manifests to install the Tigera Operator:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):

<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Calico, Calico Enterprise

This update clarifies a networking requirement when running KubeVirt workloads in hosted clusters with encapsulation.

By default, Calico drops encapsulated traffic (IP-in-IP or VXLAN) originating from workloads for security reasons. This can prevent communication between KubeVirt pods across nodes.