### PR TITLE
DOCS-2875: Publish Calico Open Source 3.31.5

### DIFF
--- a/calico_versioned_docs/version-3.31/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.31/release-notes/index.mdx
@@ -317,3 +317,15 @@ February 20, 2025
 #### Updating
 
 To update a previous version of Calico, see [our upgrade guides](../operations/upgrading/index.mdx).
+
+### Calico Open Source 3.31.5 bug fix release
+
+April 14, 2026
+
+#### Bug fixes
+
+- TBD
+
+#### Updating
+
+To update a previous version of Calico, see [our upgrade guides](../operations/upgrading/index.mdx).

--- a/calico_versioned_docs/version-3.31/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.31/release-notes/index.mdx
@@ -290,10 +290,6 @@ To update a previous version of Calico, see [our upgrade guides](../operations/u
 
 February 20, 2025
 
-### Enhancements
-
-* TBD
-
 #### Bug fixes
 
 - Fix race in EndpointSlice logic for BGP service advertisement [calico 11786](https://github.com/projectcalico/calico/pull/11786) (@MichalFupso)
@@ -324,7 +320,24 @@ April 14, 2026
 
 #### Bug fixes
 
-- TBD
+- Fix memory leak in LoadBalancer controller where `deleteService` and `releaseAddressFromService` left stale entries in the `ipsByBlock` index, causing unbounded memory growth in kube-controllers in clusters with high LoadBalancer service churn. [calico 12369](https://github.com/projectcalico/calico/pull/12369) (@caseydavenport)
+- ebpf: Fix  conntrack counter accounting for NAT-outgoing flows where bytes_in and packets_in were always zero. [calico 12324](https://github.com/projectcalico/calico/pull/12324) (@lucastigera)
+- ebpf: Fix that BPF programs could be incorrectly removed from workload interfaces on recent kernels due to change in kernel use of IFLA_LINK netlink message. [calico 12210](https://github.com/projectcalico/calico/pull/12210) (@tomastigera)
+- Fix memory leak in routing table logic. The "interfaces to ARP" set was not properly cleaned out when an interface was removed, resulting in leaving old interface names in the set. [calico 12193](https://github.com/projectcalico/calico/pull/12193) (@fasaxc)
+- Fix a goroutine leak in Felix's interface monitor that could occur on netlink reconnect. [calico 12193](https://github.com/projectcalico/calico/pull/12193) (@fasaxc)
+- Fix goroutine leak after nflog reader restart. [calico 12193](https://github.com/projectcalico/calico/pull/12193) (@fasaxc)
+- Fix BGP syncing on Windows [calico 12063](https://github.com/projectcalico/calico/pull/12063) (@rbrtbnfgl)
+- Fix failure to enable ingress bandwidth QoS controls when a non-default qdisc previously existed on the workload interface (handle != 0). [calico 11972](https://github.com/projectcalico/calico/pull/11972) (@coutinhop)
+- Fix CNI delete timeout to start after IPAM lock acquisition, preventing "context deadline exceeded" failures during high pod churn [calico 11942](https://github.com/projectcalico/calico/pull/11942) (@sridhartigera)
+- LoadBalancer controller prevent nil pointer dereference in handleBlockUpdate [calico 11924](https://github.com/projectcalico/calico/pull/11924) (@MichalFupso)
+- ebpf: corrected setting of bpf_skb_adjust_room flags for UDP [calico 11661](https://github.com/projectcalico/calico/pull/11661) (@tomastigera)
+
+#### Other changes
+
+- ebpf: Add JSON output support to calico-bpf dump commands (counters, conntrack, NAT, routes, arp, ifstate, maps) [calico 12313](https://github.com/projectcalico/calico/pull/12313) (@tomastigera)
+- Use indexer for EndpointSlice lookups to avoid O(n) scans in confd [calico 11936](https://github.com/projectcalico/calico/pull/11936) (@haojiwu)
+- Skip nftables cache reload for cleaned disabled tables [calico 11869](https://github.com/projectcalico/calico/pull/11869) (@haojiwu)
+- ebpf:  Added support to Kubernetes Service Traffic Distribution for Services and for the `service.kubernetes.io/topology-mode` annotation, replacing the deprecated `service.kubernetes.io/topology-aware-hints` behavior. [calico 11859](https://github.com/projectcalico/calico/pull/11859) (@lucastigera)
 
 #### Updating
 

--- a/calico_versioned_docs/version-3.31/releases.json
+++ b/calico_versioned_docs/version-3.31/releases.json
@@ -4,7 +4,7 @@
     "tigera-operator": {
       "image": "tigera/operator",
       "registry": "quay.io",
-      "version": "vTBD"
+      "version": "v1.40.8"
     },
     "components": {
       "calico/typha": {

--- a/calico_versioned_docs/version-3.31/releases.json
+++ b/calico_versioned_docs/version-3.31/releases.json
@@ -1,5 +1,103 @@
 [
   {
+    "title": "v3.31.5",
+    "tigera-operator": {
+      "image": "tigera/operator",
+      "registry": "quay.io",
+      "version": "vTBD"
+    },
+    "components": {
+      "calico/typha": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/ctl": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/node": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/node-windows": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/cni": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/cni-windows": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/apiserver": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/kube-controllers": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/envoy-gateway": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/envoy-proxy": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/envoy-ratelimit": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/flannel-migration-controller": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "flannel": {
+        "version": "v0.24.4",
+        "registry": "docker.io"
+      },
+      "calico/dikastes": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "flexvol": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/csi": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/node-driver-registrar": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/pod2daemon-flexvol": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/key-cert-provisioner": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/goldmane": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/whisker": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      },
+      "calico/whisker-backend": {
+        "version": "v3.31.5",
+        "registry": "quay.io"
+      }
+    }
+  },
+  {
     "title": "v3.31.4",
     "tigera-operator": {
       "image": "tigera/operator",

--- a/calico_versioned_docs/version-3.31/variables.js
+++ b/calico_versioned_docs/version-3.31/variables.js
@@ -1,7 +1,7 @@
 const releases = require('./releases.json');
 
 const variables = {
-  releaseTitle: 'v3.31.4',
+  releaseTitle: 'v3.31.5',
   prodname: 'Calico',
   prodnamedash: 'calico',
   version: 'v3.31',
@@ -16,7 +16,7 @@ const variables = {
   noderunning: 'calico-node',
   rootDirWindows: 'C:\\CalicoWindows',
   ppa_repo_name: 'calico-3.31',
-  manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.31.4',
+  manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.31.5',
   releases,
   registry: '',
   vppbranch: 'v3.31.0',


### PR DESCRIPTION
## Summary
- Update `variables.js` with v3.31.5 release title and manifests URL
- Add v3.31.5 entry to `releases.json` with placeholder operator version
- Add placeholder release notes to `release-notes/index.mdx`

## Test plan
- [ ] Verify release notes page renders correctly
- [ ] Confirm version numbers in install/upgrade pages point to v3.31.5
- [ ] Fill in actual release notes content and operator version from release engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)