### PR TITLE
docs(openstack): remove python-etcd from upgrade instructions

### DIFF
--- a/calico/operations/upgrading/openstack-upgrade.mdx
+++ b/calico/operations/upgrading/openstack-upgrade.mdx
@@ -120,7 +120,7 @@ This may result in unexpected behavior and data.
    ```
    sudo apt-get update
    sudo apt-get install calico-compute calico-felix calico-common \
-                        python-etcd networking-calico calico-dhcp-agent
+                        networking-calico calico-dhcp-agent
 
    ```
 
@@ -132,7 +132,7 @@ This may result in unexpected behavior and data.
 
    It should return `$[version]`.
 
-1. On all compute nodes, add the following line to the end of `/etc/calico/felix.cfg`:
+1. On all compute nodes, make sure the datastore type is `etcdv3` in `/etc/calico/felix.cfg`:
 
    ```
    DatastoreType = etcdv3
@@ -146,7 +146,7 @@ This may result in unexpected behavior and data.
 
    ```
    sudo apt-get update
-   sudo apt-get install calico-control calico-common python-etcd networking-calico
+   sudo apt-get install calico-control calico-common networking-calico
    ```
 
 1. On all control nodes, restart `neutron-server`:

--- a/calico_versioned_docs/version-3.30/operations/upgrading/openstack-upgrade.mdx
+++ b/calico_versioned_docs/version-3.30/operations/upgrading/openstack-upgrade.mdx
@@ -120,7 +120,7 @@ This may result in unexpected behavior and data.
    ```
    sudo apt-get update
    sudo apt-get install calico-compute calico-felix calico-common \
-                        python-etcd networking-calico calico-dhcp-agent
+                        networking-calico calico-dhcp-agent
 
    ```
 
@@ -132,7 +132,7 @@ This may result in unexpected behavior and data.
 
    It should return `$[version]`.
 
-1. On all compute nodes, add the following line to the end of `/etc/calico/felix.cfg`:
+1. On all compute nodes, make sure the datastore type is `etcdv3` in `/etc/calico/felix.cfg`:
 
    ```
    DatastoreType = etcdv3
@@ -146,7 +146,7 @@ This may result in unexpected behavior and data.
 
    ```
    sudo apt-get update
-   sudo apt-get install calico-control calico-common python-etcd networking-calico
+   sudo apt-get install calico-control calico-common networking-calico
    ```
 
 1. On all control nodes, restart `neutron-server`:

--- a/calico_versioned_docs/version-3.31/operations/upgrading/openstack-upgrade.mdx
+++ b/calico_versioned_docs/version-3.31/operations/upgrading/openstack-upgrade.mdx
@@ -120,7 +120,7 @@ This may result in unexpected behavior and data.
    ```
    sudo apt-get update
    sudo apt-get install calico-compute calico-felix calico-common \
-                        python-etcd networking-calico calico-dhcp-agent
+                        networking-calico calico-dhcp-agent
 
    ```
 
@@ -132,7 +132,7 @@ This may result in unexpected behavior and data.
 
    It should return `$[version]`.
 
-1. On all compute nodes, add the following line to the end of `/etc/calico/felix.cfg`:
+1. On all compute nodes, make sure the datastore type is `etcdv3` in `/etc/calico/felix.cfg`:
 
    ```
    DatastoreType = etcdv3
@@ -146,7 +146,7 @@ This may result in unexpected behavior and data.
 
    ```
    sudo apt-get update
-   sudo apt-get install calico-control calico-common python-etcd networking-calico
+   sudo apt-get install calico-control calico-common networking-calico
    ```
 
 1. On all control nodes, restart `neutron-server`:


### PR DESCRIPTION
Remove the obsolete python-etcd package from compute and control node install commands, and reword the felix.cfg instruction to verify the etcdv3 datastore type rather than appending the line unconditionally.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->