### PR TITLE
Recommend reencrypt over passthrough for OpenShift routes

### DIFF
--- a/calico-enterprise/operations/cnx/access-the-manager.mdx
+++ b/calico-enterprise/operations/cnx/access-the-manager.mdx
@@ -136,6 +136,14 @@ To expose the web console using OpenShift routes, create the following route wit
 - name: `calico-manager`
 - targetPort: `9443`
 
+Both `passthrough` and `reencrypt` TLS termination work, but we recommend `reencrypt` because `passthrough` can cause intermittent routing issues when wildcard certificates are in use.
+
+The route requires a `destinationCACertificate` so HAProxy can verify the backend connection. If you provided your own `manager-tls` secret, use your own root CA here. Otherwise, extract the operator's CA with:
+
+```bash
+kubectl get secret tigera-ca-private -n tigera-operator -o jsonpath='{.data.tls\.crt}' | base64 -d
+```
+
 **Example**
 
 ```yaml
@@ -153,14 +161,18 @@ spec:
   port:
     targetPort: 9443
   tls:
-    termination: passthrough
+    termination: reencrypt
     insecureEdgeTerminationPolicy: Redirect
+    destinationCACertificate: |
+      -----BEGIN CERTIFICATE-----
+      <CA certificate — see above>
+      -----END CERTIFICATE-----
   wildcardPolicy: None
 ```
 
 ### Log in to the $[prodname] web console
 
-Access the $[prodname] web console in your browser using the URL with clustername. For example: `https://manager.apps.demo-ocp.tigera-solutions.io:9443`
+Access the $[prodname] web console in your browser using the URL with clustername. For example: `https://manager.apps.demo-ocp.tigera-solutions.io`
 
 </TabItem>
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/operations/cnx/access-the-manager.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/operations/cnx/access-the-manager.mdx
@@ -136,6 +136,14 @@ To expose the web console using OpenShift routes, create the following route wit
 - name: `tigera-manager`
 - targetPort: `9443`
 
+Both `passthrough` and `reencrypt` TLS termination work, but we recommend `reencrypt` because `passthrough` can cause intermittent routing issues when wildcard certificates are in use.
+
+The route requires a `destinationCACertificate` so HAProxy can verify the backend connection. If you provided your own `manager-tls` secret, use your own root CA here. Otherwise, extract the operator's CA with:
+
+```bash
+kubectl get secret tigera-ca-private -n tigera-operator -o jsonpath='{.data.tls\.crt}' | base64 -d
+```
+
 **Example**
 
 ```yaml
@@ -153,14 +161,18 @@ spec:
   port:
     targetPort: 9443
   tls:
-    termination: passthrough
+    termination: reencrypt
     insecureEdgeTerminationPolicy: Redirect
+    destinationCACertificate: |
+      -----BEGIN CERTIFICATE-----
+      <CA certificate — see above>
+      -----END CERTIFICATE-----
   wildcardPolicy: None
 ```
 
 ### Log in to the $[prodname] web console
 
-Access the $[prodname] web console in your browser using the URL with clustername. For example: `https://manager.apps.demo-ocp.tigera-solutions.io:9443`
+Access the $[prodname] web console in your browser using the URL with clustername. For example: `https://manager.apps.demo-ocp.tigera-solutions.io`
 
 </TabItem>
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/operations/cnx/access-the-manager.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/operations/cnx/access-the-manager.mdx
@@ -136,6 +136,14 @@ To expose the web console using OpenShift routes, create the following route wit
 - name: `tigera-manager`
 - targetPort: `9443`
 
+Both `passthrough` and `reencrypt` TLS termination work, but we recommend `reencrypt` because `passthrough` can cause intermittent routing issues when wildcard certificates are in use.
+
+The route requires a `destinationCACertificate` so HAProxy can verify the backend connection. If you provided your own `manager-tls` secret, use your own root CA here. Otherwise, extract the operator's CA with:
+
+```bash
+kubectl get secret tigera-ca-private -n tigera-operator -o jsonpath='{.data.tls\.crt}' | base64 -d
+```
+
 **Example**
 
 ```yaml
@@ -153,14 +161,18 @@ spec:
   port:
     targetPort: 9443
   tls:
-    termination: passthrough
+    termination: reencrypt
     insecureEdgeTerminationPolicy: Redirect
+    destinationCACertificate: |
+      -----BEGIN CERTIFICATE-----
+      <CA certificate — see above>
+      -----END CERTIFICATE-----
   wildcardPolicy: None
 ```
 
 ### Log in to the $[prodname] web console
 
-Access the $[prodname] web console in your browser using the URL with clustername. For example: `https://manager.apps.demo-ocp.tigera-solutions.io:9443`
+Access the $[prodname] web console in your browser using the URL with clustername. For example: `https://manager.apps.demo-ocp.tigera-solutions.io`
 
 </TabItem>
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/cnx/access-the-manager.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/cnx/access-the-manager.mdx
@@ -136,6 +136,14 @@ To expose the web console using OpenShift routes, create the following route wit
 - name: `tigera-manager`
 - targetPort: `9443`
 
+Both `passthrough` and `reencrypt` TLS termination work, but we recommend `reencrypt` because `passthrough` can cause intermittent routing issues when wildcard certificates are in use.
+
+The route requires a `destinationCACertificate` so HAProxy can verify the backend connection. If you provided your own `manager-tls` secret, use your own root CA here. Otherwise, extract the operator's CA with:
+
+```bash
+kubectl get secret tigera-ca-private -n tigera-operator -o jsonpath='{.data.tls\.crt}' | base64 -d
+```
+
 **Example**
 
 ```yaml
@@ -153,14 +161,18 @@ spec:
   port:
     targetPort: 9443
   tls:
-    termination: passthrough
+    termination: reencrypt
     insecureEdgeTerminationPolicy: Redirect
+    destinationCACertificate: |
+      -----BEGIN CERTIFICATE-----
+      <CA certificate — see above>
+      -----END CERTIFICATE-----
   wildcardPolicy: None
 ```
 
 ### Log in to the $[prodname] web console
 
-Access the $[prodname] web console in your browser using the URL with clustername. For example: `https://manager.apps.demo-ocp.tigera-solutions.io:9443`
+Access the $[prodname] web console in your browser using the URL with clustername. For example: `https://manager.apps.demo-ocp.tigera-solutions.io`
 
 </TabItem>
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/cnx/access-the-manager.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/cnx/access-the-manager.mdx
@@ -136,6 +136,14 @@ To expose the web console using OpenShift routes, create the following route wit
 - name: `calico-manager`
 - targetPort: `9443`
 
+Both `passthrough` and `reencrypt` TLS termination work, but we recommend `reencrypt` because `passthrough` can cause intermittent routing issues when wildcard certificates are in use.
+
+The route requires a `destinationCACertificate` so HAProxy can verify the backend connection. If you provided your own `manager-tls` secret, use your own root CA here. Otherwise, extract the operator's CA with:
+
+```bash
+kubectl get secret tigera-ca-private -n tigera-operator -o jsonpath='{.data.tls\.crt}' | base64 -d
+```
+
 **Example**
 
 ```yaml
@@ -153,14 +161,18 @@ spec:
   port:
     targetPort: 9443
   tls:
-    termination: passthrough
+    termination: reencrypt
     insecureEdgeTerminationPolicy: Redirect
+    destinationCACertificate: |
+      -----BEGIN CERTIFICATE-----
+      <CA certificate — see above>
+      -----END CERTIFICATE-----
   wildcardPolicy: None
 ```
 
 ### Log in to the $[prodname] web console
 
-Access the $[prodname] web console in your browser using the URL with clustername. For example: `https://manager.apps.demo-ocp.tigera-solutions.io:9443`
+Access the $[prodname] web console in your browser using the URL with clustername. For example: `https://manager.apps.demo-ocp.tigera-solutions.io`
 
 </TabItem>
 


### PR DESCRIPTION
## Summary
- Change the recommended OpenShift route TLS termination from `passthrough` to `reencrypt` for tigera-manager
- Add a cautionary note explaining why `passthrough` + wildcard certs causes intermittent OIDC redirect loops
- Document how to obtain the CA certificate for the `destinationCACertificate` field

```release-note
Docs: recommend reencrypt TLS termination for the tigera-manager OpenShift route to avoid misrouting with wildcard certificates.
```

## Context
CI-1933: With `passthrough` termination and a wildcard cert (`*.apps.<domain>`), HAProxy routes based on SNI. During router reloads, traffic for other hostnames (e.g. `oauth-openshift`) can silently fall through to tigera-manager, causing OIDC redirect loops. Switching to `reencrypt` makes HAProxy route on the `Host` header instead, preventing this.

## Test plan
- [ ] Verify the mdx renders correctly
- [ ] Consider backporting to versioned docs (3.20-3.23) if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)