### PR TITLE
Move IPVS-to-iptables prerequisite to all platforms in eBPF docs

### DIFF
--- a/calico-enterprise/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise/operations/ebpf/enabling-ebpf.mdx
@@ -130,6 +130,12 @@ If you do not see the pods restart then it's possible that the `ConfigMap` wasn'
 In eBPF mode $[prodname] replaces `kube-proxy` so it wastes resources (and reduces performance) to run both.  
 This section explains how to disable `kube-proxy` in some common environments.
 
+:::caution
+
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+
+:::
+
 #### Clusters that run `kube-proxy` with a `DaemonSet` (such as `kubeadm`)
 
 For a cluster that runs `kube-proxy` in a `DaemonSet` (such as a `kubeadm`-created cluster), you can disable `kube-proxy` reversibly by adding a node selector to `kube-proxy`'s `DaemonSet` that matches no nodes, for example:
@@ -162,11 +168,6 @@ To re-enable it:
 kubectl patch networks.operator.openshift.io cluster --type merge -p '{"spec":{"deployKubeProxy": true}}'
 ```
 
-:::note
-
-If you are running kube-proxy in IPVS mode, switch to iptables mode before disabling.
-
-:::
 
 #### MKE
 

--- a/calico-enterprise/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise/operations/ebpf/enabling-ebpf.mdx
@@ -132,7 +132,7 @@ This section explains how to disable `kube-proxy` in some common environments.
 
 :::caution
 
-If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart your nodes before proceeding.
 
 :::
 

--- a/calico-enterprise/operations/ebpf/install.mdx
+++ b/calico-enterprise/operations/ebpf/install.mdx
@@ -382,6 +382,12 @@ In eBPF mode, to avoid conflicts with `kube-proxy` it's necessary to either disa
 $[prodname] not to clean up `kube-proxy`'s iptables rules. If you didn't disable `kube-proxy` when starting
 your cluster then follow the steps below to avoid conflicts:
 
+:::caution
+
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+
+:::
+
 <Tabs groupId="k8s-distro">
 <TabItem label="Generic or kubeadm" value="Generic or kubeadm-0">
 
@@ -448,11 +454,6 @@ Then, should you want to start `kube-proxy` again, you can simply remove the nod
 </TabItem>
 </Tabs>
 
-:::note
-
-If you are running kube-proxy in IPVS mode, switch to iptables mode before disabling.
-
-:::
 
 ## Next steps
 

--- a/calico-enterprise/operations/ebpf/install.mdx
+++ b/calico-enterprise/operations/ebpf/install.mdx
@@ -384,7 +384,7 @@ your cluster then follow the steps below to avoid conflicts:
 
 :::caution
 
-If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart your nodes before proceeding.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/operations/ebpf/enabling-ebpf.mdx
@@ -130,6 +130,12 @@ If you do not see the pods restart then it's possible that the `ConfigMap` wasn'
 In eBPF mode $[prodname] replaces `kube-proxy` so it wastes resources (and reduces performance) to run both.  
 This section explains how to disable `kube-proxy` in some common environments.
 
+:::caution
+
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+
+:::
+
 #### Clusters that run `kube-proxy` with a `DaemonSet` (such as `kubeadm`)
 
 For a cluster that runs `kube-proxy` in a `DaemonSet` (such as a `kubeadm`-created cluster), you can disable `kube-proxy` reversibly by adding a node selector to `kube-proxy`'s `DaemonSet` that matches no nodes, for example:
@@ -162,11 +168,6 @@ To re-enable it:
 kubectl patch networks.operator.openshift.io cluster --type merge -p '{"spec":{"deployKubeProxy": true}}'
 ```
 
-:::note
-
-If you are running kube-proxy in IPVS mode, switch to iptables mode before disabling.
-
-:::
 
 #### MKE
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/operations/ebpf/enabling-ebpf.mdx
@@ -132,7 +132,7 @@ This section explains how to disable `kube-proxy` in some common environments.
 
 :::caution
 
-If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart your nodes before proceeding.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/operations/ebpf/install.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/operations/ebpf/install.mdx
@@ -351,7 +351,7 @@ your cluster then follow the steps below to avoid conflicts:
 
 :::caution
 
-If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart your nodes before proceeding.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/operations/ebpf/install.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/operations/ebpf/install.mdx
@@ -349,6 +349,12 @@ In eBPF mode, to avoid conflicts with `kube-proxy` it's necessary to either disa
 $[prodname] not to clean up `kube-proxy`'s iptables rules. If you didn't disable `kube-proxy` when starting
 your cluster then follow the steps below to avoid conflicts:
 
+:::caution
+
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+
+:::
+
 <Tabs groupId="k8s-distro">
 <TabItem label="Generic or kubeadm" value="Generic or kubeadm-0">
 
@@ -415,11 +421,6 @@ Then, should you want to start `kube-proxy` again, you can simply remove the nod
 </TabItem>
 </Tabs>
 
-:::note
-
-If you are running kube-proxy in IPVS mode, switch to iptables mode before disabling.
-
-:::
 
 ## Next steps
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/operations/ebpf/enabling-ebpf.mdx
@@ -130,6 +130,12 @@ If you do not see the pods restart then it's possible that the `ConfigMap` wasn'
 In eBPF mode $[prodname] replaces `kube-proxy` so it wastes resources (and reduces performance) to run both.  
 This section explains how to disable `kube-proxy` in some common environments.
 
+:::caution
+
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+
+:::
+
 #### Clusters that run `kube-proxy` with a `DaemonSet` (such as `kubeadm`)
 
 For a cluster that runs `kube-proxy` in a `DaemonSet` (such as a `kubeadm`-created cluster), you can disable `kube-proxy` reversibly by adding a node selector to `kube-proxy`'s `DaemonSet` that matches no nodes, for example:
@@ -162,11 +168,6 @@ To re-enable it:
 kubectl patch networks.operator.openshift.io cluster --type merge -p '{"spec":{"deployKubeProxy": true}}'
 ```
 
-:::note
-
-If you are running kube-proxy in IPVS mode, switch to iptables mode before disabling.
-
-:::
 
 #### MKE
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/operations/ebpf/enabling-ebpf.mdx
@@ -132,7 +132,7 @@ This section explains how to disable `kube-proxy` in some common environments.
 
 :::caution
 
-If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart your nodes before proceeding.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/operations/ebpf/install.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/operations/ebpf/install.mdx
@@ -351,7 +351,7 @@ your cluster then follow the steps below to avoid conflicts:
 
 :::caution
 
-If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart your nodes before proceeding.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/operations/ebpf/install.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/operations/ebpf/install.mdx
@@ -349,6 +349,12 @@ In eBPF mode, to avoid conflicts with `kube-proxy` it's necessary to either disa
 $[prodname] not to clean up `kube-proxy`'s iptables rules. If you didn't disable `kube-proxy` when starting
 your cluster then follow the steps below to avoid conflicts:
 
+:::caution
+
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+
+:::
+
 <Tabs groupId="k8s-distro">
 <TabItem label="Generic or kubeadm" value="Generic or kubeadm-0">
 
@@ -415,11 +421,6 @@ Then, should you want to start `kube-proxy` again, you can simply remove the nod
 </TabItem>
 </Tabs>
 
-:::note
-
-If you are running kube-proxy in IPVS mode, switch to iptables mode before disabling.
-
-:::
 
 ## Next steps
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/enabling-ebpf.mdx
@@ -130,6 +130,12 @@ If you do not see the pods restart then it's possible that the `ConfigMap` wasn'
 In eBPF mode $[prodname] replaces `kube-proxy` so it wastes resources (and reduces performance) to run both.  
 This section explains how to disable `kube-proxy` in some common environments.
 
+:::caution
+
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+
+:::
+
 #### Clusters that run `kube-proxy` with a `DaemonSet` (such as `kubeadm`)
 
 For a cluster that runs `kube-proxy` in a `DaemonSet` (such as a `kubeadm`-created cluster), you can disable `kube-proxy` reversibly by adding a node selector to `kube-proxy`'s `DaemonSet` that matches no nodes, for example:
@@ -162,11 +168,6 @@ To re-enable it:
 kubectl patch networks.operator.openshift.io cluster --type merge -p '{"spec":{"deployKubeProxy": true}}'
 ```
 
-:::note
-
-If you are running kube-proxy in IPVS mode, switch to iptables mode before disabling.
-
-:::
 
 #### MKE
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/enabling-ebpf.mdx
@@ -132,7 +132,7 @@ This section explains how to disable `kube-proxy` in some common environments.
 
 :::caution
 
-If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart your nodes before proceeding.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/install.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/install.mdx
@@ -353,7 +353,7 @@ your cluster then follow the steps below to avoid conflicts:
 
 :::caution
 
-If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart your nodes before proceeding.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/install.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/install.mdx
@@ -351,6 +351,12 @@ In eBPF mode, to avoid conflicts with `kube-proxy` it's necessary to either disa
 $[prodname] not to clean up `kube-proxy`'s iptables rules. If you didn't disable `kube-proxy` when starting
 your cluster then follow the steps below to avoid conflicts:
 
+:::caution
+
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+
+:::
+
 <Tabs groupId="k8s-distro">
 <TabItem label="Generic or kubeadm" value="Generic or kubeadm-0">
 
@@ -417,11 +423,6 @@ Then, should you want to start `kube-proxy` again, you can simply remove the nod
 </TabItem>
 </Tabs>
 
-:::note
-
-If you are running kube-proxy in IPVS mode, switch to iptables mode before disabling.
-
-:::
 
 ## Next steps
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/enabling-ebpf.mdx
@@ -130,6 +130,12 @@ If you do not see the pods restart then it's possible that the `ConfigMap` wasn'
 In eBPF mode $[prodname] replaces `kube-proxy` so it wastes resources (and reduces performance) to run both.  
 This section explains how to disable `kube-proxy` in some common environments.
 
+:::caution
+
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+
+:::
+
 #### Clusters that run `kube-proxy` with a `DaemonSet` (such as `kubeadm`)
 
 For a cluster that runs `kube-proxy` in a `DaemonSet` (such as a `kubeadm`-created cluster), you can disable `kube-proxy` reversibly by adding a node selector to `kube-proxy`'s `DaemonSet` that matches no nodes, for example:
@@ -162,11 +168,6 @@ To re-enable it:
 kubectl patch networks.operator.openshift.io cluster --type merge -p '{"spec":{"deployKubeProxy": true}}'
 ```
 
-:::note
-
-If you are running kube-proxy in IPVS mode, switch to iptables mode before disabling.
-
-:::
 
 #### MKE
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/enabling-ebpf.mdx
@@ -132,7 +132,7 @@ This section explains how to disable `kube-proxy` in some common environments.
 
 :::caution
 
-If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart your nodes before proceeding.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/install.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/install.mdx
@@ -382,6 +382,12 @@ In eBPF mode, to avoid conflicts with `kube-proxy` it's necessary to either disa
 $[prodname] not to clean up `kube-proxy`'s iptables rules. If you didn't disable `kube-proxy` when starting
 your cluster then follow the steps below to avoid conflicts:
 
+:::caution
+
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+
+:::
+
 <Tabs groupId="k8s-distro">
 <TabItem label="Generic or kubeadm" value="Generic or kubeadm-0">
 
@@ -448,11 +454,6 @@ Then, should you want to start `kube-proxy` again, you can simply remove the nod
 </TabItem>
 </Tabs>
 
-:::note
-
-If you are running kube-proxy in IPVS mode, switch to iptables mode before disabling.
-
-:::
 
 ## Next steps
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/install.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/install.mdx
@@ -384,7 +384,7 @@ your cluster then follow the steps below to avoid conflicts:
 
 :::caution
 
-If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart your nodes before proceeding.
 
 :::
 

--- a/calico/operations/ebpf/enabling-ebpf.mdx
+++ b/calico/operations/ebpf/enabling-ebpf.mdx
@@ -271,6 +271,12 @@ You should see the following log, with the correct `KUBERNETES_SERVICE_...` valu
 In eBPF mode $[prodname] replaces `kube-proxy` so it wastes resources (and reduces performance) to run both.
 This section explains how to disable `kube-proxy` in some common environments.
 
+:::caution
+
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+
+:::
+
 ##### Clusters that run `kube-proxy` with a `DaemonSet` (such as `kubeadm`)
 
 For a cluster that runs `kube-proxy` in a `DaemonSet` (such as a `kubeadm`-created cluster), you can disable `kube-proxy` reversibly by adding a node selector to `kube-proxy`'s `DaemonSet` that matches no nodes, for example:
@@ -309,12 +315,6 @@ If you are running MKE, you can disable `kube-proxy` as follows:
 
 Follow the step procedure in [Modify an existing MKE configuration](https://docs.mirantis.com/mke/current/ops/administer-cluster/configure-an-mke-cluster/use-an-mke-configuration-file.html#modify-an-existing-mke-configuration) to download, edit, and upload your MKE configuration. During the editing step, add the following configuration:
 `kube_proxy_mode=disabled` and `kube_default_drop_masq_bits=true`.
-
-:::note
-
-If you are running kube-proxy in IPVS mode, switch to iptables mode before disabling.
-
-:::
 
 #### Avoiding conflicts with kube-proxy
 

--- a/calico/operations/ebpf/enabling-ebpf.mdx
+++ b/calico/operations/ebpf/enabling-ebpf.mdx
@@ -273,7 +273,7 @@ This section explains how to disable `kube-proxy` in some common environments.
 
 :::caution
 
-If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart your nodes before proceeding.
 
 :::
 

--- a/calico/operations/ebpf/install.mdx
+++ b/calico/operations/ebpf/install.mdx
@@ -416,7 +416,7 @@ your cluster then follow the steps below to avoid conflicts:
 
 :::caution
 
-If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart your nodes before proceeding.
 
 :::
 

--- a/calico/operations/ebpf/install.mdx
+++ b/calico/operations/ebpf/install.mdx
@@ -414,6 +414,12 @@ In eBPF mode, to avoid conflicts with `kube-proxy` it's necessary to either disa
 $[prodname] not to clean up `kube-proxy`'s iptables rules. If you didn't disable `kube-proxy` when starting
 your cluster then follow the steps below to avoid conflicts:
 
+:::caution
+
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+
+:::
+
 <Tabs groupId="k8s-distro">
 <TabItem label="Generic or kubeadm" value="Generic or kubeadm-0">
 
@@ -472,11 +478,6 @@ Then, should you want to start `kube-proxy` again, you can simply remove the nod
 </TabItem>
 </Tabs>
 
-:::note
-
-If you are running kube-proxy in IPVS mode, switch to iptables mode before disabling.
-
-:::
 
 ## Next steps
 

--- a/calico_versioned_docs/version-3.29/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.29/operations/ebpf/enabling-ebpf.mdx
@@ -265,7 +265,7 @@ This section explains how to disable `kube-proxy` in some common environments.
 
 :::caution
 
-If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart your nodes before proceeding.
 
 :::
 

--- a/calico_versioned_docs/version-3.29/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.29/operations/ebpf/enabling-ebpf.mdx
@@ -263,6 +263,12 @@ You should see the following log, with the correct `KUBERNETES_SERVICE_...` valu
 In eBPF mode $[prodname] replaces `kube-proxy` so it wastes resources (and reduces performance) to run both.  
 This section explains how to disable `kube-proxy` in some common environments.
 
+:::caution
+
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+
+:::
+
 #### Clusters that run `kube-proxy` with a `DaemonSet` (such as `kubeadm`)
 
 For a cluster that runs `kube-proxy` in a `DaemonSet` (such as a `kubeadm`-created cluster), you can disable `kube-proxy` reversibly by adding a node selector to `kube-proxy`'s `DaemonSet` that matches no nodes, for example:
@@ -302,11 +308,6 @@ If you are running MKE, you can disable `kube-proxy` as follows:
 Follow the step procedure in [Modify an existing MKE configuration](https://docs.mirantis.com/mke/current/ops/administer-cluster/configure-an-mke-cluster/use-an-mke-configuration-file.html#modify-an-existing-mke-configuration) to download, edit, and upload your MKE configuration. During the editing step, add the following configuration:
 `kube_proxy_mode=disabled` and `kube_default_drop_masq_bits=true`.
  
-:::note
-
-If you are running kube-proxy in IPVS mode, switch to iptables mode before disabling.
-
-:::
 
 ### Avoiding conflicts with kube-proxy
 

--- a/calico_versioned_docs/version-3.29/operations/ebpf/install.mdx
+++ b/calico_versioned_docs/version-3.29/operations/ebpf/install.mdx
@@ -377,7 +377,7 @@ your cluster then follow the steps below to avoid conflicts:
 
 :::caution
 
-If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart your nodes before proceeding.
 
 :::
 

--- a/calico_versioned_docs/version-3.29/operations/ebpf/install.mdx
+++ b/calico_versioned_docs/version-3.29/operations/ebpf/install.mdx
@@ -375,6 +375,12 @@ In eBPF mode, to avoid conflicts with `kube-proxy` it's necessary to either disa
 $[prodname] not to clean up `kube-proxy`'s iptables rules. If you didn't disable `kube-proxy` when starting
 your cluster then follow the steps below to avoid conflicts:
 
+:::caution
+
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+
+:::
+
 <Tabs groupId="k8s-distro">
 <TabItem label="Generic or kubeadm" value="Generic or kubeadm-0">
 
@@ -441,11 +447,6 @@ Then, should you want to start `kube-proxy` again, you can simply remove the nod
 </TabItem>
 </Tabs>
 
-:::note
-
-If you are running kube-proxy in IPVS mode, switch to iptables mode before disabling.
-
-:::
 
 ## Next steps
 

--- a/calico_versioned_docs/version-3.30/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.30/operations/ebpf/enabling-ebpf.mdx
@@ -265,7 +265,7 @@ This section explains how to disable `kube-proxy` in some common environments.
 
 :::caution
 
-If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart your nodes before proceeding.
 
 :::
 

--- a/calico_versioned_docs/version-3.30/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.30/operations/ebpf/enabling-ebpf.mdx
@@ -263,6 +263,12 @@ You should see the following log, with the correct `KUBERNETES_SERVICE_...` valu
 In eBPF mode $[prodname] replaces `kube-proxy` so it wastes resources (and reduces performance) to run both.  
 This section explains how to disable `kube-proxy` in some common environments.
 
+:::caution
+
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+
+:::
+
 #### Clusters that run `kube-proxy` with a `DaemonSet` (such as `kubeadm`)
 
 For a cluster that runs `kube-proxy` in a `DaemonSet` (such as a `kubeadm`-created cluster), you can disable `kube-proxy` reversibly by adding a node selector to `kube-proxy`'s `DaemonSet` that matches no nodes, for example:
@@ -302,11 +308,6 @@ If you are running MKE, you can disable `kube-proxy` as follows:
 Follow the step procedure in [Modify an existing MKE configuration](https://docs.mirantis.com/mke/current/ops/administer-cluster/configure-an-mke-cluster/use-an-mke-configuration-file.html#modify-an-existing-mke-configuration) to download, edit, and upload your MKE configuration. During the editing step, add the following configuration:
 `kube_proxy_mode=disabled` and `kube_default_drop_masq_bits=true`.
  
-:::note
-
-If you are running kube-proxy in IPVS mode, switch to iptables mode before disabling.
-
-:::
 
 ### Avoiding conflicts with kube-proxy
 

--- a/calico_versioned_docs/version-3.30/operations/ebpf/install.mdx
+++ b/calico_versioned_docs/version-3.30/operations/ebpf/install.mdx
@@ -370,6 +370,12 @@ In eBPF mode, to avoid conflicts with `kube-proxy` it's necessary to either disa
 $[prodname] not to clean up `kube-proxy`'s iptables rules. If you didn't disable `kube-proxy` when starting
 your cluster then follow the steps below to avoid conflicts:
 
+:::caution
+
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+
+:::
+
 <Tabs groupId="k8s-distro">
 <TabItem label="Generic or kubeadm" value="Generic or kubeadm-0">
 
@@ -428,11 +434,6 @@ Then, should you want to start `kube-proxy` again, you can simply remove the nod
 </TabItem>
 </Tabs>
 
-:::note
-
-If you are running kube-proxy in IPVS mode, switch to iptables mode before disabling.
-
-:::
 
 ## Next steps
 

--- a/calico_versioned_docs/version-3.30/operations/ebpf/install.mdx
+++ b/calico_versioned_docs/version-3.30/operations/ebpf/install.mdx
@@ -372,7 +372,7 @@ your cluster then follow the steps below to avoid conflicts:
 
 :::caution
 
-If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart your nodes before proceeding.
 
 :::
 

--- a/calico_versioned_docs/version-3.31/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.31/operations/ebpf/enabling-ebpf.mdx
@@ -271,6 +271,12 @@ You should see the following log, with the correct `KUBERNETES_SERVICE_...` valu
 In eBPF mode $[prodname] replaces `kube-proxy` so it wastes resources (and reduces performance) to run both.
 This section explains how to disable `kube-proxy` in some common environments.
 
+:::caution
+
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+
+:::
+
 ##### Clusters that run `kube-proxy` with a `DaemonSet` (such as `kubeadm`)
 
 For a cluster that runs `kube-proxy` in a `DaemonSet` (such as a `kubeadm`-created cluster), you can disable `kube-proxy` reversibly by adding a node selector to `kube-proxy`'s `DaemonSet` that matches no nodes, for example:
@@ -310,11 +316,6 @@ If you are running MKE, you can disable `kube-proxy` as follows:
 Follow the step procedure in [Modify an existing MKE configuration](https://docs.mirantis.com/mke/current/ops/administer-cluster/configure-an-mke-cluster/use-an-mke-configuration-file.html#modify-an-existing-mke-configuration) to download, edit, and upload your MKE configuration. During the editing step, add the following configuration:
 `kube_proxy_mode=disabled` and `kube_default_drop_masq_bits=true`.
 
-:::note
-
-If you are running kube-proxy in IPVS mode, switch to iptables mode before disabling.
-
-:::
 
 #### Avoiding conflicts with kube-proxy
 

--- a/calico_versioned_docs/version-3.31/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.31/operations/ebpf/enabling-ebpf.mdx
@@ -273,7 +273,7 @@ This section explains how to disable `kube-proxy` in some common environments.
 
 :::caution
 
-If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart your nodes before proceeding.
 
 :::
 

--- a/calico_versioned_docs/version-3.31/operations/ebpf/install.mdx
+++ b/calico_versioned_docs/version-3.31/operations/ebpf/install.mdx
@@ -416,7 +416,7 @@ your cluster then follow the steps below to avoid conflicts:
 
 :::caution
 
-If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart your nodes before proceeding.
 
 :::
 

--- a/calico_versioned_docs/version-3.31/operations/ebpf/install.mdx
+++ b/calico_versioned_docs/version-3.31/operations/ebpf/install.mdx
@@ -414,6 +414,12 @@ In eBPF mode, to avoid conflicts with `kube-proxy` it's necessary to either disa
 $[prodname] not to clean up `kube-proxy`'s iptables rules. If you didn't disable `kube-proxy` when starting
 your cluster then follow the steps below to avoid conflicts:
 
+:::caution
+
+If you are running `kube-proxy` in IPVS mode, you must switch it to iptables mode before disabling `kube-proxy` or enabling eBPF mode. This applies to all platforms and is required for a successful migration. After switching to iptables mode, restart or roll your nodes before proceeding.
+
+:::
+
 <Tabs groupId="k8s-distro">
 <TabItem label="Generic or kubeadm" value="Generic or kubeadm-0">
 
@@ -472,11 +478,6 @@ Then, should you want to start `kube-proxy` again, you can simply remove the nod
 </TabItem>
 </Tabs>
 
-:::note
-
-If you are running kube-proxy in IPVS mode, switch to iptables mode before disabling.
-
-:::
 
 ## Next steps
 


### PR DESCRIPTION
## Summary
- Moves the IPVS-to-iptables warning from platform-specific sections (MKE in Calico, between OpenShift/MKE in Calico Enterprise) to a general caution admonition at the top of the kube-proxy configuration section
- Makes it clear this prerequisite applies to **all platforms**, not just MKE
- Adds guidance about restarting/rolling nodes after switching from IPVS to iptables mode (per user reports in the issue)
- Applied across all affected products and versions:
  - **Calico**: current, 3.29, 3.30, 3.31 (`enabling-ebpf.mdx` + `install.mdx`)
  - **Calico Enterprise**: current, 3.20-2, 3.21-2, 3.22-2, 3.23-1 (`enabling-ebpf.mdx` + `install.mdx`)
- 18 files updated total

Fixes projectcalico/calico#12476

## Test plan
- [ ] Verify the caution admonition renders correctly at the top of the kube-proxy section in each product
- [ ] Verify the old MKE/OpenShift-scoped notes are removed
- [ ] Confirm the warning is visible before any platform-specific instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)