### PR TITLE
Fix v3 mode install and migration docs

### DIFF
--- a/calico/getting-started/kubernetes/quickstart.mdx
+++ b/calico/getting-started/kubernetes/quickstart.mdx
@@ -94,7 +94,13 @@ In this step, you will:
 
 In this step, you will install Calico in your cluster.
 
-1. Install the Tigera Operator and custom resource definitions.
+1. Install the $[prodname] custom resource definitions.
+
+   ```bash
+   kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
+   ```
+
+2. Install the Tigera Operator.
 
    ```bash
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
@@ -110,7 +116,7 @@ In this step, you will install Calico in your cluster.
    deployment.apps/tigera-operator created
    ```
 
-2. Install $[prodname] by creating the necessary custom resources.
+3. Install $[prodname] by creating the necessary custom resources.
 
    ```bash
    kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml
@@ -123,7 +129,7 @@ In this step, you will install Calico in your cluster.
    whisker.operator.tigera.io/default created
    ```
 
-3. Monitor the deployment by running the following command:
+4. Monitor the deployment by running the following command:
 
    ```bash
    watch kubectl get tigerastatus

--- a/calico/operations/crd-migration.mdx
+++ b/calico/operations/crd-migration.mdx
@@ -53,6 +53,7 @@ The locked window is typically short (seconds to a few minutes depending on clus
 
 - $[prodname] v3.32+ (or the release that includes the migration controller)
 - Cluster is currently running in API server mode (the aggregated API server is deployed)
+- The `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) must be enabled on the Kubernetes API server before starting the migration. Native `projectcalico.org/v3` CRDs rely on MutatingAdmissionPolicies for defaulting, which are currently a **beta** Kubernetes feature and are not enabled by default.
 - **If using GitOps (ArgoCD, Flux):** pause sync before starting the migration. These tools may interfere with the API group switchover. You'll update your manifests to use `projectcalico.org/v3` after migration completes.
 
 ## How to

--- a/calico/operations/native-v3-crds.mdx
+++ b/calico/operations/native-v3-crds.mdx
@@ -106,10 +106,16 @@ Select the method below based on your preferred installation method.
 
    :::
 
-1. Install the Tigera Operator and custom resources:
+1. Install the Tigera Operator:
 
    ```bash
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
+   ```
+
+1. Install $[prodname] by creating the necessary custom resources:
+
+   ```bash
+   kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml
    ```
 
 </TabItem>


### PR DESCRIPTION
Fixes three bugs in the v3 mode install and migration docs:

- The Calico quickstart skips installing the `v1_crd_projectcalico_org.yaml` CRDs before the Tigera Operator. Every other operator-based install guide applies them first - added a step to do the same.
- The native v3 CRDs page's Manifest install tab installs the operator but never creates the `Installation` CR. Added a step to apply `custom-resources.yaml`. (Helm install doesn't need this - the `Installation` CR is in `values.yaml`.)
- The CRD migration page doesn't mention that the `MutatingAdmissionPolicy` feature gate must be enabled before starting the migration. Added it to the Before you begin section, mirroring the wording already on the native v3 CRDs page.

Jira: https://tigera.atlassian.net/browse/CORE-12607