### PR TITLE
Document v3 CRD mode for manifest installs

### DIFF
--- a/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
+++ b/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
@@ -135,6 +135,8 @@ If you're setting up a new cluster and don't need to customize the underlying Ku
 
 :::
 
+Before installing, enable the `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) on the Kubernetes API server. Native `projectcalico.org/v3` CRDs rely on MutatingAdmissionPolicies for defaulting, which are currently a **beta** Kubernetes feature and are not enabled by default.
+
 1. Download the $[prodname] v3 CRD manifest.
 
    ```bash
@@ -179,6 +181,7 @@ If you have an existing manifest-based $[prodname] install using the legacy `crd
 - $[prodname] installed via `calico.yaml` manifest (not operator)
 - `kubectl` access to the cluster
 - A recent $[prodname] version that includes the migration controller
+- The `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) must be enabled on the Kubernetes API server before starting the migration. Native `projectcalico.org/v3` CRDs rely on MutatingAdmissionPolicies for defaulting, which are currently a **beta** Kubernetes feature and are not enabled by default.
 
 #### Migration steps
 

--- a/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
+++ b/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
@@ -119,7 +119,46 @@ $[prodname] can also be installed using raw manifests as an alternative to the o
 />
 
 </TabItem>
-<TabItem label="Manifest" value="Manifest-1">
+<TabItem label="Manifest (v3 CRDs)" value="Manifest-v3">
+
+This manifest installs $[prodname] using the native `projectcalico.org/v3` CRD API group. This is the recommended manifest-based install for new clusters - the v3 API group supports tiered policy, admission webhooks, and other features that aren't available with the legacy `crd.projectcalico.org/v1` API group.
+
+:::note
+
+If you're setting up a new cluster and don't need to customize the underlying Kubernetes resources, we recommend using the operator instead. The operator automatically manages the lifecycle of $[prodname] components, including upgrades and scaling.
+
+:::
+
+1. Download the $[prodname] v3 CRD manifest.
+
+   ```bash
+   curl $[manifestsUrl]/manifests/calico-v3-crds.yaml -O
+   ```
+
+1. If you are using pod CIDR `192.168.0.0/16`, skip to the next step.
+   If you are using a different pod CIDR with kubeadm, no changes are required - Calico will automatically detect the CIDR based on the running configuration.
+   For other platforms, make sure you uncomment the CALICO_IPV4POOL_CIDR variable in the manifest and set it to the same value as your chosen pod CIDR.
+1. Customize the manifest as necessary.
+1. Apply the manifest.
+
+   ```bash
+   kubectl apply -f calico-v3-crds.yaml
+   ```
+
+1. (Optional) Install the tiered RBAC webhooks. This adds a validating admission webhook that enforces tier-based access control for Calico network policies. The webhooks require TLS certificates - see the instructions at the top of the manifest for setup.
+
+   ```bash
+   curl $[manifestsUrl]/manifests/webhooks.yaml -O
+   kubectl apply -f webhooks.yaml
+   ```
+
+<GeekDetails
+  prodname='$[prodname]'
+  details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:IPIP,Routing:BGP,Datastore:Kubernetes'
+/>
+
+</TabItem>
+<TabItem label="Manifest (legacy)" value="Manifest-1">
 
 Based on your datastore and number of nodes, select a link below to install $[prodname].
 

--- a/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
+++ b/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
@@ -151,7 +151,7 @@ If you're setting up a new cluster and don't need to customize the underlying Ku
    kubectl apply -f calico-v3-crds.yaml
    ```
 
-1. (Optional) Install the tiered RBAC webhooks. This adds a validating admission webhook that enforces tier-based access control for Calico network policies. The webhooks require TLS certificates - see the instructions at the top of the manifest for setup.
+1. Install the $[prodname] webhooks. These provide validating and mutating admission webhooks for Calico policy resources. The webhooks require TLS certificates - see the instructions at the top of the manifest for setup.
 
    ```bash
    curl $[manifestsUrl]/manifests/webhooks.yaml -O
@@ -241,7 +241,7 @@ If you have an existing manifest-based $[prodname] install using the legacy `crd
 
    The finalizer on the resource deletes all `crd.projectcalico.org` CRDs before removing the resource.
 
-1. (Optional) Install the tiered RBAC webhooks.
+1. Install the $[prodname] webhooks. The webhooks require TLS certificates - see the instructions at the top of the manifest for setup.
 
    ```bash
    curl $[manifestsUrl]/manifests/webhooks.yaml -O

--- a/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
+++ b/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
@@ -164,6 +164,91 @@ If you're setting up a new cluster and don't need to customize the underlying Ku
 />
 
 </TabItem>
+<TabItem label="Migrate to v3 CRDs" value="Migrate-v3">
+
+:::note
+
+This feature is tech preview. Tech preview features may be subject to significant changes before they become GA.
+
+:::
+
+If you have an existing manifest-based $[prodname] install using the legacy `crd.projectcalico.org/v1` CRDs, you can migrate to the native `projectcalico.org/v3` CRDs. This enables tiered policy, admission webhooks, and other v3-only features.
+
+#### Prerequisites
+
+- $[prodname] installed via `calico.yaml` manifest (not operator)
+- `kubectl` access to the cluster
+- A recent $[prodname] version that includes the migration controller
+
+#### Migration steps
+
+1. Install the v3 CRDs alongside the existing v1 CRDs.
+
+   ```bash
+   kubectl apply --server-side --force-conflicts -f $[manifestsUrl]/api/config/crd/
+   ```
+
+1. Install the DatastoreMigration CRD.
+
+   ```bash
+   kubectl apply --server-side -f $[manifestsUrl]/kube-controllers/pkg/controllers/migration/crd/migration.projectcalico.org_datastoremigrations.yaml
+   ```
+
+1. Create a DatastoreMigration resource to start the migration. The migration controller copies all Calico resources from v1 CRDs to v3 CRDs.
+
+   ```bash
+   kubectl apply -f - <<EOF
+   apiVersion: migration.projectcalico.org/v1beta1
+   kind: DatastoreMigration
+   metadata:
+     name: v1-to-v3
+   spec:
+     type: APIServerToCRDs
+   EOF
+   ```
+
+1. Monitor the migration progress.
+
+   ```bash
+   kubectl get datastoremigration v1-to-v3 -w
+   ```
+
+   The migration transitions through `Pending` → `Migrating` → `Converged`. Once it reaches `Converged`, all resources have been copied to v3 CRDs.
+
+1. When the migration reaches `Converged`, configure calico-node (and calico-typha if present) to use the v3 API group.
+
+   ```bash
+   kubectl set env -n kube-system daemonset/calico-node CALICO_API_GROUP=projectcalico.org/v3
+   ```
+
+   If you're running calico-typha, update it as well:
+
+   ```bash
+   kubectl set env -n kube-system deployment/calico-typha CALICO_API_GROUP=projectcalico.org/v3
+   ```
+
+1. The migration controller monitors the rollout and transitions to `Complete` once all pods are running with the v3 API group. kube-controllers restarts automatically to pick up the new API group.
+
+   ```bash
+   kubectl get datastoremigration v1-to-v3 -w
+   ```
+
+1. Once the migration is `Complete`, delete the DatastoreMigration resource to clean up the old v1 CRDs.
+
+   ```bash
+   kubectl delete datastoremigration v1-to-v3
+   ```
+
+   The finalizer on the resource deletes all `crd.projectcalico.org` CRDs before removing the resource.
+
+1. (Optional) Install the tiered RBAC webhooks.
+
+   ```bash
+   curl $[manifestsUrl]/manifests/webhooks.yaml -O
+   kubectl apply -f webhooks.yaml
+   ```
+
+</TabItem>
 <TabItem label="Manifest" value="Manifest-1">
 
 Based on your datastore and number of nodes, select a link below to install $[prodname].

--- a/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
+++ b/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
@@ -121,7 +121,13 @@ $[prodname] can also be installed using raw manifests as an alternative to the o
 </TabItem>
 <TabItem label="Manifest (v3 CRDs)" value="Manifest-v3">
 
-This manifest installs $[prodname] using the native `projectcalico.org/v3` CRD API group. This is the recommended manifest-based install for new clusters - the v3 API group supports tiered policy, admission webhooks, and other features that aren't available with the legacy `crd.projectcalico.org/v1` API group.
+:::note
+
+This feature is tech preview. Tech preview features may be subject to significant changes before they become GA.
+
+:::
+
+This manifest installs $[prodname] using the native `projectcalico.org/v3` CRD API group. The v3 API group supports tiered policy, admission webhooks, and other features that aren't available with the legacy `crd.projectcalico.org/v1` API group.
 
 :::note
 
@@ -158,7 +164,7 @@ If you're setting up a new cluster and don't need to customize the underlying Ku
 />
 
 </TabItem>
-<TabItem label="Manifest (legacy)" value="Manifest-1">
+<TabItem label="Manifest" value="Manifest-1">
 
 Based on your datastore and number of nodes, select a link below to install $[prodname].
 


### PR DESCRIPTION
Adds two new tabs to the on-premises manifest install page:

- **Manifest (v3 CRDs)** — fresh install using the native `projectcalico.org/v3` CRD API group (tech preview).
- **Migrate to v3 CRDs** — migration path from an existing `calico.yaml`/v1 CRD install to native v3 CRDs.

Both tabs note the `MutatingAdmissionPolicy` feature gate prereq, matching what's already documented in `native-v3-crds.mdx` and `crd-migration.mdx`.

Related: #2545, #2595