### PR TITLE
Document Inline DNS policy mode prefix-wildcard limitation

### DIFF
--- a/calico-cloud/_includes/content/_domain-names.mdx
+++ b/calico-cloud/_includes/content/_domain-names.mdx
@@ -18,6 +18,6 @@ With a single asterisk in any part of the domain name, it matches 1 or more path
 
 :::note
 
-The `Inline` DNS policy mode only supports prefix wildcards like `*.example.com`. Non-prefix wildcards (for example, `www.*.com` or `update.*.mycompany.com`) are not matched in `Inline` mode and require `DelayDeniedPacket` or `NoDelay` mode. `Inline` is available for the eBPF data plane (`BPFDNSPolicyMode: Inline`, the default on kernels 5.17+ / RedHat 5.14+) and for the iptables data plane (`DNSPolicyMode: Inline`). See [DNSPolicyMode](../reference/resources/felixconfig.mdx#dnspolicymode) and [BPFDNSPolicyMode](../reference/resources/felixconfig.mdx#bpfdnspolicymode).
+The `Inline` DNS policy mode only supports prefix wildcards like `*.example.com`. Non-prefix wildcards (for example, `www.*.com` or `update.*.mycompany.com`) are not matched in `Inline` mode and require `DelayDeniedPacket` or `NoDelay` mode. `Inline` is available for the eBPF data plane (`BPFDNSPolicyMode: Inline`, the default on kernels 5.17+ / RedHat 5.14+) and for the iptables data plane (`DNSPolicyMode: Inline`). See [DNSPolicyMode](../../reference/resources/felixconfig.mdx#dnspolicymode) and [BPFDNSPolicyMode](../../reference/resources/felixconfig.mdx#bpfdnspolicymode).
 
 :::

--- a/calico-cloud/_includes/content/_domain-names.mdx
+++ b/calico-cloud/_includes/content/_domain-names.mdx
@@ -15,3 +15,9 @@ With a single asterisk in any part of the domain name, it matches 1 or more path
 - Asterisks that are not the entire component, for example: `www.g*.com`
 - A wildcard as the last component, for example: `www.mycompany.*`
 - More general wildcards, such as regular expressions
+
+:::note
+
+The `Inline` DNS policy mode only supports prefix wildcards like `*.example.com`. Non-prefix wildcards (for example, `www.*.com` or `update.*.mycompany.com`) are not matched in `Inline` mode and require `DelayDeniedPacket` or `NoDelay` mode. `Inline` is available for the eBPF data plane (`BPFDNSPolicyMode: Inline`, the default on kernels 5.17+ / RedHat 5.14+) and for the iptables data plane (`DNSPolicyMode: Inline`). See [DNSPolicyMode](../reference/resources/felixconfig.mdx#dnspolicymode) and [BPFDNSPolicyMode](../reference/resources/felixconfig.mdx#bpfdnspolicymode).
+
+:::

--- a/calico-enterprise/_includes/content/_domain-names.mdx
+++ b/calico-enterprise/_includes/content/_domain-names.mdx
@@ -18,6 +18,6 @@ With a single asterisk in any part of the domain name, it matches 1 or more path
 
 :::note
 
-The `Inline` DNS policy mode only supports prefix wildcards like `*.example.com`. Non-prefix wildcards (for example, `www.*.com` or `update.*.mycompany.com`) are not matched in `Inline` mode and require `DelayDeniedPacket` or `NoDelay` mode. `Inline` is available for the eBPF data plane (`BPFDNSPolicyMode: Inline`, the default on kernels 5.17+ / RedHat 5.14+) and for the iptables data plane (`DNSPolicyMode: Inline`). See [DNSPolicyMode](../reference/resources/felixconfig.mdx#dnspolicymode) and [BPFDNSPolicyMode](../reference/resources/felixconfig.mdx#bpfdnspolicymode).
+The `Inline` DNS policy mode only supports prefix wildcards like `*.example.com`. Non-prefix wildcards (for example, `www.*.com` or `update.*.mycompany.com`) are not matched in `Inline` mode and require `DelayDeniedPacket` or `NoDelay` mode. `Inline` is available for the eBPF data plane (`BPFDNSPolicyMode: Inline`, the default on kernels 5.17+ / RedHat 5.14+) and for the iptables data plane (`DNSPolicyMode: Inline`). See [DNSPolicyMode](../../reference/resources/felixconfig.mdx#dnspolicymode) and [BPFDNSPolicyMode](../../reference/resources/felixconfig.mdx#bpfdnspolicymode).
 
 :::

--- a/calico-enterprise/_includes/content/_domain-names.mdx
+++ b/calico-enterprise/_includes/content/_domain-names.mdx
@@ -15,3 +15,9 @@ With a single asterisk in any part of the domain name, it matches 1 or more path
 - Asterisks that are not the entire component, for example: `www.g*.com`
 - A wildcard as the last component, for example: `www.mycompany.*`
 - More general wildcards, such as regular expressions
+
+:::note
+
+The `Inline` DNS policy mode only supports prefix wildcards like `*.example.com`. Non-prefix wildcards (for example, `www.*.com` or `update.*.mycompany.com`) are not matched in `Inline` mode and require `DelayDeniedPacket` or `NoDelay` mode. `Inline` is available for the eBPF data plane (`BPFDNSPolicyMode: Inline`, the default on kernels 5.17+ / RedHat 5.14+) and for the iptables data plane (`DNSPolicyMode: Inline`). See [DNSPolicyMode](../reference/resources/felixconfig.mdx#dnspolicymode) and [BPFDNSPolicyMode](../reference/resources/felixconfig.mdx#bpfdnspolicymode).
+
+:::


### PR DESCRIPTION
## Summary

- Add a note to the shared `_domain-names.mdx` partial clarifying that `Inline` DNS policy mode only supports prefix wildcards like `*.example.com`.
- Non-prefix wildcards (e.g. `www.*.com`, `update.*.mycompany.com`) only match under `DelayDeniedPacket` or `NoDelay` mode.
- `Inline` applies to `BPFDNSPolicyMode` (default on kernels 5.17+ / RHEL 5.14+) and `DNSPolicyMode` for iptables.

## Context

Flagged by Shaun Crampton in Slack — users following the DNS policy page with an inline data plane can configure middle-wildcard domains that silently never match.

## Test plan

- [ ] Preview the DNS policy page in calico-cloud and calico-enterprise and confirm the note renders under "Domain name matching"
- [ ] Confirm anchor links to `DNSPolicyMode` and `BPFDNSPolicyMode` resolve on both variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)