### PR TITLE
Add KubeVirt live migration setup steps and ToR BGP config example

### DIFF
--- a/calico-enterprise/networking/configuring/vxlan-ipip.mdx
+++ b/calico-enterprise/networking/configuring/vxlan-ipip.mdx
@@ -32,7 +32,7 @@ Encapsulation of workload traffic is typically required only when traffic crosse
 
 Each Calico node needs routes to pods on other nodes; these are called _cluster routes_. By default, Felix programs cluster routes for VXLAN IP pools, while BGP distributes cluster routes for IP-in-IP pools and for pools with no encapsulation. You can configure Felix to program cluster routes in all cases by setting `programClusterRoutes` in `FelixConfiguration` to `Enabled` and `programClusterRoutes` in `BGPConfiguration` to `Disabled`. Alternatively, if you use the operator, set `clusterRoutingMode` in the `calicoNetwork` of the default installation resource to `Felix` instead of the default `BIRD` value.
 
-When Felix is programming cluster routes, BGP is not required for internal cluster routing. However, BGP is still required if cluster routes need to be advertised to external BGP peers. If you do not need to advertise routes externally, you can disable BGP to reduce the moving parts in your cluster by [Customizing the manifests](../../getting-started/kubernetes/self-managed-onprem/config-options.mdx).
+When Felix is programming cluster routes, BGP is not required for internal cluster routing. However, BGP is still required if cluster routes need to be advertised to external BGP peers. If you do not need to advertise routes externally, you can disable BGP to reduce the moving parts in your cluster by setting `bgp` to `Disabled` in the [Installation](../../reference/installation/api.mdx#bgpoption) resource.
 
 ## Before you begin
 

--- a/calico-enterprise/networking/kubevirt/kubevirt-networking.mdx
+++ b/calico-enterprise/networking/kubevirt/kubevirt-networking.mdx
@@ -131,9 +131,11 @@ If $[prodname] was installed before the KubeVirt CRDs were available (the common
 order on fresh clusters), you must restart Typha so it can discover KubeVirt CRDs
 (e.g. `VirtualMachineInstanceMigration`) needed for live migration support.
 
+Adjust the namespace to match your installation (commonly `calico-system` or `kube-system`):
+
 ```bash
-kubectl rollout restart deployment calico-typha -n calico-system
-kubectl rollout status deployment calico-typha -n calico-system --timeout=60s
+kubectl rollout restart deployment calico-typha -n <namespace>
+kubectl rollout status deployment calico-typha -n <namespace> --timeout=60s
 ```
 
 If KubeVirt was installed before $[prodname], this step is not needed.
@@ -166,8 +168,11 @@ If you want continuous connectivity from a migrating VM to any destination, the 
 must not be SNATed anywhere on the path between the VM and that destination. You must disable
 `natOutgoing` on any IP pool used by KubeVirt VMs that will be live-migrated.
 
-Live migration relies on VM IP address persistence — SNAT defeats this purpose by rewriting
-the VM's source IP to the node's IP after migration.
+In a live migration, by definition the VM moves from one node to another.
+If `natOutgoing` is configured for the VM, and there is an ongoing connection
+between the VM and a server outside the cluster, that server will see the
+source IP for the connection change from the old node IP to the new node IP
+— which unfortunately means that the connection will break.
 
 If $[prodname] was installed using the operator, disable `natOutgoing` through the
 `Installation` resource:
@@ -176,6 +181,10 @@ If $[prodname] was installed using the operator, disable `natOutgoing` through t
 kubectl patch installation default --type=json \
   -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/natOutgoing","value":"Disabled"}]'
 ```
+
+The path `/spec/calicoNetwork/ipPools/0` targets the first IP pool. If your cluster has
+multiple pools, identify the correct index for the pool used by your KubeVirt VMs and
+adjust the path accordingly.
 
 :::caution
 

--- a/calico-enterprise/networking/kubevirt/kubevirt-networking.mdx
+++ b/calico-enterprise/networking/kubevirt/kubevirt-networking.mdx
@@ -125,6 +125,19 @@ VM itself). Without this annotation, KubeVirt rejects live migration attempts fo
 bridge binding with an error like:
 `cannot migrate VMI which does not use masquerade to connect to the pod network`.
 
+### Restart Typha after installing KubeVirt
+
+If $[prodname] was installed before the KubeVirt CRDs were available (the common bootstrap
+order on fresh clusters), you must restart Typha so it can discover KubeVirt CRDs
+(e.g. `VirtualMachineInstanceMigration`) needed for live migration support.
+
+```bash
+kubectl rollout restart deployment calico-typha -n calico-system
+kubectl rollout status deployment calico-typha -n calico-system --timeout=60s
+```
+
+If KubeVirt was installed before $[prodname], this step is not needed.
+
 ### Enable KubeVirt VM IP address persistence
 
 IP address persistence is enabled by default. If it has been previously disabled, re-enable

--- a/calico-enterprise/networking/kubevirt/kubevirt-networking.mdx
+++ b/calico-enterprise/networking/kubevirt/kubevirt-networking.mdx
@@ -53,6 +53,12 @@ This is a cluster-wide setting controlled by the `IPAMConfiguration` resource.
 
 ### Live migration
 
+:::note
+
+Live migration support is a tech preview feature. Tech preview features may be subject to significant changes before they become GA.
+
+:::
+
 When a KubeVirt VM live-migrates from one host to another, $[prodname] coordinates the network
 transition:
 
@@ -140,6 +146,33 @@ IP address persistence must be enabled for live migration to work. If persistenc
 the CNI plugin rejects migration target pods.
 
 :::
+
+### Disable NAT outgoing for VM IP pools
+
+If you want continuous connectivity from a migrating VM to any destination, the VM's IP address
+must not be SNATed anywhere on the path between the VM and that destination. You must disable
+`natOutgoing` on any IP pool used by KubeVirt VMs that will be live-migrated.
+
+Live migration relies on VM IP address persistence — SNAT defeats this purpose by rewriting
+the VM's source IP to the node's IP after migration.
+
+If $[prodname] was installed using the operator, disable `natOutgoing` through the
+`Installation` resource:
+
+```bash
+kubectl patch installation default --type=json \
+  -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/natOutgoing","value":"Disabled"}]'
+```
+
+:::caution
+
+Do not patch the `IPPool` resource directly when using the operator — the operator reconciles
+`IPPool` resources from the `Installation` resource and will silently revert direct changes.
+
+:::
+
+For manifest-based installations, set `natOutgoing: false` on the
+[IPPool](../../reference/resources/ippool.mdx) resource directly.
 
 ### Allow live migration ports through host endpoint policy
 

--- a/calico-enterprise/networking/kubevirt/live-migration-bgp.mdx
+++ b/calico-enterprise/networking/kubevirt/live-migration-bgp.mdx
@@ -184,13 +184,35 @@ spec:
     - kubevirt-live-migration
 ```
 
-#### Step 3: Configure ToR to propagate routes with communities
+#### Step 3: Configure the ToR to select elevated-priority routes
 
-Ensure your ToR switches are configured to pass through the BGP communities used in the
-`BGPFilter` (e.g., `65000:100`). The ToR must re-advertise these /32 routes
-with their communities intact to compute nodes in other racks, so that the receiving nodes'
-import filters can reconstruct the correct route priority. This configuration is done on the
-ToR switch itself (outside of $[prodname]) and depends on your switch vendor and network OS.
+The ToR must be configured to read the BGP community (`65000:100`) attached by $[prodname]'s
+BGPFilter and prefer those routes over normal-priority routes. Without this, the ToR may
+treat both the source and target routes as equal and install them as ECMP, causing
+split-brain routing during live migration.
+
+The following BIRD 1.x import filter example shows how to match the community and set a
+higher preference for elevated-priority routes:
+
+```
+filter import_community_priority {
+  if ((65000, 100) ~ bgp_community) then {
+    preference = 200;
+  }
+  accept;
+}
+```
+
+Routes carrying community `(65000, 100)` get BIRD `preference = 200` (default is 100),
+ensuring the target route is preferred over the source route during live migration.
+
+#### Step 3 (alternative): Configure hardware ToR to propagate routes with communities
+
+If your ToR is a hardware switch (not running BIRD), ensure it is configured to pass through
+the BGP communities used in the `BGPFilter` (e.g., `65000:100`). The ToR must re-advertise
+these /32 routes with their communities intact to compute nodes in other racks, so that the
+receiving nodes' import filters can reconstruct the correct route priority. This configuration
+depends on your switch vendor and network OS.
 
 ## Additional resources
 

--- a/calico/networking/kubevirt/kubevirt-networking.mdx
+++ b/calico/networking/kubevirt/kubevirt-networking.mdx
@@ -121,9 +121,11 @@ If $[prodname] was installed before the KubeVirt CRDs were available (the common
 order on fresh clusters), you must restart Typha so it can discover KubeVirt CRDs
 (e.g. `VirtualMachineInstanceMigration`) needed for live migration support.
 
+Adjust the namespace to match your installation (commonly `calico-system` or `kube-system`):
+
 ```bash
-kubectl rollout restart deployment calico-typha -n calico-system
-kubectl rollout status deployment calico-typha -n calico-system --timeout=60s
+kubectl rollout restart deployment calico-typha -n <namespace>
+kubectl rollout status deployment calico-typha -n <namespace> --timeout=60s
 ```
 
 If KubeVirt was installed before $[prodname], this step is not needed.
@@ -156,8 +158,11 @@ If you want continuous connectivity from a migrating VM to any destination, the 
 must not be SNATed anywhere on the path between the VM and that destination. You must disable
 `natOutgoing` on any IP pool used by KubeVirt VMs that will be live-migrated.
 
-Live migration relies on VM IP address persistence — SNAT defeats this purpose by rewriting
-the VM's source IP to the node's IP after migration.
+In a live migration, by definition the VM moves from one node to another.
+If `natOutgoing` is configured for the VM, and there is an ongoing connection
+between the VM and a server outside the cluster, that server will see the
+source IP for the connection change from the old node IP to the new node IP
+— which unfortunately means that the connection will break.
 
 If $[prodname] was installed using the operator, disable `natOutgoing` through the
 `Installation` resource:
@@ -166,6 +171,10 @@ If $[prodname] was installed using the operator, disable `natOutgoing` through t
 kubectl patch installation default --type=json \
   -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/natOutgoing","value":"Disabled"}]'
 ```
+
+The path `/spec/calicoNetwork/ipPools/0` targets the first IP pool. If your cluster has
+multiple pools, identify the correct index for the pool used by your KubeVirt VMs and
+adjust the path accordingly.
 
 :::caution
 

--- a/calico/networking/kubevirt/kubevirt-networking.mdx
+++ b/calico/networking/kubevirt/kubevirt-networking.mdx
@@ -115,6 +115,19 @@ VM itself). Without this annotation, KubeVirt rejects live migration attempts fo
 bridge binding with an error like:
 `cannot migrate VMI which does not use masquerade to connect to the pod network`.
 
+### Restart Typha after installing KubeVirt
+
+If $[prodname] was installed before the KubeVirt CRDs were available (the common bootstrap
+order on fresh clusters), you must restart Typha so it can discover KubeVirt CRDs
+(e.g. `VirtualMachineInstanceMigration`) needed for live migration support.
+
+```bash
+kubectl rollout restart deployment calico-typha -n calico-system
+kubectl rollout status deployment calico-typha -n calico-system --timeout=60s
+```
+
+If KubeVirt was installed before $[prodname], this step is not needed.
+
 ### Enable KubeVirt VM IP address persistence
 
 IP address persistence is enabled by default. If it has been previously disabled, re-enable

--- a/calico/networking/kubevirt/kubevirt-networking.mdx
+++ b/calico/networking/kubevirt/kubevirt-networking.mdx
@@ -137,6 +137,33 @@ the CNI plugin rejects migration target pods.
 
 :::
 
+### Disable NAT outgoing for VM IP pools
+
+If you want continuous connectivity from a migrating VM to any destination, the VM's IP address
+must not be SNATed anywhere on the path between the VM and that destination. You must disable
+`natOutgoing` on any IP pool used by KubeVirt VMs that will be live-migrated.
+
+Live migration relies on VM IP address persistence — SNAT defeats this purpose by rewriting
+the VM's source IP to the node's IP after migration.
+
+If $[prodname] was installed using the operator, disable `natOutgoing` through the
+`Installation` resource:
+
+```bash
+kubectl patch installation default --type=json \
+  -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/natOutgoing","value":"Disabled"}]'
+```
+
+:::caution
+
+Do not patch the `IPPool` resource directly when using the operator — the operator reconciles
+`IPPool` resources from the `Installation` resource and will silently revert direct changes.
+
+:::
+
+For manifest-based installations, set `natOutgoing: false` on the
+[IPPool](../../reference/resources/ippool.mdx) resource directly.
+
 ### Allow live migration ports through host endpoint policy
 
 If you use [host endpoint policies](../../reference/host-endpoints/overview.mdx), you must

--- a/calico/networking/kubevirt/live-migration-bgp.mdx
+++ b/calico/networking/kubevirt/live-migration-bgp.mdx
@@ -184,13 +184,35 @@ spec:
     - kubevirt-live-migration
 ```
 
-#### Step 3: Configure ToR to propagate routes with communities
+#### Step 3: Configure the ToR to select elevated-priority routes
 
-Ensure your ToR switches are configured to pass through the BGP communities used in the
-`BGPFilter` (e.g., `65000:100`). The ToR must re-advertise these /32 routes
-with their communities intact to compute nodes in other racks, so that the receiving nodes'
-import filters can reconstruct the correct route priority. This configuration is done on the
-ToR switch itself (outside of $[prodname]) and depends on your switch vendor and network OS.
+The ToR must be configured to read the BGP community (`65000:100`) attached by $[prodname]'s
+BGPFilter and prefer those routes over normal-priority routes. Without this, the ToR may
+treat both the source and target routes as equal and install them as ECMP, causing
+split-brain routing during live migration.
+
+The following BIRD 1.x import filter example shows how to match the community and set a
+higher preference for elevated-priority routes:
+
+```
+filter import_community_priority {
+  if ((65000, 100) ~ bgp_community) then {
+    preference = 200;
+  }
+  accept;
+}
+```
+
+Routes carrying community `(65000, 100)` get BIRD `preference = 200` (default is 100),
+ensuring the target route is preferred over the source route during live migration.
+
+#### Step 3 (alternative): Configure hardware ToR to propagate routes with communities
+
+If your ToR is a hardware switch (not running BIRD), ensure it is configured to pass through
+the BGP communities used in the `BGPFilter` (e.g., `65000:100`). The ToR must re-advertise
+these /32 routes with their communities intact to compute nodes in other racks, so that the
+receiving nodes' import filters can reconstruct the correct route priority. This configuration
+depends on your switch vendor and network OS.
 
 ## Additional resources
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


Summary
- Add a step to restart Typha after installing KubeVirt so it can discover KubeVirt CRDs needed for live migration support
- Add a step to disable natOutgoing on IP pools used by VMs — SNAT breaks VM IP persistence after migration
- Mark live migration as tech preview on the Calico Enterprise docs
- Add a BIRD 1.x import filter example for configuring the ToR to prefer elevated-priority routes via community matching



DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->