### PR TITLE
Add MKE 3.9 to CE 3.22 compatibility matrix

### DIFF
--- a/calico-enterprise/getting-started/compatibility.mdx
+++ b/calico-enterprise/getting-started/compatibility.mdx
@@ -80,7 +80,8 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | $[prodname] version | MKE version | $[prodname] support                 | Kubernetes versions |
 | -------------------- | ----------- | ------------------------------------ | ------------------- |
-| 3.23                 | MKE 3.8     | $[prodname] CNI with network policy | 1.31                |
+| 3.23                 | MKE 3.9     | $[prodname] CNI with network policy | 1.34                |
+| 3.22                 | MKE 3.9     | $[prodname] CNI with network policy | 1.34                |
 | 3.22                 | MKE 3.8     | $[prodname] CNI with network policy | 1.31                |
 | 3.21                 | MKE 3.8     | $[prodname] CNI with network policy | 1.31                |
 | 3.20                 | MKE 3.8     | $[prodname] CNI with network policy | 1.31                |

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/compatibility.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/compatibility.mdx
@@ -77,6 +77,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | $[prodname] version | MKE version | $[prodname] support                 | Kubernetes versions |
 | -------------------- | ----------- | ------------------------------------ | ------------------- |
+| 3.22                 | MKE 3.9     | $[prodname] CNI with network policy | 1.34                |
 | 3.22                 | MKE 3.8     | $[prodname] CNI with network policy | 1.31                |
 | 3.21                 | MKE 3.8     | $[prodname] CNI with network policy | 1.31                |
 | 3.20                 | MKE 3.8     | $[prodname] CNI with network policy | 1.31                |

--- a/calico-enterprise_versioned_docs/version-3.23-1/getting-started/compatibility.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/getting-started/compatibility.mdx
@@ -81,6 +81,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 | $[prodname] version | MKE version | $[prodname] support                 | Kubernetes versions |
 | -------------------- | ----------- | ------------------------------------ | ------------------- |
 | 3.23                 | MKE 3.8     | $[prodname] CNI with network policy | 1.31                |
+| 3.22                 | MKE 3.9     | $[prodname] CNI with network policy | 1.34                |
 | 3.22                 | MKE 3.8     | $[prodname] CNI with network policy | 1.31                |
 | 3.21                 | MKE 3.8     | $[prodname] CNI with network policy | 1.31                |
 | 3.20                 | MKE 3.8     | $[prodname] CNI with network policy | 1.31                |


### PR DESCRIPTION
## Summary

CE 3.22 is now validated against MKE 3.9 with Kubernetes 1.34. Update the compatibility tables to reflect this:

- **3.22 versioned docs**: add a new row \`3.22 / MKE 3.9 / 1.34\` alongside the existing MKE 3.8 row
- **3.23 versioned docs**: add the back-claim \`3.22 / MKE 3.9 / 1.34\` row. **CE 3.23 with MKE 3.9 has not been validated**, so the 3.23 row continues to list MKE 3.8 only.
- **main (unversioned)**: add MKE 3.9 rows for both 3.22 and 3.23. The 3.23 / MKE 3.8 row is dropped since 3.23 has fully transitioned to MKE 3.9.

## Test plan

- [ ] Deploy preview renders the MKE table in each version of the compatibility page correctly
- [ ] No other compatibility sections (MKE 4k, OpenShift, etc.) are affected