### PR TITLE
docs: fix admonition title syntax to use brackets

### DIFF
--- a/calico-enterprise/compliance/compliance-reports-cis.mdx
+++ b/calico-enterprise/compliance/compliance-reports-cis.mdx
@@ -4,7 +4,7 @@ description: Configure reports to assess compliance for all assets in a Kubernet
 
 # Configure CIS benchmark reports
 
-:::info deprecation notice
+:::info[deprecation notice]
 
 The compliance features described on this page are deprecated and will be removed in a future release.
 We're building a new compliance reporting system that will eventually replace the current one.

--- a/calico-enterprise/compliance/enable-compliance.mdx
+++ b/calico-enterprise/compliance/enable-compliance.mdx
@@ -4,7 +4,7 @@ description: Enable compliance reports to configure reports to assess compliance
 
 # Enable compliance reports
 
-:::info deprecation notice
+:::info[deprecation notice]
 
 The compliance features described on this page are deprecated and will be removed in a future release.
 We're building a new compliance reporting system that will eventually replace the current one.

--- a/calico-enterprise/compliance/overview.mdx
+++ b/calico-enterprise/compliance/overview.mdx
@@ -4,7 +4,7 @@ description: Get the reports for regulatory compliance on Kubernetes workloads a
 
 # Schedule and run compliance reports
 
-:::info deprecation notice
+:::info[deprecation notice]
 
 The compliance features described on this page are deprecated and will be removed in a future release.
 We're building a new compliance reporting system that will eventually replace the current one.

--- a/calico-enterprise/operations/ebpf/install.mdx
+++ b/calico-enterprise/operations/ebpf/install.mdx
@@ -180,7 +180,7 @@ can do that by setting `--kube-proxy-mode=disabled` and `--kube-default-drop-mas
 
 More details can be found in [the MKE documentation](https://docs.mirantis.com/mke/current/install/predeployment/configure-networking/cluster-service-networking-options.html)
 
-:::caution VXLAN port conflict
+:::caution[VXLAN port conflict]
 
 MKE's Docker Swarm overlay networking uses UDP port 4789 for its own VXLAN devices. In eBPF mode, when BTF is available on the node (typically kernel v5.8+),
 $[prodname] creates the `vxlan.calico` device in flow mode, which conflicts with Docker Swarm's use of the same port.

--- a/calico-enterprise/release-notes/index.mdx
+++ b/calico-enterprise/release-notes/index.mdx
@@ -5,7 +5,7 @@ title: Release notes
 
 # Calico Enterprise X.Y release notes
 
-:::info early preview release
+:::info[early preview release]
 
 Calico Enterprise X.Y can be used for previewing and testing purposes only.
 It is not supported for use in production.

--- a/calico-enterprise_versioned_docs/version-3.20-2/compliance/compliance-reports-cis.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/compliance/compliance-reports-cis.mdx
@@ -4,7 +4,7 @@ description: Configure reports to assess compliance for all assets in a Kubernet
 
 # Configure CIS benchmark reports
 
-:::info deprecation notice
+:::info[deprecation notice]
 
 The compliance features described on this page are deprecated and will be removed in a future release.
 We're building a new compliance reporting system that will eventually replace the current one.

--- a/calico-enterprise_versioned_docs/version-3.20-2/compliance/enable-compliance.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/compliance/enable-compliance.mdx
@@ -4,7 +4,7 @@ description: Enable compliance reports to configure reports to assess compliance
 
 # Enable compliance reports
 
-:::info deprecation notice
+:::info[deprecation notice]
 
 The compliance features described on this page are deprecated and will be removed in a future release.
 We're building a new compliance reporting system that will eventually replace the current one.

--- a/calico-enterprise_versioned_docs/version-3.20-2/compliance/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/compliance/overview.mdx
@@ -4,7 +4,7 @@ description: Get the reports for regulatory compliance on Kubernetes workloads a
 
 # Schedule and run compliance reports
 
-:::info deprecation notice
+:::info[deprecation notice]
 
 The compliance features described on this page are deprecated and will be removed in a future release.
 We're building a new compliance reporting system that will eventually replace the current one.

--- a/calico-enterprise_versioned_docs/version-3.20-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/release-notes/index.mdx
@@ -64,7 +64,7 @@ For more information, see [Installing Calico Enterprise on an OpenShift HCP clus
 We've changed the default behavior for packet capturing and compliance reporting.
 These features are now disabled by default.
 
-:::note Update note
+:::note[Update note]
 Updating to Calico Enterprise 3.20 will disable the packet capture and compliance reporting features.
 To continue using these features, you must re-enable them during or after the update.
 * **Multi-cluster management** You must enable compliance reports first in the management cluster, followed by the managed clusters.

--- a/calico-enterprise_versioned_docs/version-3.21-2/compliance/compliance-reports-cis.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/compliance/compliance-reports-cis.mdx
@@ -4,7 +4,7 @@ description: Configure reports to assess compliance for all assets in a Kubernet
 
 # Configure CIS benchmark reports
 
-:::info deprecation notice
+:::info[deprecation notice]
 
 The compliance features described on this page are deprecated and will be removed in a future release.
 We're building a new compliance reporting system that will eventually replace the current one.

--- a/calico-enterprise_versioned_docs/version-3.21-2/compliance/enable-compliance.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/compliance/enable-compliance.mdx
@@ -4,7 +4,7 @@ description: Enable compliance reports to configure reports to assess compliance
 
 # Enable compliance reports
 
-:::info deprecation notice
+:::info[deprecation notice]
 
 The compliance features described on this page are deprecated and will be removed in a future release.
 We're building a new compliance reporting system that will eventually replace the current one.

--- a/calico-enterprise_versioned_docs/version-3.21-2/compliance/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/compliance/overview.mdx
@@ -4,7 +4,7 @@ description: Get the reports for regulatory compliance on Kubernetes workloads a
 
 # Schedule and run compliance reports
 
-:::info deprecation notice
+:::info[deprecation notice]
 
 The compliance features described on this page are deprecated and will be removed in a future release.
 We're building a new compliance reporting system that will eventually replace the current one.

--- a/calico-enterprise_versioned_docs/version-3.22-2/compliance/compliance-reports-cis.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/compliance/compliance-reports-cis.mdx
@@ -4,7 +4,7 @@ description: Configure reports to assess compliance for all assets in a Kubernet
 
 # Configure CIS benchmark reports
 
-:::info deprecation notice
+:::info[deprecation notice]
 
 The compliance features described on this page are deprecated and will be removed in a future release.
 We're building a new compliance reporting system that will eventually replace the current one.

--- a/calico-enterprise_versioned_docs/version-3.22-2/compliance/enable-compliance.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/compliance/enable-compliance.mdx
@@ -4,7 +4,7 @@ description: Enable compliance reports to configure reports to assess compliance
 
 # Enable compliance reports
 
-:::info deprecation notice
+:::info[deprecation notice]
 
 The compliance features described on this page are deprecated and will be removed in a future release.
 We're building a new compliance reporting system that will eventually replace the current one.

--- a/calico-enterprise_versioned_docs/version-3.22-2/compliance/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/compliance/overview.mdx
@@ -4,7 +4,7 @@ description: Get the reports for regulatory compliance on Kubernetes workloads a
 
 # Schedule and run compliance reports
 
-:::info deprecation notice
+:::info[deprecation notice]
 
 The compliance features described on this page are deprecated and will be removed in a future release.
 We're building a new compliance reporting system that will eventually replace the current one.

--- a/calico-enterprise_versioned_docs/version-3.23-1/compliance/compliance-reports-cis.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/compliance/compliance-reports-cis.mdx
@@ -4,7 +4,7 @@ description: Configure reports to assess compliance for all assets in a Kubernet
 
 # Configure CIS benchmark reports
 
-:::info deprecation notice
+:::info[deprecation notice]
 
 The compliance features described on this page are deprecated and will be removed in a future release.
 We're building a new compliance reporting system that will eventually replace the current one.

--- a/calico-enterprise_versioned_docs/version-3.23-1/compliance/enable-compliance.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/compliance/enable-compliance.mdx
@@ -4,7 +4,7 @@ description: Enable compliance reports to configure reports to assess compliance
 
 # Enable compliance reports
 
-:::info deprecation notice
+:::info[deprecation notice]
 
 The compliance features described on this page are deprecated and will be removed in a future release.
 We're building a new compliance reporting system that will eventually replace the current one.

--- a/calico-enterprise_versioned_docs/version-3.23-1/compliance/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/compliance/overview.mdx
@@ -4,7 +4,7 @@ description: Get the reports for regulatory compliance on Kubernetes workloads a
 
 # Schedule and run compliance reports
 
-:::info deprecation notice
+:::info[deprecation notice]
 
 The compliance features described on this page are deprecated and will be removed in a future release.
 We're building a new compliance reporting system that will eventually replace the current one.

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/install.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/install.mdx
@@ -180,7 +180,7 @@ can do that by setting `--kube-proxy-mode=disabled` and `--kube-default-drop-mas
 
 More details can be found in [the MKE documentation](https://docs.mirantis.com/mke/current/install/predeployment/configure-networking/cluster-service-networking-options.html)
 
-:::caution VXLAN port conflict
+:::caution[VXLAN port conflict]
 
 MKE's Docker Swarm overlay networking uses UDP port 4789 for its own VXLAN devices. In eBPF mode, when BTF is available on the node (typically kernel v5.8+),
 $[prodname] creates the `vxlan.calico` device in flow mode, which conflicts with Docker Swarm's use of the same port.

--- a/calico-enterprise_versioned_docs/version-3.23-1/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/release-notes/index.mdx
@@ -5,7 +5,7 @@ title: Release notes
 
 # Calico Enterprise 3.23 release notes
 
-:::info early preview release
+:::info[early preview release]
 
 Calico Enterprise 3.23 can be used for previewing and testing purposes only.
 It is not supported for use in production.

--- a/calico/operations/ebpf/install.mdx
+++ b/calico/operations/ebpf/install.mdx
@@ -208,7 +208,7 @@ can do that by setting `--kube-proxy-mode=disabled` and `--kube-default-drop-mas
 
 More details can be found in [the MKE documentation](https://docs.mirantis.com/mke/current/install/predeployment/configure-networking/cluster-service-networking-options.html)
 
-:::caution VXLAN port conflict
+:::caution[VXLAN port conflict]
 
 MKE's Docker Swarm overlay networking uses UDP port 4789 for its own VXLAN devices. In eBPF mode, when BTF is available on the node (typically kernel v5.8+),
 $[prodname] creates the `vxlan.calico` device in flow mode, which conflicts with Docker Swarm's use of the same port.

--- a/calico/operations/fips.mdx
+++ b/calico/operations/fips.mdx
@@ -4,7 +4,7 @@ description: Run Calico using FIPS validated cryptography.
 
 # FIPS mode
 
-:::info deprecation notice
+:::info[deprecation notice]
 
 FIPS mode is deprecated and will be removed in a future release.
 

--- a/calico/reference/resources/felixconfig.mdx
+++ b/calico/reference/resources/felixconfig.mdx
@@ -36,7 +36,7 @@ spec:
 - The resources with the name `node.<nodename>` contain the node-specific overrides, and will be applied to the node `<nodename>`. When deleting a node the FelixConfiguration resource associated with the node will also be deleted.
 - Resources with any other name can use the `nodeSelector` field to target a group of nodes by label (see [Selector-scoped configuration](#selector-scoped-configuration) below).
 
-### Selector-scoped configuration (tech preview) {#selector-scoped-configuration}
+### Selector-scoped configuration
 
 :::note
 

--- a/calico_versioned_docs/version-3.30/operations/fips.mdx
+++ b/calico_versioned_docs/version-3.30/operations/fips.mdx
@@ -4,7 +4,7 @@ description: Run Calico using FIPS validated cryptography.
 
 # FIPS mode
 
-:::info deprecation notice
+:::info[deprecation notice]
 
 FIPS mode is deprecated and will be removed in a future release.
 

--- a/calico_versioned_docs/version-3.31/operations/ebpf/install.mdx
+++ b/calico_versioned_docs/version-3.31/operations/ebpf/install.mdx
@@ -208,7 +208,7 @@ can do that by setting `--kube-proxy-mode=disabled` and `--kube-default-drop-mas
 
 More details can be found in [the MKE documentation](https://docs.mirantis.com/mke/current/install/predeployment/configure-networking/cluster-service-networking-options.html)
 
-:::caution VXLAN port conflict
+:::caution[VXLAN port conflict]
 
 MKE's Docker Swarm overlay networking uses UDP port 4789 for its own VXLAN devices. In eBPF mode, when BTF is available on the node (typically kernel v5.8+),
 $[prodname] creates the `vxlan.calico` device in flow mode, which conflicts with Docker Swarm's use of the same port.

--- a/calico_versioned_docs/version-3.31/operations/fips.mdx
+++ b/calico_versioned_docs/version-3.31/operations/fips.mdx
@@ -4,7 +4,7 @@ description: Run Calico using FIPS validated cryptography.
 
 # FIPS mode
 
-:::info deprecation notice
+:::info[deprecation notice]
 
 FIPS mode is deprecated and will be removed in a future release.
 


### PR DESCRIPTION
## Summary

- Wrap admonition titles in brackets (e.g. `:::info[title]`) — Docusaurus 3 no longer accepts the unbracketed form, so admonitions like the FIPS deprecation notice were rendering as literal `:::info deprecation notice` text on the live site (reported in [Slack](https://tigera.slack.com/archives/C0FQH92CA/p1777381255897319), visible at https://docs.tigera.io/calico/latest/operations/fips).
- Apply the same fix to every other unbracketed admonition title across `calico`, `calico-enterprise`, and their versioned docs (compliance overview/enable/CIS, eBPF install MKE callout, Calico Enterprise release notes, etc.).

## Test plan

- [x] `yarn build` succeeds
- [x] `build/calico/latest/operations/fips/index.html` now contains `<div class="admonition theme-admonition-info ...">` instead of the raw `:::info deprecation notice` text
- [x] Spot-checked rebuilt HTML for `calico/latest/operations/ebpf/install` and `calico-enterprise/latest/compliance/overview` — admonitions render as styled callouts
- [x] `grep -r '^:::\(info\|note\|tip\|caution\|warning\|danger\)\s\+\S' --include='*.mdx'` returns no remaining matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)