### PR TITLE
docs(oss): add Istio Ambient Mode pages for OSS 3.32

### DIFF
--- a/calico/operations/istio/about-istio-ambient.mdx
+++ b/calico/operations/istio/about-istio-ambient.mdx
@@ -1,0 +1,53 @@
+---
+description: An overview of Calico's bundled version of Istio Ambient Mode
+---
+
+# Istio Ambient Mode
+
+You can use $[prodname] to deploy and manage an Istio service mesh on your cluster.
+$[prodname] installs Istio in ambient mode, which conserves resources while providing the same robust mTLS encryption for your workloads.
+
+:::note
+
+Istio Ambient Mode is a tech preview feature.
+Tech preview features are subject to significant changes before they become GA.
+
+:::
+
+## About Istio Ambient Mode
+
+Istio is a service mesh that manages and secures communication between microservices.
+Typically, Istio uses sidecar proxies that are deployed alongside every pod in the service mesh.
+At scale, running these sidecar proxies can be difficult to manage and a drain on resources.
+
+Istio Ambient Mode is a simplified service mesh architecture that removes the need for a sidecar proxy next to every pod.
+Instead, it uses node-level components for shared security and a layered approach for advanced traffic management.
+This design saves on computing resources and simplifies operations.
+
+## About Istio Ambient Mode on Calico
+
+$[prodname] provides a bundled version of Istio that can be installed and managed by the Tigera Operator.
+
+This integration automates the lifecycle of the Istio components to reduce manual configuration overhead.
+CVEs are addressed as part of the regular $[prodname] patch release cadence.
+Administrators provision the Istio service mesh by defining a standard `Istio` custom resource.
+
+### The enhanced zTunnel proxy
+
+The zTunnel component in Istio Ambient Mode is a lightweight proxy that runs on every node.
+
+Its main job is to handle encryption, authentication, and policy enforcement for traffic at Layer 4.
+
+A challenge in the original Istio Ambient Mode is that when traffic is routed through the zTunnel, it gets placed into a tunnel on a specific port (15008).
+This change makes it impossible for existing Layer 3 or Layer 4 network policies (like those from Calico) to see the original destination port of the traffic.
+
+Calico addresses this by using an enhanced zTunnel that is modified to preserve the original destination port.
+This modification allows existing Calico and Kubernetes network policies to continue functioning exactly as they did before, without needing any rewrites, even though the traffic is now encrypted with mTLS.
+
+These zTunnel enhancements are not compatible with Istio's application-layer Waypoint proxy.
+If you deploy Waypoint, the reported destination ports will follow the original behavior.
+Existing network policies need to be adapted to allow communication to port 15008.
+
+## Additional resources
+* [Overview of Istio ambient mode](https://istio.io/latest/docs/ambient/overview/).
+* [Ambient and Kubernetes NetworkPolicy](https://istio.io/latest/docs/ambient/usage/networkpolicy/)

--- a/calico/operations/istio/deploy-istio-ambient.mdx
+++ b/calico/operations/istio/deploy-istio-ambient.mdx
@@ -1,0 +1,148 @@
+---
+description: This page explains how to deploy Calico's bundled version of Istio in ambient mode.
+---
+
+# Deploy Istio Ambient Mode on your cluster
+
+You can deploy Calico's bundled version of Istio in ambient mode to provide mTLS encryption to your workloads.
+
+:::note
+
+Istio Ambient Mode is a tech preview feature.
+Tech preview features are subject to significant changes before they become GA.
+
+:::
+
+## Limitations
+
+* [Application layer network policies](../../network-policy/istio/app-layer-policy.mdx) are not compatible with the Istio service mesh.
+* Destination ports are preserved only when Istio is deployed without Waypoint.
+  If you deploy Waypoint, all traffic through Waypoint will show port 15008 as its destination port.
+* Connect-time load balancing is not compatible with Istio Ambient Mode.
+
+## Prerequisites
+
+* $[prodname] is installed and managed by the Tigera Operator.
+
+## Install Istio in ambient mode on your cluster
+
+You can create an Istio service mesh in ambient mode by creating the `Istio` custom resource.
+
+* To install Istio in ambient mode, apply the `Istio` custom resource to your cluster:
+
+   ```bash
+   cat <<EOF | kubectl apply -f -
+   apiVersion: operator.tigera.io/v1
+   kind: Istio
+   metadata:
+     name: default
+   EOF
+   ```
+
+   :::note
+   To customize resource requirements for your Istio deployment, see the options available in the [installation API documentation](../../reference/installation/api.mdx).
+   :::
+
+   To verify the installation:
+
+   ```bash
+   kubectl get tigerastatus
+   ```
+
+   ```shell title='Example output'
+   NAME        AVAILABLE   PROGRESSING   DEGRADED   SINCE
+   apiserver   True        False         False      4m9s
+   calico      True        False         False      3m29s
+   goldmane    True        False         False      3m39s
+   ippools     True        False         False      6m4s
+   // highlight-next-line
+   istio       True        False         False      19s
+   whisker     True        False         False      3m19s
+   ```
+   Now you can add your workloads to the Istio service mesh.
+
+## Add a workload to the Istio service mesh
+
+You can add workloads to the mesh by labeling them.
+Communication between labelled namespaces and pods goes through the mesh and uses mTLS encryption.
+
+:::warning
+
+Don't label $[prodname] resources to add them to the service mesh.
+Doing this can cause interruptions and failure to your cluster network.
+
+If you want to secure $[prodname] components, see [Secure Calico component communications](../../network-policy/comms/index.mdx).
+:::
+
+1. To add workloads to your Istio service mesh, add the `istio.io/dataplane-mode=ambient` label to a pod or namespace resource:
+
+   ```bash title='Adding a namespace to the Istio service mesh'
+   kubectl label namespace <namespace> istio.io/dataplane-mode=ambient
+   ```
+   Replace `<namespace>` with the namespace you want to include in the mesh.
+
+   ```bash title='Adding a pod to the Istio service mesh'
+   kubectl label pod --namespace=<namespace> <pod> istio.io/dataplane-mode=ambient
+   ```
+   Replace the following:
+   * `<pod>`: The name of the pod you want to include in the mesh.
+   * `<namespace>`: The namespace your pod is in.
+
+## Removing Istio
+
+If you want to remove Istio, first remove the labels you applied to pods and namespaces.
+When that's done, you can delete the `Istio` custom resource.
+
+1. Remove the label from namespaces and pods by running the following commands:
+
+   ```bash
+   kubectl label namespaces --all istio.io/dataplane-mode=ambient-
+   kubectl label pods --all --all-namespaces istio.io/dataplane-mode=ambient-
+   ```
+1. Remove the `Istio` custom resource:
+
+   ```bash
+   kubectl delete istio.operator.tigera.io default
+   ```
+
+## Troubleshooting commands
+
+Check whether Istio pods are deployed:
+
+```bash
+kubectl get pods -n calico-system | grep 'istio\|ztunnel'
+```
+
+Check whether Istio CRDs are deployed:
+
+```bash
+kubectl get crd | grep istio
+```
+
+Check which pods and namespaces are in the mesh:
+
+* Requires [istioctl](https://istio.io/latest/docs/ops/diagnostic-tools/istioctl/).
+
+```bash
+istioctl ztunnel-config workloads -n calico-system
+```
+
+Check for errors logged by the zTunnel component:
+
+```bash
+ZTUNNEL_PODS=$(kubectl get pod -n calico-system \
+  -l app.kubernetes.io/name=ztunnel \
+  -o jsonpath='{.items[*].metadata.name}')
+
+for P in $ZTUNNEL_PODS; do
+  echo "--- Checking logs for pod: $P ---"
+  kubectl logs $P -n calico-system 2>/dev/null | \
+    grep -i error | \
+    grep -i app1
+done
+```
+
+## Additional resources
+
+* [Overview of Istio ambient mode](https://istio.io/latest/docs/ambient/overview/).
+* [Configuration options](../../reference/installation/api).

--- a/calico_versioned_docs/version-3.32/operations/istio/about-istio-ambient.mdx
+++ b/calico_versioned_docs/version-3.32/operations/istio/about-istio-ambient.mdx
@@ -1,0 +1,53 @@
+---
+description: An overview of Calico's bundled version of Istio Ambient Mode
+---
+
+# Istio Ambient Mode
+
+You can use $[prodname] to deploy and manage an Istio service mesh on your cluster.
+$[prodname] installs Istio in ambient mode, which conserves resources while providing the same robust mTLS encryption for your workloads.
+
+:::note
+
+Istio Ambient Mode is a tech preview feature.
+Tech preview features are subject to significant changes before they become GA.
+
+:::
+
+## About Istio Ambient Mode
+
+Istio is a service mesh that manages and secures communication between microservices.
+Typically, Istio uses sidecar proxies that are deployed alongside every pod in the service mesh.
+At scale, running these sidecar proxies can be difficult to manage and a drain on resources.
+
+Istio Ambient Mode is a simplified service mesh architecture that removes the need for a sidecar proxy next to every pod.
+Instead, it uses node-level components for shared security and a layered approach for advanced traffic management.
+This design saves on computing resources and simplifies operations.
+
+## About Istio Ambient Mode on Calico
+
+$[prodname] provides a bundled version of Istio that can be installed and managed by the Tigera Operator.
+
+This integration automates the lifecycle of the Istio components to reduce manual configuration overhead.
+CVEs are addressed as part of the regular $[prodname] patch release cadence.
+Administrators provision the Istio service mesh by defining a standard `Istio` custom resource.
+
+### The enhanced zTunnel proxy
+
+The zTunnel component in Istio Ambient Mode is a lightweight proxy that runs on every node.
+
+Its main job is to handle encryption, authentication, and policy enforcement for traffic at Layer 4.
+
+A challenge in the original Istio Ambient Mode is that when traffic is routed through the zTunnel, it gets placed into a tunnel on a specific port (15008).
+This change makes it impossible for existing Layer 3 or Layer 4 network policies (like those from Calico) to see the original destination port of the traffic.
+
+Calico addresses this by using an enhanced zTunnel that is modified to preserve the original destination port.
+This modification allows existing Calico and Kubernetes network policies to continue functioning exactly as they did before, without needing any rewrites, even though the traffic is now encrypted with mTLS.
+
+These zTunnel enhancements are not compatible with Istio's application-layer Waypoint proxy.
+If you deploy Waypoint, the reported destination ports will follow the original behavior.
+Existing network policies need to be adapted to allow communication to port 15008.
+
+## Additional resources
+* [Overview of Istio ambient mode](https://istio.io/latest/docs/ambient/overview/).
+* [Ambient and Kubernetes NetworkPolicy](https://istio.io/latest/docs/ambient/usage/networkpolicy/)

--- a/calico_versioned_docs/version-3.32/operations/istio/deploy-istio-ambient.mdx
+++ b/calico_versioned_docs/version-3.32/operations/istio/deploy-istio-ambient.mdx
@@ -1,0 +1,148 @@
+---
+description: This page explains how to deploy Calico's bundled version of Istio in ambient mode.
+---
+
+# Deploy Istio Ambient Mode on your cluster
+
+You can deploy Calico's bundled version of Istio in ambient mode to provide mTLS encryption to your workloads.
+
+:::note
+
+Istio Ambient Mode is a tech preview feature.
+Tech preview features are subject to significant changes before they become GA.
+
+:::
+
+## Limitations
+
+* [Application layer network policies](../../network-policy/istio/app-layer-policy.mdx) are not compatible with the Istio service mesh.
+* Destination ports are preserved only when Istio is deployed without Waypoint.
+  If you deploy Waypoint, all traffic through Waypoint will show port 15008 as its destination port.
+* Connect-time load balancing is not compatible with Istio Ambient Mode.
+
+## Prerequisites
+
+* $[prodname] is installed and managed by the Tigera Operator.
+
+## Install Istio in ambient mode on your cluster
+
+You can create an Istio service mesh in ambient mode by creating the `Istio` custom resource.
+
+* To install Istio in ambient mode, apply the `Istio` custom resource to your cluster:
+
+   ```bash
+   cat <<EOF | kubectl apply -f -
+   apiVersion: operator.tigera.io/v1
+   kind: Istio
+   metadata:
+     name: default
+   EOF
+   ```
+
+   :::note
+   To customize resource requirements for your Istio deployment, see the options available in the [installation API documentation](../../reference/installation/api.mdx).
+   :::
+
+   To verify the installation:
+
+   ```bash
+   kubectl get tigerastatus
+   ```
+
+   ```shell title='Example output'
+   NAME        AVAILABLE   PROGRESSING   DEGRADED   SINCE
+   apiserver   True        False         False      4m9s
+   calico      True        False         False      3m29s
+   goldmane    True        False         False      3m39s
+   ippools     True        False         False      6m4s
+   // highlight-next-line
+   istio       True        False         False      19s
+   whisker     True        False         False      3m19s
+   ```
+   Now you can add your workloads to the Istio service mesh.
+
+## Add a workload to the Istio service mesh
+
+You can add workloads to the mesh by labeling them.
+Communication between labelled namespaces and pods goes through the mesh and uses mTLS encryption.
+
+:::warning
+
+Don't label $[prodname] resources to add them to the service mesh.
+Doing this can cause interruptions and failure to your cluster network.
+
+If you want to secure $[prodname] components, see [Secure Calico component communications](../../network-policy/comms/index.mdx).
+:::
+
+1. To add workloads to your Istio service mesh, add the `istio.io/dataplane-mode=ambient` label to a pod or namespace resource:
+
+   ```bash title='Adding a namespace to the Istio service mesh'
+   kubectl label namespace <namespace> istio.io/dataplane-mode=ambient
+   ```
+   Replace `<namespace>` with the namespace you want to include in the mesh.
+
+   ```bash title='Adding a pod to the Istio service mesh'
+   kubectl label pod --namespace=<namespace> <pod> istio.io/dataplane-mode=ambient
+   ```
+   Replace the following:
+   * `<pod>`: The name of the pod you want to include in the mesh.
+   * `<namespace>`: The namespace your pod is in.
+
+## Removing Istio
+
+If you want to remove Istio, first remove the labels you applied to pods and namespaces.
+When that's done, you can delete the `Istio` custom resource.
+
+1. Remove the label from namespaces and pods by running the following commands:
+
+   ```bash
+   kubectl label namespaces --all istio.io/dataplane-mode=ambient-
+   kubectl label pods --all --all-namespaces istio.io/dataplane-mode=ambient-
+   ```
+1. Remove the `Istio` custom resource:
+
+   ```bash
+   kubectl delete istio.operator.tigera.io default
+   ```
+
+## Troubleshooting commands
+
+Check whether Istio pods are deployed:
+
+```bash
+kubectl get pods -n calico-system | grep 'istio\|ztunnel'
+```
+
+Check whether Istio CRDs are deployed:
+
+```bash
+kubectl get crd | grep istio
+```
+
+Check which pods and namespaces are in the mesh:
+
+* Requires [istioctl](https://istio.io/latest/docs/ops/diagnostic-tools/istioctl/).
+
+```bash
+istioctl ztunnel-config workloads -n calico-system
+```
+
+Check for errors logged by the zTunnel component:
+
+```bash
+ZTUNNEL_PODS=$(kubectl get pod -n calico-system \
+  -l app.kubernetes.io/name=ztunnel \
+  -o jsonpath='{.items[*].metadata.name}')
+
+for P in $ZTUNNEL_PODS; do
+  echo "--- Checking logs for pod: $P ---"
+  kubectl logs $P -n calico-system 2>/dev/null | \
+    grep -i error | \
+    grep -i app1
+done
+```
+
+## Additional resources
+
+* [Overview of Istio ambient mode](https://istio.io/latest/docs/ambient/overview/).
+* [Configuration options](../../reference/installation/api).

--- a/calico_versioned_sidebars/version-3.32-sidebars.json
+++ b/calico_versioned_sidebars/version-3.32-sidebars.json
@@ -507,6 +507,15 @@
       "items": [
         {
           "type": "category",
+          "label": "Istio Ambient Mode",
+          "link": null,
+          "items": [
+            "operations/istio/about-istio-ambient",
+            "operations/istio/deploy-istio-ambient"
+          ]
+        },
+        {
+          "type": "category",
           "label": "calicoctl",
           "link": {
             "type": "doc",

--- a/sidebars-calico.js
+++ b/sidebars-calico.js
@@ -510,6 +510,15 @@ module.exports = {
       items: [
         {
           type: 'category',
+          label: 'Istio Ambient Mode',
+          link: null,
+          items: [
+            'operations/istio/about-istio-ambient',
+            'operations/istio/deploy-istio-ambient',
+          ],
+        },
+        {
+          type: 'category',
           label: 'calicoctl',
           link: {
             type: 'doc',


### PR DESCRIPTION
## Summary
- Adds Istio Ambient Mode docs (about + deploy) to the OSS Calico **Operations** section, mirroring the Calico Enterprise pages, for the OSS 3.32 release.
- Dropped CE-only limitation bullets (WAF and cluster mesh).
- Repointed cross-references to OSS equivalents (`network-policy/istio/app-layer-policy.mdx` and `network-policy/comms/index.mdx`).
- Trimmed the `kubectl get tigerastatus` example output to OSS-realistic components and highlighted the new `istio` row.
- Sidebar entries added in both the `next` (`sidebars-calico.js`) and versioned (`calico_versioned_sidebars/version-3.32-sidebars.json`) sidebars.
- Files mirrored into `calico_versioned_docs/version-3.32/operations/istio/`.

## Test plan
- [ ] `yarn start` and confirm the new **Istio Ambient Mode** category appears under Operations in the Calico sidebar.
- [ ] Open `/calico/next/operations/istio/about-istio-ambient` and `/calico/next/operations/istio/deploy-istio-ambient` and confirm they render.
- [ ] Open the same paths under `/calico/3.32/...` and confirm they render in the versioned docs.
- [ ] Confirm in-page links (app-layer-policy, comms, installation API) resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)