### PR TITLE
Publish Calico Open Source 3.32

### DIFF
--- a/calico_versioned_docs/version-3.31/variables.js
+++ b/calico_versioned_docs/version-3.31/variables.js
@@ -5,7 +5,7 @@ const variables = {
   prodname: 'Calico',
   prodnamedash: 'calico',
   version: 'v3.31',
-  baseUrl: '/calico/latest',
+  baseUrl: '/calico/3.31',
   filesUrl: 'https://projectcalico.docs.tigera.io/v3.31',
   tutorialFilesURL: 'https://docs.tigera.io/files',
   calicoReleasesURL: 'https://github.com/projectcalico/calico/releases/download',

--- a/calico_versioned_docs/version-3.32/releases.json
+++ b/calico_versioned_docs/version-3.32/releases.json
@@ -1,6 +1,6 @@
 [
   {
-    "title": "master",
+    "title": "v3.32.0",
     "tigera-operator": {
       "image": "tigera/operator",
       "registry": "quay.io",
@@ -8,51 +8,51 @@
     },
     "components": {
       "calico/typha": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "calico/ctl": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "calico/node": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "calico/node-windows": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "calico/cni": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "calico/cni-windows": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "calico/apiserver": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "calico/kube-controllers": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "calico/envoy-gateway": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "calico/envoy-proxy": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "calico/envoy-ratelimit": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "calico/flannel-migration-controller": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "flannel": {
@@ -60,39 +60,39 @@
         "registry": "docker.io"
       },
       "calico/dikastes": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "flexvol": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "calico/csi": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "calico/node-driver-registrar": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "calico/pod2daemon-flexvol": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "calico/key-cert-provisioner": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "calico/goldmane": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "calico/whisker": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       },
       "calico/whisker-backend": {
-        "version": "master",
+        "version": "v3.32.0",
         "registry": "quay.io"
       }
     }

--- a/calico_versioned_docs/version-3.32/variables.js
+++ b/calico_versioned_docs/version-3.32/variables.js
@@ -1,28 +1,26 @@
 const releases = require('./releases.json');
 
 const variables = {
-  releaseTitle: 'master',
+  releaseTitle: 'v3.32.0',
   prodname: 'Calico',
   prodnamedash: 'calico',
-  version: 'master',
+  version: 'v3.32',
   baseUrl: '/calico/latest',
-  filesUrl: 'https://projectcalico.docs.tigera.io/master',
+  filesUrl: 'https://projectcalico.docs.tigera.io/v3.32',
   tutorialFilesURL: 'https://docs.tigera.io/files',
   calicoReleasesURL: 'https://github.com/projectcalico/calico/releases/download',
-  tmpScriptsURL: 'https://docs.tigera.io/calico/next',
   windowsScriptsURL: 'https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hostprocess',
   prodnameWindows: 'Calico for Windows',
   prodnamedashWindows: 'calico-for-windows',
   nodecontainer: 'calico/node',
   noderunning: 'calico-node',
   rootDirWindows: 'C:\\CalicoWindows',
-  ppa_repo_name: 'calico-master',
-  manifestsUrl: 'https://2025-10-03-v3-31-quarterly.docs.eng.tigera.net', //Replace with hashrelease
+  ppa_repo_name: 'calico-3.32',
+  manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.32.0',
   releases,
   registry: '',
-  vppbranch: 'master',
-  envoyVersion: '1.7.2',
-  istioVersion: '1.29.2',
+  vppbranch: 'v3.32.0',
+  envoyVersion: '1.5.0',
   tigeraOperator: releases[0]['tigera-operator'],
   tigeraOperatorVersionShort: releases[0]['tigera-operator'].version.split('.').slice(0, 2).join('.'),
   imageNames: {
@@ -42,6 +40,13 @@ const variables = {
     flexvol: 'calico/pod2daemon-flexvol',
     'csi-driver': 'calico/csi',
     'csi-node-driver-registrar': 'calico/node-driver-registrar',
+    'calico/envoy-gateway': 'calico/envoy-gateway',
+    'calico/envoy-proxy': 'calico/envoy-proxy',
+    'calico/envoy-ratelimit': 'calico/envoy-ratelimit',
+    'calico/key-cert-provisioner': 'calico/key-cert-provisioner',
+    'calico/goldmane': 'calico/goldmane',
+    'calico/whisker': 'calico/whisker',
+    'calico/whisker-backend': 'calico/whisker-backend'
   },
 };
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -419,17 +419,22 @@ export default async function createAsyncConfig() {
           path: 'calico',
           routeBasePath: 'calico',
           editCurrentVersion: true,
-          onlyIncludeVersions: [...nextVersion, '3.31', '3.30', '3.29'],
-          lastVersion: '3.31',
+          onlyIncludeVersions: [...nextVersion, '3.32', '3.31', '3.30', '3.29'],
+          lastVersion: '3.32',
           versions: {
             current: {
               label: 'Next',
               path: 'next',
               banner: 'unreleased',
             },
-            3.31: {
-              label: '3.31 (latest)',
+            3.32: {
+              label: '3.32 (latest)',
               path: 'latest',
+              banner: 'none',
+            },
+            3.31: {
+              label: '3.31',
+              path: '3.31',
               banner: 'none',
             },
             '3.30': {

--- a/src/pages/archive.md
+++ b/src/pages/archive.md
@@ -7,7 +7,8 @@ description: Links to all versions of product documentation for Calico, Calico E
 
 ## Calico Open Source
 
-* [Calico Open Source 3.31](https://docs.tigera.io/calico/latest/about)
+* [Calico Open Source 3.32](https://docs.tigera.io/calico/latest/about)
+* [Calico Open Source 3.31](https://docs.tigera.io/calico/3.31/about)
 * [Calico Open Source 3.30](https://docs.tigera.io/calico/3.30/about)
 * [Calico Open Source 3.29](https://docs.tigera.io/calico/3.29/about)
 * [Calico Open Source 3.28](https://archive-os-3-28.netlify.app/calico/3.28/about)

--- a/static/_redirects
+++ b/static/_redirects
@@ -4,7 +4,7 @@
 # Manifest redirects to help out some 3.15 stragglers.
 /v3.15/manifests/* https://downloads.tigera.io/ee/v3.15.1/manifests/:splat 301!
 
-/calico/latest/manifests/*  https://raw.githubusercontent.com/projectcalico/calico/v3.31.0/manifests/:splat 302
+/calico/latest/manifests/*  https://raw.githubusercontent.com/projectcalico/calico/v3.32.0/manifests/:splat 302
 
 # Redirect version Next to calico-docs-preview-next.netlify.app
 /calico/next/* https://calico-docs-preview-next.netlify.app/calico/next/:splat
@@ -12,7 +12,7 @@
 
 # Splat rule for 'latest' X.Y to 'latest' URL
 
-/calico/3.31/* /calico/latest/:splat 302
+/calico/3.32/* /calico/latest/:splat 302
 /calico-enterprise/3.22/* /calico-enterprise/latest/:splat 302
 
 # Calico OSS pages moved

--- a/static/calico/3.32/licenses/third-party-attributions.html
+++ b/static/calico/3.32/licenses/third-party-attributions.html
@@ -1,0 +1,1 @@
+<!-- Placeholder. Third-party attributions will be regenerated and populated as part of the v3.32.0 release. -->


### PR DESCRIPTION
## Summary

Combines the publish-time updates that were deliberately left out of the v3.32 cut commit (`aaf136de`), plus the switch from 3.31 → 3.32 as the documented "latest" Calico Open Source version.

Modeled on the 3.31 publish commits (`39d60ae2 Prepare for publication OSS 3.31` and `48fb9d38 Publish OSS 3.31`), combined here into a single PR.

## Changes

- **`calico_versioned_docs/version-3.32/variables.js`** — reseed from the 3.31 template and bump version-specific fields (`releaseTitle`, `version`, `filesUrl`, `ppa_repo_name`, `manifestsUrl`, `vppbranch`). Revert `envoyVersion` to `'1.5.0'` (the speculative `'1.7.2'` was added during the RN draft for a bundled-component-updates section that was later removed). Drop the unused `istioVersion` variable (no `$[istioVersion]` reference exists in the 3.32 docs). Expand `imageNames` with the seven entries 3.31 had but the master snapshot didn't (`envoy-gateway`, `envoy-proxy`, `envoy-ratelimit`, `key-cert-provisioner`, `goldmane`, `whisker`, `whisker-backend`).
- **`calico_versioned_docs/version-3.32/releases.json`** — replace `master` placeholders with `v3.32.0` component versions, matching 3.31's schema. `tigera-operator.version` is intentionally left as `'master'` so the release engineer can pin the correct operator build separately.
- **`docusaurus.config.js`** — register 3.32 as `latest`, demote 3.31 to `path: '3.31'`. Adds 3.32 to `onlyIncludeVersions`. Updates `lastVersion` to `'3.32'`.
- **`calico_versioned_docs/version-3.31/variables.js`** — un-latest the `baseUrl` from `/calico/latest` to `/calico/3.31`.
- **`static/_redirects`** — bump the latest-manifests redirect to `v3.32.0` and switch the splat-to-latest rule from `3.31` to `3.32`.
- **`src/pages/archive.md`** — add 3.32 at the top of the Calico Open Source list pointing at `/calico/latest/about`, and demote the 3.31 entry from `/calico/latest/about` to `/calico/3.31/about`.
- **`static/calico/3.32/licenses/third-party-attributions.html`** — empty placeholder; the actual attributions HTML is regenerated and populated separately as part of the v3.32.0 release.

## Out of scope

- Archiving the oldest supported OSS version (3.29) — separate change.
- Pinning the `tigera-operator` version in `releases.json` — release engineer.
- Populating `static/calico/3.32/licenses/third-party-attributions.html` — release tooling.

## Local verification

Verified with `yarn start` against this branch:

- Rspack compiles successfully, no broken-link or config warnings.
- `.docusaurus/globalData.json` shows the four OSS versions resolving as expected:
  - `3.32` → label `3.32 (latest)`, path `/calico/latest`, `isLast: true`
  - `3.31` → label `3.31`, path `/calico/3.31`
  - `3.30` → label `3.30`, path `/calico/3.30`
  - `3.29` → label `3.29`, path `/calico/3.29`
- The release-notes route at `/calico/latest/release-notes` resolves to `version-3.32/release-notes/index.mdx`.
- The release-notes route at `/calico/3.31/release-notes` resolves to `version-3.31/release-notes/index.mdx`.

## Test plan

- [ ] Netlify deploy preview renders `/calico/latest/` against 3.32 docs.
- [ ] `/calico/3.31/...` routes resolve to 3.31 docs (not 3.32).
- [ ] `/calico/latest/manifests/foo.yaml` 302s to `https://raw.githubusercontent.com/projectcalico/calico/v3.32.0/manifests/foo.yaml`.
- [ ] Archive page lists 3.32 at top with the latest pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)