### PR TITLE
Bump transitive immutable to patched versions (CVE-2026-29063)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12049,16 +12049,16 @@ __metadata:
   linkType: hard
 
 "immutable@npm:^3.x.x":
-  version: 3.8.2
-  resolution: "immutable@npm:3.8.2"
-  checksum: 10c0/fb6a2999ad3bda9e51741721e42547076dd492635ee4df9241224055fe953ec843583a700088cc4915f23dc326e5084f4e17f1bbd7388c3e872ef5a242e0ac5e
+  version: 3.8.3
+  resolution: "immutable@npm:3.8.3"
+  checksum: 10c0/bafa7b8371b7622bc3d128cd9e6bba3a654b968f09a237929629f43ac26f7e974a5879cd38baad0c26f6f0628753968611bf832add7bf0c44d647bf4306a2988
   languageName: node
   linkType: hard
 
 "immutable@npm:^5.0.2":
-  version: 5.1.3
-  resolution: "immutable@npm:5.1.3"
-  checksum: 10c0/f094891dcefb9488a84598376c9218ebff3a130c8b807bda3f6b703c45fe7ef238b8bf9a1eb9961db0523c8d7eb116ab6f47166702e4bbb1927ff5884157cd97
+  version: 5.1.5
+  resolution: "immutable@npm:5.1.5"
+  checksum: 10c0/8017ece1578e3c5939ba3305176aee059def1b8a90c7fa2a347ef583ebbd38cbe77ce1bbd786a5fab57e2da00bbcb0493b92e4332cdc4e1fe5cfb09a4688df31
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Pins transitive `immutable@^3.x.x` to **3.8.3** (pulled in by `swagger-ui-react@4.19.1`)
- Pins transitive `immutable@^5.0.2` to **5.1.5** (pulled in by `sass@1.89.2`)
- Remediates prototype pollution vulnerability [GHSA-wf6x-7x77-mvgw / CVE-2026-29063](https://github.com/immutable-js/immutable-js/security/advisories/GHSA-wf6x-7x77-mvgw) (CVSS 9.8)

Closes Dependabot alerts [#120](https://github.com/tigera/docs/security/dependabot/120) and [#124](https://github.com/tigera/docs/security/dependabot/124).

## Why this approach

`yarn.lock`-only change. Both parent packages already declare ranges (`^3.x.x` and `^5.0.2`) that accept the patched releases, so no `package.json` edit is needed and no API surface changes. Applied via `yarn set resolution` so future installs can't regress to a vulnerable version.

`swagger-ui-react@latest` (5.32.5) still requires `immutable@^3.x.x`, so bumping the parent doesn't help for the 3.x line — pinning the transitive is the right path.

## Test plan

- [ ] CI: `yarn build` (docusaurus build)
- [ ] CI: `yarn test:components` (jest unit tests)
- [ ] CI: Playwright tests
- [ ] Spot-check an API reference page (rendered via swagger-ui-react) loads correctly in the preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)