### PR TITLE
Fix Windows requirements: IPPool patch is reverted by operator

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/windows-calico/requirements.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/windows-calico/requirements.mdx
@@ -2,6 +2,9 @@
 description: Cluster and Windows host requirements you must meet before installing Calico Enterprise for Windows.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Requirements
 
 ## What's supported in this release
@@ -50,11 +53,31 @@ When using Operator install and Windows hostprocess containers (HPC), see [here 
 
 - At least four Linux Kubernetes worker nodes to run $[prodname]'s cluster-wide components that meets [Linux system requirements](../requirements.mdx), and is installed with $[prodname] v3.5.0+
 - Must not be running in eBPF mode
-- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Use the following command to turn off IPIP.
+- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Turn off IPIP on the default IP pool.
+
+  <Tabs groupId="install-method">
+  <TabItem label="Operator" value="Operator-0">
+
+  Patch the `Installation` resource. The operator reconciles `IPPool` resources from the `Installation` and will silently revert direct edits to the `IPPool`.
+
+  ```bash
+  kubectl patch installation default --type=json \
+    -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/encapsulation","value":"VXLAN"}]'
+  ```
+
+  The path `/spec/calicoNetwork/ipPools/0` targets the first IP pool. If your cluster has multiple pools, identify the correct index and adjust the path accordingly. Use `encapsulation: None` instead if you are running BGP without encapsulation.
+
+  </TabItem>
+  <TabItem label="Manifest" value="Manifest-1">
+
+  Disable IPIP through `FelixConfiguration`.
 
   ```bash
   kubectl patch felixconfiguration default -p '{"spec":{"ipipEnabled":false}}'
   ```
+
+  </TabItem>
+  </Tabs>
 
 - If using $[prodname] IPAM, strict affinity of IPAM configuration must be set to `true`.
 

--- a/calico-enterprise/getting-started/install-on-clusters/windows-calico/requirements.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/windows-calico/requirements.mdx
@@ -2,9 +2,6 @@
 description: Cluster and Windows host requirements you must meet before installing Calico Enterprise for Windows.
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Requirements
 
 ## What's supported in this release
@@ -53,31 +50,18 @@ When using Operator install and Windows hostprocess containers (HPC), see [here 
 
 - At least four Linux Kubernetes worker nodes to run $[prodname]'s cluster-wide components that meets [Linux system requirements](../requirements.mdx), and is installed with $[prodname] v3.5.0+
 - Must not be running in eBPF mode
-- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Turn off IPIP on the default IP pool.
+- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported.
 
-  <Tabs groupId="install-method">
-  <TabItem label="Operator" value="Operator-0">
-
-  Patch the `Installation` resource. The operator reconciles `IPPool` resources from the `Installation` and will silently revert direct edits to the `IPPool`.
+  To turn off IPIP for the default IP pool, patch the `Installation` resource:
 
   ```bash
   kubectl patch installation default --type=json \
     -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/encapsulation","value":"VXLAN"}]'
   ```
 
-  The path `/spec/calicoNetwork/ipPools/0` targets the first IP pool. If your cluster has multiple pools, identify the correct index and adjust the path accordingly. Use `encapsulation: None` instead if you are running BGP without encapsulation.
+  The operator reconciles `IPPool` resources from the `Installation`, so direct edits to the `IPPool` are silently reverted.
 
-  </TabItem>
-  <TabItem label="Manifest" value="Manifest-1">
-
-  Disable IPIP through `FelixConfiguration`.
-
-  ```bash
-  kubectl patch felixconfiguration default -p '{"spec":{"ipipEnabled":false}}'
-  ```
-
-  </TabItem>
-  </Tabs>
+  If your cluster has additional IP pools, repeat the command for each, replacing `0` in `/spec/calicoNetwork/ipPools/0` with the index of the pool. Use `"None"` instead of `"VXLAN"` for BGP without encapsulation.
 
 - If using $[prodname] IPAM, strict affinity of IPAM configuration must be set to `true`.
 

--- a/calico-enterprise/getting-started/install-on-clusters/windows-calico/requirements.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/windows-calico/requirements.mdx
@@ -2,6 +2,9 @@
 description: Cluster and Windows host requirements you must meet before installing Calico Enterprise for Windows.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Requirements
 
 ## What's supported in this release
@@ -50,18 +53,31 @@ When using Operator install and Windows hostprocess containers (HPC), see [here 
 
 - At least four Linux Kubernetes worker nodes to run $[prodname]'s cluster-wide components that meets [Linux system requirements](../requirements.mdx), and is installed with $[prodname] v3.5.0+
 - Must not be running in eBPF mode
-- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported.
+- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Turn off IPIP on the default IP pool.
 
-  To turn off IPIP for the default IP pool, patch the `Installation` resource:
+  <Tabs groupId="ip-pool-management">
+  <TabItem label="Operator managed IP pools" value="operator-managed">
+
+  For IP pools managed through the `Installation` resource, patch the `Installation` to update the encapsulation. The operator reconciles these `IPPool` resources from the `Installation`, so direct edits to the `IPPool` are silently reverted.
 
   ```bash
   kubectl patch installation default --type=json \
     -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/encapsulation","value":"VXLAN"}]'
   ```
 
-  The operator reconciles `IPPool` resources from the `Installation`, so direct edits to the `IPPool` are silently reverted.
+  If your cluster has additional operator-managed IP pools, repeat the command for each, replacing `0` in `/spec/calicoNetwork/ipPools/0` with the index of the pool. Use `"None"` instead of `"VXLAN"` for BGP without encapsulation.
 
-  If your cluster has additional IP pools, repeat the command for each, replacing `0` in `/spec/calicoNetwork/ipPools/0` with the index of the pool. Use `"None"` instead of `"VXLAN"` for BGP without encapsulation.
+  </TabItem>
+  <TabItem label="User managed IP pools" value="user-managed">
+
+  For `IPPool` resources created directly (not through the `Installation`), patch the `IPPool`:
+
+  ```bash
+  kubectl patch ippool default-ipv4-ippool -p '{"spec":{"ipipMode":"Never","vxlanMode":"Always"}}'
+  ```
+
+  </TabItem>
+  </Tabs>
 
 - If using $[prodname] IPAM, strict affinity of IPAM configuration must be set to `true`.
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/windows-calico/requirements.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/windows-calico/requirements.mdx
@@ -2,6 +2,9 @@
 description: Cluster and Windows host requirements you must meet before installing Calico Enterprise for Windows.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Requirements
 
 ## What's supported in this release
@@ -50,11 +53,31 @@ When using Operator install and Windows hostprocess containers (HPC), see [here 
 
 - At least four Linux Kubernetes worker nodes to run $[prodname]'s cluster-wide components that meets [Linux system requirements](../requirements.mdx), and is installed with $[prodname] v3.5.0+
 - Must not be running in eBPF mode
-- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Use the following command to turn off IPIP.
+- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Turn off IPIP on the default IP pool.
+
+  <Tabs groupId="install-method">
+  <TabItem label="Operator" value="Operator-0">
+
+  Patch the `Installation` resource. The operator reconciles `IPPool` resources from the `Installation` and will silently revert direct edits to the `IPPool`.
+
+  ```bash
+  kubectl patch installation default --type=json \
+    -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/encapsulation","value":"VXLAN"}]'
+  ```
+
+  The path `/spec/calicoNetwork/ipPools/0` targets the first IP pool. If your cluster has multiple pools, identify the correct index and adjust the path accordingly. Use `encapsulation: None` instead if you are running BGP without encapsulation.
+
+  </TabItem>
+  <TabItem label="Manifest" value="Manifest-1">
+
+  Disable IPIP through `FelixConfiguration`.
 
   ```bash
   kubectl patch felixconfiguration default -p '{"spec":{"ipipEnabled":false}}'
   ```
+
+  </TabItem>
+  </Tabs>
 
 - If using $[prodname] IPAM, strict affinity of IPAM configuration must be set to `true`.
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/windows-calico/requirements.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/windows-calico/requirements.mdx
@@ -2,9 +2,6 @@
 description: Cluster and Windows host requirements you must meet before installing Calico Enterprise for Windows.
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Requirements
 
 ## What's supported in this release
@@ -53,31 +50,18 @@ When using Operator install and Windows hostprocess containers (HPC), see [here 
 
 - At least four Linux Kubernetes worker nodes to run $[prodname]'s cluster-wide components that meets [Linux system requirements](../requirements.mdx), and is installed with $[prodname] v3.5.0+
 - Must not be running in eBPF mode
-- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Turn off IPIP on the default IP pool.
+- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported.
 
-  <Tabs groupId="install-method">
-  <TabItem label="Operator" value="Operator-0">
-
-  Patch the `Installation` resource. The operator reconciles `IPPool` resources from the `Installation` and will silently revert direct edits to the `IPPool`.
+  To turn off IPIP for the default IP pool, patch the `Installation` resource:
 
   ```bash
   kubectl patch installation default --type=json \
     -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/encapsulation","value":"VXLAN"}]'
   ```
 
-  The path `/spec/calicoNetwork/ipPools/0` targets the first IP pool. If your cluster has multiple pools, identify the correct index and adjust the path accordingly. Use `encapsulation: None` instead if you are running BGP without encapsulation.
+  The operator reconciles `IPPool` resources from the `Installation`, so direct edits to the `IPPool` are silently reverted.
 
-  </TabItem>
-  <TabItem label="Manifest" value="Manifest-1">
-
-  Disable IPIP through `FelixConfiguration`.
-
-  ```bash
-  kubectl patch felixconfiguration default -p '{"spec":{"ipipEnabled":false}}'
-  ```
-
-  </TabItem>
-  </Tabs>
+  If your cluster has additional IP pools, repeat the command for each, replacing `0` in `/spec/calicoNetwork/ipPools/0` with the index of the pool. Use `"None"` instead of `"VXLAN"` for BGP without encapsulation.
 
 - If using $[prodname] IPAM, strict affinity of IPAM configuration must be set to `true`.
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/windows-calico/requirements.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/windows-calico/requirements.mdx
@@ -2,6 +2,9 @@
 description: Cluster and Windows host requirements you must meet before installing Calico Enterprise for Windows.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Requirements
 
 ## What's supported in this release
@@ -50,18 +53,31 @@ When using Operator install and Windows hostprocess containers (HPC), see [here 
 
 - At least four Linux Kubernetes worker nodes to run $[prodname]'s cluster-wide components that meets [Linux system requirements](../requirements.mdx), and is installed with $[prodname] v3.5.0+
 - Must not be running in eBPF mode
-- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported.
+- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Turn off IPIP on the default IP pool.
 
-  To turn off IPIP for the default IP pool, patch the `Installation` resource:
+  <Tabs groupId="ip-pool-management">
+  <TabItem label="Operator managed IP pools" value="operator-managed">
+
+  For IP pools managed through the `Installation` resource, patch the `Installation` to update the encapsulation. The operator reconciles these `IPPool` resources from the `Installation`, so direct edits to the `IPPool` are silently reverted.
 
   ```bash
   kubectl patch installation default --type=json \
     -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/encapsulation","value":"VXLAN"}]'
   ```
 
-  The operator reconciles `IPPool` resources from the `Installation`, so direct edits to the `IPPool` are silently reverted.
+  If your cluster has additional operator-managed IP pools, repeat the command for each, replacing `0` in `/spec/calicoNetwork/ipPools/0` with the index of the pool. Use `"None"` instead of `"VXLAN"` for BGP without encapsulation.
 
-  If your cluster has additional IP pools, repeat the command for each, replacing `0` in `/spec/calicoNetwork/ipPools/0` with the index of the pool. Use `"None"` instead of `"VXLAN"` for BGP without encapsulation.
+  </TabItem>
+  <TabItem label="User managed IP pools" value="user-managed">
+
+  For `IPPool` resources created directly (not through the `Installation`), patch the `IPPool`:
+
+  ```bash
+  kubectl patch ippool default-ipv4-ippool -p '{"spec":{"ipipMode":"Never","vxlanMode":"Always"}}'
+  ```
+
+  </TabItem>
+  </Tabs>
 
 - If using $[prodname] IPAM, strict affinity of IPAM configuration must be set to `true`.
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/getting-started/install-on-clusters/windows-calico/requirements.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/getting-started/install-on-clusters/windows-calico/requirements.mdx
@@ -2,6 +2,9 @@
 description: Cluster and Windows host requirements you must meet before installing Calico Enterprise for Windows.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Requirements
 
 ## What's supported in this release
@@ -50,11 +53,31 @@ When using Operator install and Windows hostprocess containers (HPC), see [here 
 
 - At least four Linux Kubernetes worker nodes to run $[prodname]'s cluster-wide components that meets [Linux system requirements](../requirements.mdx), and is installed with $[prodname] v3.5.0+
 - Must not be running in eBPF mode
-- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Use the following command to turn off IPIP.
+- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Turn off IPIP on the default IP pool.
+
+  <Tabs groupId="install-method">
+  <TabItem label="Operator" value="Operator-0">
+
+  Patch the `Installation` resource. The operator reconciles `IPPool` resources from the `Installation` and will silently revert direct edits to the `IPPool`.
+
+  ```bash
+  kubectl patch installation default --type=json \
+    -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/encapsulation","value":"VXLAN"}]'
+  ```
+
+  The path `/spec/calicoNetwork/ipPools/0` targets the first IP pool. If your cluster has multiple pools, identify the correct index and adjust the path accordingly. Use `encapsulation: None` instead if you are running BGP without encapsulation.
+
+  </TabItem>
+  <TabItem label="Manifest" value="Manifest-1">
+
+  Disable IPIP through `FelixConfiguration`.
 
   ```bash
   kubectl patch felixconfiguration default -p '{"spec":{"ipipEnabled":false}}'
   ```
+
+  </TabItem>
+  </Tabs>
 
 - If using $[prodname] IPAM, strict affinity of IPAM configuration must be set to `true`.
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/getting-started/install-on-clusters/windows-calico/requirements.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/getting-started/install-on-clusters/windows-calico/requirements.mdx
@@ -2,9 +2,6 @@
 description: Cluster and Windows host requirements you must meet before installing Calico Enterprise for Windows.
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Requirements
 
 ## What's supported in this release
@@ -53,31 +50,18 @@ When using Operator install and Windows hostprocess containers (HPC), see [here 
 
 - At least four Linux Kubernetes worker nodes to run $[prodname]'s cluster-wide components that meets [Linux system requirements](../requirements.mdx), and is installed with $[prodname] v3.5.0+
 - Must not be running in eBPF mode
-- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Turn off IPIP on the default IP pool.
+- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported.
 
-  <Tabs groupId="install-method">
-  <TabItem label="Operator" value="Operator-0">
-
-  Patch the `Installation` resource. The operator reconciles `IPPool` resources from the `Installation` and will silently revert direct edits to the `IPPool`.
+  To turn off IPIP for the default IP pool, patch the `Installation` resource:
 
   ```bash
   kubectl patch installation default --type=json \
     -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/encapsulation","value":"VXLAN"}]'
   ```
 
-  The path `/spec/calicoNetwork/ipPools/0` targets the first IP pool. If your cluster has multiple pools, identify the correct index and adjust the path accordingly. Use `encapsulation: None` instead if you are running BGP without encapsulation.
+  The operator reconciles `IPPool` resources from the `Installation`, so direct edits to the `IPPool` are silently reverted.
 
-  </TabItem>
-  <TabItem label="Manifest" value="Manifest-1">
-
-  Disable IPIP through `FelixConfiguration`.
-
-  ```bash
-  kubectl patch felixconfiguration default -p '{"spec":{"ipipEnabled":false}}'
-  ```
-
-  </TabItem>
-  </Tabs>
+  If your cluster has additional IP pools, repeat the command for each, replacing `0` in `/spec/calicoNetwork/ipPools/0` with the index of the pool. Use `"None"` instead of `"VXLAN"` for BGP without encapsulation.
 
 - If using $[prodname] IPAM, strict affinity of IPAM configuration must be set to `true`.
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/getting-started/install-on-clusters/windows-calico/requirements.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/getting-started/install-on-clusters/windows-calico/requirements.mdx
@@ -2,6 +2,9 @@
 description: Cluster and Windows host requirements you must meet before installing Calico Enterprise for Windows.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Requirements
 
 ## What's supported in this release
@@ -50,18 +53,31 @@ When using Operator install and Windows hostprocess containers (HPC), see [here 
 
 - At least four Linux Kubernetes worker nodes to run $[prodname]'s cluster-wide components that meets [Linux system requirements](../requirements.mdx), and is installed with $[prodname] v3.5.0+
 - Must not be running in eBPF mode
-- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported.
+- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Turn off IPIP on the default IP pool.
 
-  To turn off IPIP for the default IP pool, patch the `Installation` resource:
+  <Tabs groupId="ip-pool-management">
+  <TabItem label="Operator managed IP pools" value="operator-managed">
+
+  For IP pools managed through the `Installation` resource, patch the `Installation` to update the encapsulation. The operator reconciles these `IPPool` resources from the `Installation`, so direct edits to the `IPPool` are silently reverted.
 
   ```bash
   kubectl patch installation default --type=json \
     -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/encapsulation","value":"VXLAN"}]'
   ```
 
-  The operator reconciles `IPPool` resources from the `Installation`, so direct edits to the `IPPool` are silently reverted.
+  If your cluster has additional operator-managed IP pools, repeat the command for each, replacing `0` in `/spec/calicoNetwork/ipPools/0` with the index of the pool. Use `"None"` instead of `"VXLAN"` for BGP without encapsulation.
 
-  If your cluster has additional IP pools, repeat the command for each, replacing `0` in `/spec/calicoNetwork/ipPools/0` with the index of the pool. Use `"None"` instead of `"VXLAN"` for BGP without encapsulation.
+  </TabItem>
+  <TabItem label="User managed IP pools" value="user-managed">
+
+  For `IPPool` resources created directly (not through the `Installation`), patch the `IPPool`:
+
+  ```bash
+  kubectl patch ippool default-ipv4-ippool -p '{"spec":{"ipipMode":"Never","vxlanMode":"Always"}}'
+  ```
+
+  </TabItem>
+  </Tabs>
 
 - If using $[prodname] IPAM, strict affinity of IPAM configuration must be set to `true`.
 

--- a/calico/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -2,6 +2,9 @@
 description: Cluster and Windows host requirements you must meet before installing Calico Open Source for Windows.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Requirements
 
 ## What's supported in this release
@@ -54,11 +57,31 @@ Earlier versions may work, but we do not actively test $[prodnameWindows] agains
 ### Linux platform requirements
 
 - At least one Linux Kubernetes worker node to run $[prodname]'s cluster-wide components that meets [Linux system requirements](../requirements.mdx), and is installed with $[prodname]. $[prodname] v3.27+ is required for Operator installs.
-- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Use the following command to turn off IPIP on the default IP pool.
+- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Turn off IPIP on the default IP pool.
+
+  <Tabs groupId="install-method">
+  <TabItem label="Operator" value="Operator-0">
+
+  Patch the `Installation` resource. The operator reconciles `IPPool` resources from the `Installation` and will silently revert direct edits to the `IPPool`.
+
+  ```bash
+  kubectl patch installation default --type=json \
+    -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/encapsulation","value":"VXLAN"}]'
+  ```
+
+  The path `/spec/calicoNetwork/ipPools/0` targets the first IP pool. If your cluster has multiple pools, identify the correct index and adjust the path accordingly. Use `encapsulation: None` instead if you are running BGP without encapsulation.
+
+  </TabItem>
+  <TabItem label="Manifest" value="Manifest-1">
+
+  Patch the `IPPool` resource directly.
 
   ```bash
   kubectl patch ippool default-ipv4-ippool -p '{"spec":{"ipipMode":"Never","vxlanMode":"Always"}}'
   ```
+
+  </TabItem>
+  </Tabs>
 
 - If using $[prodname] IPAM, strict affinity of IPAM configuration must be set to `true`.
 

--- a/calico/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -59,24 +59,22 @@ Earlier versions may work, but we do not actively test $[prodnameWindows] agains
 - At least one Linux Kubernetes worker node to run $[prodname]'s cluster-wide components that meets [Linux system requirements](../requirements.mdx), and is installed with $[prodname]. $[prodname] v3.27+ is required for Operator installs.
 - VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Turn off IPIP on the default IP pool.
 
-  <Tabs groupId="install-method">
-  <TabItem label="Operator" value="Operator-0">
+  <Tabs groupId="ip-pool-management">
+  <TabItem label="Operator managed IP pools" value="operator-managed">
 
-  To turn off IPIP for the default IP pool, patch the `Installation` resource:
+  For IP pools managed through the `Installation` resource, patch the `Installation` to update the encapsulation. The operator reconciles these `IPPool` resources from the `Installation`, so direct edits to the `IPPool` are silently reverted.
 
   ```bash
   kubectl patch installation default --type=json \
     -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/encapsulation","value":"VXLAN"}]'
   ```
 
-  The operator reconciles `IPPool` resources from the `Installation`, so direct edits to the `IPPool` are silently reverted.
-
-  If your cluster has additional IP pools, repeat the command for each, replacing `0` in `/spec/calicoNetwork/ipPools/0` with the index of the pool. Use `"None"` instead of `"VXLAN"` for BGP without encapsulation.
+  If your cluster has additional operator-managed IP pools, repeat the command for each, replacing `0` in `/spec/calicoNetwork/ipPools/0` with the index of the pool. Use `"None"` instead of `"VXLAN"` for BGP without encapsulation.
 
   </TabItem>
-  <TabItem label="Manifest" value="Manifest-1">
+  <TabItem label="User managed IP pools" value="user-managed">
 
-  Patch the `IPPool` resource directly.
+  For `IPPool` resources created directly (not through the `Installation`), patch the `IPPool`:
 
   ```bash
   kubectl patch ippool default-ipv4-ippool -p '{"spec":{"ipipMode":"Never","vxlanMode":"Always"}}'

--- a/calico/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -62,14 +62,16 @@ Earlier versions may work, but we do not actively test $[prodnameWindows] agains
   <Tabs groupId="install-method">
   <TabItem label="Operator" value="Operator-0">
 
-  Patch the `Installation` resource. The operator reconciles `IPPool` resources from the `Installation` and will silently revert direct edits to the `IPPool`.
+  To turn off IPIP for the default IP pool, patch the `Installation` resource:
 
   ```bash
   kubectl patch installation default --type=json \
     -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/encapsulation","value":"VXLAN"}]'
   ```
 
-  The path `/spec/calicoNetwork/ipPools/0` targets the first IP pool. If your cluster has multiple pools, identify the correct index and adjust the path accordingly. Use `encapsulation: None` instead if you are running BGP without encapsulation.
+  The operator reconciles `IPPool` resources from the `Installation`, so direct edits to the `IPPool` are silently reverted.
+
+  If your cluster has additional IP pools, repeat the command for each, replacing `0` in `/spec/calicoNetwork/ipPools/0` with the index of the pool. Use `"None"` instead of `"VXLAN"` for BGP without encapsulation.
 
   </TabItem>
   <TabItem label="Manifest" value="Manifest-1">

--- a/calico/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -74,10 +74,16 @@ Earlier versions may work, but we do not actively test $[prodnameWindows] agains
   </TabItem>
   <TabItem label="User managed IP pools" value="user-managed">
 
-  For `IPPool` resources created directly (not through the `Installation`), patch the `IPPool`:
+  For `IPPool` resources created directly (not through the `Installation`), patch the `IPPool`. For VXLAN:
 
   ```bash
   kubectl patch ippool default-ipv4-ippool -p '{"spec":{"ipipMode":"Never","vxlanMode":"Always"}}'
+  ```
+
+  For BGP without encapsulation, set both modes to `Never`:
+
+  ```bash
+  kubectl patch ippool default-ipv4-ippool -p '{"spec":{"ipipMode":"Never","vxlanMode":"Never"}}'
   ```
 
   </TabItem>

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -2,6 +2,9 @@
 description: Review the requirements for Calico for Windows.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Requirements
 
 ## What's supported in this release
@@ -54,11 +57,31 @@ Earlier versions may work, but we do not actively test $[prodnameWindows] agains
 ### Linux platform requirements
 
 - At least one Linux Kubernetes worker node to run $[prodname]'s cluster-wide components that meets [Linux system requirements](../requirements.mdx), and is installed with $[prodname]. $[prodname] v3.27+ is required for Operator installs.
-- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Use the following command to turn off IPIP on the default IP pool.
+- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Turn off IPIP on the default IP pool.
+
+  <Tabs groupId="install-method">
+  <TabItem label="Operator" value="Operator-0">
+
+  Patch the `Installation` resource. The operator reconciles `IPPool` resources from the `Installation` and will silently revert direct edits to the `IPPool`.
+
+  ```bash
+  kubectl patch installation default --type=json \
+    -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/encapsulation","value":"VXLAN"}]'
+  ```
+
+  The path `/spec/calicoNetwork/ipPools/0` targets the first IP pool. If your cluster has multiple pools, identify the correct index and adjust the path accordingly. Use `encapsulation: None` instead if you are running BGP without encapsulation.
+
+  </TabItem>
+  <TabItem label="Manifest" value="Manifest-1">
+
+  Patch the `IPPool` resource directly.
 
   ```bash
   kubectl patch ippool default-ipv4-ippool -p '{"spec":{"ipipMode":"Never","vxlanMode":"Always"}}'
   ```
+
+  </TabItem>
+  </Tabs>
 
 - If using $[prodname] IPAM, strict affinity of IPAM configuration must be set to `true`.
 

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -59,24 +59,22 @@ Earlier versions may work, but we do not actively test $[prodnameWindows] agains
 - At least one Linux Kubernetes worker node to run $[prodname]'s cluster-wide components that meets [Linux system requirements](../requirements.mdx), and is installed with $[prodname]. $[prodname] v3.27+ is required for Operator installs.
 - VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Turn off IPIP on the default IP pool.
 
-  <Tabs groupId="install-method">
-  <TabItem label="Operator" value="Operator-0">
+  <Tabs groupId="ip-pool-management">
+  <TabItem label="Operator managed IP pools" value="operator-managed">
 
-  To turn off IPIP for the default IP pool, patch the `Installation` resource:
+  For IP pools managed through the `Installation` resource, patch the `Installation` to update the encapsulation. The operator reconciles these `IPPool` resources from the `Installation`, so direct edits to the `IPPool` are silently reverted.
 
   ```bash
   kubectl patch installation default --type=json \
     -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/encapsulation","value":"VXLAN"}]'
   ```
 
-  The operator reconciles `IPPool` resources from the `Installation`, so direct edits to the `IPPool` are silently reverted.
-
-  If your cluster has additional IP pools, repeat the command for each, replacing `0` in `/spec/calicoNetwork/ipPools/0` with the index of the pool. Use `"None"` instead of `"VXLAN"` for BGP without encapsulation.
+  If your cluster has additional operator-managed IP pools, repeat the command for each, replacing `0` in `/spec/calicoNetwork/ipPools/0` with the index of the pool. Use `"None"` instead of `"VXLAN"` for BGP without encapsulation.
 
   </TabItem>
-  <TabItem label="Manifest" value="Manifest-1">
+  <TabItem label="User managed IP pools" value="user-managed">
 
-  Patch the `IPPool` resource directly.
+  For `IPPool` resources created directly (not through the `Installation`), patch the `IPPool`:
 
   ```bash
   kubectl patch ippool default-ipv4-ippool -p '{"spec":{"ipipMode":"Never","vxlanMode":"Always"}}'

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -62,14 +62,16 @@ Earlier versions may work, but we do not actively test $[prodnameWindows] agains
   <Tabs groupId="install-method">
   <TabItem label="Operator" value="Operator-0">
 
-  Patch the `Installation` resource. The operator reconciles `IPPool` resources from the `Installation` and will silently revert direct edits to the `IPPool`.
+  To turn off IPIP for the default IP pool, patch the `Installation` resource:
 
   ```bash
   kubectl patch installation default --type=json \
     -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/encapsulation","value":"VXLAN"}]'
   ```
 
-  The path `/spec/calicoNetwork/ipPools/0` targets the first IP pool. If your cluster has multiple pools, identify the correct index and adjust the path accordingly. Use `encapsulation: None` instead if you are running BGP without encapsulation.
+  The operator reconciles `IPPool` resources from the `Installation`, so direct edits to the `IPPool` are silently reverted.
+
+  If your cluster has additional IP pools, repeat the command for each, replacing `0` in `/spec/calicoNetwork/ipPools/0` with the index of the pool. Use `"None"` instead of `"VXLAN"` for BGP without encapsulation.
 
   </TabItem>
   <TabItem label="Manifest" value="Manifest-1">

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -74,10 +74,16 @@ Earlier versions may work, but we do not actively test $[prodnameWindows] agains
   </TabItem>
   <TabItem label="User managed IP pools" value="user-managed">
 
-  For `IPPool` resources created directly (not through the `Installation`), patch the `IPPool`:
+  For `IPPool` resources created directly (not through the `Installation`), patch the `IPPool`. For VXLAN:
 
   ```bash
   kubectl patch ippool default-ipv4-ippool -p '{"spec":{"ipipMode":"Never","vxlanMode":"Always"}}'
+  ```
+
+  For BGP without encapsulation, set both modes to `Never`:
+
+  ```bash
+  kubectl patch ippool default-ipv4-ippool -p '{"spec":{"ipipMode":"Never","vxlanMode":"Never"}}'
   ```
 
   </TabItem>

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -2,6 +2,9 @@
 description: Cluster and Windows host requirements you must meet before installing Calico Open Source for Windows.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Requirements
 
 ## What's supported in this release
@@ -54,11 +57,31 @@ Earlier versions may work, but we do not actively test $[prodnameWindows] agains
 ### Linux platform requirements
 
 - At least one Linux Kubernetes worker node to run $[prodname]'s cluster-wide components that meets [Linux system requirements](../requirements.mdx), and is installed with $[prodname]. $[prodname] v3.27+ is required for Operator installs.
-- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Use the following command to turn off IPIP on the default IP pool.
+- VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Turn off IPIP on the default IP pool.
+
+  <Tabs groupId="install-method">
+  <TabItem label="Operator" value="Operator-0">
+
+  Patch the `Installation` resource. The operator reconciles `IPPool` resources from the `Installation` and will silently revert direct edits to the `IPPool`.
+
+  ```bash
+  kubectl patch installation default --type=json \
+    -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/encapsulation","value":"VXLAN"}]'
+  ```
+
+  The path `/spec/calicoNetwork/ipPools/0` targets the first IP pool. If your cluster has multiple pools, identify the correct index and adjust the path accordingly. Use `encapsulation: None` instead if you are running BGP without encapsulation.
+
+  </TabItem>
+  <TabItem label="Manifest" value="Manifest-1">
+
+  Patch the `IPPool` resource directly.
 
   ```bash
   kubectl patch ippool default-ipv4-ippool -p '{"spec":{"ipipMode":"Never","vxlanMode":"Always"}}'
   ```
+
+  </TabItem>
+  </Tabs>
 
 - If using $[prodname] IPAM, strict affinity of IPAM configuration must be set to `true`.
 

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -59,24 +59,22 @@ Earlier versions may work, but we do not actively test $[prodnameWindows] agains
 - At least one Linux Kubernetes worker node to run $[prodname]'s cluster-wide components that meets [Linux system requirements](../requirements.mdx), and is installed with $[prodname]. $[prodname] v3.27+ is required for Operator installs.
 - VXLAN or BGP without encapsulation is supported if using $[prodname] CNI. IPIP ($[prodname]'s default encapsulation mode) is not supported. Turn off IPIP on the default IP pool.
 
-  <Tabs groupId="install-method">
-  <TabItem label="Operator" value="Operator-0">
+  <Tabs groupId="ip-pool-management">
+  <TabItem label="Operator managed IP pools" value="operator-managed">
 
-  To turn off IPIP for the default IP pool, patch the `Installation` resource:
+  For IP pools managed through the `Installation` resource, patch the `Installation` to update the encapsulation. The operator reconciles these `IPPool` resources from the `Installation`, so direct edits to the `IPPool` are silently reverted.
 
   ```bash
   kubectl patch installation default --type=json \
     -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/encapsulation","value":"VXLAN"}]'
   ```
 
-  The operator reconciles `IPPool` resources from the `Installation`, so direct edits to the `IPPool` are silently reverted.
-
-  If your cluster has additional IP pools, repeat the command for each, replacing `0` in `/spec/calicoNetwork/ipPools/0` with the index of the pool. Use `"None"` instead of `"VXLAN"` for BGP without encapsulation.
+  If your cluster has additional operator-managed IP pools, repeat the command for each, replacing `0` in `/spec/calicoNetwork/ipPools/0` with the index of the pool. Use `"None"` instead of `"VXLAN"` for BGP without encapsulation.
 
   </TabItem>
-  <TabItem label="Manifest" value="Manifest-1">
+  <TabItem label="User managed IP pools" value="user-managed">
 
-  Patch the `IPPool` resource directly.
+  For `IPPool` resources created directly (not through the `Installation`), patch the `IPPool`:
 
   ```bash
   kubectl patch ippool default-ipv4-ippool -p '{"spec":{"ipipMode":"Never","vxlanMode":"Always"}}'

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -62,14 +62,16 @@ Earlier versions may work, but we do not actively test $[prodnameWindows] agains
   <Tabs groupId="install-method">
   <TabItem label="Operator" value="Operator-0">
 
-  Patch the `Installation` resource. The operator reconciles `IPPool` resources from the `Installation` and will silently revert direct edits to the `IPPool`.
+  To turn off IPIP for the default IP pool, patch the `Installation` resource:
 
   ```bash
   kubectl patch installation default --type=json \
     -p '[{"op":"replace","path":"/spec/calicoNetwork/ipPools/0/encapsulation","value":"VXLAN"}]'
   ```
 
-  The path `/spec/calicoNetwork/ipPools/0` targets the first IP pool. If your cluster has multiple pools, identify the correct index and adjust the path accordingly. Use `encapsulation: None` instead if you are running BGP without encapsulation.
+  The operator reconciles `IPPool` resources from the `Installation`, so direct edits to the `IPPool` are silently reverted.
+
+  If your cluster has additional IP pools, repeat the command for each, replacing `0` in `/spec/calicoNetwork/ipPools/0` with the index of the pool. Use `"None"` instead of `"VXLAN"` for BGP without encapsulation.
 
   </TabItem>
   <TabItem label="Manifest" value="Manifest-1">

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/windows-calico/requirements.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/windows-calico/requirements.mdx
@@ -74,10 +74,16 @@ Earlier versions may work, but we do not actively test $[prodnameWindows] agains
   </TabItem>
   <TabItem label="User managed IP pools" value="user-managed">
 
-  For `IPPool` resources created directly (not through the `Installation`), patch the `IPPool`:
+  For `IPPool` resources created directly (not through the `Installation`), patch the `IPPool`. For VXLAN:
 
   ```bash
   kubectl patch ippool default-ipv4-ippool -p '{"spec":{"ipipMode":"Never","vxlanMode":"Always"}}'
+  ```
+
+  For BGP without encapsulation, set both modes to `Never`:
+
+  ```bash
+  kubectl patch ippool default-ipv4-ippool -p '{"spec":{"ipipMode":"Never","vxlanMode":"Never"}}'
   ```
 
   </TabItem>


### PR DESCRIPTION
The Windows requirements page tells users to disable IPIP via `kubectl patch ippool default-ipv4-ippool ...`, but on operator-managed clusters the operator reconciles IP pools from the `Installation` and silently reverts those edits, so the documented step has no effect. That is what projectcalico/calico#9426 hit.

Split the encapsulation step into two tabs: **Operator managed IP pools** patches `spec.calicoNetwork.ipPools[*].encapsulation` on the `Installation`, and **User managed IP pools** patches the `IPPool` directly. Both modes are valid on operator installs, so this framing works on both OSS and Enterprise.

Applied to OSS main, v3.32, v3.31 and Enterprise main, v3.23-1, v3.22-2.

Fixes projectcalico/calico#9426