### PR TITLE
DOCS-2837: Publish Calico Enterprise 3.21.7

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -220,9 +220,51 @@ To update an existing installation of Calico Enterprise 3.21, see [Install a pat
 
 May 5, 2026
 
+#### Enhancements
+
+* Display the `Degraded` condition's message when running `kubectl get tigerastatus`, making it easier to see error details at a glance without needing to describe the resource.
+
+  ```console
+  $ kubectl get tigerastatus
+  NAME                          AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
+  apiserver                     True        False         False      4m51s   All objects available
+  calico                        False       False         True       106s    Pod calico-system/calico-node-tjlnv failed to pull container image for: ebpf-bootstrap
+  intrusion-detection           False       False         True       11m     Error creating TLS certificate: secret tigera-operator/deep-packet-inspection-tls must specify ext key usages: ExtKeyUsageClientAuth, ExtKeyUsageServerAuth
+  log-storage-access            False       False         True       11m     Pod tigera-elasticsearch/tigera-linseed-58745b7574-p6zmx has crash looping container: tigera-linseed
+  manager                       True        False         False      6s      All objects available; Warning: user provided certificate "manager-tls" expires in 21 days
+  ...
+  ```
+
+* Surface certificate metadata (issuer, expiry, DNS SANs, IP SANs) as annotations and add filtering labels (`secret-type`, `signer`) on TLS secrets produced by `Secret()` and `CreateSelfSignedSecret()`.
+
+  ```console
+  $ kubectl get secrets -n tigera-operator -l operator.tigera.io/signer \
+      -o custom-columns='NAME:.metadata.name,EXPIRY:.metadata.annotations.operator\.tigera\.io/cert-expiry,SIGNER:.metadata.annotations.operator\.tigera\.io/cert-signer'
+  NAME                                        EXPIRY                 SIGNER
+  calico-apiserver-certs                      2028-05-28T23:56:09Z   tigera-operator-signer
+  calico-kube-controllers-metrics-tls         2028-05-28T23:56:09Z   tigera-operator-signer
+  calico-node-prometheus-client-tls           2028-05-29T18:28:09Z   tigera-operator-signer
+  ...
+  ```
+
+* Added a named "https" port on the calico-manager Service and, when the OpenShift IDP is configured, publish a tigera-ca-public Secret in calico-system so OpenShift's Ingress→Route conversion can produce a reencrypt Route fronting the manager.
+
 #### Bug fixes
 
-* TBD
+* Fixed Kibana crashloop when upgrading from Calico Enterprise 3.20 or earlier to 3.21. The orphan `ingest_manager_settings` saved object left by Fleet 7.17 is now discarded during Kibana 8.x saved-object migration.
+* ECK certificates are now rotated 30 days before expiry, just like all certificates that are managed by our operator.
+* Deprecated the Installation.spec.nonPrivileged field. The Operator ignores this setting and will mark Calico as Degraded if it is set to Enabled.
+* Fixed the rendering resource limits and requests for Egress Gateway.
+* Added validation for the logstorage node count and replicas settings.
+* Fixed flow logs not recording pass policies in transit_policies when all forward or pre-DNAT tiers pass without an explicit allow or deny verdict. Pass-only forward and pre-DNAT policies now appear in transit_policies on both iptables/nftables and BPF dataplanes.
+* Fixed flow log aggregation to preserve distinct transit policy traces instead of overwriting them, ensuring accurate policy trace reporting at all aggregation levels.
+* Fixed l7-admission-controller webhook returning an invalid response when a pod has the sidecar label but no feature annotations.
+* Fixed an issue in the eBPF dataplane where link-local discovery packets were incorrectly dropped during strict reverse path forwarding (RPF) checks.
+* Fixed eBPF dataplane to delete stale NAT conntrack entries from userspace.
+* Fixed a panic in Felix's NetworkSet processor on invalid CIDRs.
+* Fixed the LoadBalancer controller to prevent a nil pointer dereference in handleBlockUpdate.
+* Multi-NIC support: fix the projectcalico.org/network label; strip the namespace prefix added by Multus in recent versions. The prefix was not documented in our docs and, due to using a / separator, it could fail validation when CNI plugin tried to read a multi-NIC endpoint after node reboot causing pods to fail to come back up after reboot.
+* Security updates.
 
 To update an existing installation of Calico Enterprise 3.21, see [Install a patch release](../getting-started/manifest-archive.mdx).
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -216,3 +216,13 @@ February 6, 2025
 
 To update an existing installation of Calico Enterprise 3.21, see [Install a patch release](../getting-started/manifest-archive.mdx).
 
+### Calico Enterprise 3.21.7 bug fix release
+
+May 5, 2026
+
+#### Bug fixes
+
+* TBD
+
+To update an existing installation of Calico Enterprise 3.21, see [Install a patch release](../getting-started/manifest-archive.mdx).
+

--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -218,7 +218,7 @@ To update an existing installation of Calico Enterprise 3.21, see [Install a pat
 
 ### Calico Enterprise 3.21.7 bug fix release
 
-May 5, 2026
+May 13, 2026
 
 #### Enhancements
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -256,7 +256,7 @@ May 5, 2026
 * Deprecated the Installation.spec.nonPrivileged field. The Operator ignores this setting and will mark Calico as Degraded if it is set to Enabled.
 * Fixed the rendering resource limits and requests for Egress Gateway.
 * Added validation for the logstorage node count and replicas settings.
-* Fixed flow logs not recording pass policies in transit_policies when all forward or pre-DNAT tiers pass without an explicit allow or deny verdict. Pass-only forward and pre-DNAT policies now appear in transit_policies on both iptables/nftables and BPF dataplanes.
+* Fixed flow logs so the [`transit_policies` field](../observability/elastic/flow/datatypes.mdx) records pass-only forward and pre-DNAT host-endpoint policies even when all tiers pass without an explicit allow or deny verdict. Applies to iptables, nftables, and BPF dataplanes.
 * Fixed flow log aggregation to preserve distinct transit policy traces instead of overwriting them, ensuring accurate policy trace reporting at all aggregation levels.
 * Fixed l7-admission-controller webhook returning an invalid response when a pod has the sidecar label but no feature annotations.
 * Fixed an issue in the eBPF dataplane where link-local discovery packets were incorrectly dropped during strict reverse path forwarding (RPF) checks.

--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -247,22 +247,22 @@ May 5, 2026
   ...
   ```
 
-* Added a named "https" port on the calico-manager Service and, when the OpenShift IDP is configured, publish a tigera-ca-public Secret in calico-system so OpenShift's Ingress→Route conversion can produce a reencrypt Route fronting the manager.
+* Added a named "https" port on the calico-manager Service and, when the OpenShift IDP is configured, publish a `tigera-ca-public` Secret in the `calico-system` namespace so that OpenShift's Ingress→Route conversion can produce a reencrypt Route fronting the manager.
 
 #### Bug fixes
 
 * Fixed Kibana crashloop when upgrading from Calico Enterprise 3.20 or earlier to 3.21. The orphan `ingest_manager_settings` saved object left by Fleet 7.17 is now discarded during Kibana 8.x saved-object migration.
 * ECK certificates are now rotated 30 days before expiry, just like all certificates that are managed by our operator.
-* Deprecated the Installation.spec.nonPrivileged field. The Operator ignores this setting and will mark Calico as Degraded if it is set to Enabled.
+* Deprecated the `Installation.spec.nonPrivileged` field. The Operator ignores this setting and will mark Calico as Degraded if it is set to Enabled.
 * Fixed the rendering resource limits and requests for Egress Gateway.
 * Added validation for the logstorage node count and replicas settings.
 * Fixed flow logs so the [`transit_policies` field](../observability/elastic/flow/datatypes.mdx) records pass-only forward and pre-DNAT host-endpoint policies even when all tiers pass without an explicit allow or deny verdict. Applies to iptables, nftables, and BPF dataplanes.
 * Fixed flow log aggregation to preserve distinct transit policy traces instead of overwriting them, ensuring accurate policy trace reporting at all aggregation levels.
 * Fixed l7-admission-controller webhook returning an invalid response when a pod has the sidecar label but no feature annotations.
 * Fixed an issue in the eBPF dataplane where link-local discovery packets were incorrectly dropped during strict reverse path forwarding (RPF) checks.
-* Fixed eBPF dataplane to delete stale NAT conntrack entries from userspace.
-* Fixed a panic in Felix's NetworkSet processor on invalid CIDRs.
-* Fixed the LoadBalancer controller to prevent a nil pointer dereference in handleBlockUpdate.
+* Fixed eBPF dataplane not deleting stale NAT conntrack entries from userspace.
+* Fixed a panic in Felix's `NetworkSet` processor on invalid CIDRs.
+* Fixed the `LoadBalancer` controller to prevent a nil pointer dereference in handleBlockUpdate.
 * Multi-NIC support: fix the `projectcalico.org/network` label; strip the namespace prefix added by Multus in recent versions. The prefix was not documented in our docs and, due to using a / separator, it could fail validation when CNI plugin tried to read a multi-NIC endpoint after node reboot causing pods to fail to come back up after reboot.
 * Security updates.
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -263,7 +263,7 @@ May 5, 2026
 * Fixed eBPF dataplane to delete stale NAT conntrack entries from userspace.
 * Fixed a panic in Felix's NetworkSet processor on invalid CIDRs.
 * Fixed the LoadBalancer controller to prevent a nil pointer dereference in handleBlockUpdate.
-* Multi-NIC support: fix the projectcalico.org/network label; strip the namespace prefix added by Multus in recent versions. The prefix was not documented in our docs and, due to using a / separator, it could fail validation when CNI plugin tried to read a multi-NIC endpoint after node reboot causing pods to fail to come back up after reboot.
+* Multi-NIC support: fix the `projectcalico.org/network` label; strip the namespace prefix added by Multus in recent versions. The prefix was not documented in our docs and, due to using a / separator, it could fail validation when CNI plugin tried to read a multi-NIC endpoint after node reboot causing pods to fail to come back up after reboot.
 * Security updates.
 
 To update an existing installation of Calico Enterprise 3.21, see [Install a patch release](../getting-started/manifest-archive.mdx).

--- a/calico-enterprise_versioned_docs/version-3.21-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.21-2/releases.json
@@ -2,7 +2,7 @@
   {
     "title": "v3.21.7",
     "tigera-operator": {
-      "version": "v1.38.12",
+      "version": "v1.38.14",
       "image": "tigera/operator",
       "registry": "quay.io"
     },
@@ -71,19 +71,19 @@
         "version": "v0.28.1"
       },
       "coreos-config-reloader": {
-        "version": "v0.76.2"
+        "version": "v0.91.0"
       },
       "coreos-dex": {
         "version": "v2.41.1"
       },
       "coreos-fluentd": {
-        "version": "1.18.0"
+        "version": "1.19.2"
       },
       "coreos-prometheus": {
         "version": "v2.55.1"
       },
       "coreos-prometheus-operator": {
-        "version": "v0.76.2"
+        "version": "v0.91.0"
       },
       "csi": {
         "version": "v3.21.7",
@@ -106,13 +106,13 @@
         "image": "tigera/dikastes"
       },
       "eck-elasticsearch": {
-        "version": "8.18.8"
+        "version": "8.19.15"
       },
       "eck-elasticsearch-operator": {
-        "version": "2.16.0"
+        "version": "2.16.1"
       },
       "eck-kibana": {
-        "version": "8.18.8"
+        "version": "8.19.15"
       },
       "egress-gateway": {
         "version": "v3.21.7",

--- a/calico-enterprise_versioned_docs/version-3.21-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.21-2/releases.json
@@ -1,5 +1,266 @@
 [
   {
+    "title": "v3.21.7",
+    "tigera-operator": {
+      "version": "v1.38.12",
+      "image": "tigera/operator",
+      "registry": "quay.io"
+    },
+    "calico": {
+      "minor_version": "v3.30",
+      "archive_path": "archive"
+    },
+    "components": {
+      "alertmanager": {
+        "version": "v3.21.7",
+        "image": "tigera/alertmanager"
+      },
+      "calicoctl": {
+        "version": "v3.21.7",
+        "image": "tigera/calicoctl"
+      },
+      "calicoq": {
+        "version": "v3.21.7",
+        "image": "tigera/calicoq"
+      },
+      "cnx-apiserver": {
+        "version": "v3.21.7",
+        "image": "tigera/cnx-apiserver"
+      },
+      "cnx-kube-controllers": {
+        "version": "v3.21.7",
+        "image": "tigera/kube-controllers"
+      },
+      "cnx-manager": {
+        "version": "v3.21.7",
+        "image": "tigera/cnx-manager"
+      },
+      "cnx-node": {
+        "version": "v3.21.7",
+        "image": "tigera/cnx-node"
+      },
+      "cnx-node-windows": {
+        "version": "v3.21.7",
+        "image": "tigera/cnx-node-windows"
+      },
+      "cnx-queryserver": {
+        "version": "v3.21.7",
+        "image": "tigera/cnx-queryserver"
+      },
+      "compliance-benchmarker": {
+        "version": "v3.21.7",
+        "image": "tigera/compliance-benchmarker"
+      },
+      "compliance-controller": {
+        "version": "v3.21.7",
+        "image": "tigera/compliance-controller"
+      },
+      "compliance-reporter": {
+        "version": "v3.21.7",
+        "image": "tigera/compliance-reporter"
+      },
+      "compliance-server": {
+        "version": "v3.21.7",
+        "image": "tigera/compliance-server"
+      },
+      "compliance-snapshotter": {
+        "version": "v3.21.7",
+        "image": "tigera/compliance-snapshotter"
+      },
+      "coreos-alertmanager": {
+        "version": "v0.28.1"
+      },
+      "coreos-config-reloader": {
+        "version": "v0.76.2"
+      },
+      "coreos-dex": {
+        "version": "v2.41.1"
+      },
+      "coreos-fluentd": {
+        "version": "1.18.0"
+      },
+      "coreos-prometheus": {
+        "version": "v2.55.1"
+      },
+      "coreos-prometheus-operator": {
+        "version": "v0.76.2"
+      },
+      "csi": {
+        "version": "v3.21.7",
+        "image": "tigera/csi"
+      },
+      "csi-node-driver-registrar": {
+        "version": "v3.21.7",
+        "image": "tigera/node-driver-registrar"
+      },
+      "deep-packet-inspection": {
+        "version": "v3.21.7",
+        "image": "tigera/deep-packet-inspection"
+      },
+      "dex": {
+        "version": "v3.21.7",
+        "image": "tigera/dex"
+      },
+      "dikastes": {
+        "version": "v3.21.7",
+        "image": "tigera/dikastes"
+      },
+      "eck-elasticsearch": {
+        "version": "8.18.8"
+      },
+      "eck-elasticsearch-operator": {
+        "version": "2.16.0"
+      },
+      "eck-kibana": {
+        "version": "8.18.8"
+      },
+      "egress-gateway": {
+        "version": "v3.21.7",
+        "image": "tigera/egress-gateway"
+      },
+      "elastic-tsee-installer": {
+        "version": "v3.21.7",
+        "image": "tigera/intrusion-detection-job-installer"
+      },
+      "elasticsearch": {
+        "version": "v3.21.7",
+        "image": "tigera/elasticsearch"
+      },
+      "elasticsearch-metrics": {
+        "version": "v3.21.7",
+        "image": "tigera/elasticsearch-metrics"
+      },
+      "elasticsearch-operator": {
+        "version": "v3.21.7",
+        "image": "tigera/eck-operator"
+      },
+      "envoy": {
+        "version": "v3.21.7",
+        "image": "tigera/envoy"
+      },
+      "envoy-init": {
+        "version": "v3.21.7",
+        "image": "tigera/envoy-init"
+      },
+      "es-gateway": {
+        "version": "v3.21.7",
+        "image": "tigera/es-gateway"
+      },
+      "firewall-integration": {
+        "version": "v3.21.7",
+        "image": "tigera/firewall-integration"
+      },
+      "flexvol": {
+        "version": "v3.21.7",
+        "image": "tigera/pod2daemon-flexvol"
+      },
+      "fluentd": {
+        "version": "v3.21.7",
+        "image": "tigera/fluentd"
+      },
+      "fluentd-windows": {
+        "version": "v3.21.7",
+        "image": "tigera/fluentd-windows"
+      },
+      "gateway-api-envoy-gateway": {
+        "version": "v3.21.7",
+        "image": "tigera/envoy-gateway"
+      },
+      "gateway-api-envoy-proxy": {
+        "version": "v3.21.7",
+        "image": "tigera/envoy-proxy"
+      },
+      "gateway-api-envoy-ratelimit": {
+        "version": "v3.21.7",
+        "image": "tigera/envoy-ratelimit"
+      },
+      "guardian": {
+        "version": "v3.21.7",
+        "image": "tigera/guardian"
+      },
+      "ingress-collector": {
+        "version": "v3.21.7",
+        "image": "tigera/ingress-collector"
+      },
+      "intrusion-detection-controller": {
+        "version": "v3.21.7",
+        "image": "tigera/intrusion-detection-controller"
+      },
+      "key-cert-provisioner": {
+        "version": "v3.21.7",
+        "image": "tigera/key-cert-provisioner"
+      },
+      "kibana": {
+        "version": "v3.21.7",
+        "image": "tigera/kibana"
+      },
+      "l7-admission-controller": {
+        "version": "v3.21.7",
+        "image": "tigera/l7-admission-controller"
+      },
+      "l7-collector": {
+        "version": "v3.21.7",
+        "image": "tigera/l7-collector"
+      },
+      "license-agent": {
+        "version": "v3.21.7",
+        "image": "tigera/license-agent"
+      },
+      "linseed": {
+        "version": "v3.21.7",
+        "image": "tigera/linseed"
+      },
+      "packetcapture": {
+        "version": "v3.21.7",
+        "image": "tigera/packetcapture"
+      },
+      "policy-recommendation": {
+        "version": "v3.21.7",
+        "image": "tigera/policy-recommendation"
+      },
+      "prometheus": {
+        "version": "v3.21.7",
+        "image": "tigera/prometheus"
+      },
+      "prometheus-config-reloader": {
+        "version": "v3.21.7",
+        "image": "tigera/prometheus-config-reloader"
+      },
+      "prometheus-operator": {
+        "version": "v3.21.7",
+        "image": "tigera/prometheus-operator"
+      },
+      "tigera-cni": {
+        "version": "v3.21.7",
+        "image": "tigera/cni"
+      },
+      "tigera-cni-windows": {
+        "version": "v3.21.7",
+        "image": "tigera/cni-windows"
+      },
+      "tigera-prometheus-service": {
+        "version": "v3.21.7",
+        "image": "tigera/prometheus-service"
+      },
+      "typha": {
+        "version": "v3.21.7",
+        "image": "tigera/typha"
+      },
+      "ui-apis": {
+        "version": "v3.21.7",
+        "image": "tigera/ui-apis"
+      },
+      "voltron": {
+        "version": "v3.21.7",
+        "image": "tigera/voltron"
+      },
+      "webhooks-processor": {
+        "version": "v3.21.7",
+        "image": "tigera/webhooks-processor"
+      }
+    }
+  },
+  {
     "title": "v3.21.6",
     "tigera-operator": {
       "version": "v1.38.12",

--- a/calico-enterprise_versioned_docs/version-3.21-2/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/variables.js
@@ -2,13 +2,13 @@ const releases = require('./releases.json');
 const componentImage = require('../../src/components/utils/componentImage');
 
 const variables = {
-  releaseTitle: 'v3.21.6',
+  releaseTitle: 'v3.21.7',
   prodname: 'Calico Enterprise',
   prodnamedash: 'calico-enterprise',
   version: 'v3.21',
   openSourceVersion: releases[0].calico.minor_version.slice(1),
   baseUrl: '/calico-enterprise/3.21',
-  filesUrl: 'https://downloads.tigera.io/ee/v3.21.6',
+  filesUrl: 'https://downloads.tigera.io/ee/v3.21.7',
   rpmsUrl: 'https://downloads.tigera.io/ee/rpms/' + releases[0].title.slice(0, 5),
   tutorialFilesURL: 'https://docs.tigera.io/files',
   tmpScriptsURL: 'https://docs.tigera.io/calico-enterprise/3.21',
@@ -20,7 +20,7 @@ const variables = {
   rootDirWindows: 'C:\\TigeraCalico',
   registry: 'quay.io/',
   envoyVersion: '1.3.2',
-  chart_version_name: 'v3.21.6-0',
+  chart_version_name: 'v3.21.7-0',
   tigeraOperator: releases[0]['tigera-operator'],
   dikastesVersion: releases[0].components.dikastes.version,
   releases,


### PR DESCRIPTION
Product Version(s): Calico Enterprise 3.21.7

Issue:

Link to docs preview:

Scaffolding for the 3.21.7 patch release. Adds a new \`v3.21.7\` entry in \`releases.json\` (mirrors v3.21.6 component versions, with operator/CoreOS/eck pinned versions left at v3.21.6 values to be synced in a follow-up commit), bumps \`variables.js\`, and appends a stub release-notes section dated May 5, 2026.

SME review:
- [ ] An SME has approved this change.

DOCS review:
- [ ] A member of the docs team has approved this change.

Additional information:

Merge checklist:
- [ ] Deploy preview inspected wherever changes were made
- [ ] Build completed successfully
- [ ] Test have passed