### PR TITLE
Publish Calico Enterprise 3.22.4

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -353,13 +353,13 @@ Use v3.22.4 instead, which includes a fix for this issue.
 
 To update an existing installation of Calico Enterprise 3.22, see [Install a patch release](../getting-started/manifest-archive.mdx).
 
-### Calico Enterprise 3.22.4 bug release
+### Calico Enterprise 3.22.4 bug fix release
 
-May 5, 2026
+May 6, 2026
 
 #### Bug fixes
 
-* Fix calico-apiserver logging "[SHOULD NOT HAPPEN] failed to update managedFields ... no corresponding type for projectcalico.org/v3, Kind=..." on every Calico v3 resource update.
-* Restore correct OpenAPI definition names for ArgoCD schema validation.
+* Fixed and issue that caused the `calico-apiserver` to log `[SHOULD NOT HAPPEN] failed to update managedFields ... no corresponding type for projectcalico.org/v3, Kind=...` on every Calico v3 resource update.
+* Restored correct OpenAPI definition names for ArgoCD schema validation.
 
 To update an existing installation of Calico Enterprise 3.22, see [Install a patch release](../getting-started/manifest-archive.mdx).

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -286,9 +286,10 @@ April 24, 2026
 
 :::warning[Not recommended for use in clusters using gitops tooling]
 
-Due to an issue introduced updating Kubernetes dependencies, this patch release is *not recommended for use* if you are using gitops tools such as ArgoCD.
-v3.22.4 will be released urgently with a fix for this issue, likely by May 11th.  For ArgoCD, the cluster will become disconnected, disabling all management.
-The impact on other similar gitops tools is not known at this time but potentially similar.
+Due to an issue introduced updating Kubernetes dependencies, this patch release is *not recommended for use* if using GitOps tools such as ArgoCD.
+For ArgoCD, the cluster will become disconnected, disabling all management. The impact on other similar GitOps tools is not known at this time but potentially similar.
+
+Use v3.22.4 instead, which includes a fix for this issue.
 
 :::
 
@@ -352,12 +353,13 @@ The impact on other similar gitops tools is not known at this time but potential
 
 To update an existing installation of Calico Enterprise 3.22, see [Install a patch release](../getting-started/manifest-archive.mdx).
 
-### Calico Enterprise 3.22.4 hotfix release
+### Calico Enterprise 3.22.4 bug release
 
 May 5, 2026
 
 #### Bug fixes
 
-* TBD
+* Fix calico-apiserver logging "[SHOULD NOT HAPPEN] failed to update managedFields ... no corresponding type for projectcalico.org/v3, Kind=..." on every Calico v3 resource update.
+* Restore correct OpenAPI definition names for ArgoCD schema validation.
 
 To update an existing installation of Calico Enterprise 3.22, see [Install a patch release](../getting-started/manifest-archive.mdx).

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -351,3 +351,13 @@ The impact on other similar gitops tools is not known at this time but potential
 * Security updates.
 
 To update an existing installation of Calico Enterprise 3.22, see [Install a patch release](../getting-started/manifest-archive.mdx).
+
+### Calico Enterprise 3.22.4 hotfix release
+
+May 5, 2026
+
+#### Bug fixes
+
+* TBD
+
+To update an existing installation of Calico Enterprise 3.22, see [Install a patch release](../getting-started/manifest-archive.mdx).

--- a/calico-enterprise_versioned_docs/version-3.22-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.22-2/releases.json
@@ -1,5 +1,269 @@
 [
   {
+    "title": "v3.22.4",
+    "tigera-operator": {
+      "version": "v1.40.9",
+      "image": "tigera/operator",
+      "registry": "quay.io"
+    },
+    "calico": {
+      "minor_version": "v3.31",
+      "archive_path": "archive"
+    },
+    "components": {
+      "alertmanager": {
+        "version": "v3.22.4",
+        "image": "tigera/alertmanager"
+      },
+      "calicoctl": {
+        "version": "v3.22.4",
+        "image": "tigera/calicoctl"
+      },
+      "calicoq": {
+        "version": "v3.22.4",
+        "image": "tigera/calicoq"
+      },
+      "apiserver": {
+        "version": "v3.22.4",
+        "image": "tigera/apiserver"
+      },
+      "kube-controllers": {
+        "version": "v3.22.4",
+        "image": "tigera/kube-controllers"
+      },
+      "manager": {
+        "version": "v3.22.4",
+        "image": "tigera/manager"
+      },
+      "node": {
+        "version": "v3.22.4",
+        "image": "tigera/node"
+      },
+      "node-windows": {
+        "version": "v3.22.4",
+        "image": "tigera/node-windows"
+      },
+      "queryserver": {
+        "version": "v3.22.4",
+        "image": "tigera/queryserver"
+      },
+      "compliance-benchmarker": {
+        "version": "v3.22.4",
+        "image": "tigera/compliance-benchmarker"
+      },
+      "compliance-controller": {
+        "version": "v3.22.4",
+        "image": "tigera/compliance-controller"
+      },
+      "compliance-reporter": {
+        "version": "v3.22.4",
+        "image": "tigera/compliance-reporter"
+      },
+      "compliance-server": {
+        "version": "v3.22.4",
+        "image": "tigera/compliance-server"
+      },
+      "compliance-snapshotter": {
+        "version": "v3.22.4",
+        "image": "tigera/compliance-snapshotter"
+      },
+      "coreos-alertmanager": {
+        "version": "v0.32.0"
+      },
+      "coreos-config-reloader": {
+        "version": "v0.90.1"
+      },
+      "coreos-dex": {
+        "version": "v2.45.1"
+      },
+      "coreos-fluentd": {
+        "version": "1.19.2"
+      },
+      "upstream-istio": {
+        "version": "1.28.1"
+      },
+      "coreos-prometheus": {
+        "version": "v3.11.1"
+      },
+      "coreos-prometheus-operator": {
+        "version": "v0.90.1"
+      },
+      "csi": {
+        "version": "v3.22.4",
+        "image": "tigera/csi"
+      },
+      "csi-node-driver-registrar": {
+        "version": "v3.22.4",
+        "image": "tigera/node-driver-registrar"
+      },
+      "deep-packet-inspection": {
+        "version": "v3.22.4",
+        "image": "tigera/deep-packet-inspection"
+      },
+      "dex": {
+        "version": "v3.22.4",
+        "image": "tigera/dex"
+      },
+      "dikastes": {
+        "version": "v3.22.4",
+        "image": "tigera/dikastes"
+      },
+      "eck-elasticsearch": {
+        "version": "8.19.14"
+      },
+      "eck-elasticsearch-operator": {
+        "version": "2.16.1"
+      },
+      "eck-kibana": {
+        "version": "8.19.14"
+      },
+      "egress-gateway": {
+        "version": "v3.22.4",
+        "image": "tigera/egress-gateway"
+      },
+      "elastic-tsee-installer": {
+        "version": "v3.22.4",
+        "image": "tigera/intrusion-detection-job-installer"
+      },
+      "elasticsearch": {
+        "version": "v3.22.4",
+        "image": "tigera/elasticsearch"
+      },
+      "elasticsearch-metrics": {
+        "version": "v3.22.4",
+        "image": "tigera/elasticsearch-metrics"
+      },
+      "elasticsearch-operator": {
+        "version": "v3.22.4",
+        "image": "tigera/eck-operator"
+      },
+      "envoy": {
+        "version": "v3.22.4",
+        "image": "tigera/envoy"
+      },
+      "es-gateway": {
+        "version": "v3.22.4",
+        "image": "tigera/es-gateway"
+      },
+      "firewall-integration": {
+        "version": "v3.22.4",
+        "image": "tigera/firewall-integration"
+      },
+      "flexvol": {
+        "version": "v3.22.4",
+        "image": "tigera/pod2daemon-flexvol"
+      },
+      "fluentd": {
+        "version": "v3.22.4",
+        "image": "tigera/fluentd"
+      },
+      "fluentd-windows": {
+        "version": "v3.22.4",
+        "image": "tigera/fluentd-windows"
+      },
+      "gateway-api-envoy-gateway": {
+        "version": "v3.22.4",
+        "image": "tigera/envoy-gateway"
+      },
+      "gateway-api-envoy-proxy": {
+        "version": "v3.22.4",
+        "image": "tigera/envoy-proxy"
+      },
+      "gateway-api-envoy-ratelimit": {
+        "version": "v3.22.4",
+        "image": "tigera/envoy-ratelimit"
+      },
+      "guardian": {
+        "version": "v3.22.4",
+        "image": "tigera/guardian"
+      },
+      "ingress-collector": {
+        "version": "v3.22.4",
+        "image": "tigera/ingress-collector"
+      },
+      "intrusion-detection-controller": {
+        "version": "v3.22.4",
+        "image": "tigera/intrusion-detection-controller"
+      },
+      "key-cert-provisioner": {
+        "version": "v3.22.4",
+        "image": "tigera/key-cert-provisioner"
+      },
+      "kibana": {
+        "version": "v3.22.4",
+        "image": "tigera/kibana"
+      },
+      "l7-admission-controller": {
+        "version": "v3.22.4",
+        "image": "tigera/l7-admission-controller"
+      },
+      "l7-collector": {
+        "version": "v3.22.4",
+        "image": "tigera/l7-collector"
+      },
+      "license-agent": {
+        "version": "v3.22.4",
+        "image": "tigera/license-agent"
+      },
+      "linseed": {
+        "version": "v3.22.4",
+        "image": "tigera/linseed"
+      },
+      "packetcapture": {
+        "version": "v3.22.4",
+        "image": "tigera/packetcapture"
+      },
+      "policy-recommendation": {
+        "version": "v3.22.4",
+        "image": "tigera/policy-recommendation"
+      },
+      "prometheus": {
+        "version": "v3.22.4",
+        "image": "tigera/prometheus"
+      },
+      "prometheus-config-reloader": {
+        "version": "v3.22.4",
+        "image": "tigera/prometheus-config-reloader"
+      },
+      "prometheus-operator": {
+        "version": "v3.22.4",
+        "image": "tigera/prometheus-operator"
+      },
+      "tigera-cni": {
+        "version": "v3.22.4",
+        "image": "tigera/cni"
+      },
+      "tigera-cni-windows": {
+        "version": "v3.22.4",
+        "image": "tigera/cni-windows"
+      },
+      "tigera-prometheus-service": {
+        "version": "v3.22.4",
+        "image": "tigera/prometheus-service"
+      },
+      "typha": {
+        "version": "v3.22.4",
+        "image": "tigera/typha"
+      },
+      "ui-apis": {
+        "version": "v3.22.4",
+        "image": "tigera/ui-apis"
+      },
+      "voltron": {
+        "version": "v3.22.4",
+        "image": "tigera/voltron"
+      },
+      "waf-http-filter": {
+        "version": "v3.22.4",
+        "image": "tigera/waf-http-filter"
+      },
+      "webhooks-processor": {
+        "version": "v3.22.4",
+        "image": "tigera/webhooks-processor"
+      }
+    }
+  },
+  {
     "title": "v3.22.3",
     "tigera-operator": {
       "version": "v1.40.9",

--- a/calico-enterprise_versioned_docs/version-3.22-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.22-2/releases.json
@@ -2,7 +2,7 @@
   {
     "title": "v3.22.4",
     "tigera-operator": {
-      "version": "v1.40.9",
+      "version": "v1.40.10",
       "image": "tigera/operator",
       "registry": "quay.io"
     },

--- a/calico-enterprise_versioned_docs/version-3.22-2/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.22-2/variables.js
@@ -2,13 +2,13 @@ const releases = require('./releases.json');
 const componentImage = require('../../src/components/utils/componentImage');
 
 const variables = {
-  releaseTitle: 'v3.22.3',
+  releaseTitle: 'v3.22.4',
   prodname: 'Calico Enterprise',
   prodnamedash: 'calico-enterprise',
   version: 'v3.22',
   openSourceVersion: releases[0].calico.minor_version.slice(1),
   baseUrl: '/calico-enterprise/latest',
-  filesUrl: 'https://downloads.tigera.io/ee/v3.22.3',
+  filesUrl: 'https://downloads.tigera.io/ee/v3.22.4',
   rpmsUrl: 'https://downloads.tigera.io/ee/rpms/' + releases[0].title.slice(0, 5),
   tutorialFilesURL: 'https://docs.tigera.io/files',
   tmpScriptsURL: 'https://docs.tigera.io/calico-enterprise/3.22',
@@ -20,7 +20,7 @@ const variables = {
   rootDirWindows: 'C:\\TigeraCalico',
   registry: 'quay.io/',
   envoyVersion: '1.5.0',
-  chart_version_name: 'v3.22.3-0',
+  chart_version_name: 'v3.22.4-0',
   tigeraOperator: releases[0]['tigera-operator'],
   dikastesVersion: releases[0].components.dikastes.version,
   releases,


### PR DESCRIPTION
Product Version(s): Calico Enterprise 3.22.4

Issue:

Link to docs preview:

Scaffolding for the 3.22.4 patch release. Adds a new \`v3.22.4\` entry in \`releases.json\` (mirrors v3.22.3 component versions, with operator/CoreOS/eck/upstream-istio pinned versions left at v3.22.3 values to be synced in a follow-up commit), bumps \`variables.js\`, and appends a stub release-notes section dated May 5, 2026.

SME review:
- [ ] An SME has approved this change.

DOCS review:
- [ ] A member of the docs team has approved this change.

Additional information:

Merge checklist:
- [ ] Deploy preview inspected wherever changes were made
- [ ] Build completed successfully
- [ ] Test have passed