### PR TITLE
Dedupe transitive axios to close 12 Dependabot alerts

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7836,7 +7836,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.15.2":
+"axios@npm:^1.15.2, axios@npm:^1.9.0":
   version: 1.16.0
   resolution: "axios@npm:1.16.0"
   dependencies:
@@ -7844,17 +7844,6 @@ __metadata:
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
   checksum: 10c0/1c91a5221b77b76072026b4cc95ecdf38f7c3e33e63423abec09a85e6e9a12279637dcc9ac2ba1fc333e0c447fb3b0f46d7965acb5d7cea02d188e9c6d425c0b
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.9.0":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
-  dependencies:
-    follow-redirects: "npm:^1.15.11"
-    form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
   languageName: node
   linkType: hard
 
@@ -10834,7 +10823,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.11, follow-redirects@npm:^1.16.0":
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.16.0":
   version: 1.16.0
   resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:


### PR DESCRIPTION
## Summary

`yarn dedupe axios` — collapses the duplicate axios entry in `yarn.lock`. Net change: **2 insertions, 13 deletions**. No `package.json` change.

## Background

[PR #2691](https://github.com/tigera/docs/pull/2691) bumped the direct `axios` dep to 1.15.2 (now resolved at 1.16.0 via the `^1.15.2` range). But the lockfile retained a separate `axios@1.15.0` entry pulled in transitively by `@swagger-api/apidom-reference@1.0.0-beta.44` (range `^1.9.0`). Yarn doesn't auto-dedupe — both entries stayed, and the 1.15.0 transitive remained vulnerable.

`yarn dedupe axios` collapses them: both consumers now point at the same `axios@1.16.0`, since 1.16.0 satisfies both ranges.

## Closes

| Severity | Alert |
| --- | --- |
| High | [#163](https://github.com/tigera/docs/security/dependabot/163), [#165](https://github.com/tigera/docs/security/dependabot/165), [#168](https://github.com/tigera/docs/security/dependabot/168), [#169](https://github.com/tigera/docs/security/dependabot/169) |
| Medium | [#164](https://github.com/tigera/docs/security/dependabot/164), [#166](https://github.com/tigera/docs/security/dependabot/166), [#167](https://github.com/tigera/docs/security/dependabot/167), [#170](https://github.com/tigera/docs/security/dependabot/170), [#171](https://github.com/tigera/docs/security/dependabot/171), [#172](https://github.com/tigera/docs/security/dependabot/172), [#173](https://github.com/tigera/docs/security/dependabot/173), [#174](https://github.com/tigera/docs/security/dependabot/174) |

## Test plan

- [ ] CI: `yarn build`
- [ ] CI: `yarn test:components`

axios is only imported by `__tests__/redirects.test.js` in this repo, so no runtime exposure changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)