### PR TITLE
Fix CIG WAF verification step to reference WAF logs

### DIFF
--- a/calico-cloud/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-cloud/threat/deploying-waf-ingress-gateway.mdx
@@ -70,10 +70,10 @@ To enable WAF on a Calico Ingress Gateway:
    To deploy a WAF on multiple gateways, you must create a separate `EnvoyExtensionPolicy` resource for each `Gateway` resource.
    Each `EnvoyExtensionPolicy` must reference the same `tigera-waf-backend` backend.
 
-1. To verify that the WAF is enabled for your gateway, you can simulate an SQL injection attack through your gateway and see whether it triggers a security event.
+1. To verify that the WAF is enabled for your gateway, you can simulate an SQL injection attack through your gateway and check that the WAF logs the request.
 
    :::note
-   The query string in this example has some SQL syntax embedded in the text. This is harmless and for demo purposes, but WAF will detect this pattern and create an WAF log for this HTTP request.
+   The query string in this example has some SQL syntax embedded in the text. This is harmless and for demo purposes, but WAF will detect this pattern and create a WAF log for this HTTP request. By design, Calico Ingress Gateway WAF emits WAF logs rather than security events.
    :::
 
    1. Get the service IP of your gateway:
@@ -81,12 +81,12 @@ To enable WAF on a Calico Ingress Gateway:
       ```bash
       export GATEWAY_HOST=$(kubectl get gateway/<gateway-name> -o jsonpath='{.status.addresses[0].value}')
       ```
-   1. Trigger a security event by simulating an SQL injection attack on that service IP:
+   1. Simulate an SQL injection attack on that service IP:
 
       ```bash
       curl --verbose --header "Host: www.example.com" http://$GATEWAY_HOST/?artist=0+div+1+union%23foo*%2F*bar%0D%0Aselect%23foo%0D%0A1%2C2%2Ccurrent_user
       ```
-   1. From the web console, go to **Threat > Security Events** and check for a security event with corresponds with this simulated SQL injection attack.
+   1. In Kibana, select the `tigera_secure_ee_waf*` index pattern and look for a WAF log that corresponds with this request. If blocking mode is enabled, the `curl` command also returns a `403 Forbidden` response.
 
 ## Customizing your WAF configuration for an ingress gateway
 

--- a/calico-cloud_versioned_docs/version-22-2/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/threat/deploying-waf-ingress-gateway.mdx
@@ -70,10 +70,10 @@ To enable WAF on a Calico Ingress Gateway:
    To deploy a WAF on multiple gateways, you must create a separate `EnvoyExtensionPolicy` resource for each `Gateway` resource.
    Each `EnvoyExtensionPolicy` must reference the same `tigera-waf-backend` backend.
 
-1. To verify that the WAF is enabled for your gateway, you can simulate an SQL injection attack through your gateway and see whether it triggers a security event.
+1. To verify that the WAF is enabled for your gateway, you can simulate an SQL injection attack through your gateway and check that the WAF logs the request.
 
    :::note
-   The query string in this example has some SQL syntax embedded in the text. This is harmless and for demo purposes, but WAF will detect this pattern and create an WAF log for this HTTP request.
+   The query string in this example has some SQL syntax embedded in the text. This is harmless and for demo purposes, but WAF will detect this pattern and create a WAF log for this HTTP request. By design, Calico Ingress Gateway WAF emits WAF logs rather than security events.
    :::
 
    1. Get the service IP of your gateway:
@@ -81,12 +81,12 @@ To enable WAF on a Calico Ingress Gateway:
       ```bash
       export GATEWAY_HOST=$(kubectl get gateway/<gateway-name> -o jsonpath='{.status.addresses[0].value}')
       ```
-   1. Trigger a security event by simulating an SQL injection attack on that service IP:
+   1. Simulate an SQL injection attack on that service IP:
 
       ```bash
       curl --verbose --header "Host: www.example.com" http://$GATEWAY_HOST/?artist=0+div+1+union%23foo*%2F*bar%0D%0Aselect%23foo%0D%0A1%2C2%2Ccurrent_user
       ```
-   1. From the web console, go to **Threat > Security Events** and check for a security event with corresponds with this simulated SQL injection attack.
+   1. In Kibana, select the `tigera_secure_ee_waf*` index pattern and look for a WAF log that corresponds with this request. If blocking mode is enabled, the `curl` command also returns a `403 Forbidden` response.
 
 ## Customizing your WAF configuration for an ingress gateway
 

--- a/calico-enterprise/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-enterprise/threat/deploying-waf-ingress-gateway.mdx
@@ -70,10 +70,10 @@ To enable WAF on a Calico Ingress Gateway:
    To deploy a WAF on multiple gateways, you must create a separate `EnvoyExtensionPolicy` resource for each `Gateway` resource.
    Each `EnvoyExtensionPolicy` must reference the same `tigera-waf-backend` backend.
 
-1. To verify that the WAF is enabled for your gateway, you can simulate an SQL injection attack through your gateway and see whether it triggers a security event.
+1. To verify that the WAF is enabled for your gateway, you can simulate an SQL injection attack through your gateway and check that the WAF logs the request.
 
    :::note
-   The query string in this example has some SQL syntax embedded in the text. This is harmless and for demo purposes, but WAF will detect this pattern and create an WAF log for this HTTP request.
+   The query string in this example has some SQL syntax embedded in the text. This is harmless and for demo purposes, but WAF will detect this pattern and create a WAF log for this HTTP request. By design, Calico Ingress Gateway WAF emits WAF logs rather than security events.
    :::
 
    1. Get the service IP of your gateway:
@@ -81,12 +81,12 @@ To enable WAF on a Calico Ingress Gateway:
       ```bash
       export GATEWAY_HOST=$(kubectl get gateway/<gateway-name> -o jsonpath='{.status.addresses[0].value}')
       ```
-   1. Trigger a security event by simulating an SQL injection attack on that service IP:
+   1. Simulate an SQL injection attack on that service IP:
 
       ```bash
       curl --verbose --header "Host: www.example.com" http://$GATEWAY_HOST/?artist=0+div+1+union%23foo*%2F*bar%0D%0Aselect%23foo%0D%0A1%2C2%2Ccurrent_user
       ```
-   1. From the web console, go to **Threat > Security Events** and check for a security event with corresponds with this simulated SQL injection attack.
+   1. In Kibana, select the `tigera_secure_ee_waf*` index pattern and look for a WAF log that corresponds with this request. If blocking mode is enabled, the `curl` command also returns a `403 Forbidden` response.
 
 ## Customizing your WAF configuration for an ingress gateway
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/threat/deploying-waf-ingress-gateway.mdx
@@ -70,10 +70,10 @@ To enable WAF on a Calico Ingress Gateway:
    To deploy a WAF on multiple gateways, you must create a separate `EnvoyExtensionPolicy` resource for each `Gateway` resource.
    Each `EnvoyExtensionPolicy` must reference the same `tigera-waf-backend` backend.
 
-1. To verify that the WAF is enabled for your gateway, you can simulate an SQL injection attack through your gateway and see whether it triggers a security event.
+1. To verify that the WAF is enabled for your gateway, you can simulate an SQL injection attack through your gateway and check that the WAF logs the request.
 
    :::note
-   The query string in this example has some SQL syntax embedded in the text. This is harmless and for demo purposes, but WAF will detect this pattern and create an WAF log for this HTTP request.
+   The query string in this example has some SQL syntax embedded in the text. This is harmless and for demo purposes, but WAF will detect this pattern and create a WAF log for this HTTP request. By design, Calico Ingress Gateway WAF emits WAF logs rather than security events.
    :::
 
    1. Get the service IP of your gateway:
@@ -81,12 +81,12 @@ To enable WAF on a Calico Ingress Gateway:
       ```bash
       export GATEWAY_HOST=$(kubectl get gateway/<gateway-name> -o jsonpath='{.status.addresses[0].value}')
       ```
-   1. Trigger a security event by simulating an SQL injection attack on that service IP:
+   1. Simulate an SQL injection attack on that service IP:
 
       ```bash
       curl --verbose --header "Host: www.example.com" http://$GATEWAY_HOST/?artist=0+div+1+union%23foo*%2F*bar%0D%0Aselect%23foo%0D%0A1%2C2%2Ccurrent_user
       ```
-   1. From the web console, go to **Threat > Security Events** and check for a security event with corresponds with this simulated SQL injection attack.
+   1. In Kibana, select the `tigera_secure_ee_waf*` index pattern and look for a WAF log that corresponds with this request. If blocking mode is enabled, the `curl` command also returns a `403 Forbidden` response.
 
 ## Customizing your WAF configuration for an ingress gateway
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/threat/deploying-waf-ingress-gateway.mdx
@@ -70,10 +70,10 @@ To enable WAF on a Calico Ingress Gateway:
    To deploy a WAF on multiple gateways, you must create a separate `EnvoyExtensionPolicy` resource for each `Gateway` resource.
    Each `EnvoyExtensionPolicy` must reference the same `tigera-waf-backend` backend.
 
-1. To verify that the WAF is enabled for your gateway, you can simulate an SQL injection attack through your gateway and see whether it triggers a security event.
+1. To verify that the WAF is enabled for your gateway, you can simulate an SQL injection attack through your gateway and check that the WAF logs the request.
 
    :::note
-   The query string in this example has some SQL syntax embedded in the text. This is harmless and for demo purposes, but WAF will detect this pattern and create an WAF log for this HTTP request.
+   The query string in this example has some SQL syntax embedded in the text. This is harmless and for demo purposes, but WAF will detect this pattern and create a WAF log for this HTTP request. By design, Calico Ingress Gateway WAF emits WAF logs rather than security events.
    :::
 
    1. Get the service IP of your gateway:
@@ -81,12 +81,12 @@ To enable WAF on a Calico Ingress Gateway:
       ```bash
       export GATEWAY_HOST=$(kubectl get gateway/<gateway-name> -o jsonpath='{.status.addresses[0].value}')
       ```
-   1. Trigger a security event by simulating an SQL injection attack on that service IP:
+   1. Simulate an SQL injection attack on that service IP:
 
       ```bash
       curl --verbose --header "Host: www.example.com" http://$GATEWAY_HOST/?artist=0+div+1+union%23foo*%2F*bar%0D%0Aselect%23foo%0D%0A1%2C2%2Ccurrent_user
       ```
-   1. From the web console, go to **Threat > Security Events** and check for a security event with corresponds with this simulated SQL injection attack.
+   1. In Kibana, select the `tigera_secure_ee_waf*` index pattern and look for a WAF log that corresponds with this request. If blocking mode is enabled, the `curl` command also returns a `403 Forbidden` response.
 
 ## Customizing your WAF configuration for an ingress gateway
 


### PR DESCRIPTION
## Summary

The CIG WAF deployment guide tells users to verify the WAF by checking **Threat > Security Events** in the web console — but Calico Ingress Gateway WAF does not emit security events.

This PR rewrites the verification step in `deploying-waf-ingress-gateway.mdx` (5 near-identical files) to:
- Drop the "security event" framing from the step heading and substep.
- Point users to the `tigera_secure_ee_waf*` index in Kibana.
- Add a short note that, by design, CIG WAF emits WAF logs rather than security events.
- Mention the `403 Forbidden` response as a secondary signal when blocking mode is enabled.
- Fix a small grammar nit in the existing note ("an WAF log" → "a WAF log").

Product Version(s): Calico Cloud (22-2 + next), Calico Enterprise 3.22, 3.23, next

Issue: Reported in Slack — https://tigera.slack.com/archives/G8FMPPH32/p1778086792351419?thread_ts=1777387510.268879&cid=G8FMPPH32

Link to docs preview: _will add once Netlify build finishes_

SME review:
- [ ] An SME has approved this change.

DOCS review:
- [ ] A member of the docs team has approved this change.

Additional information:

PTAL @electricjesus @BatoulSarvi — Seth as SME on the original design, Sara since you flagged this.

Merge checklist:
- [ ] Deploy preview inspected wherever changes were made
- [ ] Build completed successfully
- [ ] Tests have passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)