### PR TITLE
DOCS-2914: Remove false statement about federation controller

### DIFF
--- a/calico-cloud/reference/component-resources/kube-controllers/configuration.mdx
+++ b/calico-cloud/reference/component-resources/kube-controllers/configuration.mdx
@@ -79,8 +79,6 @@ The federation controller syncs Kubernetes federated endpoint changes to the $[p
 The controller must have read access to the Kubernetes API to monitor `Service` and `Endpoints` events, and must
 also have write access to update `Endpoints`.
 
-The federation controller is disabled by default if `ENABLED_CONTROLLERS` is not explicitly specified.
-
 This controller is valid for all $[prodname] datastore types. For more details refer to the
 [Configuring federated services](../../../multicluster/services-controller.mdx) usage guide.
 

--- a/calico-cloud_versioned_docs/version-22-2/reference/component-resources/kube-controllers/configuration.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/reference/component-resources/kube-controllers/configuration.mdx
@@ -79,8 +79,6 @@ The federation controller syncs Kubernetes federated endpoint changes to the $[p
 The controller must have read access to the Kubernetes API to monitor `Service` and `Endpoints` events, and must
 also have write access to update `Endpoints`.
 
-The federation controller is disabled by default if `ENABLED_CONTROLLERS` is not explicitly specified.
-
 This controller is valid for all $[prodname] datastore types. For more details refer to the
 [Configuring federated services](../../../multicluster/services-controller.mdx) usage guide.
 

--- a/calico-enterprise/reference/component-resources/kube-controllers/configuration.mdx
+++ b/calico-enterprise/reference/component-resources/kube-controllers/configuration.mdx
@@ -79,8 +79,6 @@ The federation controller syncs Kubernetes federated endpoint changes to the $[p
 The controller must have read access to the Kubernetes API to monitor `Service` and `Endpoints` events, and must
 also have write access to update `Endpoints`.
 
-The federation controller is disabled by default if `ENABLED_CONTROLLERS` is not explicitly specified.
-
 This controller is valid for all $[prodname] datastore types. For more details refer to the
 [Configuring federated services](../../../multicluster/federation/services-controller.mdx) usage guide.
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/component-resources/kube-controllers/configuration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/component-resources/kube-controllers/configuration.mdx
@@ -79,8 +79,6 @@ The federation controller syncs Kubernetes federated endpoint changes to the $[p
 The controller must have read access to the Kubernetes API to monitor `Service` and `Endpoints` events, and must
 also have write access to update `Endpoints`.
 
-The federation controller is disabled by default if `ENABLED_CONTROLLERS` is not explicitly specified.
-
 This controller is valid for all $[prodname] datastore types. For more details refer to the
 [Configuring federated services](../../../multicluster/federation/services-controller.mdx) usage guide.
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/component-resources/kube-controllers/configuration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/component-resources/kube-controllers/configuration.mdx
@@ -79,8 +79,6 @@ The federation controller syncs Kubernetes federated endpoint changes to the $[p
 The controller must have read access to the Kubernetes API to monitor `Service` and `Endpoints` events, and must
 also have write access to update `Endpoints`.
 
-The federation controller is disabled by default if `ENABLED_CONTROLLERS` is not explicitly specified.
-
 This controller is valid for all $[prodname] datastore types. For more details refer to the
 [Configuring federated services](../../../multicluster/federation/services-controller.mdx) usage guide.
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/reference/component-resources/kube-controllers/configuration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/reference/component-resources/kube-controllers/configuration.mdx
@@ -79,8 +79,6 @@ The federation controller syncs Kubernetes federated endpoint changes to the $[p
 The controller must have read access to the Kubernetes API to monitor `Service` and `Endpoints` events, and must
 also have write access to update `Endpoints`.
 
-The federation controller is disabled by default if `ENABLED_CONTROLLERS` is not explicitly specified.
-
 This controller is valid for all $[prodname] datastore types. For more details refer to the
 [Configuring federated services](../../../multicluster/federation/services-controller.mdx) usage guide.
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/reference/component-resources/kube-controllers/configuration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/reference/component-resources/kube-controllers/configuration.mdx
@@ -79,8 +79,6 @@ The federation controller syncs Kubernetes federated endpoint changes to the $[p
 The controller must have read access to the Kubernetes API to monitor `Service` and `Endpoints` events, and must
 also have write access to update `Endpoints`.
 
-The federation controller is disabled by default if `ENABLED_CONTROLLERS` is not explicitly specified.
-
 This controller is valid for all $[prodname] datastore types. For more details refer to the
 [Configuring federated services](../../../multicluster/federation/services-controller.mdx) usage guide.
 


### PR DESCRIPTION
The federation controller is enabled even when the ENABLED_CONTROLLERS
option is not explicitly specified.

This commit removes the false statement.

DOCS-2914

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->
https://tigera.atlassian.net/browse/DOCS-2914

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->