### PR TITLE
Override js-yaml and on-headers to close 2 Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,8 @@
   "resolutions": {
     "dompurify": "3.4.1",
     "file-type": "21.3.2",
+    "js-yaml@=4.1.0": "4.1.1",
+    "on-headers": "1.1.0",
     "prismjs": "1.30.0"
   },
   "jest-junit": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13443,14 +13443,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:=4.1.0":
-  version: 4.1.0
-  resolution: "js-yaml@npm:4.1.0"
+"js-yaml@npm:4.1.1, js-yaml@npm:^4.1.0":
+  version: 4.1.1
+  resolution: "js-yaml@npm:4.1.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/184a24b4eaacfce40ad9074c64fd42ac83cf74d8c8cd137718d456ced75051229e5061b8633c3366b8aada17945a7a356b337828c19da92b51ae62126575018f
+  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
   languageName: node
   linkType: hard
 
@@ -13463,17 +13463,6 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10c0/3261f25912f5dd76605e5993d0a126c2b6c346311885d3c483706cd722efe34f697ea0331f654ce27c00a42b426e524518ec89d65ed02ea47df8ad26dcc8ce69
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
-  dependencies:
-    argparse: "npm:^2.0.1"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
   languageName: node
   linkType: hard
 
@@ -15563,10 +15552,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-headers@npm:~1.0.2":
-  version: 1.0.2
-  resolution: "on-headers@npm:1.0.2"
-  checksum: 10c0/f649e65c197bf31505a4c0444875db0258e198292f34b884d73c2f751e91792ef96bb5cf89aa0f4fecc2e4dc662461dda606b1274b0e564f539cae5d2f5fc32f
+"on-headers@npm:1.1.0":
+  version: 1.1.0
+  resolution: "on-headers@npm:1.1.0"
+  checksum: 10c0/2c3b6b0d68ec9adbd561dc2d61c9b14da8ac03d8a2f0fd9e97bdf0600c887d5d97f664ff3be6876cf40cda6e3c587d73a4745e10b426ac50c7664fc5a0dfc0a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Closes 2 remaining Dependabot alerts via `package.json` resolutions overrides:

| Package | Bump | Mechanism | Alert |
| --- | --- | --- | --- |
| `js-yaml` | 4.1.0 → 4.1.1 | resolutions override (swagger-ui-react pins exact `=4.1.0`) | [#82](https://github.com/tigera/docs/security/dependabot/82) — medium, prototype pollution in merge `<<` |
| `on-headers` | 1.0.2 → 1.1.0 | resolutions override (webpack-dev-server > compression pins `~1.0.2`) | [#73](https://github.com/tigera/docs/security/dependabot/73) — low, HTTP response header manipulation |

## Notes

- The earlier batch [#2693](https://github.com/tigera/docs/pull/2693) covered the `^4.1.0` js-yaml consumers (Docusaurus, cosmiconfig, etc.) but missed the exact `=4.1.0` pin from `swagger-ui-react`. This catches that straggler.
- `on-headers` only appears in the dev server (`webpack-dev-server`'s `compression` middleware) — not in the published static site. The CVE is about HTTP response header manipulation, which only matters when a server is actually serving traffic, so impact for this repo is essentially nil. Closing it for hygiene.

## Test plan

- [ ] CI: `yarn build`
- [ ] CI: `yarn test:components`

🤖 Generated with [Claude Code](https://claude.com/claude-code)