### PR TITLE
Dedupe ajv to close Dependabot alert #106

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7546,19 +7546,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0":
-  version: 8.17.1
-  resolution: "ajv@npm:8.17.1"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.3"
-    fast-uri: "npm:^3.0.1"
-    json-schema-traverse: "npm:^1.0.0"
-    require-from-string: "npm:^2.0.2"
-  checksum: 10c0/ec3ba10a573c6b60f94639ffc53526275917a2df6810e4ab5a6b959d87459f9ef3f00d5e7865b82677cb7d21590355b34da14d1d0b9c32d75f95a187e76fff35
-  languageName: node
-  linkType: hard
-
-"ajv@npm:^8.9.0":
+"ajv@npm:^8.0.0, ajv@npm:^8.9.0":
   version: 8.18.0
   resolution: "ajv@npm:8.18.0"
   dependencies:


### PR DESCRIPTION
## Summary

`yarn dedupe ajv` — collapses a duplicate ajv entry. Net change: 1 insertion, 13 deletions in `yarn.lock`. No `package.json` change.

## Background

Earlier batch [#2693](https://github.com/tigera/docs/pull/2693) bumped `ajv@^8.9.0` to 8.18.0 (used by `schema-utils@4.x`). But `ajv-formats@2.1.1` declares `ajv@^8.0.0`, and yarn left that descriptor on the older 8.17.1. Both ranges accept 8.18.0 — dedupe consolidates.

## Closes

[#106](https://github.com/tigera/docs/security/dependabot/106) — medium, ReDoS via `$data` option

## Test plan

- [ ] CI: `yarn build`
- [ ] CI: `yarn test:components`

🤖 Generated with [Claude Code](https://claude.com/claude-code)