### PR TITLE
Add Istio Ambient Mode docs to Calico Cloud 22.2

### DIFF
--- a/calico-cloud_versioned_docs/version-22-2/compliance/istio/about-istio-ambient.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/compliance/istio/about-istio-ambient.mdx
@@ -1,0 +1,53 @@
+---
+description: An overview of Calico's bundled version of Istio Ambient Mode
+---
+
+# Istio Ambient Mode
+
+You can use $[prodname] to deploy and manage an Istio service mesh on your cluster.
+$[prodname] installs Istio in ambient mode, which conserves resources while providing the same robust mTLS encryption for your workloads.
+
+:::note
+
+Istio Ambient Mode is a tech preview feature.
+Tech preview features are subject to significant changes before they become GA.
+
+:::
+
+## About Istio Ambient Mode
+
+Istio is a service mesh that manages and secures communication between microservices.
+Typically, Istio uses sidecar proxies that are deployed alongside every pod in the service mesh.
+At scale, running these sidecar proxies can be difficult to manage and a drain on resources.
+
+Istio Ambient Mode is a simplified service mesh architecture that removes the need for a sidecar proxy next to every pod.
+Instead, it uses node-level components for shared security and a layered approach for advanced traffic management.
+This design saves on computing resources and simplifies operations.
+
+## About Istio Ambient Mode on Calico
+
+$[prodname] provides a bundled version of Istio that can be installed and managed by the Tigera Operator.
+
+This integration automates the lifecycle of the Istio components to reduce manual configuration overhead.
+CVEs are addressed as part of the regular $[prodname] patch release cadence.
+Administrators provision the Istio service mesh by defining a standard `Istio` custom resource.
+
+### The enhanced zTunnel proxy
+
+The zTunnel component in Istio Ambient Mode is a lightweight proxy that runs on every node.
+
+Its main job is to handle encryption, authentication, and policy enforcement for traffic at Layer 4.
+
+A challenge in the original Istio Ambient Mode is that when traffic is routed through the zTunnel, it gets placed into a tunnel on a specific port (15008).
+This change makes it impossible for existing Layer 3 or Layer 4 network policies (like those from Calico) to see the original destination port of the traffic.
+
+Calico addresses this by using an enhanced zTunnel that is modified to preserve the original destination port.
+This modification allows existing Calico and Kubernetes network policies to continue functioning exactly as they did before, without needing any rewrites, even though the traffic is now encrypted with mTLS.
+
+These zTunnel enhancements are not compatible with Istio's application-layer Waypoint proxy.
+If you deploy Waypoint, the reported destination ports will follow the original behavior.
+Existing network policies need to be adapted to allow communication to port 15008.
+
+## Additional resources
+* [Overview of Istio ambient mode](https://istio.io/latest/docs/ambient/overview/).
+* [Ambient and Kubernetes NetworkPolicy](https://istio.io/latest/docs/ambient/usage/networkpolicy/)

--- a/calico-cloud_versioned_docs/version-22-2/compliance/istio/deploy-istio-ambient.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/compliance/istio/deploy-istio-ambient.mdx
@@ -1,0 +1,161 @@
+---
+description: This page explains how to deploy Calico's bundled version of Istio in ambient mode.
+---
+
+# Deploy Istio Ambient Mode on your cluster
+
+You can deploy Calico's bundled version of Istio in ambient mode to provide mTLS encryption to your workloads.
+
+:::note
+
+Istio Ambient Mode is a tech preview feature.
+Tech preview features are subject to significant changes before they become GA.
+
+:::
+
+## Limitations
+
+* [Application layer network policies](../../network-policy/application-layer-policies/alp.mdx) are not compatible with the Istio service mesh.
+* Istio Ambient Mode does not work together with [workload-based web application firewalls](../../threat/web-application-firewall.mdx).
+* The service mesh is not supported for use on clusters that are also part of a [cluster mesh](../../multicluster/index.mdx).
+* Destination ports are preserved only when Istio is deployed without Waypoint.
+  If you deploy Waypoint, all traffic through Waypoint will show port 15008 as its destination port.
+* Connect-time load balancing is not compatible with Istio Ambient Mode.
+
+## Prerequisites
+
+* $[prodname] is installed and managed by the Tigera Operator.
+
+## Install Istio in ambient mode on your cluster
+
+You can create an Istio service mesh in ambient mode by creating the `Istio` custom resource.
+
+* To install Istio in ambient mode, apply the `Istio` custom resource to your cluster:
+
+   ```bash
+   cat <<EOF | kubectl apply -f -
+   apiVersion: operator.tigera.io/v1
+   kind: Istio
+   metadata:
+     name: default
+   EOF
+   ```
+
+   :::note
+   To customize resource requirements for your Istio deployment, see the options available in the [installation API documentation](../../reference/installation/api.mdx).
+   :::
+
+   To verify the installation:
+
+   ```bash
+   kubectl get tigerastatus
+   ```
+
+   ```shell title='Example output'
+   NAME                          AVAILABLE   PROGRESSING   DEGRADED   SINCE
+   apiserver                     True        False         False      9m59s
+   calico                        True        False         False      9m4s
+   intrusion-detection           True        False         False      5m39s
+   ippools                       True        False         False      10m
+   // highlight-next-line
+   istio                         True        False         False      19s
+   log-collector                 True        False         False      8m34s
+   log-storage                   True        False         False      10m
+   log-storage-access            True        False         False      4m24s
+   log-storage-dashboards        True        False         False      4m58s
+   log-storage-elastic           True        False         False      5m4s
+   log-storage-esmetrics         True        False         False      4m54s
+   log-storage-kubecontrollers   True        False         False      5m9s
+   log-storage-secrets           True        False         False      10m
+   manager                       True        False         False      8m24s
+   monitor                       True        False         False      9m44s
+   policy-recommendation         True        False         False      9m24s
+   tiers                         True        False         False      9m44s
+   ```
+   Now you can add your workloads to the Istio service mesh.
+
+## Add a workload to the Istio service mesh
+
+You can add workloads to the mesh by labeling them.
+Communication between labelled namespaces and pods goes through the mesh and uses mTLS encryption.
+
+:::warning
+
+Don't label $[prodname] resources to add them to the service mesh.
+Doing this can cause interruptions and failure to your cluster network.
+
+If you want to secure $[prodname] components, see [Secure Calico component communications](../../operations/comms/index.mdx).
+:::
+
+1. To add workloads to your Istio service mesh, add the `istio.io/dataplane-mode=ambient` label to a pod or namespace resource:
+
+   ```bash title='Adding a namespace to the Istio service mesh'
+   kubectl label namespace <namespace> istio.io/dataplane-mode=ambient
+   ```
+   Replace `<namespace>` with the namespace you want to include in the mesh.
+
+   ```bash title='Adding a pod to the Istio service mesh'
+   kubectl label pod --namespace=<namespace> <pod> istio.io/dataplane-mode=ambient
+   ```
+   Replace the following:
+   * `<pod>`: The name of the pod you want to include in the mesh.
+   * `<namespace>`: The namespace your pod is in.
+
+## Removing Istio
+
+If you want to remove Istio, first remove the labels you applied to pods and namespaces.
+When that's done, you can delete the `Istio` custom resource.
+
+1. Remove the label from namespaces and pods by running the following commands:
+
+   ```bash
+   kubectl label namespaces --all istio.io/dataplane-mode=ambient-
+   kubectl label pods --all --all-namespaces istio.io/dataplane-mode=ambient-
+   ```
+1. Remove the `Istio` custom resource:
+
+   ```bash
+   kubectl delete istio.operator.tigera.io default
+   ```
+
+## Troubleshooting commands
+
+Check whether Istio pods are deployed:
+
+```bash
+kubectl get pods -n calico-system | grep 'istio\|ztunnel'
+```
+
+Check whether Istio CRDs are deployed:
+
+```bash
+kubectl get crd | grep istio
+```
+
+Check which pods and namespaces are in the mesh:
+
+* Requires [istioctl](https://istio.io/latest/docs/ops/diagnostic-tools/istioctl/).
+
+```bash
+istioctl ztunnel-config workloads -n calico-system
+```
+
+Check for errors logged by the zTunnel component:
+
+```bash
+ZTUNNEL_PODS=$(kubectl get pod -n calico-system \
+  -l app.kubernetes.io/name=ztunnel \
+  -o jsonpath='{.items[*].metadata.name}')
+
+for P in $ZTUNNEL_PODS; do
+  echo "--- Checking logs for pod: $P ---"
+  kubectl logs $P -n calico-system 2>/dev/null | \
+    grep -i error | \
+    grep -i app1
+done
+```
+
+## Additional resources
+
+* [Overview of Istio ambient mode](https://istio.io/latest/docs/ambient/overview/).
+* [Configuration options](../../reference/installation/api).

--- a/calico-cloud_versioned_docs/version-22-2/release-notes/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/release-notes/index.mdx
@@ -30,6 +30,15 @@ To configure notifications, click the user icon <IconUser width="20"/> **> Notif
 
 ### New features and enhancements
 
+#### Istio Ambient Mode (tech preview)
+
+$[prodname] now provides a bundled version of Istio in ambient mode, a sidecarless architecture that delivers robust mTLS encryption and service mesh security while significantly reducing resource consumption and operational overhead.
+This implementation, managed by the Tigera Operator, features an enhanced zTunnel proxy that preserves original destination ports so existing Calico and Kubernetes network policies continue to function seamlessly without requiring rewrites.
+
+For more information, see [Istio Ambient Mode](../compliance/istio/about-istio-ambient.mdx).
+
+#### Enhancements
+
 * Enhancements to to Calico Cloud dashboards.
 
 <h2 id="february-5-2026">February 5, 2026 (web console update)</h2>

--- a/calico-cloud_versioned_sidebars/version-22-2-sidebars.json
+++ b/calico-cloud_versioned_sidebars/version-22-2-sidebars.json
@@ -400,6 +400,15 @@
         "id": "compliance/index"
       },
       "items": [
+        {
+          "type": "category",
+          "label": "Istio Ambient Mode",
+          "link": null,
+          "items": [
+            "compliance/istio/about-istio-ambient",
+            "compliance/istio/deploy-istio-ambient"
+          ]
+        },
         "compliance/enable-compliance",
         "compliance/overview",
         "compliance/compliance-reports-cis",


### PR DESCRIPTION
## Summary

- Port the Istio Ambient Mode pages (`about-istio-ambient.mdx` and `deploy-istio-ambient.mdx`) from Calico Enterprise 3.22 into the Calico Cloud 22.2 versioned docs under `compliance/istio/`.
- Add an "Istio Ambient Mode" subcategory to the Compliance and security section of the CC 22.2 versioned sidebar (matches the layout already in `sidebars-calico-cloud.js`).
- Add an "Istio Ambient Mode (tech preview)" feature entry to the March 5, 2026 (version 22.2.0) section of the CC release notes, modeled on the CE 3.22 release-note entry.

The dev branch (`calico-cloud/compliance/istio/` and `sidebars-calico-cloud.js`) already contained these pages; they just hadn't been carried into the 22.2 versioned snapshot.

## Test plan

- [ ] Build the Calico Cloud docs locally and confirm the new pages render.
- [ ] Confirm the new "Istio Ambient Mode" sidebar category appears under Compliance and security in CC 22.2.
- [ ] Verify cross-links resolve (`network-policy/application-layer-policies/alp.mdx`, `threat/web-application-firewall.mdx`, `multicluster/index.mdx`, `reference/installation/api.mdx`, `operations/comms/index.mdx`).
- [ ] Confirm the new release-note entry shows up under the March 5, 2026 (22.2.0) heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)