### PR TITLE
Skip Mirantis docs in link checker

### DIFF
--- a/src/utils/linkChecker.js
+++ b/src/utils/linkChecker.js
@@ -28,6 +28,7 @@ const defaultSkipList = [
   /^https?:\/\/docs\.openshift\.com\/.*/,
   /^https?:\/\/docs\.redhat\.com\/.*/,
   /^https?:\/\/access\.redhat\.com\/.*/,
+  /^https?:\/\/docs\.mirantis\.com\/.*/,
   'https://en.wikipedia.org/wiki/Autonomous_System_(Internet',
   'https://github.com/dims/etcd3-gateway.git@5a3157a122368c2314c7a961f61722e47355f981',
   'https://installer.calicocloud.io:443/',


### PR DESCRIPTION
## Summary
- Add `docs.mirantis.com` to the link-checker skip list. The domain is fronted by Cloudflare/bot-protection and 403s requests from Netlify build IPs even though pages load fine in a browser.
- Mirrors the existing Red Hat / OpenShift entries added in #2685.

The two links surfacing as false-positive dead links on recent deploys (e.g. PR #2705):

- `https://docs.mirantis.com/mke/3.8/install/predeployment/configure-networking/calico-networking.html` (403)
- `https://docs.mirantis.com/mke4k/4.1.0/configuration/container-network-interface/` (403)

Both are referenced from `/calico/latest/getting-started/kubernetes/community-tested`.

## Test plan
- [ ] Netlify deploy preview succeeds (no LINK-CHECK dead link errors for `docs.mirantis.com`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)