### PR TITLE
OpenStack: remove mentions of ML2

### DIFF
--- a/calico/getting-started/openstack/installation/redhat.mdx
+++ b/calico/getting-started/openstack/installation/redhat.mdx
@@ -32,8 +32,7 @@ combined control and compute node, work through all three sections.
   Enterprise Linux (RHEL) hosts.
 - Make sure you have working DNS between the RHEL hosts (use `/etc/hosts` if you
   don't have DNS on your network).
-- [Install OpenStack with Neutron and ML2 networking](http://docs.openstack.org)
-  on the RHEL hosts.
+- [Install OpenStack](http://docs.openstack.org) on the RHEL hosts.
 
 ## Common steps
 

--- a/calico/getting-started/openstack/installation/ubuntu.mdx
+++ b/calico/getting-started/openstack/installation/ubuntu.mdx
@@ -22,8 +22,7 @@ combined control and compute node, work through all three sections.
 - Ensure that you meet the [requirements](../requirements.mdx).
 - Confirm that you have SSH access to and root privileges on one or more Ubuntu hosts
   (your OpenStack compute or control nodes).
-- [Install OpenStack with Neutron and ML2 networking](http://docs.openstack.org)
-  on the Ubuntu hosts.
+- [Install OpenStack](http://docs.openstack.org) on the Ubuntu hosts.
 
 ## Common steps
 

--- a/calico/network-policy/comms/crypto-auth.mdx
+++ b/calico/network-policy/comms/crypto-auth.mdx
@@ -33,7 +33,7 @@ its connections as follows.
   - [Felix](../../reference/felix/configuration.mdx#etcd-datastore-configuration)
   - [Typha](../../reference/typha/configuration.mdx#etcd-datastore-configuration) (often deployed in
     larger Kubernetes deployments)
-  - [Neutron plugin or ML2 driver](../../networking/openstack/configuration.mdx#neutron-server-etcneutronneutronconf) (OpenStack only)
+  - [Neutron plugin](../../networking/openstack/configuration.mdx#neutron-server-etcneutronneutronconf) (OpenStack only)
   - [DHCP agent](../../networking/openstack/configuration.mdx#neutron-server-etcneutronneutronconf) (OpenStack only)
 
 </TabItem>

--- a/calico/networking/openstack/configuration.mdx
+++ b/calico/networking/openstack/configuration.mdx
@@ -27,7 +27,7 @@ configure the Neutron service.
 | core_plugin          | calico    | Use the $[prodname] core plugin          |
 
 The following options in the `[calico]` section of `/etc/neutron/neutron.conf` govern how
-the $[prodname] plugin/driver and DHCP agent connect to the $[prodname] etcd
+the $[prodname] plugin and DHCP agent connect to the $[prodname] etcd
 datastore. You should set `etcd_host` to the IP of your etcd server, and `etcd_port` if
 that server is using a non-standard port. If the etcd server is TLS-secured, also set:
 

--- a/calico/networking/openstack/configuration.mdx
+++ b/calico/networking/openstack/configuration.mdx
@@ -26,19 +26,6 @@ configure the Neutron service.
 | -------------------- | --------- | ---------------------------------------- |
 | core_plugin          | calico    | Use the $[prodname] core plugin          |
 
-$[prodname] can operate either as a core plugin or as an ML2 mechanism driver. The
-function is the same both ways, except that floating IPs are only supported
-when operating as a core plugin; hence the recommended setting here.
-
-However, if you don't need floating IPs and have other reasons for using ML2,
-you can, instead, set
-
-| Setting              | Value                                  | Meaning                |
-| -------------------- | -------------------------------------- | ---------------------- |
-| core_plugin          | neutron.plugins.ml2.plugin.ML2Plugin   | Use ML2 plugin         |
-
-and then the further ML2-specific configuration as covered below.
-
 The following options in the `[calico]` section of `/etc/neutron/neutron.conf` govern how
 the $[prodname] plugin/driver and DHCP agent connect to the $[prodname] etcd
 datastore. You should set `etcd_host` to the IP of your etcd server, and `etcd_port` if
@@ -72,14 +59,3 @@ When specified, the value of `openstack_region` must be a string of lower case a
 characters or '-', starting and ending with an alphanumeric character, and must match the value of
 [`OpenStackRegion`](../../reference/felix/configuration.mdx#openstack-specific-configuration)
 configured for the Felixes in the same region.
-
-## ML2 (.../ml2_conf.ini)
-
-In `/etc/neutron/plugins/ml2/ml2_conf.ini` you need the following
-settings to configure the ML2 plugin.
-
-| Setting              | Value       | Meaning                           |
-| -------------------- | ----------- | --------------------------------- |
-| mechanism_drivers    | calico      | Use $[prodname]                   |
-| type_drivers         | local, flat | Allow 'local' and 'flat' networks |
-| tenant_network_types | local, flat | Allow 'local' and 'flat' networks |

--- a/calico/networking/openstack/floating-ips.mdx
+++ b/calico/networking/openstack/floating-ips.mdx
@@ -4,15 +4,7 @@ description: Configure floating IPs in Calico for OpenStack.
 
 # Floating IPs
 
-networking-calico includes beta support for floating IPs. Currently this
-requires running $[prodname] as a Neutron core plugin (i.e. `core_plugin = calico`) instead of as an ML2 mechanism driver.
-
-:::note
-
-We would like it to work as an ML2 mechanism driver too—patches
-and/or advice welcome!
-
-:::
+networking-calico includes support for floating IPs.
 
 To set up a floating IP, you need the same pattern of Neutron data model
 objects as you do for Neutron in general, which means:

--- a/calico/networking/openstack/kuryr.mdx
+++ b/calico/networking/openstack/kuryr.mdx
@@ -5,7 +5,7 @@ description: Use Kuryr with Calico networking.
 # Kuryr
 
 networking-calico works with Kuryr; this means using Neutron, with the $[prodname]
-ML2 driver, to provide networking for container workloads.
+core plugin, to provide networking for container workloads.
 
 You can use DevStack to install a single node $[prodname]/Kuryr system, with a
 `local.conf` file like this:

--- a/calico/networking/openstack/neutron-api.mdx
+++ b/calico/networking/openstack/neutron-api.mdx
@@ -130,7 +130,7 @@ All the attributes of security groups remain unchanged in $[prodname].
 
 ## Floating IPs
 
-Floating IPs are supported at beta level. For more information, see [Floating IPs](floating-ips.mdx).
+Floating IPs are supported. For more information, see [Floating IPs](floating-ips.mdx).
 
 ## Neutron Routers
 

--- a/calico/networking/openstack/semantics.mdx
+++ b/calico/networking/openstack/semantics.mdx
@@ -6,7 +6,7 @@ description: Calico provides connectivity that is different from traditional Neu
 
 A $[prodname] network is a Neutron network (either provider or tenant) whose
 connectivity is implemented, on every compute host with instances attached to
-that network, by the `calico` plugin or ML2 mechanism driver. There can be
+that network, by the `calico` plugin. There can be
 just one $[prodname] network, or any number of them. This page describes the
 connectivity that $[prodname] provides between instances attached to the same
 network, and between instances attached to different $[prodname] networks, and

--- a/calico/reference/faq.mdx
+++ b/calico/reference/faq.mdx
@@ -182,7 +182,7 @@ The bulk of global state is mastered in whatever component hosts the
 plugin.
 
 - In the case of OpenStack, this means a Neutron database. Our
-  OpenStack plugin (more strictly a Neutron ML2 driver) queries the
+  OpenStack plugin queries the
   Neutron database to find out state about the entire deployment. That
   state is then reflected to `etcd` and so to Felix.
 - In certain cases, `etcd` itself contains the master copy of

--- a/calico_versioned_docs/version-3.32/getting-started/openstack/installation/redhat.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/openstack/installation/redhat.mdx
@@ -32,8 +32,7 @@ combined control and compute node, work through all three sections.
   Enterprise Linux (RHEL) hosts.
 - Make sure you have working DNS between the RHEL hosts (use `/etc/hosts` if you
   don't have DNS on your network).
-- [Install OpenStack with Neutron and ML2 networking](http://docs.openstack.org)
-  on the RHEL hosts.
+- [Install OpenStack](http://docs.openstack.org) on the RHEL hosts.
 
 ## Common steps
 

--- a/calico_versioned_docs/version-3.32/getting-started/openstack/installation/ubuntu.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/openstack/installation/ubuntu.mdx
@@ -22,8 +22,7 @@ combined control and compute node, work through all three sections.
 - Ensure that you meet the [requirements](../requirements.mdx).
 - Confirm that you have SSH access to and root privileges on one or more Ubuntu hosts
   (your OpenStack compute or control nodes).
-- [Install OpenStack with Neutron and ML2 networking](http://docs.openstack.org)
-  on the Ubuntu hosts.
+- [Install OpenStack](http://docs.openstack.org) on the Ubuntu hosts.
 
 ## Common steps
 

--- a/calico_versioned_docs/version-3.32/network-policy/comms/crypto-auth.mdx
+++ b/calico_versioned_docs/version-3.32/network-policy/comms/crypto-auth.mdx
@@ -33,7 +33,7 @@ its connections as follows.
   - [Felix](../../reference/felix/configuration.mdx#etcd-datastore-configuration)
   - [Typha](../../reference/typha/configuration.mdx#etcd-datastore-configuration) (often deployed in
     larger Kubernetes deployments)
-  - [Neutron plugin or ML2 driver](../../networking/openstack/configuration.mdx#neutron-server-etcneutronneutronconf) (OpenStack only)
+  - [Neutron plugin](../../networking/openstack/configuration.mdx#neutron-server-etcneutronneutronconf) (OpenStack only)
   - [DHCP agent](../../networking/openstack/configuration.mdx#neutron-server-etcneutronneutronconf) (OpenStack only)
 
 </TabItem>

--- a/calico_versioned_docs/version-3.32/networking/openstack/configuration.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/configuration.mdx
@@ -27,7 +27,7 @@ configure the Neutron service.
 | core_plugin          | calico    | Use the $[prodname] core plugin          |
 
 The following options in the `[calico]` section of `/etc/neutron/neutron.conf` govern how
-the $[prodname] plugin/driver and DHCP agent connect to the $[prodname] etcd
+the $[prodname] plugin and DHCP agent connect to the $[prodname] etcd
 datastore. You should set `etcd_host` to the IP of your etcd server, and `etcd_port` if
 that server is using a non-standard port. If the etcd server is TLS-secured, also set:
 

--- a/calico_versioned_docs/version-3.32/networking/openstack/configuration.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/configuration.mdx
@@ -26,19 +26,6 @@ configure the Neutron service.
 | -------------------- | --------- | ---------------------------------------- |
 | core_plugin          | calico    | Use the $[prodname] core plugin          |
 
-$[prodname] can operate either as a core plugin or as an ML2 mechanism driver. The
-function is the same both ways, except that floating IPs are only supported
-when operating as a core plugin; hence the recommended setting here.
-
-However, if you don't need floating IPs and have other reasons for using ML2,
-you can, instead, set
-
-| Setting              | Value                                  | Meaning                |
-| -------------------- | -------------------------------------- | ---------------------- |
-| core_plugin          | neutron.plugins.ml2.plugin.ML2Plugin   | Use ML2 plugin         |
-
-and then the further ML2-specific configuration as covered below.
-
 The following options in the `[calico]` section of `/etc/neutron/neutron.conf` govern how
 the $[prodname] plugin/driver and DHCP agent connect to the $[prodname] etcd
 datastore. You should set `etcd_host` to the IP of your etcd server, and `etcd_port` if
@@ -72,14 +59,3 @@ When specified, the value of `openstack_region` must be a string of lower case a
 characters or '-', starting and ending with an alphanumeric character, and must match the value of
 [`OpenStackRegion`](../../reference/felix/configuration.mdx#openstack-specific-configuration)
 configured for the Felixes in the same region.
-
-## ML2 (.../ml2_conf.ini)
-
-In `/etc/neutron/plugins/ml2/ml2_conf.ini` you need the following
-settings to configure the ML2 plugin.
-
-| Setting              | Value       | Meaning                           |
-| -------------------- | ----------- | --------------------------------- |
-| mechanism_drivers    | calico      | Use $[prodname]                   |
-| type_drivers         | local, flat | Allow 'local' and 'flat' networks |
-| tenant_network_types | local, flat | Allow 'local' and 'flat' networks |

--- a/calico_versioned_docs/version-3.32/networking/openstack/floating-ips.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/floating-ips.mdx
@@ -4,15 +4,7 @@ description: Configure floating IPs in Calico for OpenStack.
 
 # Floating IPs
 
-networking-calico includes beta support for floating IPs. Currently this
-requires running $[prodname] as a Neutron core plugin (i.e. `core_plugin = calico`) instead of as an ML2 mechanism driver.
-
-:::note
-
-We would like it to work as an ML2 mechanism driver too—patches
-and/or advice welcome!
-
-:::
+networking-calico includes support for floating IPs.
 
 To set up a floating IP, you need the same pattern of Neutron data model
 objects as you do for Neutron in general, which means:

--- a/calico_versioned_docs/version-3.32/networking/openstack/kuryr.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/kuryr.mdx
@@ -5,7 +5,7 @@ description: Use Kuryr with Calico networking.
 # Kuryr
 
 networking-calico works with Kuryr; this means using Neutron, with the $[prodname]
-ML2 driver, to provide networking for container workloads.
+core plugin, to provide networking for container workloads.
 
 You can use DevStack to install a single node $[prodname]/Kuryr system, with a
 `local.conf` file like this:

--- a/calico_versioned_docs/version-3.32/networking/openstack/neutron-api.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/neutron-api.mdx
@@ -130,7 +130,7 @@ All the attributes of security groups remain unchanged in $[prodname].
 
 ## Floating IPs
 
-Floating IPs are supported at beta level. For more information, see [Floating IPs](floating-ips.mdx).
+Floating IPs are supported. For more information, see [Floating IPs](floating-ips.mdx).
 
 ## Neutron Routers
 

--- a/calico_versioned_docs/version-3.32/networking/openstack/semantics.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/semantics.mdx
@@ -6,7 +6,7 @@ description: Calico provides connectivity that is different from traditional Neu
 
 A $[prodname] network is a Neutron network (either provider or tenant) whose
 connectivity is implemented, on every compute host with instances attached to
-that network, by the `calico` plugin or ML2 mechanism driver. There can be
+that network, by the `calico` plugin. There can be
 just one $[prodname] network, or any number of them. This page describes the
 connectivity that $[prodname] provides between instances attached to the same
 network, and between instances attached to different $[prodname] networks, and

--- a/calico_versioned_docs/version-3.32/reference/faq.mdx
+++ b/calico_versioned_docs/version-3.32/reference/faq.mdx
@@ -182,7 +182,7 @@ The bulk of global state is mastered in whatever component hosts the
 plugin.
 
 - In the case of OpenStack, this means a Neutron database. Our
-  OpenStack plugin (more strictly a Neutron ML2 driver) queries the
+  OpenStack plugin queries the
   Neutron database to find out state about the entire deployment. That
   state is then reflected to `etcd` and so to Felix.
 - In certain cases, `etcd` itself contains the master copy of


### PR DESCRIPTION
We now only support running as a Neutron core plugin; no longer as an ML2 mechanism driver.

Only update for current release and next.  We could possibly go further back, but I'm not sure when we dropped pieces of the ML2 support, and anyone using an older release presumably already knows what is working for them.