### PR TITLE
Rewrite observability page descriptions (next trees)

### DIFF
--- a/calico-cloud/observability/alerts.mdx
+++ b/calico-cloud/observability/alerts.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manage alerts and events for Calico Enterprise features.
+description: Configure alerts and review alert events for Calico Cloud features in the web console or CLI. Use built-in templates for visibility and security signals.
 ---
 
 # Manage alerts

--- a/calico-cloud/observability/create-custom-dashboard.mdx
+++ b/calico-cloud/observability/create-custom-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create a custom dashboard
+description: Build custom dashboards in the Calico Cloud web console by importing cards from standard dashboards or constructing new cards from flow, DNS, and L7 fields.
 ---
 
 import Screenshot from '/src/___new___/components/Screenshot'

--- a/calico-cloud/observability/dashboards.mdx
+++ b/calico-cloud/observability/dashboards.mdx
@@ -1,5 +1,5 @@
 ---
-description: Visualize connected cluster activity in the Calico Cloud web console with prebuilt and custom dashboards for cluster health, policy, DNS, and L7 data.
+description: Visualize connected cluster activity in the Calico Cloud web console with prebuilt and custom dashboards for cluster health, traffic volume, DNS, flow logs, and HTTP traffic.
 ---
 
 import Screenshot from '/src/___new___/components/Screenshot'

--- a/calico-cloud/observability/dashboards.mdx
+++ b/calico-cloud/observability/dashboards.mdx
@@ -1,5 +1,5 @@
 ---
-description: Dashboards help you see what's going on in your cluster. See how your cluster is performing and visualize your system's log data.
+description: Visualize connected cluster activity in the Calico Cloud web console with prebuilt and custom dashboards for cluster health, policy, DNS, and L7 data.
 ---
 
 import Screenshot from '/src/___new___/components/Screenshot'

--- a/calico-cloud/observability/elastic/archive-storage.mdx
+++ b/calico-cloud/observability/elastic/archive-storage.mdx
@@ -1,5 +1,5 @@
 ---
-description: Archive logs to Syslog, Splunk, or Amazon S3 for maintaining compliance data.
+description: Forward Calico Cloud flow, DNS, audit, and L7 logs to Syslog, Splunk, or Amazon S3 to retain compliance data beyond managed retention windows.
 ---
 
 # Archive logs

--- a/calico-cloud/observability/elastic/audit-overview.mdx
+++ b/calico-cloud/observability/elastic/audit-overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico Cloud audit logs provide data on changes to resources.
+description: Calico Cloud audit logs record changes to network policies, tiers, network sets, host endpoints, and other resources across connected clusters.
 ---
 
 # Audit logs

--- a/calico-cloud/observability/elastic/bgp.mdx
+++ b/calico-cloud/observability/elastic/bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Key/value pairs of BGP activity logs and how to construct queries.
+description: Reference of key/value fields in Calico Cloud BGP activity logs in Elasticsearch, with sample queries for IPv4, IPv6, and per-node lookups.
 ---
 
 # BGP logs

--- a/calico-cloud/observability/elastic/dns/dns-logs.mdx
+++ b/calico-cloud/observability/elastic/dns/dns-logs.mdx
@@ -1,5 +1,5 @@
 ---
-description: Key/value pairs of DNS activity logs and how to construct queries.
+description: Reference of key/value fields in Calico Cloud DNS activity logs in Elasticsearch, with guidance for building client and query lookups.
 ---
 
 # Query DNS logs

--- a/calico-cloud/observability/elastic/dns/filtering-dns.mdx
+++ b/calico-cloud/observability/elastic/dns/filtering-dns.mdx
@@ -1,5 +1,5 @@
 ---
-description: Suppress DNS logs of low significance using filters.
+description: Suppress low-value Calico Cloud DNS log entries with Fluentd filters configured through a ConfigMap in the operator namespace of connected clusters.
 ---
 
 # Filter DNS logs

--- a/calico-cloud/observability/elastic/dns/index.mdx
+++ b/calico-cloud/observability/elastic/dns/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure and filter DNS logs.
+description: Configure and filter DNS activity logs for Calico Cloud. Review the schema, build Elasticsearch queries, and trim low-value entries.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud/observability/elastic/flow/aggregation.mdx
+++ b/calico-cloud/observability/elastic/flow/aggregation.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure flow log aggregation to reduce log volume and costs.
+description: Tune Calico Cloud flow log aggregation levels to balance managed Elasticsearch volume and cost against pod and IP visibility for allowed and denied traffic.
 ---
 
 # Configure flow log aggregation

--- a/calico-cloud/observability/elastic/flow/datatypes.mdx
+++ b/calico-cloud/observability/elastic/flow/datatypes.mdx
@@ -1,5 +1,5 @@
 ---
-description: Data that Calico Cloud sends to Elasticsearch.
+description: Reference of key/value fields that Calico Cloud sends to Elasticsearch for flow logs, including endpoints, actions, byte counts, and policy verdicts.
 ---
 
 # Flow log data types

--- a/calico-cloud/observability/elastic/flow/filtering.mdx
+++ b/calico-cloud/observability/elastic/flow/filtering.mdx
@@ -1,5 +1,5 @@
 ---
-description: Filter Calico Cloud flow logs.
+description: Filter Calico Cloud flow logs through Fluentd to drop low-significance traffic and reduce managed Elasticsearch volume and cost.
 ---
 
 # Filter flow logs

--- a/calico-cloud/observability/elastic/flow/hep.mdx
+++ b/calico-cloud/observability/elastic/flow/hep.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable hostendpoint reporting in flow logs.
+description: Turn on host endpoint reporting in Calico Cloud flow logs to gain visibility into traffic at HostEndpoint interfaces on Kubernetes nodes.
 ---
 
 # Enable HostEndpoint reporting in flow logs

--- a/calico-cloud/observability/elastic/flow/index.mdx
+++ b/calico-cloud/observability/elastic/flow/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure, filter, and aggregate flow logs.
+description: Configure, filter, and aggregate Calico Cloud flow logs. Add host endpoint, process path, and TCP socket statistics from managed Elasticsearch.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud/observability/elastic/flow/processpath.mdx
+++ b/calico-cloud/observability/elastic/flow/processpath.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add process executable paths and arguments to Calico Cloud flow logs with eBPF kprobe programs for process-level visibility into network activity.
+description: Add process executable paths and arguments to Calico Cloud flow logs with eBPF instrumentation for process-level visibility into network activity.
 ---
 
 # Enable process-level information in flow logs

--- a/calico-cloud/observability/elastic/flow/processpath.mdx
+++ b/calico-cloud/observability/elastic/flow/processpath.mdx
@@ -1,5 +1,5 @@
 ---
-description: Get visibility into process-level network activity in flow logs.
+description: Add process executable paths and arguments to Calico Cloud flow logs with eBPF kprobe programs for process-level visibility into network activity.
 ---
 
 # Enable process-level information in flow logs

--- a/calico-cloud/observability/elastic/flow/tcpstats.mdx
+++ b/calico-cloud/observability/elastic/flow/tcpstats.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enabling TCP socket stats information in flow logs
+description: Add TCP socket statistics to Calico Cloud flow logs with eBPF programs that capture round-trip time, retransmits, and other per-socket metrics.
 ---
 
 # Enabling TCP socket stats in flow logs

--- a/calico-cloud/observability/elastic/index.mdx
+++ b/calico-cloud/observability/elastic/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure logs for visibility in the web console.
+description: Configure managed Elasticsearch logs for Calico Cloud so the web console and Kibana can surface flow, DNS, audit, and L7 data from connected clusters.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud/observability/elastic/l7/configure.mdx
+++ b/calico-cloud/observability/elastic/l7/configure.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure and aggregate L7 logs.
+description: Deploy Envoy and aggregate Calico Cloud L7 logs to monitor HTTP traffic patterns between application workloads on connected clusters.
 ---
 
 # Configure L7 logs

--- a/calico-cloud/observability/elastic/l7/datatypes.mdx
+++ b/calico-cloud/observability/elastic/l7/datatypes.mdx
@@ -1,5 +1,5 @@
 ---
-description: L7 data that Calico Cloud sends to Elasticsearch.
+description: Reference of key/value fields that Calico Cloud sends to Elasticsearch for L7 logs, including durations, byte counts, and HTTP request metadata.
 ---
 
 # L7 log data types

--- a/calico-cloud/observability/elastic/l7/index.mdx
+++ b/calico-cloud/observability/elastic/l7/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Elasticsearch L7 logs.
+description: Configure L7 application traffic logs for Calico Cloud. Deploy Envoy, set aggregation, and review the Elasticsearch L7 log schema for connected clusters.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud/observability/elastic/overview.mdx
+++ b/calico-cloud/observability/elastic/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Summary of the out-of-box features for Calico Cloud logs.
+description: Calico Cloud uses managed Elasticsearch and Kibana for flow, DNS, audit, BGP, and L7 logs with workload context, RBAC, and archival to external SIEMs.
 ---
 
 # Overview

--- a/calico-cloud/observability/index.mdx
+++ b/calico-cloud/observability/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use Elasticsearch logs for visibility into all network traffic with Kubernetes context.
+description: Observe and troubleshoot connected clusters with Calico Cloud web console dashboards, Service Graph, packet capture, and managed Elasticsearch logs.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud/observability/iptables.mdx
+++ b/calico-cloud/observability/iptables.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how policy audit mode rules can affect the number of iptables logs.
+description: Reference explaining how Calico Cloud policy audit mode and the Log rule action influence iptables log volume on connected cluster nodes.
 ---
 
 # iptables logs

--- a/calico-cloud/observability/kibana.mdx
+++ b/calico-cloud/observability/kibana.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the basics of using Elasticsearch logs and Kibana to gain visibility and troubleshoot.
+description: Use Kibana with Calico Cloud Elasticsearch to explore flow, L7, audit, BGP, DNS, and intrusion detection event logs from connected clusters.
 ---
 
 # Kibana dashboards and logs

--- a/calico-cloud/observability/kube-audit.mdx
+++ b/calico-cloud/observability/kube-audit.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable Kubernetes audit logs on changes to Kubernetes resources.
+description: Turn on Kubernetes API audit logging for Calico Cloud connected clusters so security teams can review changes to pods, namespaces, and network policies.
 ---
 
 # Kubernetes audit logs

--- a/calico-cloud/observability/packetcapture.mdx
+++ b/calico-cloud/observability/packetcapture.mdx
@@ -1,5 +1,5 @@
 ---
-description: Capture live traffic for debugging microservices and application interaction.
+description: Capture live pod traffic in Calico Cloud connected clusters from Service Graph or the CLI and export pcap files to Wireshark for analysis.
 ---
 
 # Packet capture

--- a/calico-cloud/observability/visualize-traffic.mdx
+++ b/calico-cloud/observability/visualize-traffic.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the power of network sets.
+description: Visualize cluster traffic to and from external endpoints in Calico Cloud Service Graph with network sets that group external IP ranges by purpose.
 ---
 
 # Visualize traffic to and from a cluster

--- a/calico-cloud_versioned_docs/version-22-2/observability/alerts.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/alerts.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manage alerts and events for Calico Enterprise features.
+description: Configure alerts and review alert events for Calico Cloud features in the web console or CLI. Use built-in templates for visibility and security signals.
 ---
 
 # Manage alerts

--- a/calico-cloud_versioned_docs/version-22-2/observability/create-custom-dashboard.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/create-custom-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create a custom dashboard
+description: Build custom dashboards in the Calico Cloud web console by importing cards from standard dashboards or constructing new cards from flow, DNS, and L7 fields.
 ---
 
 import Screenshot from '/src/___new___/components/Screenshot'

--- a/calico-cloud_versioned_docs/version-22-2/observability/dashboards.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/dashboards.mdx
@@ -1,5 +1,5 @@
 ---
-description: Dashboards help you see what's going on in your cluster. See how your cluster is performing and visualize your system's log data.
+description: Visualize connected cluster activity in the Calico Cloud web console with prebuilt and custom dashboards for cluster health, policy, DNS, and L7 data.
 ---
 
 import Screenshot from '/src/___new___/components/Screenshot'

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/archive-storage.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/archive-storage.mdx
@@ -1,5 +1,5 @@
 ---
-description: Archive logs to Syslog, Splunk, or Amazon S3 for maintaining compliance data.
+description: Forward Calico Cloud flow, DNS, audit, and L7 logs to Syslog, Splunk, or Amazon S3 to retain compliance data beyond managed retention windows.
 ---
 
 # Archive logs

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/audit-overview.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/audit-overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico Cloud audit logs provide data on changes to resources.
+description: Calico Cloud audit logs record changes to network policies, tiers, network sets, host endpoints, and other resources across connected clusters.
 ---
 
 # Audit logs

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/bgp.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Key/value pairs of BGP activity logs and how to construct queries.
+description: Reference of key/value fields in Calico Cloud BGP activity logs in Elasticsearch, with sample queries for IPv4, IPv6, and per-node lookups.
 ---
 
 # BGP logs

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/dns/dns-logs.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/dns/dns-logs.mdx
@@ -1,5 +1,5 @@
 ---
-description: Key/value pairs of DNS activity logs and how to construct queries.
+description: Reference of key/value fields in Calico Cloud DNS activity logs in Elasticsearch, with guidance for building client and query lookups.
 ---
 
 # Query DNS logs

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/dns/filtering-dns.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/dns/filtering-dns.mdx
@@ -1,5 +1,5 @@
 ---
-description: Suppress DNS logs of low significance using filters.
+description: Suppress low-value Calico Cloud DNS log entries with Fluentd filters configured through a ConfigMap in the operator namespace of connected clusters.
 ---
 
 # Filter DNS logs

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/dns/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/dns/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure and filter DNS logs.
+description: Configure and filter DNS activity logs for Calico Cloud. Review the schema, build Elasticsearch queries, and trim low-value entries.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/aggregation.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/aggregation.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure flow log aggregation to reduce log volume and costs.
+description: Tune Calico Cloud flow log aggregation levels to balance managed Elasticsearch volume and cost against pod and IP visibility for allowed and denied traffic.
 ---
 
 # Configure flow log aggregation

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/datatypes.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/datatypes.mdx
@@ -1,5 +1,5 @@
 ---
-description: Data that Calico Cloud sends to Elasticsearch.
+description: Reference of key/value fields that Calico Cloud sends to Elasticsearch for flow logs, including endpoints, actions, byte counts, and policy verdicts.
 ---
 
 # Flow log data types

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/filtering.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/filtering.mdx
@@ -1,5 +1,5 @@
 ---
-description: Filter Calico Cloud flow logs.
+description: Filter Calico Cloud flow logs through Fluentd to drop low-significance traffic and reduce managed Elasticsearch volume and cost.
 ---
 
 # Filter flow logs

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/hep.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/hep.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable hostendpoint reporting in flow logs.
+description: Turn on host endpoint reporting in Calico Cloud flow logs to gain visibility into traffic at HostEndpoint interfaces on Kubernetes nodes.
 ---
 
 # Enable HostEndpoint reporting in flow logs

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure, filter, and aggregate flow logs.
+description: Configure, filter, and aggregate Calico Cloud flow logs. Add host endpoint, process path, and TCP socket statistics from managed Elasticsearch.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/processpath.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/processpath.mdx
@@ -1,5 +1,5 @@
 ---
-description: Get visibility into process-level network activity in flow logs.
+description: Add process executable paths and arguments to Calico Cloud flow logs with eBPF instrumentation for process-level visibility into network activity.
 ---
 
 # Enable process-level information in flow logs

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/tcpstats.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/flow/tcpstats.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enabling TCP socket stats information in flow logs
+description: Add TCP socket statistics to Calico Cloud flow logs with eBPF programs that capture round-trip time, retransmits, and other per-socket metrics.
 ---
 
 # Enabling TCP socket stats in flow logs

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure logs for visibility in the web console.
+description: Configure managed Elasticsearch logs for Calico Cloud so the web console and Kibana can surface flow, DNS, audit, and L7 data from connected clusters.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/l7/configure.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/l7/configure.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure and aggregate L7 logs.
+description: Deploy Envoy and aggregate Calico Cloud L7 logs to monitor HTTP traffic patterns between application workloads on connected clusters.
 ---
 
 # Configure L7 logs

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/l7/datatypes.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/l7/datatypes.mdx
@@ -1,5 +1,5 @@
 ---
-description: L7 data that Calico Cloud sends to Elasticsearch.
+description: Reference of key/value fields that Calico Cloud sends to Elasticsearch for L7 logs, including durations, byte counts, and HTTP request metadata.
 ---
 
 # L7 log data types

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/l7/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/l7/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Elasticsearch L7 logs.
+description: Configure L7 application traffic logs for Calico Cloud. Deploy Envoy, set aggregation, and review the Elasticsearch L7 log schema for connected clusters.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/observability/elastic/overview.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/elastic/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Summary of the out-of-box features for Calico Cloud logs.
+description: Calico Cloud uses managed Elasticsearch and Kibana for flow, DNS, audit, BGP, and L7 logs with workload context, RBAC, and archival to external SIEMs.
 ---
 
 # Overview

--- a/calico-cloud_versioned_docs/version-22-2/observability/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use Elasticsearch logs for visibility into all network traffic with Kubernetes context.
+description: Observe and troubleshoot connected clusters with Calico Cloud web console dashboards, Service Graph, packet capture, and managed Elasticsearch logs.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/observability/iptables.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/iptables.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how policy audit mode rules can affect the number of iptables logs.
+description: Reference explaining how Calico Cloud policy audit mode and the Log rule action influence iptables log volume on connected cluster nodes.
 ---
 
 # iptables logs

--- a/calico-cloud_versioned_docs/version-22-2/observability/kibana.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/kibana.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the basics of using Elasticsearch logs and Kibana to gain visibility and troubleshoot.
+description: Use Kibana with Calico Cloud Elasticsearch to explore flow, L7, audit, BGP, DNS, and intrusion detection event logs from connected clusters.
 ---
 
 # Kibana dashboards and logs

--- a/calico-cloud_versioned_docs/version-22-2/observability/kube-audit.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/kube-audit.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable Kubernetes audit logs on changes to Kubernetes resources.
+description: Turn on Kubernetes API audit logging for Calico Cloud connected clusters so security teams can review changes to pods, namespaces, and network policies.
 ---
 
 # Kubernetes audit logs

--- a/calico-cloud_versioned_docs/version-22-2/observability/packetcapture.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/packetcapture.mdx
@@ -1,5 +1,5 @@
 ---
-description: Capture live traffic for debugging microservices and application interaction.
+description: Capture live pod traffic in Calico Cloud connected clusters from Service Graph or the CLI and export pcap files to Wireshark for analysis.
 ---
 
 # Packet capture

--- a/calico-cloud_versioned_docs/version-22-2/observability/visualize-traffic.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/observability/visualize-traffic.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the power of network sets.
+description: Visualize cluster traffic to and from external endpoints in Calico Cloud Service Graph with network sets that group external IP ranges by purpose.
 ---
 
 # Visualize traffic to and from a cluster

--- a/calico-enterprise/observability/alerts.mdx
+++ b/calico-enterprise/observability/alerts.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manage alerts and events for Calico Enterprise features.
+description: Configure alerts and review alert events for Calico Enterprise features from the Manager UI or CLI. Use built-in templates for visibility and security.
 ---
 
 # Manage alerts

--- a/calico-enterprise/observability/dashboards.mdx
+++ b/calico-enterprise/observability/dashboards.mdx
@@ -1,5 +1,5 @@
 ---
-description: Visualize cluster activity in the Calico Enterprise Manager UI with prebuilt dashboards for cluster health, policy, DNS, and L7 log data.
+description: Visualize cluster activity in the Calico Enterprise Manager UI with prebuilt dashboards for cluster health, traffic volume, DNS, flow logs, and HTTP traffic.
 ---
 
 import Screenshot from '/src/___new___/components/Screenshot'

--- a/calico-enterprise/observability/dashboards.mdx
+++ b/calico-enterprise/observability/dashboards.mdx
@@ -1,5 +1,5 @@
 ---
-description: Dashboards help you see what's going on in your cluster. See how your cluster is performing and visualize your system's log data.
+description: Visualize cluster activity in the Calico Enterprise Manager UI with prebuilt dashboards for cluster health, policy, DNS, and L7 log data.
 ---
 
 import Screenshot from '/src/___new___/components/Screenshot'

--- a/calico-enterprise/observability/elastic/archive-storage.mdx
+++ b/calico-enterprise/observability/elastic/archive-storage.mdx
@@ -1,5 +1,5 @@
 ---
-description: Archive logs to Syslog, Splunk, or Amazon S3 for maintaining compliance data.
+description: Forward Calico Enterprise flow, DNS, audit, and L7 logs to Syslog, Splunk, or Amazon S3 to retain compliance data beyond in-cluster Elasticsearch retention.
 ---
 
 # Archive logs

--- a/calico-enterprise/observability/elastic/audit-overview.mdx
+++ b/calico-enterprise/observability/elastic/audit-overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico Enterprise audit logs provide data on changes to resources.
+description: Calico Enterprise audit logs record changes to network policies, tiers, network sets, host endpoints, and other resources for security and compliance review.
 ---
 
 # Audit logs

--- a/calico-enterprise/observability/elastic/bgp.mdx
+++ b/calico-enterprise/observability/elastic/bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Key/value pairs of BGP activity logs and how to construct queries.
+description: Reference of key/value fields in Calico Enterprise BGP activity logs stored in Elasticsearch, with sample queries for IPv4, IPv6, and per-node lookups.
 ---
 
 # BGP logs

--- a/calico-enterprise/observability/elastic/dns/dns-logs.mdx
+++ b/calico-enterprise/observability/elastic/dns/dns-logs.mdx
@@ -1,5 +1,5 @@
 ---
-description: Key/value pairs of DNS activity logs and how to construct queries.
+description: Reference of key/value fields in Calico Enterprise DNS activity logs stored in Elasticsearch, with guidance for constructing client and query lookups.
 ---
 
 # Configure DNS logs

--- a/calico-enterprise/observability/elastic/dns/filtering-dns.mdx
+++ b/calico-enterprise/observability/elastic/dns/filtering-dns.mdx
@@ -1,5 +1,5 @@
 ---
-description: Suppress DNS logs of low significance using filters.
+description: Suppress low-value Calico Enterprise DNS log entries with Fluentd filters configured through a ConfigMap in the operator namespace.
 ---
 
 # Filter DNS logs

--- a/calico-enterprise/observability/elastic/dns/index.mdx
+++ b/calico-enterprise/observability/elastic/dns/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure and filter DNS logs.
+description: Configure and filter DNS activity logs for Calico Enterprise. Review the schema, build Elasticsearch queries, and trim low-value entries.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/observability/elastic/flow/aggregation.mdx
+++ b/calico-enterprise/observability/elastic/flow/aggregation.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure flow log aggregation to reduce log volume and costs.
+description: Tune Calico Enterprise flow log aggregation levels to balance Elasticsearch volume and cost against pod and IP visibility for allowed and denied traffic.
 ---
 
 # Configure flow log aggregation

--- a/calico-enterprise/observability/elastic/flow/datatypes.mdx
+++ b/calico-enterprise/observability/elastic/flow/datatypes.mdx
@@ -1,5 +1,5 @@
 ---
-description: Data that Calico Enterprise sends to Elasticsearch.
+description: Reference of key/value fields that Calico Enterprise sends to Elasticsearch for flow logs, including endpoints, actions, byte counts, and policy verdicts.
 ---
 
 # Flow log data types

--- a/calico-enterprise/observability/elastic/flow/filtering.mdx
+++ b/calico-enterprise/observability/elastic/flow/filtering.mdx
@@ -1,5 +1,5 @@
 ---
-description: Filter Calico Enterprise flow logs.
+description: Filter Calico Enterprise flow logs through Fluentd to drop low-significance traffic and reduce in-cluster Elasticsearch volume and cost.
 ---
 
 # Filter flow logs

--- a/calico-enterprise/observability/elastic/flow/hep.mdx
+++ b/calico-enterprise/observability/elastic/flow/hep.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable hostendpoint reporting in flow logs.
+description: Turn on host endpoint reporting in Calico Enterprise flow logs to gain visibility into traffic at HostEndpoint interfaces on Kubernetes nodes.
 ---
 
 # Enable HostEndpoint reporting in flow logs

--- a/calico-enterprise/observability/elastic/flow/index.mdx
+++ b/calico-enterprise/observability/elastic/flow/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure, filter, and aggregate flow logs.
+description: Configure, filter, and aggregate Calico Enterprise flow logs. Add host endpoint, process path, and TCP socket statistics from in-cluster Elasticsearch.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/observability/elastic/flow/processpath.mdx
+++ b/calico-enterprise/observability/elastic/flow/processpath.mdx
@@ -1,5 +1,5 @@
 ---
-description: Get visibility into process-level network activity in flow logs.
+description: Add process executable paths and arguments to Calico Enterprise flow logs with eBPF kprobe programs for process-level visibility into network activity.
 ---
 
 # Enable process-level information in flow logs

--- a/calico-enterprise/observability/elastic/flow/processpath.mdx
+++ b/calico-enterprise/observability/elastic/flow/processpath.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add process executable paths and arguments to Calico Enterprise flow logs with eBPF kprobe programs for process-level visibility into network activity.
+description: Add process executable paths and arguments to Calico Enterprise flow logs with eBPF instrumentation for process-level visibility into network activity.
 ---
 
 # Enable process-level information in flow logs

--- a/calico-enterprise/observability/elastic/flow/tcpstats.mdx
+++ b/calico-enterprise/observability/elastic/flow/tcpstats.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enabling TCP socket stats information in flow logs
+description: Add TCP socket statistics to Calico Enterprise flow logs with eBPF programs that capture round-trip time, retransmits, and other per-socket metrics.
 ---
 
 # Enabling TCP socket stats in flow logs

--- a/calico-enterprise/observability/elastic/index.mdx
+++ b/calico-enterprise/observability/elastic/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure logs for visibility in the web console.
+description: Configure in-cluster Elasticsearch logs for Calico Enterprise so the Manager UI, Kibana, and the Elasticsearch API can surface flow, DNS, audit, and L7 data.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/observability/elastic/l7/configure.mdx
+++ b/calico-enterprise/observability/elastic/l7/configure.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure and aggregate L7 logs.
+description: Deploy Envoy and aggregate Calico Enterprise L7 logs to monitor HTTP traffic patterns between application workloads in self-managed clusters.
 ---
 
 # Configure L7 logs

--- a/calico-enterprise/observability/elastic/l7/datatypes.mdx
+++ b/calico-enterprise/observability/elastic/l7/datatypes.mdx
@@ -1,5 +1,5 @@
 ---
-description: L7 data that Calico Enterprise sends to Elasticsearch.
+description: Reference of key/value fields that Calico Enterprise sends to Elasticsearch for L7 logs, including durations, byte counts, and HTTP request metadata.
 ---
 
 # L7 log data types

--- a/calico-enterprise/observability/elastic/l7/index.mdx
+++ b/calico-enterprise/observability/elastic/l7/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Elasticsearch L7 logs.
+description: Configure L7 application traffic logs for Calico Enterprise. Deploy Envoy, set aggregation, and review the Elasticsearch L7 log schema.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/observability/elastic/overview.mdx
+++ b/calico-enterprise/observability/elastic/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Summary of the out-of-box features for Calico Enterprise logs.
+description: Calico Enterprise deploys an in-cluster Elasticsearch and Kibana stack for flow, DNS, audit, BGP, and L7 logs with workload context, RBAC, and archival to SIEMs.
 ---
 
 # Overview

--- a/calico-enterprise/observability/elastic/rbac-elasticsearch.mdx
+++ b/calico-enterprise/observability/elastic/rbac-elasticsearch.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure RBAC to control access to Elasticsearch logs and events.
+description: Set fine-grained Kubernetes RBAC permissions in Calico Enterprise to control access to Elasticsearch flow, audit, DNS, and intrusion detection event indices.
 ---
 
 # Configure RBAC for Elasticsearch logs and events

--- a/calico-enterprise/observability/elastic/retention.mdx
+++ b/calico-enterprise/observability/elastic/retention.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure how long to retain logs and compliance reports.
+description: Set retention windows for Calico Enterprise flow, DNS, audit, BGP, L7, snapshot, and compliance report data in the in-cluster LogStorage resource.
 ---
 
 # Configure data retention

--- a/calico-enterprise/observability/elastic/troubleshoot.mdx
+++ b/calico-enterprise/observability/elastic/troubleshoot.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how to troubleshoot common issues with Elasticsearch.
+description: Troubleshooting guide for in-cluster Elasticsearch problems in Calico Enterprise covering LogStorage, storage classes, persistent volumes, and diagnostic logs.
 ---
 
 # Troubleshoot logs

--- a/calico-enterprise/observability/get-started-cem.mdx
+++ b/calico-enterprise/observability/get-started-cem.mdx
@@ -1,5 +1,5 @@
 ---
-description: Tour the main features of the web console.
+description: Tour of the Calico Enterprise Manager UI navbar covering dashboards, Service Graph, policies, alerts, Kibana, and packet capture controls.
 ---
 
 # Web console tutorial

--- a/calico-enterprise/observability/index.mdx
+++ b/calico-enterprise/observability/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use Elasticsearch logs for visibility into all network traffic with Kubernetes context.
+description: Observe and troubleshoot self-managed Calico Enterprise clusters with Manager UI dashboards, Service Graph, packet capture, and Elasticsearch logs.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/observability/iptables.mdx
+++ b/calico-enterprise/observability/iptables.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how policy audit mode rules can affect the number of iptables logs.
+description: Reference explaining how Calico Enterprise policy audit mode and the Log rule action affect iptables log volume on cluster nodes.
 ---
 
 # iptables logs

--- a/calico-enterprise/observability/kibana.mdx
+++ b/calico-enterprise/observability/kibana.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the basics of using Elasticsearch logs and Kibana to gain visibility and troubleshoot.
+description: Use Kibana with Calico Enterprise Elasticsearch to explore flow, L7, audit, BGP, DNS, and intrusion detection event logs across managed clusters.
 ---
 
 # Kibana dashboards and logs

--- a/calico-enterprise/observability/kube-audit.mdx
+++ b/calico-enterprise/observability/kube-audit.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable Kubernetes audit logs on changes to Kubernetes resources.
+description: Turn on Kubernetes API audit logging for Calico Enterprise so security teams can review changes to pods, namespaces, network policies, and other resources.
 ---
 
 # Kubernetes audit logs

--- a/calico-enterprise/observability/packetcapture.mdx
+++ b/calico-enterprise/observability/packetcapture.mdx
@@ -1,5 +1,5 @@
 ---
-description: Capture live traffic for debugging microservices and application interaction.
+description: Capture live pod traffic in self-managed Calico Enterprise clusters from Service Graph or the CLI and export pcap files to Wireshark for analysis.
 ---
 
 # Packet capture

--- a/calico-enterprise/observability/review-unused-network-policies.mdx
+++ b/calico-enterprise/observability/review-unused-network-policies.mdx
@@ -1,5 +1,5 @@
 ---
-description: Identify unused network policies and rules to maintain least privilege and reduce compliance risk.
+description: Find unused Calico Enterprise network policies and rules with Last Evaluated timestamps in the Manager UI or with calicoctl to maintain least privilege.
 ---
 
 # Review unused network policies

--- a/calico-enterprise/observability/visualize-traffic.mdx
+++ b/calico-enterprise/observability/visualize-traffic.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the power of network sets.
+description: Use Service Graph in the Calico Enterprise Manager UI to visualize namespace, service, and pod communication patterns and investigate traffic flows.
 ---
 
 # Network visualization

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/alerts.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/alerts.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manage alerts and events for Calico Enterprise features.
+description: Configure alerts and review alert events for Calico Enterprise features from the Manager UI or CLI. Use built-in templates for visibility and security.
 ---
 
 # Manage alerts

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/dashboards.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/dashboards.mdx
@@ -1,5 +1,5 @@
 ---
-description: Dashboards help you see what's going on in your cluster. See how your cluster is performing and visualize your system's log data.
+description: Visualize cluster activity in the Calico Enterprise Manager UI with prebuilt dashboards for cluster health, policy, DNS, and L7 log data.
 ---
 
 import Screenshot from '/src/___new___/components/Screenshot'

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/archive-storage.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/archive-storage.mdx
@@ -1,5 +1,5 @@
 ---
-description: Archive logs to Syslog, Splunk, or Amazon S3 for maintaining compliance data.
+description: Forward Calico Enterprise flow, DNS, audit, and L7 logs to Syslog, Splunk, or Amazon S3 to retain compliance data beyond in-cluster Elasticsearch retention.
 ---
 
 # Archive logs

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/audit-overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/audit-overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico Enterprise audit logs provide data on changes to resources.
+description: Calico Enterprise audit logs record changes to network policies, tiers, network sets, host endpoints, and other resources for security and compliance review.
 ---
 
 # Audit logs

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/bgp.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Key/value pairs of BGP activity logs and how to construct queries.
+description: Reference of key/value fields in Calico Enterprise BGP activity logs stored in Elasticsearch, with sample queries for IPv4, IPv6, and per-node lookups.
 ---
 
 # BGP logs

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/dns/dns-logs.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/dns/dns-logs.mdx
@@ -1,5 +1,5 @@
 ---
-description: Key/value pairs of DNS activity logs and how to construct queries.
+description: Reference of key/value fields in Calico Enterprise DNS activity logs stored in Elasticsearch, with guidance for constructing client and query lookups.
 ---
 
 # Configure DNS logs

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/dns/filtering-dns.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/dns/filtering-dns.mdx
@@ -1,5 +1,5 @@
 ---
-description: Suppress DNS logs of low significance using filters.
+description: Suppress low-value Calico Enterprise DNS log entries with Fluentd filters configured through a ConfigMap in the operator namespace.
 ---
 
 # Filter DNS logs

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/dns/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/dns/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure and filter DNS logs.
+description: Configure and filter DNS activity logs for Calico Enterprise. Review the schema, build Elasticsearch queries, and trim low-value entries.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/flow/aggregation.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/flow/aggregation.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure flow log aggregation to reduce log volume and costs.
+description: Tune Calico Enterprise flow log aggregation levels to balance Elasticsearch volume and cost against pod and IP visibility for allowed and denied traffic.
 ---
 
 # Configure flow log aggregation

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/flow/datatypes.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/flow/datatypes.mdx
@@ -1,5 +1,5 @@
 ---
-description: Data that Calico Enterprise sends to Elasticsearch.
+description: Reference of key/value fields that Calico Enterprise sends to Elasticsearch for flow logs, including endpoints, actions, byte counts, and policy verdicts.
 ---
 
 # Flow log data types

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/flow/filtering.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/flow/filtering.mdx
@@ -1,5 +1,5 @@
 ---
-description: Filter Calico Enterprise flow logs.
+description: Filter Calico Enterprise flow logs through Fluentd to drop low-significance traffic and reduce in-cluster Elasticsearch volume and cost.
 ---
 
 # Filter flow logs

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/flow/hep.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/flow/hep.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable hostendpoint reporting in flow logs.
+description: Turn on host endpoint reporting in Calico Enterprise flow logs to gain visibility into traffic at HostEndpoint interfaces on Kubernetes nodes.
 ---
 
 # Enable HostEndpoint reporting in flow logs

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/flow/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/flow/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure, filter, and aggregate flow logs.
+description: Configure, filter, and aggregate Calico Enterprise flow logs. Add host endpoint, process path, and TCP socket statistics from in-cluster Elasticsearch.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/flow/processpath.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/flow/processpath.mdx
@@ -1,5 +1,5 @@
 ---
-description: Get visibility into process-level network activity in flow logs.
+description: Add process executable paths and arguments to Calico Enterprise flow logs with eBPF instrumentation for process-level visibility into network activity.
 ---
 
 # Enable process-level information in flow logs

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/flow/tcpstats.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/flow/tcpstats.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enabling TCP socket stats information in flow logs
+description: Add TCP socket statistics to Calico Enterprise flow logs with eBPF programs that capture round-trip time, retransmits, and other per-socket metrics.
 ---
 
 # Enabling TCP socket stats in flow logs

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure logs for visibility in the web console.
+description: Configure in-cluster Elasticsearch logs for Calico Enterprise so the Manager UI, Kibana, and the Elasticsearch API can surface flow, DNS, audit, and L7 data.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/l7/configure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/l7/configure.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure and aggregate L7 logs.
+description: Deploy Envoy and aggregate Calico Enterprise L7 logs to monitor HTTP traffic patterns between application workloads in self-managed clusters.
 ---
 
 # Configure L7 logs

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/l7/datatypes.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/l7/datatypes.mdx
@@ -1,5 +1,5 @@
 ---
-description: L7 data that Calico Enterprise sends to Elasticsearch.
+description: Reference of key/value fields that Calico Enterprise sends to Elasticsearch for L7 logs, including durations, byte counts, and HTTP request metadata.
 ---
 
 # L7 log data types

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/l7/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/l7/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Elasticsearch L7 logs.
+description: Configure L7 application traffic logs for Calico Enterprise. Deploy Envoy, set aggregation, and review the Elasticsearch L7 log schema.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Summary of the out-of-box features for Calico Enterprise logs.
+description: Calico Enterprise deploys an in-cluster Elasticsearch and Kibana stack for flow, DNS, audit, BGP, and L7 logs with workload context, RBAC, and archival to SIEMs.
 ---
 
 # Overview

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/rbac-elasticsearch.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/rbac-elasticsearch.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure RBAC to control access to Elasticsearch logs and events.
+description: Set fine-grained Kubernetes RBAC permissions in Calico Enterprise to control access to Elasticsearch flow, audit, DNS, and intrusion detection event indices.
 ---
 
 # Configure RBAC for Elasticsearch logs and events

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/retention.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/retention.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure how long to retain logs and compliance reports.
+description: Set retention windows for Calico Enterprise flow, DNS, audit, BGP, L7, snapshot, and compliance report data in the in-cluster LogStorage resource.
 ---
 
 # Configure data retention

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/troubleshoot.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/elastic/troubleshoot.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how to troubleshoot common issues with Elasticsearch.
+description: Troubleshooting guide for in-cluster Elasticsearch problems in Calico Enterprise covering LogStorage, storage classes, persistent volumes, and diagnostic logs.
 ---
 
 # Troubleshoot logs

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/get-started-cem.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/get-started-cem.mdx
@@ -1,5 +1,5 @@
 ---
-description: Tour the main features of the web console.
+description: Tour of the Calico Enterprise Manager UI navbar covering dashboards, Service Graph, policies, alerts, Kibana, and packet capture controls.
 ---
 
 # Web console tutorial

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use Elasticsearch logs for visibility into all network traffic with Kubernetes context.
+description: Observe and troubleshoot self-managed Calico Enterprise clusters with Manager UI dashboards, Service Graph, packet capture, and Elasticsearch logs.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/iptables.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/iptables.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how policy audit mode rules can affect the number of iptables logs.
+description: Reference explaining how Calico Enterprise policy audit mode and the Log rule action affect iptables log volume on cluster nodes.
 ---
 
 # iptables logs

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/kibana.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/kibana.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the basics of using Elasticsearch logs and Kibana to gain visibility and troubleshoot.
+description: Use Kibana with Calico Enterprise Elasticsearch to explore flow, L7, audit, BGP, DNS, and intrusion detection event logs across managed clusters.
 ---
 
 # Kibana dashboards and logs

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/kube-audit.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/kube-audit.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable Kubernetes audit logs on changes to Kubernetes resources.
+description: Turn on Kubernetes API audit logging for Calico Enterprise so security teams can review changes to pods, namespaces, network policies, and other resources.
 ---
 
 # Kubernetes audit logs

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/packetcapture.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/packetcapture.mdx
@@ -1,5 +1,5 @@
 ---
-description: Capture live traffic for debugging microservices and application interaction.
+description: Capture live pod traffic in self-managed Calico Enterprise clusters from Service Graph or the CLI and export pcap files to Wireshark for analysis.
 ---
 
 # Packet capture

--- a/calico-enterprise_versioned_docs/version-3.22-2/observability/visualize-traffic.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/observability/visualize-traffic.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the power of network sets.
+description: Use Service Graph in the Calico Enterprise Manager UI to visualize namespace, service, and pod communication patterns and investigate traffic flows.
 ---
 
 # Network visualization

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/alerts.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/alerts.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manage alerts and events for Calico Enterprise features.
+description: Configure alerts and review alert events for Calico Enterprise features from the Manager UI or CLI. Use built-in templates for visibility and security.
 ---
 
 # Manage alerts

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/dashboards.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/dashboards.mdx
@@ -1,5 +1,5 @@
 ---
-description: Dashboards help you see what's going on in your cluster. See how your cluster is performing and visualize your system's log data.
+description: Visualize cluster activity in the Calico Enterprise Manager UI with prebuilt dashboards for cluster health, policy, DNS, and L7 log data.
 ---
 
 import Screenshot from '/src/___new___/components/Screenshot'

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/archive-storage.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/archive-storage.mdx
@@ -1,5 +1,5 @@
 ---
-description: Archive logs to Syslog, Splunk, or Amazon S3 for maintaining compliance data.
+description: Forward Calico Enterprise flow, DNS, audit, and L7 logs to Syslog, Splunk, or Amazon S3 to retain compliance data beyond in-cluster Elasticsearch retention.
 ---
 
 # Archive logs

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/audit-overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/audit-overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico Enterprise audit logs provide data on changes to resources.
+description: Calico Enterprise audit logs record changes to network policies, tiers, network sets, host endpoints, and other resources for security and compliance review.
 ---
 
 # Audit logs

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/bgp.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Key/value pairs of BGP activity logs and how to construct queries.
+description: Reference of key/value fields in Calico Enterprise BGP activity logs stored in Elasticsearch, with sample queries for IPv4, IPv6, and per-node lookups.
 ---
 
 # BGP logs

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/dns/dns-logs.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/dns/dns-logs.mdx
@@ -1,5 +1,5 @@
 ---
-description: Key/value pairs of DNS activity logs and how to construct queries.
+description: Reference of key/value fields in Calico Enterprise DNS activity logs stored in Elasticsearch, with guidance for constructing client and query lookups.
 ---
 
 # Configure DNS logs

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/dns/filtering-dns.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/dns/filtering-dns.mdx
@@ -1,5 +1,5 @@
 ---
-description: Suppress DNS logs of low significance using filters.
+description: Suppress low-value Calico Enterprise DNS log entries with Fluentd filters configured through a ConfigMap in the operator namespace.
 ---
 
 # Filter DNS logs

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/dns/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/dns/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure and filter DNS logs.
+description: Configure and filter DNS activity logs for Calico Enterprise. Review the schema, build Elasticsearch queries, and trim low-value entries.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/aggregation.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/aggregation.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure flow log aggregation to reduce log volume and costs.
+description: Tune Calico Enterprise flow log aggregation levels to balance Elasticsearch volume and cost against pod and IP visibility for allowed and denied traffic.
 ---
 
 # Configure flow log aggregation

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/datatypes.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/datatypes.mdx
@@ -1,5 +1,5 @@
 ---
-description: Data that Calico Enterprise sends to Elasticsearch.
+description: Reference of key/value fields that Calico Enterprise sends to Elasticsearch for flow logs, including endpoints, actions, byte counts, and policy verdicts.
 ---
 
 # Flow log data types

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/filtering.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/filtering.mdx
@@ -1,5 +1,5 @@
 ---
-description: Filter Calico Enterprise flow logs.
+description: Filter Calico Enterprise flow logs through Fluentd to drop low-significance traffic and reduce in-cluster Elasticsearch volume and cost.
 ---
 
 # Filter flow logs

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/hep.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/hep.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable hostendpoint reporting in flow logs.
+description: Turn on host endpoint reporting in Calico Enterprise flow logs to gain visibility into traffic at HostEndpoint interfaces on Kubernetes nodes.
 ---
 
 # Enable HostEndpoint reporting in flow logs

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure, filter, and aggregate flow logs.
+description: Configure, filter, and aggregate Calico Enterprise flow logs. Add host endpoint, process path, and TCP socket statistics from in-cluster Elasticsearch.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/processpath.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/processpath.mdx
@@ -1,5 +1,5 @@
 ---
-description: Get visibility into process-level network activity in flow logs.
+description: Add process executable paths and arguments to Calico Enterprise flow logs with eBPF instrumentation for process-level visibility into network activity.
 ---
 
 # Enable process-level information in flow logs

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/tcpstats.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/flow/tcpstats.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enabling TCP socket stats information in flow logs
+description: Add TCP socket statistics to Calico Enterprise flow logs with eBPF programs that capture round-trip time, retransmits, and other per-socket metrics.
 ---
 
 # Enabling TCP socket stats in flow logs

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure logs for visibility in the web console.
+description: Configure in-cluster Elasticsearch logs for Calico Enterprise so the Manager UI, Kibana, and the Elasticsearch API can surface flow, DNS, audit, and L7 data.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/l7/configure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/l7/configure.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure and aggregate L7 logs.
+description: Deploy Envoy and aggregate Calico Enterprise L7 logs to monitor HTTP traffic patterns between application workloads in self-managed clusters.
 ---
 
 # Configure L7 logs

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/l7/datatypes.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/l7/datatypes.mdx
@@ -1,5 +1,5 @@
 ---
-description: L7 data that Calico Enterprise sends to Elasticsearch.
+description: Reference of key/value fields that Calico Enterprise sends to Elasticsearch for L7 logs, including durations, byte counts, and HTTP request metadata.
 ---
 
 # L7 log data types

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/l7/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/l7/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Elasticsearch L7 logs.
+description: Configure L7 application traffic logs for Calico Enterprise. Deploy Envoy, set aggregation, and review the Elasticsearch L7 log schema.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Summary of the out-of-box features for Calico Enterprise logs.
+description: Calico Enterprise deploys an in-cluster Elasticsearch and Kibana stack for flow, DNS, audit, BGP, and L7 logs with workload context, RBAC, and archival to SIEMs.
 ---
 
 # Overview

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/rbac-elasticsearch.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/rbac-elasticsearch.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure RBAC to control access to Elasticsearch logs and events.
+description: Set fine-grained Kubernetes RBAC permissions in Calico Enterprise to control access to Elasticsearch flow, audit, DNS, and intrusion detection event indices.
 ---
 
 # Configure RBAC for Elasticsearch logs and events

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/retention.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/retention.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure how long to retain logs and compliance reports.
+description: Set retention windows for Calico Enterprise flow, DNS, audit, BGP, L7, snapshot, and compliance report data in the in-cluster LogStorage resource.
 ---
 
 # Configure data retention

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/troubleshoot.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/elastic/troubleshoot.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how to troubleshoot common issues with Elasticsearch.
+description: Troubleshooting guide for in-cluster Elasticsearch problems in Calico Enterprise covering LogStorage, storage classes, persistent volumes, and diagnostic logs.
 ---
 
 # Troubleshoot logs

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/get-started-cem.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/get-started-cem.mdx
@@ -1,5 +1,5 @@
 ---
-description: Tour the main features of the web console.
+description: Tour of the Calico Enterprise Manager UI navbar covering dashboards, Service Graph, policies, alerts, Kibana, and packet capture controls.
 ---
 
 # Web console tutorial

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use Elasticsearch logs for visibility into all network traffic with Kubernetes context.
+description: Observe and troubleshoot self-managed Calico Enterprise clusters with Manager UI dashboards, Service Graph, packet capture, and Elasticsearch logs.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/iptables.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/iptables.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how policy audit mode rules can affect the number of iptables logs.
+description: Reference explaining how Calico Enterprise policy audit mode and the Log rule action affect iptables log volume on cluster nodes.
 ---
 
 # iptables logs

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/kibana.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/kibana.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the basics of using Elasticsearch logs and Kibana to gain visibility and troubleshoot.
+description: Use Kibana with Calico Enterprise Elasticsearch to explore flow, L7, audit, BGP, DNS, and intrusion detection event logs across managed clusters.
 ---
 
 # Kibana dashboards and logs

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/kube-audit.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/kube-audit.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable Kubernetes audit logs on changes to Kubernetes resources.
+description: Turn on Kubernetes API audit logging for Calico Enterprise so security teams can review changes to pods, namespaces, network policies, and other resources.
 ---
 
 # Kubernetes audit logs

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/packetcapture.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/packetcapture.mdx
@@ -1,5 +1,5 @@
 ---
-description: Capture live traffic for debugging microservices and application interaction.
+description: Capture live pod traffic in self-managed Calico Enterprise clusters from Service Graph or the CLI and export pcap files to Wireshark for analysis.
 ---
 
 # Packet capture

--- a/calico-enterprise_versioned_docs/version-3.23-1/observability/visualize-traffic.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/observability/visualize-traffic.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the power of network sets.
+description: Use Service Graph in the Calico Enterprise Manager UI to visualize namespace, service, and pod communication patterns and investigate traffic flows.
 ---
 
 # Network visualization

--- a/calico/observability/enable-whisker.mdx
+++ b/calico/observability/enable-whisker.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable the flow logs API and Calico Whisker
+description: Activate the Goldmane flow logs API and the Calico Whisker web console in Calico Open Source clusters that were upgraded from earlier versions.
 title: Enable flow logs
 ---
 

--- a/calico/observability/flow-logs-api.mdx
+++ b/calico/observability/flow-logs-api.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about the flow logs API.
+description: Reference for the Goldmane flow logs API in Calico Open Source. Retrieve aggregated traffic data, policy hits, and packet and byte counts over gRPC.
 ---
 
 # Flow logs API

--- a/calico/observability/index.mdx
+++ b/calico/observability/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: View flow logs and policy metrics to better understand your network traffic.
+description: Observe Kubernetes network traffic in Calico Open Source with the Goldmane flow logs API and the Calico Whisker in-cluster web console.
 hide_table_of_contents: true
 ---
 

--- a/calico/observability/view-flow-logs.mdx
+++ b/calico/observability/view-flow-logs.mdx
@@ -1,5 +1,5 @@
 ---
-description: View flow logs in the Calico Whisker web console.
+description: Inspect aggregated network flow logs in the Calico Whisker in-cluster web console for Calico Open Source. Filter by source, destination, and policy verdicts.
 title: View flow logs
 ---
 

--- a/calico_versioned_docs/version-3.32/observability/enable-whisker.mdx
+++ b/calico_versioned_docs/version-3.32/observability/enable-whisker.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable the flow logs API and Calico Whisker
+description: Activate the Goldmane flow logs API and the Calico Whisker web console in Calico Open Source clusters that were upgraded from earlier versions.
 title: Enable flow logs
 ---
 

--- a/calico_versioned_docs/version-3.32/observability/flow-logs-api.mdx
+++ b/calico_versioned_docs/version-3.32/observability/flow-logs-api.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about the flow logs API.
+description: Reference for the Goldmane flow logs API in Calico Open Source. Retrieve aggregated traffic data, policy hits, and packet and byte counts over gRPC.
 ---
 
 # Flow logs API

--- a/calico_versioned_docs/version-3.32/observability/index.mdx
+++ b/calico_versioned_docs/version-3.32/observability/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: View flow logs and policy metrics to better understand your network traffic.
+description: Observe Kubernetes network traffic in Calico Open Source with the Goldmane flow logs API and the Calico Whisker in-cluster web console.
 hide_table_of_contents: true
 ---
 

--- a/calico_versioned_docs/version-3.32/observability/view-flow-logs.mdx
+++ b/calico_versioned_docs/version-3.32/observability/view-flow-logs.mdx
@@ -1,5 +1,5 @@
 ---
-description: View flow logs in the Calico Whisker web console.
+description: Inspect aggregated network flow logs in the Calico Whisker in-cluster web console for Calico Open Source. Filter by source, destination, and policy verdicts.
 title: View flow logs
 ---
 


### PR DESCRIPTION
## Summary

Refreshes the frontmatter `description` field on all 62 observability pages in the next (unversioned) trees:

- `calico/observability/` — 4 files (Whisker / Goldmane / basic flow visibility)
- `calico-enterprise/observability/` — 31 files
- `calico-cloud/observability/` — 27 files

Each rewritten description names its canonical product (`Calico Open Source`, `Calico Enterprise`, or `Calico Cloud`), stays within 200 characters, drops the forbidden verbs `enable`, `disable`, `teaching`, avoids YAML-breaking colons, and is unique across products.

CE and CC overlap heavily on this surface area, so descriptions disambiguate by deployment context: Calico Enterprise pages reference the in-cluster Manager UI and in-cluster Elasticsearch/Kibana; Calico Cloud pages reference the web console for connected clusters and managed Elasticsearch. Calico Open Source uses Whisker / Goldmane vocabulary instead.

This follows the same format and rules as #2696 (getting-started) and #2697 (network-policy).

## Pre-fix violation summary

Inventory of the 62 existing descriptions before the rewrite:

| Issue | Count |
|---|---|
| Missing description | 0 |
| > 200 characters | 0 |
| Forbidden words (`enable`, `disable`, `teaching`) | 5 |
| Stray colon in value | 0 |
| Cross-product duplicates | several (CE↔CC: alerts, dashboards, kibana, packetcapture, iptables, kube-audit, archive-storage, bgp, l7 datatypes, dns datatypes, flow datatypes, retention pages, etc.) |

The pre-fix `description: Enable ...` lines were:

- `calico/observability/enable-whisker.mdx`
- `calico-enterprise/observability/kube-audit.mdx`
- `calico-cloud/observability/kube-audit.mdx`
- `calico-enterprise/observability/elastic/flow/hep.mdx`
- `calico-cloud/observability/elastic/flow/hep.mdx`

## Scope

Next (unversioned) trees only. Versioned mirrors under `*_versioned_docs/` will be updated in a follow-up PR after review.

## Reproducible verification

After the rewrite, all four content checks return zero:

```bash
# forbidden verbs
grep -nEri "^description:.*\b(enable|disable|teaching)\b" \
  calico/observability calico-enterprise/observability calico-cloud/observability

# length, uniqueness, and presence checks
python3 - <<'PY'
import os, re
from collections import Counter
descs = {}
for root in ['calico/observability','calico-enterprise/observability','calico-cloud/observability']:
    for dp, _, fs in os.walk(root):
        for f in sorted(fs):
            if f.endswith(('.mdx','.md')):
                p = os.path.join(dp, f); t = open(p).read()
                m = re.search(r'^description:[ \t]*(.*)$', t, re.MULTILINE)
                d = m.group(1).strip() if m else ''
                if d.startswith('"') and d.endswith('"'): d = d[1:-1]
                descs[p] = d
print('total', len(descs))
print('missing', sum(1 for d in descs.values() if not d))
print('over_200', sum(1 for d in descs.values() if len(d) > 200))
print('with_colon', sum(1 for d in descs.values() if ':' in d))
print('dupes', sum(1 for d, n in Counter(descs.values()).items() if n > 1))
PY
```

Vale was also re-run on the changed files; zero new line-2 (description-line) issues remain.

## Test plan

- [ ] CI Vale lint passes on the changed files
- [ ] Spot-check that each rewritten description still matches its page's actual purpose
- [ ] Confirm the next/unversioned scope (no versioned files touched)