### PR TITLE
Rewrite networking page descriptions (next trees)

### DIFF
--- a/calico-cloud/networking/configuring/add-maglev-load-balancing.mdx
+++ b/calico-cloud/networking/configuring/add-maglev-load-balancing.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add Maglev load balancing to a Kubernetes service.
+description: Switch a Kubernetes service to Maglev consistent-hash load balancing on the Calico Cloud eBPF data plane for stable backend selection in connected clusters.
 ---
 
 # Add Maglev load balancing to a service

--- a/calico-cloud/networking/configuring/advertise-service-ips.mdx
+++ b/calico-cloud/networking/configuring/advertise-service-ips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to advertise Kubernetes service cluster IPs and external IPs outside the cluster using BGP.
+description: Advertise Kubernetes service cluster IPs and external IPs out of a Calico Cloud connected cluster over BGP so upstream routers can reach them directly.
 ---
 
 # Advertise Kubernetes service IP addresses

--- a/calico-cloud/networking/configuring/bgp-to-workload.mdx
+++ b/calico-cloud/networking/configuring/bgp-to-workload.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP peering with nested clusters running on KubeVirt VMs
+description: Peer Calico Cloud nodes with BGP speakers inside KubeVirt VMs so nested clusters connected to Calico Cloud can announce routes from their workloads.
 ---
 
 # Configure BGP peering with nested clusters running on KubeVirt VMs

--- a/calico-cloud/networking/configuring/bgp.mdx
+++ b/calico-cloud/networking/configuring/bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP peering with full mesh, node-specific peering, ToR, and/or Calico route reflectors.
+description: Set up BGP peering for Calico Cloud connected clusters — full mesh, per-node peers, top-of-rack switches, and route reflectors — with BGPPeer and BGPConfiguration resources.
 ---
 
 # Configure BGP peering

--- a/calico-cloud/networking/configuring/custom-bgp-config.mdx
+++ b/calico-cloud/networking/configuring/custom-bgp-config.mdx
@@ -1,5 +1,5 @@
 ---
-description: Apply a custom BGP configuration
+description: Override the default BIRD BGP templates in a Calico Cloud connected cluster to access advanced BIRD features for proof-of-concept and special-case routing.
 ---
 
 # Custom BGP Configuration

--- a/calico-cloud/networking/configuring/dual-tor.mdx
+++ b/calico-cloud/networking/configuring/dual-tor.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a dual plane cluster for redundant connectivity between workloads.
+description: Deploy a dual ToR cluster connected to Calico Cloud so two independent connectivity planes provide redundancy between racks for on-premises clusters.
 ---
 
 # Deploy a dual ToR cluster

--- a/calico-cloud/networking/configuring/index.mdx
+++ b/calico-cloud/networking/configuring/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico networking options.
+description: Networking configuration tasks for Calico Cloud connected clusters — BGP, overlay encapsulation, MTU, multiple pod networks, dual ToR, IPVS, NAT, and QoS controls.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud/networking/configuring/mark-lb-node-for-maintenance.mdx
+++ b/calico-cloud/networking/configuring/mark-lb-node-for-maintenance.mdx
@@ -1,5 +1,5 @@
 ---
-description: Mark a load balancer node for maintenance
+description: Mark a node in a Calico Cloud connected cluster for load balancer maintenance with an annotation so the eBPF data plane stops sending new service traffic to its pods.
 ---
 
 # Mark a load balancer node for maintenance

--- a/calico-cloud/networking/configuring/mtu.mdx
+++ b/calico-cloud/networking/configuring/mtu.mdx
@@ -1,5 +1,5 @@
 ---
-description: Optimize network performance for workloads by configuring the MTU in Calico to best suit your underlying network.
+description: Tune the Calico Cloud MTU on the Installation resource so pod traffic matches the underlay, accounting for VXLAN, IP-in-IP, and WireGuard overhead.
 ---
 
 # Configure MTU to maximize network performance

--- a/calico-cloud/networking/configuring/multiple-networks.mdx
+++ b/calico-cloud/networking/configuring/multiple-networks.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a cluster with multiple Calico Cloud networks on each pod, and enforce security using Calico Cloud tiered network policy.
+description: Add extra Calico Cloud networks to each pod in a connected cluster with the Multus-CNI plugin, then control access with tiered network policy on every interface.
 ---
 
 # Configure multiple Calico Cloud networks on a pod

--- a/calico-cloud/networking/configuring/node-local-dns-cache.mdx
+++ b/calico-cloud/networking/configuring/node-local-dns-cache.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install NodeLocal DNSCache
+description: Run NodeLocal DNSCache alongside Calico Cloud in a connected cluster and write the network policy that lets pod DNS traffic reach the per-node cache.
 ---
 
 # Use NodeLocal DNSCache in your cluster

--- a/calico-cloud/networking/configuring/pod-mac-address.mdx
+++ b/calico-cloud/networking/configuring/pod-mac-address.mdx
@@ -1,5 +1,5 @@
 ---
-description: Specify the MAC address for a pod instead of allowing the operating system to assign one
+description: Pin a chosen MAC address on a Kubernetes pod interface in a Calico Cloud connected cluster with the CNI plugin, for cases such as MAC-bound software licenses.
 ---
 
 # Use a specific MAC address for a pod

--- a/calico-cloud/networking/configuring/qos-controls.mdx
+++ b/calico-cloud/networking/configuring/qos-controls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure QoS (Quality of Service) Controls to limit ingress and/or egress bandwidth, packet rate and number of connections of Calico workloads.
+description: Apply Calico Cloud QoS controls to cap pod ingress and egress bandwidth, packet rate, and connection counts in a connected cluster, plus DiffServ marking on egress.
 ---
 
 # Configure QoS Controls

--- a/calico-cloud/networking/configuring/vxlan-ipip.mdx
+++ b/calico-cloud/networking/configuring/vxlan-ipip.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to use IP in IP or VXLAN overlay networking so the underlying network doesn’t need to understand pod addresses.
+description: Choose VXLAN or IP-in-IP overlay encapsulation in a Calico Cloud connected cluster so pod traffic crosses underlay networks that don't route pod CIDRs natively.
 ---
 
 # Overlay networking

--- a/calico-cloud/networking/configuring/workloads-outside-cluster.mdx
+++ b/calico-cloud/networking/configuring/workloads-outside-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico Cloud networking to perform outbound NAT for connections from pods to outside of the cluster.
+description: Configure NAT outgoing on Calico Cloud IP pools in a connected cluster so pod traffic destined outside the cluster is source-NATed to the node IP.
 ---
 
 # Configure outgoing NAT

--- a/calico-cloud/networking/egress/egress-gateway-aws.mdx
+++ b/calico-cloud/networking/egress/egress-gateway-aws.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway with a native AWS IP address.
+description: Route selected application traffic out of a Calico Cloud connected cluster through egress gateways with native AWS VPC subnet IPs.
 ---
 
 # Configure egress gateways, AWS

--- a/calico-cloud/networking/egress/egress-gateway-azure.mdx
+++ b/calico-cloud/networking/egress/egress-gateway-azure.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway with a native Azure IP address.
+description: Route selected application traffic out of a Calico Cloud connected cluster through egress gateways with native Azure VNet IPs.
 ---
 
 # Configure egress gateways, Azure

--- a/calico-cloud/networking/egress/egress-gateway-maintenance.mdx
+++ b/calico-cloud/networking/egress/egress-gateway-maintenance.mdx
@@ -1,5 +1,5 @@
 ---
-description: React to egress gateway maintenance windows and minimize the impact of egress gateway downtime on sensitive workloads
+description: Reduce egress gateway downtime impact on long-lived TCP sessions in Calico Cloud connected clusters by reading termination annotations and draining gracefully.
 ---
 
 # Optimize egress networking for workloads with long-lived TCP connections

--- a/calico-cloud/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-cloud/networking/egress/egress-gateway-on-prem.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway.
+description: Send selected application traffic through Calico Cloud egress gateways on-premises so external firewalls see a predictable source IP for cluster workloads.
 redirect_from:
   - /compliance/egress-gateways
 ---

--- a/calico-cloud/networking/egress/external-network.mdx
+++ b/calico-cloud/networking/egress/external-network.mdx
@@ -1,5 +1,5 @@
 ---
-description: Allows workloads from different namespaces of a Kubernetes cluster to egress onto different external networks that (may) have overlapping IPs with each other.
+description: Direct Calico Cloud egress gateway traffic onto multiple external networks with potentially overlapping IPs by associating gateways with named ExternalNetworks.
 ---
 
 # Configure egress traffic to multiple external networks

--- a/calico-cloud/networking/egress/index.mdx
+++ b/calico-cloud/networking/egress/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway for additional security.
+description: Egress gateways in Calico Cloud — pin per-namespace or per-pod source IPs for outbound traffic, segment external networks, and integrate with cloud fabrics.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud/networking/egress/troubleshoot.mdx
+++ b/calico-cloud/networking/egress/troubleshoot.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use checklist to troubleshoot common problems.
+description: Troubleshooting guide for Calico Cloud egress gateways covering connection failures, source IP mismatches, BGP route propagation, and required pod metadata.
 ---
 
 # Troubleshoot egress gateways

--- a/calico-cloud/networking/index.mdx
+++ b/calico-cloud/networking/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico's flexible networking options reduce the barriers to adopting a CaaS platform solution. Determine the best networking option for your implementation.
+description: Calico Cloud networking covers BGP, overlay encapsulation, IPAM, egress gateways, ingress gateways, and per-cluster training across connected clusters.
 ---
 
 import { DocCardLink, DocCardLinkLayout } from '/src/___new___/components';

--- a/calico-cloud/networking/ingress-gateway/about-calico-ingress-gateway.mdx
+++ b/calico-cloud/networking/ingress-gateway/about-calico-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Understand what Calico Ingress Gateway is and how it works.
+description: Overview of Calico Ingress Gateway in Calico Cloud — a hardened Envoy Gateway build that brings the Kubernetes Gateway API to your connected clusters.
 title: Calico Ingress Gateway
 ---
 

--- a/calico-cloud/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico-cloud/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create an ingress gateway to manage ingress traffic with the Kubernetes Gateway API.
+description: Deploy a Calico Ingress Gateway in a Calico Cloud connected cluster by applying GatewayAPI and Gateway resources tied to the Tigera-managed gateway class.
 ---
 
 # Create an ingress gateway

--- a/calico-cloud/networking/ingress-gateway/customize-ingress-gateway.mdx
+++ b/calico-cloud/networking/ingress-gateway/customize-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how to customize your ingress gateway.
+description: Tune the Calico Ingress Gateway in Calico Cloud via the GatewayAPI resource — multiple gateway classes, pod placement, container resources, and load balancer annotations.
 ---
 
 # Customizing your ingress gateway

--- a/calico-cloud/networking/ingress-gateway/tutorial-ingress-gateway-canary.mdx
+++ b/calico-cloud/networking/ingress-gateway/tutorial-ingress-gateway-canary.mdx
@@ -1,5 +1,5 @@
 ---
-description: Tutorial for ingress gateways and canary deployment
+description: Step-by-step tutorial for running a canary rollout in Calico Cloud by splitting HTTPRoute weights across two backends behind an ingress gateway.
 title: "Tutorial: Canary deployment"
 ---
 

--- a/calico-cloud/networking/ipam/assign-ip-addresses-topology.mdx
+++ b/calico-cloud/networking/ipam/assign-ip-addresses-topology.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico Cloud to use specific IP pools for different topologies including zone, rack, or region.
+description: Bind Calico Cloud IP pools to zones, racks, or regions in a connected cluster with node selectors so pods get addresses that match the topology.
 ---
 
 # Assign IP addresses based on topology

--- a/calico-cloud/networking/ipam/change-block-size.mdx
+++ b/calico-cloud/networking/ipam/change-block-size.mdx
@@ -1,5 +1,5 @@
 ---
-description: Expand or shrink the IP pool block size to efficiently manage IP pool addresses.
+description: Resize a Calico Cloud IPPool block — by creating a replacement pool and migrating workloads — to use IP space more efficiently across connected clusters.
 ---
 
 # Change IP pool block size

--- a/calico-cloud/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico-cloud/networking/ipam/get-started-ip-addresses.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico Cloud to use Calico Cloud IPAM or host-local IPAM, and when to use one or the other.
+description: Pick between Calico Cloud IPAM and host-local IPAM, then configure pool selection, NAT outgoing, and per-namespace IP assignment in a connected cluster.
 ---
 
 # Get started with IP address management

--- a/calico-cloud/networking/ipam/index.mdx
+++ b/calico-cloud/networking/ipam/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico IPAM is flexible and efficient. Learn how to interoperate with legacy firewalls using IP address ranges, advertise Kubernetes service IPs, and more.
+description: IP address management in Calico Cloud — IPPools, block sizes, IPv6 dual stack, service load balancer IPAM, topology-aware allocation, and pool migration.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud/networking/ipam/initial-ippool.mdx
+++ b/calico-cloud/networking/ipam/initial-ippool.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure the default IP address ranges for operator installation.
+description: Set the default Calico Cloud IP pool CIDR, encapsulation, and NAT outgoing values during Tigera Operator installation through the Installation resource.
 ---
 
 # Configure default IP pools

--- a/calico-cloud/networking/ipam/ip-autodetection.mdx
+++ b/calico-cloud/networking/ipam/ip-autodetection.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico IP autodetection ensures the correct IP address is used for routing. Learn how to customize it.
+description: Pick how Calico Cloud detects each node's primary IP — first-found, Kubernetes internal, interface regex, CIDR, or skip-interface — for reliable routing.
 ---
 
 # Configure IP autodetection

--- a/calico-cloud/networking/ipam/ipv6.mdx
+++ b/calico-cloud/networking/ipam/ipv6.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure dual stack for workloads.
+description: Configure dual-stack pod networking in a Calico Cloud connected cluster by adding IPv6 IP pools, IPv6 autodetection, and matching CNI plugin settings.
 ---
 
 # Configure dual stack

--- a/calico-cloud/networking/ipam/legacy-firewalls.mdx
+++ b/calico-cloud/networking/ipam/legacy-firewalls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Restrict the IP address chosen for a pod to a specific range of IP addresses.
+description: Restrict pods to a defined IP range in a Calico Cloud connected cluster so legacy firewalls and appliances can recognise cluster workloads by source IP.
 ---
 
 # Restrict a pod to use an IP address in a specific range

--- a/calico-cloud/networking/ipam/migrate-pools.mdx
+++ b/calico-cloud/networking/ipam/migrate-pools.mdx
@@ -1,5 +1,5 @@
 ---
-description: Migrate pods from one IP pool to another on a running cluster without network disruption.
+description: Move workloads from one Calico Cloud IPPool to another on a running connected cluster without disrupting existing pod connectivity.
 ---
 
 # Migrate from one IP pool to another

--- a/calico-cloud/networking/ipam/service-loadbalancer.mdx
+++ b/calico-cloud/networking/ipam/service-loadbalancer.mdx
@@ -1,5 +1,5 @@
 ---
-description: LoadBalancer IP address management
+description: Use the Calico Cloud LoadBalancer controller to allocate IPs to Kubernetes Service type LoadBalancer from configured IPPool resources in a connected cluster.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico-cloud/networking/ipam/use-specific-ip.mdx
+++ b/calico-cloud/networking/ipam/use-specific-ip.mdx
@@ -1,5 +1,5 @@
 ---
-description: Specify the IP address for a pod instead of allowing Calico Cloud to automatically choose one.
+description: Pin a Kubernetes pod to a chosen address in a Calico Cloud connected cluster by setting a pod annotation that supplies the requested address.
 ---
 
 # Use a specific IP address with a pod

--- a/calico-cloud/networking/training/about-kubernetes-networking.mdx
+++ b/calico-cloud/networking/training/about-kubernetes-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn network behaviors of the Kubernetes network model.
+description: Reference primer for Kubernetes networking concepts that help when operating Calico Cloud — pod IPs, services, DNS, NAT outgoing, and dual stack.
 ---
 
 # Kubernetes network model

--- a/calico-cloud/networking/training/about-networking.mdx
+++ b/calico-cloud/networking/training/about-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about networking layers, packets, IP addressing, and routing.
+description: Reference primer for networking fundamentals — OSI layers, packet anatomy, MTU, IP addressing, routing, overlays, DNS, and NAT — that underpin Calico Cloud.
 ---
 
 # Networking overview

--- a/calico-cloud/networking/training/index.mdx
+++ b/calico-cloud/networking/training/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the basics of Kubernetes networking and Calico Cloud networking.
+description: Networking training material for Calico Cloud — fundamentals of network layers, IP addressing, routing, and the Kubernetes network model.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/networking/configuring/advertise-service-ips.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/configuring/advertise-service-ips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to advertise Kubernetes service cluster IPs and external IPs outside the cluster using BGP.
+description: Advertise Kubernetes service cluster IPs and external IPs out of a Calico Cloud connected cluster over BGP so upstream routers can reach them directly.
 ---
 
 # Advertise Kubernetes service IP addresses

--- a/calico-cloud_versioned_docs/version-22-2/networking/configuring/bgp-to-workload.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/configuring/bgp-to-workload.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP peering with nested clusters running on KubeVirt VMs
+description: Peer Calico Cloud nodes with BGP speakers inside KubeVirt VMs so nested clusters connected to Calico Cloud can announce routes from their workloads.
 ---
 
 # Configure BGP peering with nested clusters running on KubeVirt VMs

--- a/calico-cloud_versioned_docs/version-22-2/networking/configuring/bgp.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/configuring/bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP peering with full mesh, node-specific peering, ToR, and/or Calico route reflectors.
+description: Set up BGP peering for Calico Cloud connected clusters — full mesh, per-node peers, top-of-rack switches, and route reflectors — with BGPPeer and BGPConfiguration resources.
 ---
 
 # Configure BGP peering

--- a/calico-cloud_versioned_docs/version-22-2/networking/configuring/custom-bgp-config.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/configuring/custom-bgp-config.mdx
@@ -1,5 +1,5 @@
 ---
-description: Apply a custom BGP configuration
+description: Override the default BIRD BGP templates in a Calico Cloud connected cluster to access advanced BIRD features for proof-of-concept and special-case routing.
 ---
 
 # Custom BGP Configuration

--- a/calico-cloud_versioned_docs/version-22-2/networking/configuring/dual-tor.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/configuring/dual-tor.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a dual plane cluster for redundant connectivity between workloads.
+description: Deploy a dual ToR cluster connected to Calico Cloud so two independent connectivity planes provide redundancy between racks for on-premises clusters.
 ---
 
 # Deploy a dual ToR cluster

--- a/calico-cloud_versioned_docs/version-22-2/networking/configuring/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/configuring/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico networking options.
+description: Networking configuration tasks for Calico Cloud connected clusters — BGP, overlay encapsulation, MTU, multiple pod networks, dual ToR, IPVS, NAT, and QoS controls.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/networking/configuring/mtu.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/configuring/mtu.mdx
@@ -1,5 +1,5 @@
 ---
-description: Optimize network performance for workloads by configuring the MTU in Calico to best suit your underlying network.
+description: Tune the Calico Cloud MTU on the Installation resource so pod traffic matches the underlay, accounting for VXLAN, IP-in-IP, and WireGuard overhead.
 ---
 
 # Configure MTU to maximize network performance

--- a/calico-cloud_versioned_docs/version-22-2/networking/configuring/multiple-networks.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/configuring/multiple-networks.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a cluster with multiple Calico Cloud networks on each pod, and enforce security using Calico Cloud tiered network policy.
+description: Add extra Calico Cloud networks to each pod in a connected cluster with the Multus-CNI plugin, then control access with tiered network policy on every interface.
 ---
 
 # Configure multiple Calico Cloud networks on a pod

--- a/calico-cloud_versioned_docs/version-22-2/networking/configuring/node-local-dns-cache.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/configuring/node-local-dns-cache.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install NodeLocal DNSCache
+description: Run NodeLocal DNSCache alongside Calico Cloud in a connected cluster and write the network policy that lets pod DNS traffic reach the per-node cache.
 ---
 
 # Use NodeLocal DNSCache in your cluster

--- a/calico-cloud_versioned_docs/version-22-2/networking/configuring/pod-mac-address.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/configuring/pod-mac-address.mdx
@@ -1,5 +1,5 @@
 ---
-description: Specify the MAC address for a pod instead of allowing the operating system to assign one
+description: Pin a chosen MAC address on a Kubernetes pod interface in a Calico Cloud connected cluster with the CNI plugin, for cases such as MAC-bound software licenses.
 ---
 
 # Use a specific MAC address for a pod

--- a/calico-cloud_versioned_docs/version-22-2/networking/configuring/qos-controls.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/configuring/qos-controls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure QoS (Quality of Service) Controls to limit ingress and/or egress bandwidth, packet rate and number of connections of Calico workloads.
+description: Apply Calico Cloud QoS controls to cap pod ingress and egress bandwidth, packet rate, and connection counts in a connected cluster, plus DiffServ marking on egress.
 ---
 
 # Configure QoS Controls

--- a/calico-cloud_versioned_docs/version-22-2/networking/configuring/vxlan-ipip.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/configuring/vxlan-ipip.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to use IP in IP or VXLAN overlay networking so the underlying network doesn’t need to understand pod addresses.
+description: Choose VXLAN or IP-in-IP overlay encapsulation in a Calico Cloud connected cluster so pod traffic crosses underlay networks that don't route pod CIDRs natively.
 ---
 
 # Overlay networking

--- a/calico-cloud_versioned_docs/version-22-2/networking/configuring/workloads-outside-cluster.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/configuring/workloads-outside-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico Cloud networking to perform outbound NAT for connections from pods to outside of the cluster.
+description: Configure NAT outgoing on Calico Cloud IP pools in a connected cluster so pod traffic destined outside the cluster is source-NATed to the node IP.
 ---
 
 # Configure outgoing NAT

--- a/calico-cloud_versioned_docs/version-22-2/networking/egress/egress-gateway-aws.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/egress/egress-gateway-aws.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway with a native AWS IP address.
+description: Route selected application traffic out of a Calico Cloud connected cluster through egress gateways with native AWS VPC subnet IPs.
 ---
 
 # Configure egress gateways, AWS

--- a/calico-cloud_versioned_docs/version-22-2/networking/egress/egress-gateway-azure.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/egress/egress-gateway-azure.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway with a native Azure IP address.
+description: Route selected application traffic out of a Calico Cloud connected cluster through egress gateways with native Azure VNet IPs.
 ---
 
 # Configure egress gateways, Azure

--- a/calico-cloud_versioned_docs/version-22-2/networking/egress/egress-gateway-maintenance.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/egress/egress-gateway-maintenance.mdx
@@ -1,5 +1,5 @@
 ---
-description: React to egress gateway maintenance windows and minimize the impact of egress gateway downtime on sensitive workloads
+description: Reduce egress gateway downtime impact on long-lived TCP sessions in Calico Cloud connected clusters by reading termination annotations and draining gracefully.
 ---
 
 # Optimize egress networking for workloads with long-lived TCP connections

--- a/calico-cloud_versioned_docs/version-22-2/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/egress/egress-gateway-on-prem.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway.
+description: Send selected application traffic through Calico Cloud egress gateways on-premises so external firewalls see a predictable source IP for cluster workloads.
 redirect_from:
   - /compliance/egress-gateways
 ---

--- a/calico-cloud_versioned_docs/version-22-2/networking/egress/external-network.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/egress/external-network.mdx
@@ -1,5 +1,5 @@
 ---
-description: Allows workloads from different namespaces of a Kubernetes cluster to egress onto different external networks that (may) have overlapping IPs with each other.
+description: Direct Calico Cloud egress gateway traffic onto multiple external networks with potentially overlapping IPs by associating gateways with named ExternalNetworks.
 ---
 
 # Configure egress traffic to multiple external networks

--- a/calico-cloud_versioned_docs/version-22-2/networking/egress/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/egress/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway for additional security.
+description: Egress gateways in Calico Cloud — pin per-namespace or per-pod source IPs for outbound traffic, segment external networks, and integrate with cloud fabrics.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/networking/egress/troubleshoot.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/egress/troubleshoot.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use checklist to troubleshoot common problems.
+description: Troubleshooting guide for Calico Cloud egress gateways covering connection failures, source IP mismatches, BGP route propagation, and required pod metadata.
 ---
 
 # Troubleshoot egress gateways

--- a/calico-cloud_versioned_docs/version-22-2/networking/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico's flexible networking options reduce the barriers to adopting a CaaS platform solution. Determine the best networking option for your implementation.
+description: Calico Cloud networking covers BGP, overlay encapsulation, IPAM, egress gateways, ingress gateways, and per-cluster training across connected clusters.
 ---
 
 import { DocCardLink, DocCardLinkLayout } from '/src/___new___/components';

--- a/calico-cloud_versioned_docs/version-22-2/networking/ingress-gateway/about-calico-ingress-gateway.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/ingress-gateway/about-calico-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Understand what Calico Ingress Gateway is and how it works.
+description: Overview of Calico Ingress Gateway in Calico Cloud — a hardened Envoy Gateway build that brings the Kubernetes Gateway API to your connected clusters.
 title: Calico Ingress Gateway
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create an ingress gateway to manage ingress traffic with the Kubernetes Gateway API.
+description: Deploy a Calico Ingress Gateway in a Calico Cloud connected cluster by applying GatewayAPI and Gateway resources tied to the Tigera-managed gateway class.
 ---
 
 # Create an ingress gateway

--- a/calico-cloud_versioned_docs/version-22-2/networking/ingress-gateway/customize-ingress-gateway.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/ingress-gateway/customize-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how to customize your ingress gateway.
+description: Tune the Calico Ingress Gateway in Calico Cloud via the GatewayAPI resource — multiple gateway classes, pod placement, container resources, and load balancer annotations.
 ---
 
 # Customizing your ingress gateway

--- a/calico-cloud_versioned_docs/version-22-2/networking/ingress-gateway/tutorial-ingress-gateway-canary.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/ingress-gateway/tutorial-ingress-gateway-canary.mdx
@@ -1,5 +1,5 @@
 ---
-description: Tutorial for ingress gateways and canary deployment
+description: Step-by-step tutorial for running a canary rollout in Calico Cloud by splitting HTTPRoute weights across two backends behind an ingress gateway.
 title: "Tutorial: Canary deployment"
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/networking/ipam/assign-ip-addresses-topology.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/ipam/assign-ip-addresses-topology.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico Cloud to use specific IP pools for different topologies including zone, rack, or region.
+description: Bind Calico Cloud IP pools to zones, racks, or regions in a connected cluster with node selectors so pods get addresses that match the topology.
 ---
 
 # Assign IP addresses based on topology

--- a/calico-cloud_versioned_docs/version-22-2/networking/ipam/change-block-size.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/ipam/change-block-size.mdx
@@ -1,5 +1,5 @@
 ---
-description: Expand or shrink the IP pool block size to efficiently manage IP pool addresses.
+description: Resize a Calico Cloud IPPool block — by creating a replacement pool and migrating workloads — to use IP space more efficiently across connected clusters.
 ---
 
 # Change IP pool block size

--- a/calico-cloud_versioned_docs/version-22-2/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/ipam/get-started-ip-addresses.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico Cloud to use Calico Cloud IPAM or host-local IPAM, and when to use one or the other.
+description: Pick between Calico Cloud IPAM and host-local IPAM, then configure pool selection, NAT outgoing, and per-namespace IP assignment in a connected cluster.
 ---
 
 # Get started with IP address management

--- a/calico-cloud_versioned_docs/version-22-2/networking/ipam/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/ipam/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico IPAM is flexible and efficient. Learn how to interoperate with legacy firewalls using IP address ranges, advertise Kubernetes service IPs, and more.
+description: IP address management in Calico Cloud — IPPools, block sizes, IPv6 dual stack, service load balancer IPAM, topology-aware allocation, and pool migration.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/networking/ipam/initial-ippool.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/ipam/initial-ippool.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure the default IP address ranges for operator installation.
+description: Set the default Calico Cloud IP pool CIDR, encapsulation, and NAT outgoing values during Tigera Operator installation through the Installation resource.
 ---
 
 # Configure default IP pools

--- a/calico-cloud_versioned_docs/version-22-2/networking/ipam/ip-autodetection.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/ipam/ip-autodetection.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico IP autodetection ensures the correct IP address is used for routing. Learn how to customize it.
+description: Pick how Calico Cloud detects each node's primary IP — first-found, Kubernetes internal, interface regex, CIDR, or skip-interface — for reliable routing.
 ---
 
 # Configure IP autodetection

--- a/calico-cloud_versioned_docs/version-22-2/networking/ipam/ipv6.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/ipam/ipv6.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure dual stack for workloads.
+description: Configure dual-stack pod networking in a Calico Cloud connected cluster by adding IPv6 IP pools, IPv6 autodetection, and matching CNI plugin settings.
 ---
 
 # Configure dual stack

--- a/calico-cloud_versioned_docs/version-22-2/networking/ipam/legacy-firewalls.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/ipam/legacy-firewalls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Restrict the IP address chosen for a pod to a specific range of IP addresses.
+description: Restrict pods to a defined IP range in a Calico Cloud connected cluster so legacy firewalls and appliances can recognise cluster workloads by source IP.
 ---
 
 # Restrict a pod to use an IP address in a specific range

--- a/calico-cloud_versioned_docs/version-22-2/networking/ipam/migrate-pools.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/ipam/migrate-pools.mdx
@@ -1,5 +1,5 @@
 ---
-description: Migrate pods from one IP pool to another on a running cluster without network disruption.
+description: Move workloads from one Calico Cloud IPPool to another on a running connected cluster without disrupting existing pod connectivity.
 ---
 
 # Migrate from one IP pool to another

--- a/calico-cloud_versioned_docs/version-22-2/networking/ipam/service-loadbalancer.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/ipam/service-loadbalancer.mdx
@@ -1,5 +1,5 @@
 ---
-description: LoadBalancer IP address management
+description: Use the Calico Cloud LoadBalancer controller to allocate IPs to Kubernetes Service type LoadBalancer from configured IPPool resources in a connected cluster.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico-cloud_versioned_docs/version-22-2/networking/ipam/use-specific-ip.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/ipam/use-specific-ip.mdx
@@ -1,5 +1,5 @@
 ---
-description: Specify the IP address for a pod instead of allowing Calico Cloud to automatically choose one.
+description: Pin a Kubernetes pod to a chosen address in a Calico Cloud connected cluster by setting a pod annotation that supplies the requested address.
 ---
 
 # Use a specific IP address with a pod

--- a/calico-cloud_versioned_docs/version-22-2/networking/training/about-kubernetes-networking.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/training/about-kubernetes-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn network behaviors of the Kubernetes network model.
+description: Reference primer for Kubernetes networking concepts that help when operating Calico Cloud — pod IPs, services, DNS, NAT outgoing, and dual stack.
 ---
 
 # Kubernetes network model

--- a/calico-cloud_versioned_docs/version-22-2/networking/training/about-networking.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/training/about-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about networking layers, packets, IP addressing, and routing.
+description: Reference primer for networking fundamentals — OSI layers, packet anatomy, MTU, IP addressing, routing, overlays, DNS, and NAT — that underpin Calico Cloud.
 ---
 
 # Networking overview

--- a/calico-cloud_versioned_docs/version-22-2/networking/training/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/training/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the basics of Kubernetes networking and Calico Cloud networking.
+description: Networking training material for Calico Cloud — fundamentals of network layers, IP addressing, routing, and the Kubernetes network model.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/networking/configuring/add-maglev-load-balancing.mdx
+++ b/calico-enterprise/networking/configuring/add-maglev-load-balancing.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add Maglev load balancing to a Kubernetes service.
+description: Switch a Kubernetes service to Maglev consistent-hash load balancing on the Calico Enterprise eBPF data plane for stable backend selection across nodes.
 ---
 
 # Add Maglev load balancing to a service

--- a/calico-enterprise/networking/configuring/advertise-service-ips.mdx
+++ b/calico-enterprise/networking/configuring/advertise-service-ips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to advertise Kubernetes service cluster IPs and external IPs outside the cluster using BGP.
+description: Advertise Kubernetes service cluster IPs and external IPs out of the cluster over BGP with Calico Enterprise so upstream routers can reach them directly.
 ---
 
 # Advertise Kubernetes service IP addresses

--- a/calico-enterprise/networking/configuring/bgp-to-workload.mdx
+++ b/calico-enterprise/networking/configuring/bgp-to-workload.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP peering with nested clusters running on KubeVirt VMs
+description: Peer Calico Enterprise nodes with BGP speakers inside KubeVirt VMs so nested clusters can announce routes from their workloads upstream.
 ---
 
 # Configure BGP peering with nested clusters running on KubeVirt VMs

--- a/calico-enterprise/networking/configuring/bgp.mdx
+++ b/calico-enterprise/networking/configuring/bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP peering with full mesh, node-specific peering, ToR, and/or Calico route reflectors.
+description: Set up BGP peering for Calico Enterprise — full mesh, per-node peers, top-of-rack switches, and route reflectors — using BGPPeer and BGPConfiguration resources.
 ---
 
 # Configure BGP peering

--- a/calico-enterprise/networking/configuring/custom-bgp-config.mdx
+++ b/calico-enterprise/networking/configuring/custom-bgp-config.mdx
@@ -1,5 +1,5 @@
 ---
-description: Customize your BGP configuration.
+description: Override the default BIRD BGP templates for Calico Enterprise to access advanced BIRD features for proof-of-concept and special-case routing setups.
 ---
 
 # Custom BGP configuration

--- a/calico-enterprise/networking/configuring/dual-tor.mdx
+++ b/calico-enterprise/networking/configuring/dual-tor.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a dual plane cluster for redundant connectivity between workloads.
+description: Deploy a dual ToR cluster with Calico Enterprise so two independent connectivity planes provide redundancy between racks for on-premises clusters.
 ---
 
 # Deploy a dual ToR cluster

--- a/calico-enterprise/networking/configuring/index.mdx
+++ b/calico-enterprise/networking/configuring/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico networking options.
+description: Networking configuration tasks for Calico Enterprise — BGP, overlay encapsulation, MTU, multiple pod networks, dual ToR, IPVS, NAT, and QoS controls.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/networking/configuring/mark-lb-node-for-maintenance.mdx
+++ b/calico-enterprise/networking/configuring/mark-lb-node-for-maintenance.mdx
@@ -1,5 +1,5 @@
 ---
-description: Mark a load balancer node for maintenance
+description: Mark a Calico Enterprise node for load balancer maintenance with an annotation so the eBPF data plane stops sending new service traffic to its pods.
 ---
 
 # Mark a load balancer node for maintenance

--- a/calico-enterprise/networking/configuring/mtu.mdx
+++ b/calico-enterprise/networking/configuring/mtu.mdx
@@ -1,5 +1,5 @@
 ---
-description: Optimize network performance for workloads by configuring the MTU in Calico to best suit your underlying network.
+description: Tune the Calico Enterprise MTU on the Installation resource so pod traffic matches the underlay, accounting for VXLAN, IP-in-IP, and WireGuard overhead.
 ---
 
 # Configure MTU to maximize network performance

--- a/calico-enterprise/networking/configuring/multiple-networks.mdx
+++ b/calico-enterprise/networking/configuring/multiple-networks.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a cluster with multiple Calico Enterprise networks on each pod, and enforce security using Calico Enterprise tiered network policy.
+description: Add extra Calico Enterprise networks to each pod with the Multus-CNI plugin, then control access with tiered network policy on every interface.
 ---
 
 # Configure multiple Calico Enterprise networks on a pod

--- a/calico-enterprise/networking/configuring/node-local-dns-cache.mdx
+++ b/calico-enterprise/networking/configuring/node-local-dns-cache.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install NodeLocal DNSCache
+description: Run NodeLocal DNSCache alongside Calico Enterprise and write the network policy that lets pod DNS traffic reach the per-node cache.
 ---
 
 # Use NodeLocal DNSCache in your cluster

--- a/calico-enterprise/networking/configuring/pod-mac-address.mdx
+++ b/calico-enterprise/networking/configuring/pod-mac-address.mdx
@@ -1,5 +1,5 @@
 ---
-description: Specify the MAC address for a pod instead of allowing the operating system to assign one
+description: Pin a chosen MAC address on a Kubernetes pod interface with the Calico Enterprise CNI plugin for cases such as MAC-bound software licenses.
 ---
 
 # Use a specific MAC address for a pod

--- a/calico-enterprise/networking/configuring/qos-controls.mdx
+++ b/calico-enterprise/networking/configuring/qos-controls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure QoS (Quality of Service) Controls to limit ingress and/or egress bandwidth, packet rate and number of connections of Calico workloads.
+description: Apply Calico Enterprise QoS controls to cap pod ingress and egress bandwidth, packet rate, and connection counts, plus DiffServ marking on egress.
 ---
 
 # Configure QoS Controls

--- a/calico-enterprise/networking/configuring/vxlan-ipip.mdx
+++ b/calico-enterprise/networking/configuring/vxlan-ipip.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to use IP in IP or VXLAN overlay networking so the underlying network doesn’t need to understand pod addresses.
+description: Choose VXLAN or IP-in-IP overlay encapsulation in Calico Enterprise so pod traffic crosses underlay networks that don't route pod CIDRs natively.
 ---
 
 # Overlay networking

--- a/calico-enterprise/networking/configuring/workloads-outside-cluster.mdx
+++ b/calico-enterprise/networking/configuring/workloads-outside-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure networking to perform outbound NAT for connections from pods to outside of the cluster.
+description: Configure NAT outgoing on Calico Enterprise IP pools so pod traffic destined outside the cluster is source-NATed to the node IP.
 ---
 
 # Configure outgoing NAT

--- a/calico-enterprise/networking/determine-best-networking.mdx
+++ b/calico-enterprise/networking/determine-best-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about the different networking options Calico Enterprise supports so you can choose the best option for your needs.
+description: Compare networking choices in Calico Enterprise — overlay versus non-overlay, BGP, CNI, and IPAM — to land on the right configuration for your cluster.
 ---
 
 # Determine best networking option

--- a/calico-enterprise/networking/egress/egress-gateway-aws.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-aws.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway with a native AWS IP address.
+description: Route specific application traffic out of a Calico Enterprise cluster through egress gateways that use VPC subnet IPs visible to the AWS fabric.
 ---
 
 # Configure egress gateways, AWS

--- a/calico-enterprise/networking/egress/egress-gateway-azure.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-azure.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway with a native Azure IP address.
+description: Route specific application traffic out of a Calico Enterprise cluster through egress gateways that use native Azure VNet IPs recognised by Azure routing.
 ---
 
 # Configure egress gateways, Azure

--- a/calico-enterprise/networking/egress/egress-gateway-maintenance.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-maintenance.mdx
@@ -1,5 +1,5 @@
 ---
-description: React to egress gateway maintenance windows and minimize the impact of egress gateway downtime on sensitive workloads
+description: Reduce the impact of Calico Enterprise egress gateway maintenance on workloads with long-lived TCP sessions by reading termination annotations and timing draining.
 ---
 
 # Optimize egress networking for workloads with long-lived TCP connections

--- a/calico-enterprise/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-on-prem.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway.
+description: Send selected application traffic through Calico Enterprise egress gateways on-premises so external firewalls see a predictable source IP for cluster workloads.
 redirect_from:
   - /compliance/egress-gateways
 ---

--- a/calico-enterprise/networking/egress/external-network.mdx
+++ b/calico-enterprise/networking/egress/external-network.mdx
@@ -1,5 +1,5 @@
 ---
-description: Allows workloads from different namespaces of a Kubernetes cluster to egress onto different external networks that (may) have overlapping IPs with each other.
+description: Steer Calico Enterprise egress gateway traffic onto multiple external networks with potentially overlapping IPs by associating gateways with named ExternalNetworks.
 ---
 
 # Configure egress traffic to multiple external networks

--- a/calico-enterprise/networking/egress/index.mdx
+++ b/calico-enterprise/networking/egress/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway for additional security.
+description: Egress gateways in Calico Enterprise — pin per-namespace or per-pod source IPs for outbound traffic, integrate with cloud fabrics, and segment external networks.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/networking/egress/troubleshoot.mdx
+++ b/calico-enterprise/networking/egress/troubleshoot.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use checklist to troubleshoot common problems.
+description: Troubleshooting guide for Calico Enterprise egress gateways covering connection failures, source IP mismatches, BGP route advertisement, and required pod metadata.
 ---
 
 # Troubleshoot egress gateways

--- a/calico-enterprise/networking/index.mdx
+++ b/calico-enterprise/networking/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico's flexible networking options reduce the barriers to adopting a CaaS platform solution. Determine the best networking option for your implementation.
+description: Calico Enterprise networking covers BGP, overlay encapsulation, IPAM, egress gateways, ingress gateways, eBPF acceleration, and Kubernetes networking training.
 ---
 
 import { DocCardLink, DocCardLinkLayout } from '/src/___new___/components';

--- a/calico-enterprise/networking/ingress-gateway/about-calico-ingress-gateway.mdx
+++ b/calico-enterprise/networking/ingress-gateway/about-calico-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Understand what Calico Ingress Gateway is and how it works.
+description: Overview of Calico Ingress Gateway as offered in Calico Enterprise — a hardened Envoy Gateway build that implements the Kubernetes Gateway API standard.
 title: Calico Ingress Gateway
 ---
 

--- a/calico-enterprise/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico-enterprise/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create an ingress gateway to manage ingress traffic with the Kubernetes Gateway API.
+description: Deploy a Calico Ingress Gateway in a Calico Enterprise cluster by applying GatewayAPI and Gateway resources tied to the Tigera-managed gateway class.
 ---
 
 # Create an ingress gateway

--- a/calico-enterprise/networking/ingress-gateway/customize-ingress-gateway.mdx
+++ b/calico-enterprise/networking/ingress-gateway/customize-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how to customize your ingress gateway.
+description: Tune the Calico Ingress Gateway in Calico Enterprise via the GatewayAPI resource — gateway classes, pod placement, container resources, and load balancer annotations.
 ---
 
 # Customizing your ingress gateway

--- a/calico-enterprise/networking/ingress-gateway/tutorial-ingress-gateway-canary.mdx
+++ b/calico-enterprise/networking/ingress-gateway/tutorial-ingress-gateway-canary.mdx
@@ -1,5 +1,5 @@
 ---
-description: Tutorial for ingress gateways and canary deployment
+description: Step-by-step tutorial for running a canary rollout in Calico Enterprise by splitting HTTPRoute weights across two backends behind an ingress gateway.
 title: "Tutorial: Canary deployment"
 ---
 

--- a/calico-enterprise/networking/ipam/assign-ip-addresses-topology.mdx
+++ b/calico-enterprise/networking/ipam/assign-ip-addresses-topology.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico Enterprise to use specific IP pools for different topologies including zone, rack, or region.
+description: Bind Calico Enterprise IP pools to zones, racks, or regions with node selectors so pods get addresses that match the cluster topology.
 ---
 
 # Assign IP addresses based on topology

--- a/calico-enterprise/networking/ipam/change-block-size.mdx
+++ b/calico-enterprise/networking/ipam/change-block-size.mdx
@@ -1,5 +1,5 @@
 ---
-description: Expand or shrink the IP pool block size to efficiently manage IP pool addresses.
+description: Resize a Calico Enterprise IPPool block — by creating a replacement pool and migrating workloads — to use IP space more efficiently in your cluster.
 ---
 
 # Change IP pool block size

--- a/calico-enterprise/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico-enterprise/networking/ipam/get-started-ip-addresses.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico Enterprise to use Calico Enterprise IPAM or host-local IPAM, and when to use one or the other.
+description: Choose between Calico Enterprise IPAM and host-local IPAM, then configure pool selection, NAT outgoing, and per-namespace IP assignment.
 ---
 
 # Get started with IP address management

--- a/calico-enterprise/networking/ipam/index.mdx
+++ b/calico-enterprise/networking/ipam/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico IPAM is flexible and efficient. Learn how to interoperate with legacy firewalls using IP address ranges, advertise Kubernetes service IPs, and more.
+description: IP address management in Calico Enterprise — IPPools, block sizes, IPv6 dual stack, service load balancer IPAM, topology-aware allocation, and pool migration.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/networking/ipam/initial-ippool.mdx
+++ b/calico-enterprise/networking/ipam/initial-ippool.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure the default IP address ranges for operator installation.
+description: Set the default Calico Enterprise IP pool CIDR, encapsulation, and NAT outgoing values during Tigera Operator installation through the Installation resource.
 ---
 
 # Configure default IP pools

--- a/calico-enterprise/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise/networking/ipam/ip-autodetection.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico IP autodetection ensures the correct IP address is used for routing. Learn how to customize it.
+description: Pick how Calico Enterprise detects each node's primary IP — first-found, Kubernetes internal, interface regex, CIDR, or skip-interface — for reliable routing.
 ---
 
 # Configure IP autodetection

--- a/calico-enterprise/networking/ipam/ippools.mdx
+++ b/calico-enterprise/networking/ipam/ippools.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create multiple IP pools
+description: Define multiple Calico Enterprise IPPool resources at install time or on a running cluster to serve disjoint ranges, IPv6, or per-topology pod allocation.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico-enterprise/networking/ipam/ipv6.mdx
+++ b/calico-enterprise/networking/ipam/ipv6.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure dual stack for workloads.
+description: Configure dual-stack pod networking with Calico Enterprise by adding IPv6 IP pools, IPv6 autodetection, and matching CNI plugin settings.
 ---
 
 # Configure dual stack

--- a/calico-enterprise/networking/ipam/legacy-firewalls.mdx
+++ b/calico-enterprise/networking/ipam/legacy-firewalls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Restrict the IP address chosen for a pod to a specific range of IP addresses.
+description: Restrict pods to a defined IP range with Calico Enterprise so legacy firewalls and external appliances can recognise cluster workloads by source IP.
 ---
 
 # Restrict a pod to use an IP address in a specific range

--- a/calico-enterprise/networking/ipam/migrate-pools.mdx
+++ b/calico-enterprise/networking/ipam/migrate-pools.mdx
@@ -1,5 +1,5 @@
 ---
-description: Migrate pods from one IP pool to another on a running cluster without network disruption.
+description: Move workloads from one Calico Enterprise IPPool to another on a running cluster without disrupting existing pod connectivity.
 ---
 
 # Migrate from one IP pool to another

--- a/calico-enterprise/networking/ipam/service-loadbalancer.mdx
+++ b/calico-enterprise/networking/ipam/service-loadbalancer.mdx
@@ -1,5 +1,5 @@
 ---
-description: LoadBalancer IP address management
+description: Use the Calico Enterprise LoadBalancer controller to allocate IPs to Kubernetes Service type LoadBalancer from configured IPPool resources.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico-enterprise/networking/ipam/use-specific-ip.mdx
+++ b/calico-enterprise/networking/ipam/use-specific-ip.mdx
@@ -1,5 +1,5 @@
 ---
-description: Specify the IP address for a pod instead of allowing Calico Enterprise to automatically choose one.
+description: Pin a Kubernetes pod to a chosen address with Calico Enterprise IPAM by setting a pod annotation that supplies the requested address.
 ---
 
 # Use a specific IP address with a pod

--- a/calico-enterprise/networking/kubevirt/index.mdx
+++ b/calico-enterprise/networking/kubevirt/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico Enterprise networking for KubeVirt virtual machines.
+description: Run Calico Enterprise as the network for KubeVirt VMs in your cluster, with persistent IPs and BGP-aware live migration.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/networking/kubevirt/kubevirt-networking.mdx
+++ b/calico-enterprise/networking/kubevirt/kubevirt-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico Enterprise to provide networking for KubeVirt virtual machines, including IP address persistence and live migration support.
+description: Set up Calico Enterprise bridge-mode networking for KubeVirt VMs so each VM keeps a stable IP across reboots, evictions, and live migrations.
 ---
 
 # KubeVirt networking

--- a/calico-enterprise/networking/kubevirt/live-migration-bgp.mdx
+++ b/calico-enterprise/networking/kubevirt/live-migration-bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP routing to support KubeVirt live migration across racks and AS boundaries.
+description: Configure BGPFilter resources in Calico Enterprise so elevated route priorities cross AS boundaries during KubeVirt live migration in multi-rack clusters.
 ---
 
 # BGP routing for KubeVirt live migration

--- a/calico-enterprise/networking/training/about-kubernetes-networking.mdx
+++ b/calico-enterprise/networking/training/about-kubernetes-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn network behaviors of the Kubernetes network model.
+description: Reference primer for Kubernetes networking concepts that help when operating Calico Enterprise — pod IPs, services, DNS, NAT outgoing, and dual stack.
 ---
 
 # Kubernetes network model

--- a/calico-enterprise/networking/training/about-networking.mdx
+++ b/calico-enterprise/networking/training/about-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about networking layers, packets, IP addressing, and routing.
+description: Reference primer for general networking fundamentals — OSI layers, packet anatomy, MTU, IP addressing, routing, overlays, DNS, and NAT — that underpin Calico Enterprise.
 ---
 
 # Networking overview

--- a/calico-enterprise/networking/training/index.mdx
+++ b/calico-enterprise/networking/training/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the basics of Kubernetes networking and Calico Enterprise networking.
+description: Networking training material for Calico Enterprise — fundamentals of network layers, IP addressing, routing, and the Kubernetes network model.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/advertise-service-ips.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/advertise-service-ips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to advertise Kubernetes service cluster IPs and external IPs outside the cluster using BGP.
+description: Advertise Kubernetes service cluster IPs and external IPs out of the cluster over BGP with Calico Enterprise so upstream routers can reach them directly.
 ---
 
 # Advertise Kubernetes service IP addresses

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/bgp-to-workload.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/bgp-to-workload.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP peering with nested clusters running on KubeVirt VMs
+description: Peer Calico Enterprise nodes with BGP speakers inside KubeVirt VMs so nested clusters can announce routes from their workloads upstream.
 ---
 
 # Configure BGP peering with nested clusters running on KubeVirt VMs

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/bgp.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP peering with full mesh, node-specific peering, ToR, and/or Calico route reflectors.
+description: Set up BGP peering for Calico Enterprise — full mesh, per-node peers, top-of-rack switches, and route reflectors — using BGPPeer and BGPConfiguration resources.
 ---
 
 # Configure BGP peering

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/custom-bgp-config.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/custom-bgp-config.mdx
@@ -1,5 +1,5 @@
 ---
-description: Customize your BGP configuration.
+description: Override the default BIRD BGP templates for Calico Enterprise to access advanced BIRD features for proof-of-concept and special-case routing setups.
 ---
 
 # Custom BGP configuration

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/dual-tor.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/dual-tor.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a dual plane cluster for redundant connectivity between workloads.
+description: Deploy a dual ToR cluster with Calico Enterprise so two independent connectivity planes provide redundancy between racks for on-premises clusters.
 ---
 
 # Deploy a dual ToR cluster

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico networking options.
+description: Networking configuration tasks for Calico Enterprise — BGP, overlay encapsulation, MTU, multiple pod networks, dual ToR, IPVS, NAT, and QoS controls.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/mtu.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/mtu.mdx
@@ -1,5 +1,5 @@
 ---
-description: Optimize network performance for workloads by configuring the MTU in Calico to best suit your underlying network.
+description: Tune the Calico Enterprise MTU on the Installation resource so pod traffic matches the underlay, accounting for VXLAN, IP-in-IP, and WireGuard overhead.
 ---
 
 # Configure MTU to maximize network performance

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/multiple-networks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/multiple-networks.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a cluster with multiple Calico Enterprise networks on each pod, and enforce security using Calico Enterprise tiered network policy.
+description: Add extra Calico Enterprise networks to each pod with the Multus-CNI plugin, then control access with tiered network policy on every interface.
 ---
 
 # Configure multiple Calico Enterprise networks on a pod

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/node-local-dns-cache.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/node-local-dns-cache.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install NodeLocal DNSCache
+description: Run NodeLocal DNSCache alongside Calico Enterprise and write the network policy that lets pod DNS traffic reach the per-node cache.
 ---
 
 # Use NodeLocal DNSCache in your cluster

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/pod-mac-address.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/pod-mac-address.mdx
@@ -1,5 +1,5 @@
 ---
-description: Specify the MAC address for a pod instead of allowing the operating system to assign one
+description: Pin a chosen MAC address on a Kubernetes pod interface with the Calico Enterprise CNI plugin for cases such as MAC-bound software licenses.
 ---
 
 # Use a specific MAC address for a pod

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/qos-controls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/qos-controls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure QoS (Quality of Service) Controls to limit ingress and/or egress bandwidth, packet rate and number of connections of Calico workloads.
+description: Apply Calico Enterprise QoS controls to cap pod ingress and egress bandwidth, packet rate, and connection counts, plus DiffServ marking on egress.
 ---
 
 # Configure QoS Controls

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/vxlan-ipip.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/vxlan-ipip.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to use IP in IP or VXLAN overlay networking so the underlying network doesn’t need to understand pod addresses.
+description: Choose VXLAN or IP-in-IP overlay encapsulation in Calico Enterprise so pod traffic crosses underlay networks that don't route pod CIDRs natively.
 ---
 
 # Overlay networking

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/workloads-outside-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/configuring/workloads-outside-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure networking to perform outbound NAT for connections from pods to outside of the cluster.
+description: Configure NAT outgoing on Calico Enterprise IP pools so pod traffic destined outside the cluster is source-NATed to the node IP.
 ---
 
 # Configure outgoing NAT

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/determine-best-networking.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/determine-best-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about the different networking options Calico Enterprise supports so you can choose the best option for your needs.
+description: Compare networking choices in Calico Enterprise — overlay versus non-overlay, BGP, CNI, and IPAM — to land on the right configuration for your cluster.
 ---
 
 # Determine best networking option

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/egress-gateway-aws.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/egress-gateway-aws.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway with a native AWS IP address.
+description: Route specific application traffic out of a Calico Enterprise cluster through egress gateways that use VPC subnet IPs visible to the AWS fabric.
 ---
 
 # Configure egress gateways, AWS

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/egress-gateway-azure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/egress-gateway-azure.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway with a native Azure IP address.
+description: Route specific application traffic out of a Calico Enterprise cluster through egress gateways that use native Azure VNet IPs recognised by Azure routing.
 ---
 
 # Configure egress gateways, Azure

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/egress-gateway-maintenance.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/egress-gateway-maintenance.mdx
@@ -1,5 +1,5 @@
 ---
-description: React to egress gateway maintenance windows and minimize the impact of egress gateway downtime on sensitive workloads
+description: Reduce the impact of Calico Enterprise egress gateway maintenance on workloads with long-lived TCP sessions by reading termination annotations and timing draining.
 ---
 
 # Optimize egress networking for workloads with long-lived TCP connections

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/egress-gateway-on-prem.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway.
+description: Send selected application traffic through Calico Enterprise egress gateways on-premises so external firewalls see a predictable source IP for cluster workloads.
 redirect_from:
   - /compliance/egress-gateways
 ---

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/external-network.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/external-network.mdx
@@ -1,5 +1,5 @@
 ---
-description: Allows workloads from different namespaces of a Kubernetes cluster to egress onto different external networks that (may) have overlapping IPs with each other.
+description: Steer Calico Enterprise egress gateway traffic onto multiple external networks with potentially overlapping IPs by associating gateways with named ExternalNetworks.
 ---
 
 # Configure egress traffic to multiple external networks

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway for additional security.
+description: Egress gateways in Calico Enterprise — pin per-namespace or per-pod source IPs for outbound traffic, integrate with cloud fabrics, and segment external networks.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/troubleshoot.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/troubleshoot.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use checklist to troubleshoot common problems.
+description: Troubleshooting guide for Calico Enterprise egress gateways covering connection failures, source IP mismatches, BGP route advertisement, and required pod metadata.
 ---
 
 # Troubleshoot egress gateways

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico's flexible networking options reduce the barriers to adopting a CaaS platform solution. Determine the best networking option for your implementation.
+description: Calico Enterprise networking covers BGP, overlay encapsulation, IPAM, egress gateways, ingress gateways, eBPF acceleration, and Kubernetes networking training.
 ---
 
 import { DocCardLink, DocCardLinkLayout } from '/src/___new___/components';

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ingress-gateway/about-calico-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ingress-gateway/about-calico-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Understand what Calico Ingress Gateway is and how it works.
+description: Overview of Calico Ingress Gateway as offered in Calico Enterprise — a hardened Envoy Gateway build that implements the Kubernetes Gateway API standard.
 title: Calico Ingress Gateway
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create an ingress gateway to manage ingress traffic with the Kubernetes Gateway API.
+description: Deploy a Calico Ingress Gateway in a Calico Enterprise cluster by applying GatewayAPI and Gateway resources tied to the Tigera-managed gateway class.
 ---
 
 # Create an ingress gateway

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ingress-gateway/customize-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ingress-gateway/customize-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how to customize your ingress gateway.
+description: Tune the Calico Ingress Gateway in Calico Enterprise via the GatewayAPI resource — gateway classes, pod placement, container resources, and load balancer annotations.
 ---
 
 # Customizing your ingress gateway

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ingress-gateway/tutorial-ingress-gateway-canary.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ingress-gateway/tutorial-ingress-gateway-canary.mdx
@@ -1,5 +1,5 @@
 ---
-description: Tutorial for ingress gateways and canary deployment
+description: Step-by-step tutorial for running a canary rollout in Calico Enterprise by splitting HTTPRoute weights across two backends behind an ingress gateway.
 title: "Tutorial: Canary deployment"
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/assign-ip-addresses-topology.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/assign-ip-addresses-topology.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico Enterprise to use specific IP pools for different topologies including zone, rack, or region.
+description: Bind Calico Enterprise IP pools to zones, racks, or regions with node selectors so pods get addresses that match the cluster topology.
 ---
 
 # Assign IP addresses based on topology

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/change-block-size.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/change-block-size.mdx
@@ -1,5 +1,5 @@
 ---
-description: Expand or shrink the IP pool block size to efficiently manage IP pool addresses.
+description: Resize a Calico Enterprise IPPool block — by creating a replacement pool and migrating workloads — to use IP space more efficiently in your cluster.
 ---
 
 # Change IP pool block size

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/get-started-ip-addresses.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico Enterprise to use Calico Enterprise IPAM or host-local IPAM, and when to use one or the other.
+description: Choose between Calico Enterprise IPAM and host-local IPAM, then configure pool selection, NAT outgoing, and per-namespace IP assignment.
 ---
 
 # Get started with IP address management

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico IPAM is flexible and efficient. Learn how to interoperate with legacy firewalls using IP address ranges, advertise Kubernetes service IPs, and more.
+description: IP address management in Calico Enterprise — IPPools, block sizes, IPv6 dual stack, service load balancer IPAM, topology-aware allocation, and pool migration.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/initial-ippool.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/initial-ippool.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure the default IP address ranges for operator installation.
+description: Set the default Calico Enterprise IP pool CIDR, encapsulation, and NAT outgoing values during Tigera Operator installation through the Installation resource.
 ---
 
 # Configure default IP pools

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/ip-autodetection.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico IP autodetection ensures the correct IP address is used for routing. Learn how to customize it.
+description: Pick how Calico Enterprise detects each node's primary IP — first-found, Kubernetes internal, interface regex, CIDR, or skip-interface — for reliable routing.
 ---
 
 # Configure IP autodetection

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/ippools.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/ippools.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create multiple IP pools
+description: Define multiple Calico Enterprise IPPool resources at install time or on a running cluster to serve disjoint ranges, IPv6, or per-topology pod allocation.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/ipv6.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/ipv6.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure dual stack for workloads.
+description: Configure dual-stack pod networking with Calico Enterprise by adding IPv6 IP pools, IPv6 autodetection, and matching CNI plugin settings.
 ---
 
 # Configure dual stack

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/legacy-firewalls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/legacy-firewalls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Restrict the IP address chosen for a pod to a specific range of IP addresses.
+description: Restrict pods to a defined IP range with Calico Enterprise so legacy firewalls and external appliances can recognise cluster workloads by source IP.
 ---
 
 # Restrict a pod to use an IP address in a specific range

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/migrate-pools.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/migrate-pools.mdx
@@ -1,5 +1,5 @@
 ---
-description: Migrate pods from one IP pool to another on a running cluster without network disruption.
+description: Move workloads from one Calico Enterprise IPPool to another on a running cluster without disrupting existing pod connectivity.
 ---
 
 # Migrate from one IP pool to another

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/service-loadbalancer.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/service-loadbalancer.mdx
@@ -1,5 +1,5 @@
 ---
-description: LoadBalancer IP address management
+description: Use the Calico Enterprise LoadBalancer controller to allocate IPs to Kubernetes Service type LoadBalancer from configured IPPool resources.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/use-specific-ip.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/use-specific-ip.mdx
@@ -1,5 +1,5 @@
 ---
-description: Specify the IP address for a pod instead of allowing Calico Enterprise to automatically choose one.
+description: Pin a Kubernetes pod to a chosen address with Calico Enterprise IPAM by setting a pod annotation that supplies the requested address.
 ---
 
 # Use a specific IP address with a pod

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/training/about-kubernetes-networking.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/training/about-kubernetes-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn network behaviors of the Kubernetes network model.
+description: Reference primer for Kubernetes networking concepts that help when operating Calico Enterprise — pod IPs, services, DNS, NAT outgoing, and dual stack.
 ---
 
 # Kubernetes network model

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/training/about-networking.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/training/about-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about networking layers, packets, IP addressing, and routing.
+description: Reference primer for general networking fundamentals — OSI layers, packet anatomy, MTU, IP addressing, routing, overlays, DNS, and NAT — that underpin Calico Enterprise.
 ---
 
 # Networking overview

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/training/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/training/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the basics of Kubernetes networking and Calico Enterprise networking.
+description: Networking training material for Calico Enterprise — fundamentals of network layers, IP addressing, routing, and the Kubernetes network model.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/add-maglev-load-balancing.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/add-maglev-load-balancing.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add Maglev load balancing to a Kubernetes service.
+description: Switch a Kubernetes service to Maglev consistent-hash load balancing on the Calico Enterprise eBPF data plane for stable backend selection across nodes.
 ---
 
 # Add Maglev load balancing to a service

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/advertise-service-ips.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/advertise-service-ips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to advertise Kubernetes service cluster IPs and external IPs outside the cluster using BGP.
+description: Advertise Kubernetes service cluster IPs and external IPs out of the cluster over BGP with Calico Enterprise so upstream routers can reach them directly.
 ---
 
 # Advertise Kubernetes service IP addresses

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/bgp-to-workload.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/bgp-to-workload.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP peering with nested clusters running on KubeVirt VMs
+description: Peer Calico Enterprise nodes with BGP speakers inside KubeVirt VMs so nested clusters can announce routes from their workloads upstream.
 ---
 
 # Configure BGP peering with nested clusters running on KubeVirt VMs

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/bgp.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP peering with full mesh, node-specific peering, ToR, and/or Calico route reflectors.
+description: Set up BGP peering for Calico Enterprise — full mesh, per-node peers, top-of-rack switches, and route reflectors — using BGPPeer and BGPConfiguration resources.
 ---
 
 # Configure BGP peering

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/custom-bgp-config.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/custom-bgp-config.mdx
@@ -1,5 +1,5 @@
 ---
-description: Customize your BGP configuration.
+description: Override the default BIRD BGP templates for Calico Enterprise to access advanced BIRD features for proof-of-concept and special-case routing setups.
 ---
 
 # Custom BGP configuration

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/dual-tor.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/dual-tor.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a dual plane cluster for redundant connectivity between workloads.
+description: Deploy a dual ToR cluster with Calico Enterprise so two independent connectivity planes provide redundancy between racks for on-premises clusters.
 ---
 
 # Deploy a dual ToR cluster

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico networking options.
+description: Networking configuration tasks for Calico Enterprise — BGP, overlay encapsulation, MTU, multiple pod networks, dual ToR, IPVS, NAT, and QoS controls.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/mtu.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/mtu.mdx
@@ -1,5 +1,5 @@
 ---
-description: Optimize network performance for workloads by configuring the MTU in Calico to best suit your underlying network.
+description: Tune the Calico Enterprise MTU on the Installation resource so pod traffic matches the underlay, accounting for VXLAN, IP-in-IP, and WireGuard overhead.
 ---
 
 # Configure MTU to maximize network performance

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/multiple-networks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/multiple-networks.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a cluster with multiple Calico Enterprise networks on each pod, and enforce security using Calico Enterprise tiered network policy.
+description: Add extra Calico Enterprise networks to each pod with the Multus-CNI plugin, then control access with tiered network policy on every interface.
 ---
 
 # Configure multiple Calico Enterprise networks on a pod

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/node-local-dns-cache.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/node-local-dns-cache.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install NodeLocal DNSCache
+description: Run NodeLocal DNSCache alongside Calico Enterprise and write the network policy that lets pod DNS traffic reach the per-node cache.
 ---
 
 # Use NodeLocal DNSCache in your cluster

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/pod-mac-address.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/pod-mac-address.mdx
@@ -1,5 +1,5 @@
 ---
-description: Specify the MAC address for a pod instead of allowing the operating system to assign one
+description: Pin a chosen MAC address on a Kubernetes pod interface with the Calico Enterprise CNI plugin for cases such as MAC-bound software licenses.
 ---
 
 # Use a specific MAC address for a pod

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/qos-controls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/qos-controls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure QoS (Quality of Service) Controls to limit ingress and/or egress bandwidth, packet rate and number of connections of Calico workloads.
+description: Apply Calico Enterprise QoS controls to cap pod ingress and egress bandwidth, packet rate, and connection counts, plus DiffServ marking on egress.
 ---
 
 # Configure QoS Controls

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/vxlan-ipip.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/vxlan-ipip.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to use IP in IP or VXLAN overlay networking so the underlying network doesn’t need to understand pod addresses.
+description: Choose VXLAN or IP-in-IP overlay encapsulation in Calico Enterprise so pod traffic crosses underlay networks that don't route pod CIDRs natively.
 ---
 
 # Overlay networking

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/workloads-outside-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/configuring/workloads-outside-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure networking to perform outbound NAT for connections from pods to outside of the cluster.
+description: Configure NAT outgoing on Calico Enterprise IP pools so pod traffic destined outside the cluster is source-NATed to the node IP.
 ---
 
 # Configure outgoing NAT

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/determine-best-networking.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/determine-best-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about the different networking options Calico Enterprise supports so you can choose the best option for your needs.
+description: Compare networking choices in Calico Enterprise — overlay versus non-overlay, BGP, CNI, and IPAM — to land on the right configuration for your cluster.
 ---
 
 # Determine best networking option

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/egress/egress-gateway-aws.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/egress/egress-gateway-aws.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway with a native AWS IP address.
+description: Route specific application traffic out of a Calico Enterprise cluster through egress gateways that use VPC subnet IPs visible to the AWS fabric.
 ---
 
 # Configure egress gateways, AWS

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/egress/egress-gateway-azure.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/egress/egress-gateway-azure.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway with a native Azure IP address.
+description: Route specific application traffic out of a Calico Enterprise cluster through egress gateways that use native Azure VNet IPs recognised by Azure routing.
 ---
 
 # Configure egress gateways, Azure

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/egress/egress-gateway-maintenance.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/egress/egress-gateway-maintenance.mdx
@@ -1,5 +1,5 @@
 ---
-description: React to egress gateway maintenance windows and minimize the impact of egress gateway downtime on sensitive workloads
+description: Reduce the impact of Calico Enterprise egress gateway maintenance on workloads with long-lived TCP sessions by reading termination annotations and timing draining.
 ---
 
 # Optimize egress networking for workloads with long-lived TCP connections

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/egress/egress-gateway-on-prem.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/egress/egress-gateway-on-prem.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway.
+description: Send selected application traffic through Calico Enterprise egress gateways on-premises so external firewalls see a predictable source IP for cluster workloads.
 redirect_from:
   - /compliance/egress-gateways
 ---

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/egress/external-network.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/egress/external-network.mdx
@@ -1,5 +1,5 @@
 ---
-description: Allows workloads from different namespaces of a Kubernetes cluster to egress onto different external networks that (may) have overlapping IPs with each other.
+description: Steer Calico Enterprise egress gateway traffic onto multiple external networks with potentially overlapping IPs by associating gateways with named ExternalNetworks.
 ---
 
 # Configure egress traffic to multiple external networks

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/egress/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/egress/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure specific application traffic to exit the cluster through an egress gateway for additional security.
+description: Egress gateways in Calico Enterprise — pin per-namespace or per-pod source IPs for outbound traffic, integrate with cloud fabrics, and segment external networks.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/egress/troubleshoot.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/egress/troubleshoot.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use checklist to troubleshoot common problems.
+description: Troubleshooting guide for Calico Enterprise egress gateways covering connection failures, source IP mismatches, BGP route advertisement, and required pod metadata.
 ---
 
 # Troubleshoot egress gateways

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico's flexible networking options reduce the barriers to adopting a CaaS platform solution. Determine the best networking option for your implementation.
+description: Calico Enterprise networking covers BGP, overlay encapsulation, IPAM, egress gateways, ingress gateways, eBPF acceleration, and Kubernetes networking training.
 ---
 
 import { DocCardLink, DocCardLinkLayout } from '/src/___new___/components';

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/ingress-gateway/about-calico-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/ingress-gateway/about-calico-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Understand what Calico Ingress Gateway is and how it works.
+description: Overview of Calico Ingress Gateway as offered in Calico Enterprise — a hardened Envoy Gateway build that implements the Kubernetes Gateway API standard.
 title: Calico Ingress Gateway
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create an ingress gateway to manage ingress traffic with the Kubernetes Gateway API.
+description: Deploy a Calico Ingress Gateway in a Calico Enterprise cluster by applying GatewayAPI and Gateway resources tied to the Tigera-managed gateway class.
 ---
 
 # Create an ingress gateway

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/ingress-gateway/customize-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/ingress-gateway/customize-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how to customize your ingress gateway.
+description: Tune the Calico Ingress Gateway in Calico Enterprise via the GatewayAPI resource — gateway classes, pod placement, container resources, and load balancer annotations.
 ---
 
 # Customizing your ingress gateway

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/ingress-gateway/tutorial-ingress-gateway-canary.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/ingress-gateway/tutorial-ingress-gateway-canary.mdx
@@ -1,5 +1,5 @@
 ---
-description: Tutorial for ingress gateways and canary deployment
+description: Step-by-step tutorial for running a canary rollout in Calico Enterprise by splitting HTTPRoute weights across two backends behind an ingress gateway.
 title: "Tutorial: Canary deployment"
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/assign-ip-addresses-topology.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/assign-ip-addresses-topology.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico Enterprise to use specific IP pools for different topologies including zone, rack, or region.
+description: Bind Calico Enterprise IP pools to zones, racks, or regions with node selectors so pods get addresses that match the cluster topology.
 ---
 
 # Assign IP addresses based on topology

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/change-block-size.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/change-block-size.mdx
@@ -1,5 +1,5 @@
 ---
-description: Expand or shrink the IP pool block size to efficiently manage IP pool addresses.
+description: Resize a Calico Enterprise IPPool block — by creating a replacement pool and migrating workloads — to use IP space more efficiently in your cluster.
 ---
 
 # Change IP pool block size

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/get-started-ip-addresses.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico Enterprise to use Calico Enterprise IPAM or host-local IPAM, and when to use one or the other.
+description: Choose between Calico Enterprise IPAM and host-local IPAM, then configure pool selection, NAT outgoing, and per-namespace IP assignment.
 ---
 
 # Get started with IP address management

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico IPAM is flexible and efficient. Learn how to interoperate with legacy firewalls using IP address ranges, advertise Kubernetes service IPs, and more.
+description: IP address management in Calico Enterprise — IPPools, block sizes, IPv6 dual stack, service load balancer IPAM, topology-aware allocation, and pool migration.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/initial-ippool.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/initial-ippool.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure the default IP address ranges for operator installation.
+description: Set the default Calico Enterprise IP pool CIDR, encapsulation, and NAT outgoing values during Tigera Operator installation through the Installation resource.
 ---
 
 # Configure default IP pools

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/ip-autodetection.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico IP autodetection ensures the correct IP address is used for routing. Learn how to customize it.
+description: Pick how Calico Enterprise detects each node's primary IP — first-found, Kubernetes internal, interface regex, CIDR, or skip-interface — for reliable routing.
 ---
 
 # Configure IP autodetection

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/ippools.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/ippools.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create multiple IP pools
+description: Define multiple Calico Enterprise IPPool resources at install time or on a running cluster to serve disjoint ranges, IPv6, or per-topology pod allocation.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/ipv6.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/ipv6.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure dual stack for workloads.
+description: Configure dual-stack pod networking with Calico Enterprise by adding IPv6 IP pools, IPv6 autodetection, and matching CNI plugin settings.
 ---
 
 # Configure dual stack

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/legacy-firewalls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/legacy-firewalls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Restrict the IP address chosen for a pod to a specific range of IP addresses.
+description: Restrict pods to a defined IP range with Calico Enterprise so legacy firewalls and external appliances can recognise cluster workloads by source IP.
 ---
 
 # Restrict a pod to use an IP address in a specific range

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/migrate-pools.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/migrate-pools.mdx
@@ -1,5 +1,5 @@
 ---
-description: Migrate pods from one IP pool to another on a running cluster without network disruption.
+description: Move workloads from one Calico Enterprise IPPool to another on a running cluster without disrupting existing pod connectivity.
 ---
 
 # Migrate from one IP pool to another

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/service-loadbalancer.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/service-loadbalancer.mdx
@@ -1,5 +1,5 @@
 ---
-description: LoadBalancer IP address management
+description: Use the Calico Enterprise LoadBalancer controller to allocate IPs to Kubernetes Service type LoadBalancer from configured IPPool resources.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/use-specific-ip.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/ipam/use-specific-ip.mdx
@@ -1,5 +1,5 @@
 ---
-description: Specify the IP address for a pod instead of allowing Calico Enterprise to automatically choose one.
+description: Pin a Kubernetes pod to a chosen address with Calico Enterprise IPAM by setting a pod annotation that supplies the requested address.
 ---
 
 # Use a specific IP address with a pod

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/training/about-kubernetes-networking.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/training/about-kubernetes-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn network behaviors of the Kubernetes network model.
+description: Reference primer for Kubernetes networking concepts that help when operating Calico Enterprise — pod IPs, services, DNS, NAT outgoing, and dual stack.
 ---
 
 # Kubernetes network model

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/training/about-networking.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/training/about-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about networking layers, packets, IP addressing, and routing.
+description: Reference primer for general networking fundamentals — OSI layers, packet anatomy, MTU, IP addressing, routing, overlays, DNS, and NAT — that underpin Calico Enterprise.
 ---
 
 # Networking overview

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/training/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/training/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the basics of Kubernetes networking and Calico Enterprise networking.
+description: Networking training material for Calico Enterprise — fundamentals of network layers, IP addressing, routing, and the Kubernetes network model.
 hide_table_of_contents: true
 ---
 

--- a/calico/networking/configuring/add-maglev-load-balancing.mdx
+++ b/calico/networking/configuring/add-maglev-load-balancing.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add Maglev load balancing to a Kubernetes service.
+description: Switch a Kubernetes service to Maglev consistent-hash load balancing on the Calico Open Source eBPF data plane for resilient backend selection.
 ---
 
 # Add Maglev load balancing to a service

--- a/calico/networking/configuring/advertise-service-ips.mdx
+++ b/calico/networking/configuring/advertise-service-ips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to advertise Kubernetes service cluster IPs and external IPs outside the cluster using BGP.
+description: Advertise Kubernetes service cluster IPs and external IPs out of the cluster over BGP with Calico Open Source so external clients can route to them directly.
 ---
 
 # Advertise Kubernetes service IP addresses

--- a/calico/networking/configuring/bgp-to-workload.mdx
+++ b/calico/networking/configuring/bgp-to-workload.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP peering with nested clusters running on KubeVirt VMs
+description: Peer Calico Open Source nodes with BGP speakers running inside KubeVirt VMs to support nested clusters and route announcements from workloads.
 ---
 
 # Configure BGP peering with nested clusters running on KubeVirt VMs

--- a/calico/networking/configuring/bgp.mdx
+++ b/calico/networking/configuring/bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP peering with full mesh, node-specific peering, ToR, and/or Calico route reflectors.
+description: Configure BGP peering for Calico Open Source — full mesh, node-specific peers, top-of-rack switches, and Calico route reflectors — using BGPPeer and BGPConfiguration resources.
 ---
 
 # Configure BGP peering

--- a/calico/networking/configuring/index.mdx
+++ b/calico/networking/configuring/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico networking options, including overlay, non-overlay, BGP, service advertisement, MTU, NAT, and using kube-proxy in IPVS mode.
+description: Networking configuration tasks for Calico Open Source — BGP, overlay encapsulation, service advertisement, MTU, NAT, IPVS kube-proxy, and QoS controls.
 hide_table_of_contents: true
 ---
 

--- a/calico/networking/configuring/mtu.mdx
+++ b/calico/networking/configuring/mtu.mdx
@@ -1,5 +1,5 @@
 ---
-description: Optimize network performance for workloads by configuring the MTU in Calico to best suit your underlying network.
+description: Tune the Calico Open Source MTU on the FelixConfiguration resource so pod traffic matches the underlying network, including VXLAN, IP-in-IP, and WireGuard overheads.
 ---
 
 # Configure MTU to maximize network performance

--- a/calico/networking/configuring/node-local-dns-cache.mdx
+++ b/calico/networking/configuring/node-local-dns-cache.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install NodeLocal DNSCache
+description: Install NodeLocal DNSCache alongside Calico Open Source and configure network policy that lets pod DNS traffic reach the local cache.
 ---
 
 # Use NodeLocal DNSCache in your cluster

--- a/calico/networking/configuring/pod-mac-address.mdx
+++ b/calico/networking/configuring/pod-mac-address.mdx
@@ -1,5 +1,5 @@
 ---
-description: Specify the MAC address for a pod instead of allowing the operating system to assign one
+description: Set a chosen MAC address on a Kubernetes pod interface with the Calico Open Source CNI plugin, useful for software licensing tied to MAC.
 ---
 
 # Use a specific MAC address for a pod

--- a/calico/networking/configuring/qos-controls.mdx
+++ b/calico/networking/configuring/qos-controls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure QoS (Quality of Service) Controls to limit ingress and/or egress bandwidth, packet rate and number of connections of Calico workloads.
+description: Cap pod ingress and egress bandwidth, packet rate, and connection counts with Calico Open Source QoS controls, plus DiffServ marking on egress traffic.
 ---
 
 # Configure QoS Controls

--- a/calico/networking/configuring/sidecar-acceleration.mdx
+++ b/calico/networking/configuring/sidecar-acceleration.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use Calico to accelerate network performance of traffic through the Istio Envoy sidecar using eBPF.
+description: Accelerate Istio Envoy sidecar traffic on Calico Open Source by using eBPF SOCKMAP to bypass kernel networking layers between the sidecar and the application.
 ---
 
 # Accelerate Istio network performance

--- a/calico/networking/configuring/use-ipvs.mdx
+++ b/calico/networking/configuring/use-ipvs.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use IPVS kube-proxy for performance improvements.
+description: Run kube-proxy in IPVS mode with Calico Open Source for constant-time service load balancing on clusters with thousands of services.
 ---
 
 # Use IPVS kube-proxy

--- a/calico/networking/configuring/vxlan-ipip.mdx
+++ b/calico/networking/configuring/vxlan-ipip.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to use IP in IP or VXLAN overlay networking so the underlying network doesn’t need to understand pod addresses.
+description: Pick between VXLAN and IP-in-IP overlay modes in Calico Open Source so pod traffic crosses underlay networks that don't route pod CIDRs natively.
 ---
 
 # Overlay networking

--- a/calico/networking/configuring/workloads-outside-cluster.mdx
+++ b/calico/networking/configuring/workloads-outside-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure networking to perform outbound NAT for connections from pods to outside of the cluster.
+description: Set NAT outgoing on Calico Open Source IP pools so pod traffic to destinations outside the cluster is source-NATed to the node's IP.
 ---
 
 # Configure outgoing NAT

--- a/calico/networking/determine-best-networking.mdx
+++ b/calico/networking/determine-best-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about the different networking options Calico supports so you can choose the best option for your needs.
+description: Compare networking options in Calico Open Source — overlay versus non-overlay, BGP routing, CNI choices, and IPAM modes — to pick the right combination for your environment.
 ---
 
 # Determine best networking option

--- a/calico/networking/index.mdx
+++ b/calico/networking/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico's flexible networking options reduce the barriers to adopting a CaaS platform solution. Determine the best networking option for your implementation.
+description: Calico Open Source networking spans overlay and non-overlay data planes, BGP, IPAM, MTU tuning, and Kubernetes Gateway API ingress for flexible cluster connectivity.
 ---
 
 import { DocCardLink, PaidProductDocCardLink, DocCardLinkLayout } from '/src/___new___/components';

--- a/calico/networking/ingress-gateway/about-calico-ingress-gateway.mdx
+++ b/calico/networking/ingress-gateway/about-calico-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Understand what Calico Ingress Gateway is and how it works.
+description: Overview of Calico Ingress Gateway in Calico Open Source — a hardened Envoy Gateway distribution that uses the Kubernetes Gateway API for cluster ingress.
 title: Calico Ingress Gateway
 ---
 

--- a/calico/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create an ingress gateway to manage ingress traffic with the Kubernetes Gateway API.
+description: Deploy a Calico Ingress Gateway on Calico Open Source by applying a GatewayAPI resource and a Gateway that references the Tigera-managed gateway class.
 ---
 
 # Create an ingress gateway

--- a/calico/networking/ingress-gateway/customize-ingress-gateway.mdx
+++ b/calico/networking/ingress-gateway/customize-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how to customize your ingress gateway.
+description: Customize a Calico Ingress Gateway in Calico Open Source through the GatewayAPI resource — node selectors, multiple gateway classes, pod metadata, and load balancer service options.
 ---
 
 # Customizing your ingress gateway

--- a/calico/networking/ingress-gateway/migrate-from-nginx.mdx
+++ b/calico/networking/ingress-gateway/migrate-from-nginx.mdx
@@ -1,5 +1,5 @@
 ---
-description: Migrate NGINX Ingress resources to Calico Ingress Gateway with a step-by-step workflow and an optional conversion tool.
+description: Migrate from NGINX Ingress to Calico Ingress Gateway on Calico Open Source, covering the Gateway API mental model, an annotation conversion tool, and a step-by-step workflow.
 title: Migrating from NGINX
 ---
 

--- a/calico/networking/ingress-gateway/tutorial-ingress-gateway-canary.mdx
+++ b/calico/networking/ingress-gateway/tutorial-ingress-gateway-canary.mdx
@@ -1,5 +1,5 @@
 ---
-description: Tutorial for ingress gateways and canary deployment
+description: Step-by-step tutorial for shipping a canary deployment with Calico Ingress Gateway on Calico Open Source by splitting HTTPRoute traffic between stable and new versions.
 title: "Tutorial: Canary deployment"
 ---
 

--- a/calico/networking/ipam/add-floating-ip.mdx
+++ b/calico/networking/ipam/add-floating-ip.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure one or more floating IPs to use as additional IP addresses for reaching a Kubernetes pod.
+description: Attach one or more floating IPs to a Kubernetes pod with Calico Open Source IPAM so external clients can reach the workload over any IP protocol.
 ---
 
 # Add a floating IP to a pod

--- a/calico/networking/ipam/assign-ip-addresses-topology.mdx
+++ b/calico/networking/ipam/assign-ip-addresses-topology.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to use specific IP pools for different topologies including zone, rack, or region.
+description: Bind Calico Open Source IP pools to specific zones, racks, or regions with node selectors so pods receive addresses that match the cluster topology.
 ---
 
 # Assign IP addresses based on topology

--- a/calico/networking/ipam/change-block-size.mdx
+++ b/calico/networking/ipam/change-block-size.mdx
@@ -1,5 +1,5 @@
 ---
-description: Expand or shrink the IP pool block size to efficiently manage IP pool addresses.
+description: Resize an IPPool block in Calico Open Source — by creating a replacement pool and migrating workloads — to use IP space more efficiently.
 ---
 
 # Change IP pool block size

--- a/calico/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico/networking/ipam/get-started-ip-addresses.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to use Calico IPAM or host-local IPAM, and when to use one or the other.
+description: Decide between Calico Open Source IPAM and host-local IPAM, then configure IP pool allocation, NAT outgoing, and per-namespace assignment.
 ---
 
 # Get started with IP address management

--- a/calico/networking/ipam/index.mdx
+++ b/calico/networking/ipam/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico IPAM is flexible and efficient. Learn how to interoperate with legacy firewalls using IP address ranges, advertise Kubernetes service IPs, and more.
+description: IP address management with Calico Open Source — IPPools, block sizes, dual-stack IPv6, service load balancer IPAM, topology-aware assignment, and pool migration.
 hide_table_of_contents: true
 ---
 

--- a/calico/networking/ipam/ip-autodetection.mdx
+++ b/calico/networking/ipam/ip-autodetection.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico IP autodetection ensures the correct IP address is used for routing. Learn how to customize it.
+description: Choose how Calico Open Source detects each node's primary IP address, with options for first-found, Kubernetes internal, interface regex, CIDR, and skip-interface.
 ---
 
 # Configure IP autodetection

--- a/calico/networking/ipam/ippools.mdx
+++ b/calico/networking/ipam/ippools.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create multiple IP pools
+description: Create additional Calico Open Source IPPool resources at install time or on a running cluster to serve disjoint ranges, IPv6, or per-topology pod address assignment.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico/networking/ipam/ipv6-control-plane.mdx
+++ b/calico/networking/ipam/ipv6-control-plane.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure the Kubernetes control plane to operate over IPv6 for dual stack or IPv6 only.
+description: Run the Kubernetes control plane over IPv6 with Calico Open Source for dual-stack or IPv6-only clusters, including kubeadm flags and node configuration.
 ---
 
 # Configure Kubernetes control plane to operate over IPv6

--- a/calico/networking/ipam/ipv6.mdx
+++ b/calico/networking/ipam/ipv6.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure dual stack or IPv6 only for workloads.
+description: Set up dual-stack or IPv6-only pod networking on Calico Open Source by configuring IP pools, node IP autodetection, and the CNI plugin.
 ---
 
 # Configure dual stack or IPv6 only

--- a/calico/networking/ipam/legacy-firewalls.mdx
+++ b/calico/networking/ipam/legacy-firewalls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Restrict the IP address chosen for a pod to a specific range of IP addresses.
+description: Restrict pods to a defined IP address range with Calico Open Source so legacy firewalls and security appliances can recognize cluster workloads.
 ---
 
 # Restrict a pod to use an IP address in a specific range

--- a/calico/networking/ipam/migrate-pools.mdx
+++ b/calico/networking/ipam/migrate-pools.mdx
@@ -1,5 +1,5 @@
 ---
-description: Migrate pods from one IP pool to another on a running cluster without network disruption.
+description: Migrate workloads from one Calico Open Source IPPool to another on a running cluster without disrupting existing pod connectivity.
 ---
 
 # Migrate from one IP pool to another

--- a/calico/networking/ipam/service-loadbalancer.mdx
+++ b/calico/networking/ipam/service-loadbalancer.mdx
@@ -1,5 +1,5 @@
 ---
-description: LoadBalancer IP address management
+description: Use the Calico Open Source LoadBalancer controller to allocate addresses to Kubernetes Service type LoadBalancer from configured IP pools.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico/networking/ipam/use-specific-ip.mdx
+++ b/calico/networking/ipam/use-specific-ip.mdx
@@ -1,5 +1,5 @@
 ---
-description: Specify the IP address for a pod instead of allowing Calico to automatically choose one.
+description: Pin a Kubernetes pod to a chosen IP address with Calico Open Source IPAM by setting a pod annotation that supplies the requested address.
 ---
 
 # Use a specific IP address with a pod

--- a/calico/networking/kubevirt/index.mdx
+++ b/calico/networking/kubevirt/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico networking for KubeVirt virtual machines.
+description: Run Calico Open Source as the network for KubeVirt virtual machines on Kubernetes, with persistent IPs, BGP routing, and live migration support.
 hide_table_of_contents: true
 ---
 

--- a/calico/networking/kubevirt/kubevirt-networking.mdx
+++ b/calico/networking/kubevirt/kubevirt-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to provide networking for KubeVirt virtual machines, including IP address persistence and live migration support.
+description: Configure Calico Open Source bridge-mode networking for KubeVirt VMs so each VM keeps the same IP across reboots, evictions, and live migrations.
 ---
 
 # KubeVirt networking

--- a/calico/networking/kubevirt/live-migration-bgp.mdx
+++ b/calico/networking/kubevirt/live-migration-bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP routing to support KubeVirt live migration across racks and AS boundaries.
+description: Configure BGPFilter resources in Calico Open Source so elevated route priorities propagate across racks and AS boundaries during KubeVirt live migration.
 ---
 
 # BGP routing for KubeVirt live migration

--- a/calico/networking/openstack/configuration.mdx
+++ b/calico/networking/openstack/configuration.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure OpenStack components for Calico.
+description: Configure Nova, Neutron, and DHCP agent settings on OpenStack compute hosts to run Calico Open Source as either a core plugin or an ML2 mechanism driver.
 ---
 
 # Configure systems for use with Calico

--- a/calico/networking/openstack/connectivity.mdx
+++ b/calico/networking/openstack/connectivity.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure OpenStack networking for Calico.
+description: Plan IPv4 and IPv6 address ranges, gateway routing, and Neutron network setup to connect Calico Open Source OpenStack VMs with the data center fabric.
 ---
 
 # IP addressing and connectivity

--- a/calico/networking/openstack/dev-machine-setup.mdx
+++ b/calico/networking/openstack/dev-machine-setup.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico networking for OpenStack VMs.
+description: Walk-through example of provisioning a developer VM on a Calico Open Source OpenStack cloud, with security groups, an external network attachment, and SSH access.
 ---
 
 # Set up a development machine

--- a/calico/networking/openstack/floating-ips.mdx
+++ b/calico/networking/openstack/floating-ips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure floating IPs in Calico for OpenStack.
+description: Allocate Neutron floating IPs against a Calico Open Source OpenStack tenant network, including router gateways, provider subnets, and core-plugin requirements.
 ---
 
 # Floating IPs

--- a/calico/networking/openstack/host-routes.mdx
+++ b/calico/networking/openstack/host-routes.mdx
@@ -1,5 +1,5 @@
 ---
-description: Options for host routing with Calico.
+description: Configure Neutron subnet host routes so the next-hop IP points at the local hypervisor in Calico Open Source OpenStack deployments and traffic flows correctly.
 ---
 
 # Host routes

--- a/calico/networking/openstack/index.mdx
+++ b/calico/networking/openstack/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico networking in an OpenStack deployment.
+description: Run Calico Open Source as the networking layer for an OpenStack cloud, covering Neutron integration, IP address ranges, floating IPs, and live migration.
 hide_table_of_contents: true
 ---
 

--- a/calico/networking/openstack/ipv6.mdx
+++ b/calico/networking/openstack/ipv6.mdx
@@ -1,5 +1,5 @@
 ---
-description: Prepare a VM guest OS for IPv6.
+description: Prepare a guest OS image for IPv6 connectivity on Calico Open Source OpenStack VMs by configuring DHCPv6 client behavior and accepting router advertisements.
 ---
 
 # Prepare a VM guest OS for IPv6

--- a/calico/networking/openstack/kuryr.mdx
+++ b/calico/networking/openstack/kuryr.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use Kuryr with Calico networking.
+description: Use Kuryr together with the networking-calico ML2 driver in Calico Open Source so Neutron provides networking for container workloads.
 ---
 
 # Kuryr

--- a/calico/networking/openstack/labels.mdx
+++ b/calico/networking/openstack/labels.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use Calico labels to define policy for OpenStack VMs.
+description: Reference for the project, network, security-group, and namespace labels that Calico Open Source places on WorkloadEndpoints for OpenStack VMs, plus how to use them in policy.
 ---
 
 # Endpoint labels and operator policy

--- a/calico/networking/openstack/live-migration.mdx
+++ b/calico/networking/openstack/live-migration.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure live migration support.
+description: Tune route priority and BGP propagation so Calico Open Source converges OpenStack VM traffic to the destination host quickly during live migration.
 ---
 
 # Live migration for OpenStack VMs

--- a/calico/networking/openstack/multiple-regions.mdx
+++ b/calico/networking/openstack/multiple-regions.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install a multi-region OpenStack deployment with Calico.
+description: Deploy Calico Open Source across multiple OpenStack regions sharing one etcd datastore, with per-region namespaces for inter-region policy.
 ---
 
 # Multiple regions

--- a/calico/networking/openstack/neutron-api.mdx
+++ b/calico/networking/openstack/neutron-api.mdx
@@ -1,5 +1,5 @@
 ---
-description: Effects of the Neutron API calls on the network.
+description: Reference for how Calico Open Source interprets each Neutron API call — networks, subnets, ports, security groups, and Horizon actions — in an OpenStack deployment.
 ---
 
 # Calico's interpretation of Neutron API calls

--- a/calico/networking/openstack/semantics.mdx
+++ b/calico/networking/openstack/semantics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico provides connectivity that is different from traditional Neutron API semantics.
+description: Reference for the IP-only connectivity model Calico Open Source provides between OpenStack instances, and how it differs from traditional Neutron L2 semantics.
 ---
 
 # Detailed semantics

--- a/calico/networking/openstack/service-ips.mdx
+++ b/calico/networking/openstack/service-ips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use a floating or fixed IP for a Calico-networked VM.
+description: Assign a service IP to a Calico Open Source OpenStack VM by attaching either a Neutron floating IP or an additional fixed IP on the VM port.
 ---
 
 # Service IPs

--- a/calico_versioned_docs/version-3.32/networking/configuring/add-maglev-load-balancing.mdx
+++ b/calico_versioned_docs/version-3.32/networking/configuring/add-maglev-load-balancing.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add Maglev load balancing to a Kubernetes service.
+description: Switch a Kubernetes service to Maglev consistent-hash load balancing on the Calico Open Source eBPF data plane for resilient backend selection.
 ---
 
 # Add Maglev load balancing to a service

--- a/calico_versioned_docs/version-3.32/networking/configuring/advertise-service-ips.mdx
+++ b/calico_versioned_docs/version-3.32/networking/configuring/advertise-service-ips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to advertise Kubernetes service cluster IPs and external IPs outside the cluster using BGP.
+description: Advertise Kubernetes service cluster IPs and external IPs out of the cluster over BGP with Calico Open Source so external clients can route to them directly.
 ---
 
 # Advertise Kubernetes service IP addresses

--- a/calico_versioned_docs/version-3.32/networking/configuring/bgp-to-workload.mdx
+++ b/calico_versioned_docs/version-3.32/networking/configuring/bgp-to-workload.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP peering with nested clusters running on KubeVirt VMs
+description: Peer Calico Open Source nodes with BGP speakers running inside KubeVirt VMs to support nested clusters and route announcements from workloads.
 ---
 
 # Configure BGP peering with nested clusters running on KubeVirt VMs

--- a/calico_versioned_docs/version-3.32/networking/configuring/bgp.mdx
+++ b/calico_versioned_docs/version-3.32/networking/configuring/bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP peering with full mesh, node-specific peering, ToR, and/or Calico route reflectors.
+description: Configure BGP peering for Calico Open Source — full mesh, node-specific peers, top-of-rack switches, and Calico route reflectors — using BGPPeer and BGPConfiguration resources.
 ---
 
 # Configure BGP peering

--- a/calico_versioned_docs/version-3.32/networking/configuring/index.mdx
+++ b/calico_versioned_docs/version-3.32/networking/configuring/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico networking options, including overlay, non-overlay, BGP, service advertisement, MTU, NAT, and using kube-proxy in IPVS mode.
+description: Networking configuration tasks for Calico Open Source — BGP, overlay encapsulation, service advertisement, MTU, NAT, IPVS kube-proxy, and QoS controls.
 hide_table_of_contents: true
 ---
 

--- a/calico_versioned_docs/version-3.32/networking/configuring/mtu.mdx
+++ b/calico_versioned_docs/version-3.32/networking/configuring/mtu.mdx
@@ -1,5 +1,5 @@
 ---
-description: Optimize network performance for workloads by configuring the MTU in Calico to best suit your underlying network.
+description: Tune the Calico Open Source MTU on the FelixConfiguration resource so pod traffic matches the underlying network, including VXLAN, IP-in-IP, and WireGuard overheads.
 ---
 
 # Configure MTU to maximize network performance

--- a/calico_versioned_docs/version-3.32/networking/configuring/node-local-dns-cache.mdx
+++ b/calico_versioned_docs/version-3.32/networking/configuring/node-local-dns-cache.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install NodeLocal DNSCache
+description: Install NodeLocal DNSCache alongside Calico Open Source and configure network policy that lets pod DNS traffic reach the local cache.
 ---
 
 # Use NodeLocal DNSCache in your cluster

--- a/calico_versioned_docs/version-3.32/networking/configuring/pod-mac-address.mdx
+++ b/calico_versioned_docs/version-3.32/networking/configuring/pod-mac-address.mdx
@@ -1,5 +1,5 @@
 ---
-description: Specify the MAC address for a pod instead of allowing the operating system to assign one
+description: Set a chosen MAC address on a Kubernetes pod interface with the Calico Open Source CNI plugin, useful for software licensing tied to MAC.
 ---
 
 # Use a specific MAC address for a pod

--- a/calico_versioned_docs/version-3.32/networking/configuring/qos-controls.mdx
+++ b/calico_versioned_docs/version-3.32/networking/configuring/qos-controls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure QoS (Quality of Service) Controls to limit ingress and/or egress bandwidth, packet rate and number of connections of Calico workloads.
+description: Cap pod ingress and egress bandwidth, packet rate, and connection counts with Calico Open Source QoS controls, plus DiffServ marking on egress traffic.
 ---
 
 # Configure QoS Controls

--- a/calico_versioned_docs/version-3.32/networking/configuring/sidecar-acceleration.mdx
+++ b/calico_versioned_docs/version-3.32/networking/configuring/sidecar-acceleration.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use Calico to accelerate network performance of traffic through the Istio Envoy sidecar using eBPF.
+description: Accelerate Istio Envoy sidecar traffic on Calico Open Source by using eBPF SOCKMAP to bypass kernel networking layers between the sidecar and the application.
 ---
 
 # Accelerate Istio network performance

--- a/calico_versioned_docs/version-3.32/networking/configuring/use-ipvs.mdx
+++ b/calico_versioned_docs/version-3.32/networking/configuring/use-ipvs.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use IPVS kube-proxy for performance improvements.
+description: Run kube-proxy in IPVS mode with Calico Open Source for constant-time service load balancing on clusters with thousands of services.
 ---
 
 # Use IPVS kube-proxy

--- a/calico_versioned_docs/version-3.32/networking/configuring/vxlan-ipip.mdx
+++ b/calico_versioned_docs/version-3.32/networking/configuring/vxlan-ipip.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to use IP in IP or VXLAN overlay networking so the underlying network doesn’t need to understand pod addresses.
+description: Pick between VXLAN and IP-in-IP overlay modes in Calico Open Source so pod traffic crosses underlay networks that don't route pod CIDRs natively.
 ---
 
 # Overlay networking

--- a/calico_versioned_docs/version-3.32/networking/configuring/workloads-outside-cluster.mdx
+++ b/calico_versioned_docs/version-3.32/networking/configuring/workloads-outside-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure networking to perform outbound NAT for connections from pods to outside of the cluster.
+description: Set NAT outgoing on Calico Open Source IP pools so pod traffic to destinations outside the cluster is source-NATed to the node's IP.
 ---
 
 # Configure outgoing NAT

--- a/calico_versioned_docs/version-3.32/networking/determine-best-networking.mdx
+++ b/calico_versioned_docs/version-3.32/networking/determine-best-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about the different networking options Calico supports so you can choose the best option for your needs.
+description: Compare networking options in Calico Open Source — overlay versus non-overlay, BGP routing, CNI choices, and IPAM modes — to pick the right combination for your environment.
 ---
 
 # Determine best networking option

--- a/calico_versioned_docs/version-3.32/networking/index.mdx
+++ b/calico_versioned_docs/version-3.32/networking/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico's flexible networking options reduce the barriers to adopting a CaaS platform solution. Determine the best networking option for your implementation.
+description: Calico Open Source networking spans overlay and non-overlay data planes, BGP, IPAM, MTU tuning, and Kubernetes Gateway API ingress for flexible cluster connectivity.
 ---
 
 import { DocCardLink, PaidProductDocCardLink, DocCardLinkLayout } from '/src/___new___/components';

--- a/calico_versioned_docs/version-3.32/networking/ingress-gateway/about-calico-ingress-gateway.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ingress-gateway/about-calico-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Understand what Calico Ingress Gateway is and how it works.
+description: Overview of Calico Ingress Gateway in Calico Open Source — a hardened Envoy Gateway distribution that uses the Kubernetes Gateway API for cluster ingress.
 title: Calico Ingress Gateway
 ---
 

--- a/calico_versioned_docs/version-3.32/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create an ingress gateway to manage ingress traffic with the Kubernetes Gateway API.
+description: Deploy a Calico Ingress Gateway on Calico Open Source by applying a GatewayAPI resource and a Gateway that references the Tigera-managed gateway class.
 ---
 
 # Create an ingress gateway

--- a/calico_versioned_docs/version-3.32/networking/ingress-gateway/customize-ingress-gateway.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ingress-gateway/customize-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn how to customize your ingress gateway.
+description: Customize a Calico Ingress Gateway in Calico Open Source through the GatewayAPI resource — node selectors, multiple gateway classes, pod metadata, and load balancer service options.
 ---
 
 # Customizing your ingress gateway

--- a/calico_versioned_docs/version-3.32/networking/ingress-gateway/migrate-from-nginx.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ingress-gateway/migrate-from-nginx.mdx
@@ -1,5 +1,5 @@
 ---
-description: Migrate NGINX Ingress resources to Calico Ingress Gateway with a step-by-step workflow and an optional conversion tool.
+description: Migrate from NGINX Ingress to Calico Ingress Gateway on Calico Open Source, covering the Gateway API mental model, an annotation conversion tool, and a step-by-step workflow.
 title: Migrating from NGINX
 ---
 

--- a/calico_versioned_docs/version-3.32/networking/ingress-gateway/tutorial-ingress-gateway-canary.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ingress-gateway/tutorial-ingress-gateway-canary.mdx
@@ -1,5 +1,5 @@
 ---
-description: Tutorial for ingress gateways and canary deployment
+description: Step-by-step tutorial for shipping a canary deployment with Calico Ingress Gateway on Calico Open Source by splitting HTTPRoute traffic between stable and new versions.
 title: "Tutorial: Canary deployment"
 ---
 

--- a/calico_versioned_docs/version-3.32/networking/ipam/add-floating-ip.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ipam/add-floating-ip.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure one or more floating IPs to use as additional IP addresses for reaching a Kubernetes pod.
+description: Attach one or more floating IPs to a Kubernetes pod with Calico Open Source IPAM so external clients can reach the workload over any IP protocol.
 ---
 
 # Add a floating IP to a pod

--- a/calico_versioned_docs/version-3.32/networking/ipam/assign-ip-addresses-topology.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ipam/assign-ip-addresses-topology.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to use specific IP pools for different topologies including zone, rack, or region.
+description: Bind Calico Open Source IP pools to specific zones, racks, or regions with node selectors so pods receive addresses that match the cluster topology.
 ---
 
 # Assign IP addresses based on topology

--- a/calico_versioned_docs/version-3.32/networking/ipam/change-block-size.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ipam/change-block-size.mdx
@@ -1,5 +1,5 @@
 ---
-description: Expand or shrink the IP pool block size to efficiently manage IP pool addresses.
+description: Resize an IPPool block in Calico Open Source — by creating a replacement pool and migrating workloads — to use IP space more efficiently.
 ---
 
 # Change IP pool block size

--- a/calico_versioned_docs/version-3.32/networking/ipam/get-started-ip-addresses.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ipam/get-started-ip-addresses.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to use Calico IPAM or host-local IPAM, and when to use one or the other.
+description: Decide between Calico Open Source IPAM and host-local IPAM, then configure IP pool allocation, NAT outgoing, and per-namespace assignment.
 ---
 
 # Get started with IP address management

--- a/calico_versioned_docs/version-3.32/networking/ipam/index.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ipam/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico IPAM is flexible and efficient. Learn how to interoperate with legacy firewalls using IP address ranges, advertise Kubernetes service IPs, and more.
+description: IP address management with Calico Open Source — IPPools, block sizes, dual-stack IPv6, service load balancer IPAM, topology-aware assignment, and pool migration.
 hide_table_of_contents: true
 ---
 

--- a/calico_versioned_docs/version-3.32/networking/ipam/ip-autodetection.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ipam/ip-autodetection.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico IP autodetection ensures the correct IP address is used for routing. Learn how to customize it.
+description: Choose how Calico Open Source detects each node's primary IP address, with options for first-found, Kubernetes internal, interface regex, CIDR, and skip-interface.
 ---
 
 # Configure IP autodetection

--- a/calico_versioned_docs/version-3.32/networking/ipam/ippools.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ipam/ippools.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create multiple IP pools
+description: Create additional Calico Open Source IPPool resources at install time or on a running cluster to serve disjoint ranges, IPv6, or per-topology pod address assignment.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico_versioned_docs/version-3.32/networking/ipam/ipv6-control-plane.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ipam/ipv6-control-plane.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure the Kubernetes control plane to operate over IPv6 for dual stack or IPv6 only.
+description: Run the Kubernetes control plane over IPv6 with Calico Open Source for dual-stack or IPv6-only clusters, including kubeadm flags and node configuration.
 ---
 
 # Configure Kubernetes control plane to operate over IPv6

--- a/calico_versioned_docs/version-3.32/networking/ipam/ipv6.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ipam/ipv6.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure dual stack or IPv6 only for workloads.
+description: Set up dual-stack or IPv6-only pod networking on Calico Open Source by configuring IP pools, node IP autodetection, and the CNI plugin.
 ---
 
 # Configure dual stack or IPv6 only

--- a/calico_versioned_docs/version-3.32/networking/ipam/legacy-firewalls.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ipam/legacy-firewalls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Restrict the IP address chosen for a pod to a specific range of IP addresses.
+description: Restrict pods to a defined IP address range with Calico Open Source so legacy firewalls and security appliances can recognize cluster workloads.
 ---
 
 # Restrict a pod to use an IP address in a specific range

--- a/calico_versioned_docs/version-3.32/networking/ipam/migrate-pools.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ipam/migrate-pools.mdx
@@ -1,5 +1,5 @@
 ---
-description: Migrate pods from one IP pool to another on a running cluster without network disruption.
+description: Migrate workloads from one Calico Open Source IPPool to another on a running cluster without disrupting existing pod connectivity.
 ---
 
 # Migrate from one IP pool to another

--- a/calico_versioned_docs/version-3.32/networking/ipam/service-loadbalancer.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ipam/service-loadbalancer.mdx
@@ -1,5 +1,5 @@
 ---
-description: LoadBalancer IP address management
+description: Use the Calico Open Source LoadBalancer controller to allocate addresses to Kubernetes Service type LoadBalancer from configured IP pools.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico_versioned_docs/version-3.32/networking/ipam/use-specific-ip.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ipam/use-specific-ip.mdx
@@ -1,5 +1,5 @@
 ---
-description: Specify the IP address for a pod instead of allowing Calico to automatically choose one.
+description: Pin a Kubernetes pod to a chosen IP address with Calico Open Source IPAM by setting a pod annotation that supplies the requested address.
 ---
 
 # Use a specific IP address with a pod

--- a/calico_versioned_docs/version-3.32/networking/kubevirt/index.mdx
+++ b/calico_versioned_docs/version-3.32/networking/kubevirt/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico networking for KubeVirt virtual machines.
+description: Run Calico Open Source as the network for KubeVirt virtual machines on Kubernetes, with persistent IPs, BGP routing, and live migration support.
 hide_table_of_contents: true
 ---
 

--- a/calico_versioned_docs/version-3.32/networking/kubevirt/kubevirt-networking.mdx
+++ b/calico_versioned_docs/version-3.32/networking/kubevirt/kubevirt-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to provide networking for KubeVirt virtual machines, including IP address persistence and live migration support.
+description: Configure Calico Open Source bridge-mode networking for KubeVirt VMs so each VM keeps the same IP across reboots, evictions, and live migrations.
 ---
 
 # KubeVirt networking

--- a/calico_versioned_docs/version-3.32/networking/kubevirt/live-migration-bgp.mdx
+++ b/calico_versioned_docs/version-3.32/networking/kubevirt/live-migration-bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP routing to support KubeVirt live migration across racks and AS boundaries.
+description: Configure BGPFilter resources in Calico Open Source so elevated route priorities propagate across racks and AS boundaries during KubeVirt live migration.
 ---
 
 # BGP routing for KubeVirt live migration

--- a/calico_versioned_docs/version-3.32/networking/openstack/configuration.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/configuration.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure OpenStack components for Calico.
+description: Configure Nova, Neutron, and DHCP agent settings on OpenStack compute hosts to run Calico Open Source as either a core plugin or an ML2 mechanism driver.
 ---
 
 # Configure systems for use with Calico

--- a/calico_versioned_docs/version-3.32/networking/openstack/connectivity.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/connectivity.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure OpenStack networking for Calico.
+description: Plan IPv4 and IPv6 address ranges, gateway routing, and Neutron network setup to connect Calico Open Source OpenStack VMs with the data center fabric.
 ---
 
 # IP addressing and connectivity

--- a/calico_versioned_docs/version-3.32/networking/openstack/dev-machine-setup.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/dev-machine-setup.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico networking for OpenStack VMs.
+description: Walk-through example of provisioning a developer VM on a Calico Open Source OpenStack cloud, with security groups, an external network attachment, and SSH access.
 ---
 
 # Set up a development machine

--- a/calico_versioned_docs/version-3.32/networking/openstack/floating-ips.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/floating-ips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure floating IPs in Calico for OpenStack.
+description: Allocate Neutron floating IPs against a Calico Open Source OpenStack tenant network, including router gateways, provider subnets, and core-plugin requirements.
 ---
 
 # Floating IPs

--- a/calico_versioned_docs/version-3.32/networking/openstack/host-routes.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/host-routes.mdx
@@ -1,5 +1,5 @@
 ---
-description: Options for host routing with Calico.
+description: Configure Neutron subnet host routes so the next-hop IP points at the local hypervisor in Calico Open Source OpenStack deployments and traffic flows correctly.
 ---
 
 # Host routes

--- a/calico_versioned_docs/version-3.32/networking/openstack/index.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico networking in an OpenStack deployment.
+description: Run Calico Open Source as the networking layer for an OpenStack cloud, covering Neutron integration, IP address ranges, floating IPs, and live migration.
 hide_table_of_contents: true
 ---
 

--- a/calico_versioned_docs/version-3.32/networking/openstack/ipv6.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/ipv6.mdx
@@ -1,5 +1,5 @@
 ---
-description: Prepare a VM guest OS for IPv6.
+description: Prepare a guest OS image for IPv6 connectivity on Calico Open Source OpenStack VMs by configuring DHCPv6 client behavior and accepting router advertisements.
 ---
 
 # Prepare a VM guest OS for IPv6

--- a/calico_versioned_docs/version-3.32/networking/openstack/kuryr.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/kuryr.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use Kuryr with Calico networking.
+description: Use Kuryr together with the networking-calico ML2 driver in Calico Open Source so Neutron provides networking for container workloads.
 ---
 
 # Kuryr

--- a/calico_versioned_docs/version-3.32/networking/openstack/labels.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/labels.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use Calico labels to define policy for OpenStack VMs.
+description: Reference for the project, network, security-group, and namespace labels that Calico Open Source places on WorkloadEndpoints for OpenStack VMs, plus how to use them in policy.
 ---
 
 # Endpoint labels and operator policy

--- a/calico_versioned_docs/version-3.32/networking/openstack/live-migration.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/live-migration.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure live migration support.
+description: Tune route priority and BGP propagation so Calico Open Source converges OpenStack VM traffic to the destination host quickly during live migration.
 ---
 
 # Live migration for OpenStack VMs

--- a/calico_versioned_docs/version-3.32/networking/openstack/multiple-regions.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/multiple-regions.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install a multi-region OpenStack deployment with Calico.
+description: Deploy Calico Open Source across multiple OpenStack regions sharing one etcd datastore, with per-region namespaces for inter-region policy.
 ---
 
 # Multiple regions

--- a/calico_versioned_docs/version-3.32/networking/openstack/neutron-api.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/neutron-api.mdx
@@ -1,5 +1,5 @@
 ---
-description: Effects of the Neutron API calls on the network.
+description: Reference for how Calico Open Source interprets each Neutron API call — networks, subnets, ports, security groups, and Horizon actions — in an OpenStack deployment.
 ---
 
 # Calico's interpretation of Neutron API calls

--- a/calico_versioned_docs/version-3.32/networking/openstack/semantics.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/semantics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico provides connectivity that is different from traditional Neutron API semantics.
+description: Reference for the IP-only connectivity model Calico Open Source provides between OpenStack instances, and how it differs from traditional Neutron L2 semantics.
 ---
 
 # Detailed semantics

--- a/calico_versioned_docs/version-3.32/networking/openstack/service-ips.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/service-ips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use a floating or fixed IP for a Calico-networked VM.
+description: Assign a service IP to a Calico Open Source OpenStack VM by attaching either a Neutron floating IP or an additional fixed IP on the VM port.
 ---
 
 # Service IPs


### PR DESCRIPTION
## Summary

Rewrites the `description` frontmatter on every page in the networking book across the three unversioned (next-release) source trees — 137 files, 1-line replacement each. Same rule set as [#2696](https://github.com/tigera/docs/pull/2696) and [#2697](https://github.com/tigera/docs/pull/2697).

| Tree | Files |
|------|--:|
| `calico/networking/` | 50 |
| `calico-enterprise/networking/` | 46 |
| `calico-cloud/networking/` | 41 |
| **Total** | **137** |

This PR is **next-only on purpose** — landing on the unversioned source first so the descriptions can get review without being pre-mirrored to versioned snapshots that would all need amending if anything changes. After review, I will mirror to the published latest-version snapshots in a follow-up.

## What every new description follows

1. Names exactly one canonical product (`Calico Open Source`, `Calico Enterprise`, `Calico Cloud`).
2. ≤ 200 characters.
3. Action-led on procedural pages; noun-led on reference, requirements, troubleshooting, and overview pages per the `docs-frontmatter-description` skill's content-type rules.
4. No `enable`, `disable`, or `teaching`.
5. Unique across products.
6. Vale-clean on line 2 (frontmatter description line).

## What was wrong before

Pre-fix snapshot of the same files:

- **0 forbidden-word hits** — none in this bucket pre-fix.
- **0 descriptions over 200 chars** — none in this bucket pre-fix.
- **123 of 137 missing a canonical product name** — descriptions used the `$[prodname]` template variable (which Docusaurus does not interpolate inside frontmatter) or the bare word "Calico", instead of the canonical product names. Rewrites use the explicit canonical product everywhere.
- **37 cross-product literal duplicates** — features that exist in all three products (BGP peering, MTU tuning, VXLAN/IP-in-IP, IPAM, IPPools, egress gateways, ingress gateways, KubeVirt, training, dual ToR, etc.) had identical descriptions across product directories. Now disambiguated by product-specific context: Calico Cloud's "connected clusters" framing, Calico Enterprise's cluster / management-UI framing, Calico Open Source's resource-only framing.

## Verification

Run from repo root on this branch:

```
grep -nEri "^description:.*\b(enable|disable|teaching)\b" \
  calico/networking calico-enterprise/networking calico-cloud/networking
```

Length, canonical-name presence, and cross-product-uniqueness checks are equivalent one-liners over the same three directories. All four return empty post-fix.

## Test plan

- [ ] Run the forbidden-word grep above and confirm empty.
- [ ] Spot-check a handful of cross-product triples (e.g., `configuring/bgp.mdx`, `configuring/mtu.mdx`, `ipam/ippools.mdx`, `egress/index.mdx`) for distinguishability.
- [ ] Spot-check 5 random rewrites against page bodies for accuracy.
- [ ] After review, mirror to latest-version snapshots (`calico_versioned_docs/version-3.32/networking/`, `calico-enterprise_versioned_docs/version-3.23-1/networking/`, `calico-enterprise_versioned_docs/version-3.22-2/networking/`, `calico-cloud_versioned_docs/version-22-2/networking/`).