### PR TITLE
Add security updates note to CE 3.22.4 release notes

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -361,5 +361,6 @@ May 6, 2026
 
 * Fixed and issue that caused the `calico-apiserver` to log `[SHOULD NOT HAPPEN] failed to update managedFields ... no corresponding type for projectcalico.org/v3, Kind=...` on every Calico v3 resource update.
 * Restored correct OpenAPI definition names for ArgoCD schema validation.
+* Security updates.
 
 To update an existing installation of Calico Enterprise 3.22, see [Install a patch release](../getting-started/manifest-archive.mdx).


### PR DESCRIPTION
## Summary
- Added `* Security updates.` to the bug fixes list under the Calico Enterprise 3.22.4 bug fix release section, matching the pattern used in the prior 3.22.4 entry.

## Test plan
- [ ] Render preview of `calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx` and confirm the bullet appears under the 3.22.4 bug fix list.