### PR TITLE
[DOCS] Document netkit pod interfaces for Calico CNI (tech preview)

### DIFF
--- a/calico/operations/ebpf/enabling-ebpf.mdx
+++ b/calico/operations/ebpf/enabling-ebpf.mdx
@@ -420,6 +420,47 @@ calicoctl patch felixconfiguration default --patch='{"spec": {"bpfExternalServic
 
 Switching external traffic mode can disrupt in-progress connections.
 
+## Use netkit pod interfaces (tech preview)
+
+:::note
+
+This feature is tech preview. Tech preview features may be subject to significant changes before they become GA.
+
+:::
+
+By default, the Calico CNI plugin creates a veth pair for each pod's network interface.
+On Linux 6.7 and later, you can opt the CNI plugin into creating a [netkit](https://docs.kernel.org/networking/netkit.html) L2 pair instead.
+With netkit, the eBPF data plane attaches its policy and forwarding programs via `BPF_NETKIT_PRIMARY` inside `ndo_start_xmit()`, which improves throughput and tail latency under contention compared to attaching via TC/TCX on a veth.
+
+Netkit is recommended for the eBPF data plane.
+For the iptables and nftables data planes it is functionally equivalent to veth.
+
+***Prerequisites***
+
+* Kernel 6.7 or later on every node where you want netkit interfaces.
+  Older kernels silently fall back to veth, so it is safe to set the field on heterogeneous clusters &mdash; but only nodes on a 6.7+ kernel will see the performance benefit.
+* You are using the Calico CNI plugin (`spec.cni.type: Calico`).
+
+***Procedure***
+
+Set `spec.calicoNetwork.linuxPodInterfaceType` to `Netkit` on the operator's `Installation` resource:
+
+```bash
+kubectl patch installation.operator.tigera.io default --type merge -p '{"spec":{"calicoNetwork":{"linuxPodInterfaceType":"Netkit"}}}'
+```
+
+The operator updates the CNI configuration on each node.
+Existing pods keep their veth interfaces; new pods (and pods that are restarted) get netkit interfaces on nodes that support them.
+
+To revert to veth, set the field back to `Veth` (or remove it):
+
+```bash
+kubectl patch installation.operator.tigera.io default --type merge -p '{"spec":{"calicoNetwork":{"linuxPodInterfaceType":"Veth"}}}'
+```
+
+Existing pods keep their netkit interfaces, but the eBPF data plane treats those as veth (programs attach via TC/TCX, the same path used for actual veth interfaces).
+Only newly created pods get veth interfaces.
+
 ## Reversing the process
 
 To revert to standard Linux networking:

--- a/calico/operations/ebpf/enabling-ebpf.mdx
+++ b/calico/operations/ebpf/enabling-ebpf.mdx
@@ -438,7 +438,7 @@ For the iptables and nftables data planes it is functionally equivalent to veth.
 ***Prerequisites***
 
 * Kernel 6.7 or later on every node where you want netkit interfaces.
-  Older kernels silently fall back to veth, so it is safe to set the field on heterogeneous clusters &mdash; but only nodes on a 6.7+ kernel will see the performance benefit.
+  Older kernels silently fall back to veth, so it is safe to set the field on heterogeneous clusters — but only nodes on a 6.7+ kernel will see the performance benefit.
 * You are using the Calico CNI plugin (`spec.cni.type: Calico`).
 
 ***Procedure***


### PR DESCRIPTION
Product Version(s):
Calico Open Source (next, master)

Issue:
Companion to [projectcalico/calico#12619](https://github.com/projectcalico/calico/pull/12619) (CNI support for `device_type: netkit`) and [tigera/operator#4767](https://github.com/tigera/operator/pull/4767) (operator-side `linuxPodInterfaceType` field). Tracked under [CORE-10672](https://tigera.atlassian.net/browse/CORE-10672).

Link to docs preview:
_Will fill in once the build finishes._

SME review:
- [ ] An SME has approved this change.

DOCS review:
- [ ] A member of the docs team has approved this change.

Additional information:

Adds a tech-preview section to `calico/operations/ebpf/enabling-ebpf.mdx` describing how to opt the Calico CNI plugin into creating netkit L2 pairs (Linux 6.7+) instead of veth, via `spec.calicoNetwork.linuxPodInterfaceType=Netkit` on the operator `Installation`. Covers:

- The performance motivation (BPF programs attach via `BPF_NETKIT_PRIMARY` inside `ndo_start_xmit()` for better throughput and tail latency under contention).
- The 6.7 kernel prerequisite, with the silent fallback to veth on older kernels (so the field is safe on heterogeneous clusters).
- Reverting: existing netkit interfaces stay, but the eBPF data plane treats them as veth (TC/TCX) — only newly created pods get veth.

Notes:
- The `_api.mdx` reference is auto-generated from the operator API by `crd-ref-docs`, so the new `LinuxPodInterfaceType` field will pick up automatically on the next docs build.
- This page is in `calico/operations/ebpf/`; the new section is contextually with the eBPF data plane because that is where the perf benefit applies.

Merge checklist:
- [ ] Deploy preview inspected wherever changes were made
- [ ] Build completed successfully
- [ ] Tests have passed


[CORE-10672]: https://tigera.atlassian.net/browse/CORE-10672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ