### PR TITLE
Rewrite about/landing-page descriptions (next trees)

### DIFF
--- a/calico-cloud/about/calico-product-editions.mdx
+++ b/calico-cloud/about/calico-product-editions.mdx
@@ -1,5 +1,5 @@
 ---
-description: Compare Calico product editions to find the right one for your needs.
+description: Side-by-side comparison of Calico Cloud against Calico Open Source and Calico Enterprise across SaaS management, networking, security, and observability features.
 ---
 
 import { CheckIcon } from '@chakra-ui/icons';

--- a/calico-cloud/about/index.mdx
+++ b/calico-cloud/about/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: A brief description of Calico, deployment options, and features.
+description: Overview of Calico Cloud, the Tigera-hosted managed SaaS for Kubernetes networking, network security, and observability across connected clusters.
 ---
 
 import { DocCardLink, DocCardLinkLayout, PaidProductDocCardLink } from '/src/___new___/components';

--- a/calico-cloud/get-help/support.mdx
+++ b/calico-cloud/get-help/support.mdx
@@ -1,5 +1,5 @@
 ---
-description: Ways to get help and provide feedback.
+description: Support and feedback channels for Calico Cloud users, including the Tigera support portal, in-console help, status page, and the Calico Cloud support policy.
 ---
 
 import IconUser from '/img/icons/user-icon.svg';

--- a/calico-cloud_versioned_docs/version-22-2/about/calico-product-editions.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/about/calico-product-editions.mdx
@@ -1,5 +1,5 @@
 ---
-description: Compare Calico product editions to find the right one for your needs.
+description: Side-by-side comparison of Calico Cloud against Calico Open Source and Calico Enterprise across SaaS management, networking, security, and observability features.
 ---
 
 import { CheckIcon } from '@chakra-ui/icons';

--- a/calico-cloud_versioned_docs/version-22-2/about/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/about/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: A brief description of Calico, deployment options, and features.
+description: Overview of Calico Cloud, the Tigera-hosted managed SaaS for Kubernetes networking, network security, and observability across connected clusters.
 ---
 
 import { DocCardLink, DocCardLinkLayout, PaidProductDocCardLink } from '/src/___new___/components';

--- a/calico-cloud_versioned_docs/version-22-2/get-help/support.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/get-help/support.mdx
@@ -1,5 +1,5 @@
 ---
-description: Ways to get help and provide feedback.
+description: Support and feedback channels for Calico Cloud users, including the Tigera support portal, in-console help, status page, and the Calico Cloud support policy.
 ---
 
 import IconUser from '/img/icons/user-icon.svg';

--- a/calico-enterprise/about/calico-product-editions.mdx
+++ b/calico-enterprise/about/calico-product-editions.mdx
@@ -1,5 +1,5 @@
 ---
-description: Compare Calico product editions to find the right one for your needs.
+description: Side-by-side comparison of Calico Enterprise against Calico Open Source and Calico Cloud across management, networking, security, and observability features.
 ---
 
 import { CheckIcon } from '@chakra-ui/icons';

--- a/calico-enterprise/about/index.mdx
+++ b/calico-enterprise/about/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: A brief description of Calico, deployment options, and features.
+description: Overview of Calico Enterprise, the self-managed, Tigera-supported distribution for Kubernetes networking, security, and observability in production clusters.
 ---
 
 import { DocCardLink, DocCardLinkLayout, PaidProductDocCardLink } from '/src/___new___/components';

--- a/calico-enterprise/installation/install-calico-enterprise-mke-4k.mdx
+++ b/calico-enterprise/installation/install-calico-enterprise-mke-4k.mdx
@@ -1,5 +1,5 @@
 ---
-description: Draft installation guide for Mirantis Kubernetes Engine 4k
+description: Install Calico Enterprise on Mirantis Kubernetes Engine 4k by configuring the custom CNI provider and deploying with the Tigera Operator during cluster provisioning.
 title: Mirantis Kubernetes Engine 4k (MKE 4k)
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/about/calico-product-editions.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/about/calico-product-editions.mdx
@@ -1,5 +1,5 @@
 ---
-description: Compare Calico product editions to find the right one for your needs.
+description: Side-by-side comparison of Calico Enterprise against Calico Open Source and Calico Cloud across management, networking, security, and observability features.
 ---
 
 import { CheckIcon } from '@chakra-ui/icons';

--- a/calico-enterprise_versioned_docs/version-3.22-2/about/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/about/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: A brief description of Calico, deployment options, and features.
+description: Overview of Calico Enterprise, the self-managed, Tigera-supported distribution for Kubernetes networking, security, and observability in production clusters.
 ---
 
 import { DocCardLink, DocCardLinkLayout, PaidProductDocCardLink } from '/src/___new___/components';

--- a/calico-enterprise_versioned_docs/version-3.22-2/installation/install-calico-enterprise-mke-4k.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/installation/install-calico-enterprise-mke-4k.mdx
@@ -1,5 +1,5 @@
 ---
-description: Draft installation guide for Mirantis Kubernetes Engine 4k
+description: Install Calico Enterprise on Mirantis Kubernetes Engine 4k by configuring the custom CNI provider and deploying with the Tigera Operator during cluster provisioning.
 title: Mirantis Kubernetes Engine 4k (MKE 4k)
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/about/calico-product-editions.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/about/calico-product-editions.mdx
@@ -1,5 +1,5 @@
 ---
-description: Compare Calico product editions to find the right one for your needs.
+description: Side-by-side comparison of Calico Enterprise against Calico Open Source and Calico Cloud across management, networking, security, and observability features.
 ---
 
 import { CheckIcon } from '@chakra-ui/icons';

--- a/calico-enterprise_versioned_docs/version-3.23-1/about/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/about/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: A brief description of Calico, deployment options, and features.
+description: Overview of Calico Enterprise, the self-managed, Tigera-supported distribution for Kubernetes networking, security, and observability in production clusters.
 ---
 
 import { DocCardLink, DocCardLinkLayout, PaidProductDocCardLink } from '/src/___new___/components';

--- a/calico-enterprise_versioned_docs/version-3.23-1/installation/install-calico-enterprise-mke-4k.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/installation/install-calico-enterprise-mke-4k.mdx
@@ -1,5 +1,5 @@
 ---
-description: Draft installation guide for Mirantis Kubernetes Engine 4k
+description: Install Calico Enterprise on Mirantis Kubernetes Engine 4k by configuring the custom CNI provider and deploying with the Tigera Operator during cluster provisioning.
 title: Mirantis Kubernetes Engine 4k (MKE 4k)
 ---
 

--- a/calico/about/calico-product-editions.mdx
+++ b/calico/about/calico-product-editions.mdx
@@ -1,5 +1,5 @@
 ---
-description: Compare Calico product editions to find the right one for your needs.
+description: Compare Calico Open Source with Calico Cloud and Calico Enterprise across networking, security, and observability capabilities to pick the right edition.
 ---
 
 import { CheckIcon } from '@chakra-ui/icons';

--- a/calico/about/index.mdx
+++ b/calico/about/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: A brief description of Calico, deployment options, and features.
+description: Overview of Calico Open Source, the upstream Calico project for Kubernetes networking, network security, and observability across any cluster.
 ---
 
 import { DocCardLink, DocCardLinkLayout, PaidProductDocCardLink } from '/src/___new___/components';

--- a/calico/about/kubernetes-training/about-ebpf.mdx
+++ b/calico/about/kubernetes-training/about-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about eBPF!
+description: Background on eBPF and how the Calico Open Source eBPF data plane improves throughput, latency, and source IP preservation versus the standard Linux data plane.
 ---
 
 # About Calico eBPF

--- a/calico/about/kubernetes-training/about-k8s-networking.mdx
+++ b/calico/about/kubernetes-training/about-k8s-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about Kubernetes networking!
+description: Background on the Kubernetes network model, services, DNS, NAT outgoing, and dual-stack networking concepts that underpin Calico Open Source deployments.
 ---
 
 # About Kubernetes Networking

--- a/calico/about/kubernetes-training/about-kubernetes-egress.mdx
+++ b/calico/about/kubernetes-training/about-kubernetes-egress.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn why you should restrict egress traffic and how to do it.
+description: Background on Kubernetes egress traffic, including outgoing NAT, restricting outbound connections, and egress gateways for Calico Open Source clusters.
 ---
 
 # Kubernetes egress

--- a/calico/about/kubernetes-training/about-kubernetes-ingress.mdx
+++ b/calico/about/kubernetes-training/about-kubernetes-ingress.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the different ingress implementations and how ingress and policy interact.
+description: Background on Kubernetes ingress implementations, load balancing at L5-7, and how ingress controllers interact with network policy in Calico Open Source.
 ---
 
 # Kubernetes ingress

--- a/calico/about/kubernetes-training/about-kubernetes-services.mdx
+++ b/calico/about/kubernetes-training/about-kubernetes-services.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the three main service types and how to use them.
+description: Background on Kubernetes service types (ClusterIP, NodePort, LoadBalancer) and how services interact with network policy in Calico Open Source clusters.
 ---
 
 # Kubernetes services

--- a/calico/about/kubernetes-training/about-network-policy.mdx
+++ b/calico/about/kubernetes-training/about-network-policy.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the basics of Kubernetes and Calico Enterprise network policy
+description: Background on Kubernetes and Calico Open Source network policy, comparing API capabilities and offering best practices for securing cluster workloads.
 ---
 
 # What is network policy?

--- a/calico/about/kubernetes-training/about-networking.mdx
+++ b/calico/about/kubernetes-training/about-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about networking!
+description: Background on networking fundamentals such as OSI layers, IP addressing, subnets, routing, overlays, DNS, and NAT for newcomers to Calico Open Source.
 ---
 
 # About networking

--- a/calico/about/kubernetes-training/index.mdx
+++ b/calico/about/kubernetes-training/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Introduction to Kubernetes networking and network policy for beginners. 
+description: Introductory Kubernetes networking and network policy training for users new to Calico Open Source, covering services, ingress, egress, eBPF, and more.
 ---
 
 # Kubernetes networking and policy

--- a/calico/about/training-resources.mdx
+++ b/calico/about/training-resources.mdx
@@ -1,5 +1,5 @@
 ---
-description: Links to Calico resources for onboarding and training.
+description: Onboarding and training resources for Calico Open Source, including quickstart guides, certified operator courses, workshops, videos, and community channels.
 ---
 
 # Training and resources

--- a/calico/get-help/support.mdx
+++ b/calico/get-help/support.mdx
@@ -1,5 +1,5 @@
 ---
-description: How to get help and provide feedback.
+description: Community support and feedback channels for Calico Open Source, including the Calico Users Slack, GitHub project, contribution guide, and docs repository.
 ---
 
 # Support and feedback

--- a/calico_versioned_docs/version-3.32/about/calico-product-editions.mdx
+++ b/calico_versioned_docs/version-3.32/about/calico-product-editions.mdx
@@ -1,5 +1,5 @@
 ---
-description: Compare Calico product editions to find the right one for your needs.
+description: Compare Calico Open Source with Calico Cloud and Calico Enterprise across networking, security, and observability capabilities to pick the right edition.
 ---
 
 import { CheckIcon } from '@chakra-ui/icons';

--- a/calico_versioned_docs/version-3.32/about/index.mdx
+++ b/calico_versioned_docs/version-3.32/about/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: A brief description of Calico, deployment options, and features.
+description: Overview of Calico Open Source, the upstream Calico project for Kubernetes networking, network security, and observability across any cluster.
 ---
 
 import { DocCardLink, DocCardLinkLayout, PaidProductDocCardLink } from '/src/___new___/components';

--- a/calico_versioned_docs/version-3.32/about/kubernetes-training/about-ebpf.mdx
+++ b/calico_versioned_docs/version-3.32/about/kubernetes-training/about-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about eBPF!
+description: Background on eBPF and how the Calico Open Source eBPF data plane improves throughput, latency, and source IP preservation versus the standard Linux data plane.
 ---
 
 # About Calico eBPF

--- a/calico_versioned_docs/version-3.32/about/kubernetes-training/about-k8s-networking.mdx
+++ b/calico_versioned_docs/version-3.32/about/kubernetes-training/about-k8s-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about Kubernetes networking!
+description: Background on the Kubernetes network model, services, DNS, NAT outgoing, and dual-stack networking concepts that underpin Calico Open Source deployments.
 ---
 
 # About Kubernetes Networking

--- a/calico_versioned_docs/version-3.32/about/kubernetes-training/about-kubernetes-egress.mdx
+++ b/calico_versioned_docs/version-3.32/about/kubernetes-training/about-kubernetes-egress.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn why you should restrict egress traffic and how to do it.
+description: Background on Kubernetes egress traffic, including outgoing NAT, restricting outbound connections, and egress gateways for Calico Open Source clusters.
 ---
 
 # Kubernetes egress

--- a/calico_versioned_docs/version-3.32/about/kubernetes-training/about-kubernetes-ingress.mdx
+++ b/calico_versioned_docs/version-3.32/about/kubernetes-training/about-kubernetes-ingress.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the different ingress implementations and how ingress and policy interact.
+description: Background on Kubernetes ingress implementations, load balancing at L5-7, and how ingress controllers interact with network policy in Calico Open Source.
 ---
 
 # Kubernetes ingress

--- a/calico_versioned_docs/version-3.32/about/kubernetes-training/about-kubernetes-services.mdx
+++ b/calico_versioned_docs/version-3.32/about/kubernetes-training/about-kubernetes-services.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the three main service types and how to use them.
+description: Background on Kubernetes service types (ClusterIP, NodePort, LoadBalancer) and how services interact with network policy in Calico Open Source clusters.
 ---
 
 # Kubernetes services

--- a/calico_versioned_docs/version-3.32/about/kubernetes-training/about-network-policy.mdx
+++ b/calico_versioned_docs/version-3.32/about/kubernetes-training/about-network-policy.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn the basics of Kubernetes and Calico Enterprise network policy
+description: Background on Kubernetes and Calico Open Source network policy, comparing API capabilities and offering best practices for securing cluster workloads.
 ---
 
 # What is network policy?

--- a/calico_versioned_docs/version-3.32/about/kubernetes-training/about-networking.mdx
+++ b/calico_versioned_docs/version-3.32/about/kubernetes-training/about-networking.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn about networking!
+description: Background on networking fundamentals such as OSI layers, IP addressing, subnets, routing, overlays, DNS, and NAT for newcomers to Calico Open Source.
 ---
 
 # About networking

--- a/calico_versioned_docs/version-3.32/about/kubernetes-training/index.mdx
+++ b/calico_versioned_docs/version-3.32/about/kubernetes-training/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Introduction to Kubernetes networking and network policy for beginners. 
+description: Introductory Kubernetes networking and network policy training for users new to Calico Open Source, covering services, ingress, egress, eBPF, and more.
 ---
 
 # Kubernetes networking and policy

--- a/calico_versioned_docs/version-3.32/about/training-resources.mdx
+++ b/calico_versioned_docs/version-3.32/about/training-resources.mdx
@@ -1,5 +1,5 @@
 ---
-description: Links to Calico resources for onboarding and training.
+description: Onboarding and training resources for Calico Open Source, including quickstart guides, certified operator courses, workshops, videos, and community channels.
 ---
 
 # Training and resources

--- a/calico_versioned_docs/version-3.32/get-help/support.mdx
+++ b/calico_versioned_docs/version-3.32/get-help/support.mdx
@@ -1,5 +1,5 @@
 ---
-description: How to get help and provide feedback.
+description: Community support and feedback channels for Calico Open Source, including the Calico Users Slack, GitHub project, contribution guide, and docs repository.
 ---
 
 # Support and feedback


### PR DESCRIPTION
## Summary

Audit and rewrite frontmatter descriptions for the about bucket plus small orphan landing pages that did not fit into the prior buckets, across the unversioned (next) trees of all three products.

Scope spans **about + get-help + the CE installation index landing page**:
- `calico/about/` — 11 files
- `calico/get-help/` — 1 file
- `calico-enterprise/about/` — 2 files
- `calico-enterprise/installation/install-calico-enterprise-mke-4k.mdx` — 1 file
- `calico-cloud/about/` — 2 files
- `calico-cloud/get-help/` — 1 file

**Total: 18 files, 1 line each (description frontmatter only).**

Each new description names its canonical product exactly (`Calico Open Source`, `Calico Enterprise`, or `Calico Cloud`), stays under 200 characters, avoids the forbidden words `enable`/`disable`/`teaching`, contains no colons, and is unique across products. Cross-product disambiguation follows the pattern from #2696, #2697, #2708, #2709, #2710, #2711 — open-source framing for Calico Open Source, self-managed/Tigera-supported framing for Calico Enterprise, Tigera-hosted/managed-SaaS framing for Calico Cloud.

## Pre-fix violations (same 18 files)

- 0 descriptions over 200 chars
- 0 forbidden words
- 18 of 18 missing a canonical product name
- 4 cross-product duplicates from the boilerplate `A brief description of Calico, deployment options, and features.` and `Compare Calico product editions to find the right one for your needs.` strings appearing in all three products

## Verification

Diff is exactly 18 files changed, 18 insertions, 18 deletions — only the description line per file:

```
git diff upstream/main | grep -E '^[+-]' | grep -v -E '^(\+\+\+|---)' | grep -v '^[+-]description:'
# (no output)
```

Next-only on purpose — versioned mirrors will be applied in a follow-up after review.

## Test plan

- [ ] Confirm exactly 18 files changed, 1 line per file (description frontmatter only)
- [ ] Each description names the right canonical product for its tree
- [ ] No descriptions over 200 characters
- [ ] No forbidden words (`enable`, `disable`, `teaching`) and no colons
- [ ] No cross-product duplicate descriptions
- [ ] Vale lint clean on changed-file description lines (line 2)