### PR TITLE
Rewrite operations page descriptions (next trees)

### DIFF
--- a/calico-cloud/operations/cluster-management.mdx
+++ b/calico-cloud/operations/cluster-management.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manage cluster storage, add new clusters, and configure alerts.
+description: Manage Calico Cloud connected clusters from the web console by adding clusters, removing managed clusters, and configuring cluster-wide alerts.
 ---
 
 # Manage clusters

--- a/calico-cloud/operations/comms/apiserver-tls.mdx
+++ b/calico-cloud/operations/comms/apiserver-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificates to secure access to the Calico Cloud API server.
+description: Provide TLS certificates that secure access to the Calico Cloud API server on a connected cluster as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for the API server

--- a/calico-cloud/operations/comms/certificate-management.mdx
+++ b/calico-cloud/operations/comms/certificate-management.mdx
@@ -1,5 +1,5 @@
 ---
-description: Control the issuer of certificates used by Calico Cloud.
+description: Manage TLS certificates for Calico Cloud components on a connected cluster by controlling the certificate issuer through the Kubernetes Certificates API.
 ---
 
 # Manage TLS certificates used by Calico Cloud

--- a/calico-cloud/operations/comms/compliance-tls.mdx
+++ b/calico-cloud/operations/comms/compliance-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificate to secure access to compliance.
+description: Provide TLS certificates that secure access to the Calico Cloud compliance components on a connected cluster as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for compliance

--- a/calico-cloud/operations/comms/crypto-auth.mdx
+++ b/calico-cloud/operations/comms/crypto-auth.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable TLS authentication and encryption for various Calico Cloud components.
+description: Configure TLS authentication and encryption across Calico Cloud components, the Kubernetes control plane, Typha, Node, and observability traffic on connected clusters.
 ---
 
 # Configure encryption and authentication to secure Calico Cloud components

--- a/calico-cloud/operations/comms/index.mdx
+++ b/calico-cloud/operations/comms/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Secure communications for Calico components.
+description: Secure communications between Calico Cloud components on a connected cluster with mutual TLS, including API server, log storage, web console, and BGP endpoints.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud/operations/comms/log-storage-tls.mdx
+++ b/calico-cloud/operations/comms/log-storage-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificate to secure access to log storage.
+description: Provide TLS certificates that secure access to Calico Cloud log storage on a connected cluster as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for log storage

--- a/calico-cloud/operations/comms/manager-tls.mdx
+++ b/calico-cloud/operations/comms/manager-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificates to secure access to the web console user interface.
+description: Provide TLS certificates that secure browser access to the Calico Cloud web console on a connected cluster in place of the default self-signed certificate.
 ---
 
 # Provide TLS certificates for the web console

--- a/calico-cloud/operations/comms/packetcapture-tls.mdx
+++ b/calico-cloud/operations/comms/packetcapture-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificate to secure access to PacketCapture APIs.
+description: Provide TLS certificates that secure access to the Calico Cloud PacketCapture APIs on a connected cluster as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for PacketCapture APIs

--- a/calico-cloud/operations/comms/secure-bgp.mdx
+++ b/calico-cloud/operations/comms/secure-bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP passwords to prevent attackers from injecting false routing information.
+description: Configure BGP session passwords on Calico Cloud BGP peers on a connected cluster to block attackers from injecting false routing information.
 ---
 
 # Secure BGP sessions

--- a/calico-cloud/operations/comms/secure-metrics.mdx
+++ b/calico-cloud/operations/comms/secure-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Limit access to Calico Cloud metric endpoints using network policy.
+description: Restrict access to Calico Cloud Prometheus metric endpoints on a connected cluster with network policy so only authorized scrapers can read component telemetry.
 ---
 
 # Secure Calico Cloud Prometheus endpoints

--- a/calico-cloud/operations/comms/typha-node-tls.mdx
+++ b/calico-cloud/operations/comms/typha-node-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificates to secure communications between if you are using Typha to scale your deployment.
+description: Provide a custom CA and TLS certificates for mutual TLS authentication between Calico Cloud Node and Typha components on a connected cluster at scale.
 ---
 
 # Provide TLS certificates for Typha and Node

--- a/calico-cloud/operations/component-logs.mdx
+++ b/calico-cloud/operations/component-logs.mdx
@@ -1,5 +1,5 @@
 ---
-description: Where to find component logs.
+description: Reference for locating and collecting Calico Cloud component logs including calico/node, Felix, Typha, and observability agents on connected clusters.
 ---
 
 # Component logs

--- a/calico-cloud/operations/disconnect.mdx
+++ b/calico-cloud/operations/disconnect.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to use migration script to uninstall Calico Cloud from a cluster.
+description: Disconnect a cluster from Calico Cloud with the migration script that uninstalls SaaS components and reverts the cluster to open-source Project Calico.
 ---
 
 # Uninstall Calico Cloud from a cluster

--- a/calico-cloud/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-cloud/operations/ebpf/enabling-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to enable the eBPF data plane on an existing cluster.
+description: Switch a Calico Cloud connected cluster to the eBPF data plane on an existing installation as an alternative to the iptables data plane.
 ---
 
 # Enable eBPF on an existing cluster

--- a/calico-cloud/operations/ebpf/index.mdx
+++ b/calico-cloud/operations/ebpf/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Documentation for eBPF data plane mode, including how to enable eBPF data plane mode.
+description: Reference index for the Calico Cloud eBPF data plane on connected clusters covering installation, runtime switching, troubleshooting, and use-case selection.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud/operations/ebpf/troubleshoot-ebpf.mdx
+++ b/calico-cloud/operations/ebpf/troubleshoot-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: How to troubleshoot when running in eBPF mode.
+description: Troubleshooting guide for the Calico Cloud eBPF data plane on a connected cluster covering verification logs, service connectivity, BPF map inspection, and failure modes.
 ---
 
 # Troubleshoot eBPF mode

--- a/calico-cloud/operations/ebpf/use-cases-ebpf.mdx
+++ b/calico-cloud/operations/ebpf/use-cases-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn when to use eBPF, and when not to.
+description: Guidance on when the Calico Cloud eBPF data plane on a connected cluster fits a workload compared to the standard iptables data plane, with trade-offs.
 ---
 
 # eBPF use cases

--- a/calico-cloud/operations/index.mdx
+++ b/calico-cloud/operations/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manage clusters and add new users.
+description: Day-2 operations for Calico Cloud connected clusters covering cluster management, secure component communications, monitoring, eBPF, and disconnection.
 ---
 
 import { DocCardLink, DocCardLinkLayout } from '/src/___new___/components';

--- a/calico-cloud/operations/monitor/index.mdx
+++ b/calico-cloud/operations/monitor/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Tools for scraping useful metrics.
+description: Reference index for monitoring Calico Cloud connected clusters with Prometheus metrics covering BGP, policy, log collection, and component health.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud/operations/monitor/metrics/bgp-metrics.mdx
+++ b/calico-cloud/operations/monitor/metrics/bgp-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor BGP peering and route exchange in your cluster and get alerts by defining rules and thresholds.
+description: Monitor BGP peering and route exchange in Calico Cloud connected clusters by defining Prometheus rules and thresholds for peer health and route counts.
 ---
 
 # BGP metrics

--- a/calico-cloud/operations/monitor/metrics/elasticsearch-and-fluentd-metrics.mdx
+++ b/calico-cloud/operations/monitor/metrics/elasticsearch-and-fluentd-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor Fluentd metrics and get alerts on log storage or collection issues.
+description: Track Calico Cloud Fluentd metrics in Prometheus to alert on flow, DNS, and audit log collection disruptions on connected clusters.
 ---
 
 # Fluentd metrics

--- a/calico-cloud/operations/monitor/metrics/index.mdx
+++ b/calico-cloud/operations/monitor/metrics/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Prometheus metrics.
+description: Reference index for Calico Cloud Prometheus metrics on connected clusters covering BGP, policy, log collection, and recommended dashboards.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud/operations/monitor/metrics/policy-metrics.mdx
+++ b/calico-cloud/operations/monitor/metrics/policy-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor the effects of policy in your cluster and received alerts by defining rules and thresholds.
+description: Monitor the runtime effect of policies on Calico Cloud connected clusters by defining Prometheus rules and thresholds that fire alerts on policy hits.
 ---
 
 # Policy metrics

--- a/calico-cloud/operations/monitor/metrics/recommended-metrics.mdx
+++ b/calico-cloud/operations/monitor/metrics/recommended-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Recommended Prometheus metrics for monitoring Calico Enterprise components.
+description: Recommended Prometheus metrics for Calico Cloud Typha, Felix, and policy components on connected clusters, covering the signals most critical to cluster health.
 ---
 
 # Recommended Prometheus metrics

--- a/calico-cloud/operations/monitor/prometheus/alertmanager.mdx
+++ b/calico-cloud/operations/monitor/prometheus/alertmanager.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Alertmanager, a Prometheus feature that routes alerts.
+description: Configure Alertmanager in a Calico Cloud connected cluster to route Prometheus alerts to operators with deduplication, grouping, silencing, and inhibition rules.
 ---
 
 # Configure Alertmanager

--- a/calico-cloud/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-cloud/operations/monitor/prometheus/byo-prometheus.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to get Calico Cloud metrics using your own Prometheus.
+description: Scrape Calico Cloud component metrics from an existing bring-your-own Prometheus deployment instead of the bundled operator-managed Prometheus on connected clusters.
 ---
 
 # Bring your own Prometheus

--- a/calico-cloud/operations/monitor/prometheus/configure-prometheus.mdx
+++ b/calico-cloud/operations/monitor/prometheus/configure-prometheus.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure rules for alerts and denied packets, for persistent storage.
+description: Configure Calico Cloud Prometheus rules for denied-packet alerts and persistent storage on connected clusters by editing PrometheusRule and StorageClass resources.
 ---
 
 # Configure Prometheus

--- a/calico-cloud/operations/monitor/prometheus/index.mdx
+++ b/calico-cloud/operations/monitor/prometheus/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure open-source toolkit for systems monitoring and alerting.
+description: Configure the open-source Prometheus monitoring and alerting toolkit bundled with Calico Cloud for component metrics, alerts, and persistent storage on connected clusters.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud/operations/monitor/prometheus/support.mdx
+++ b/calico-cloud/operations/monitor/prometheus/support.mdx
@@ -1,5 +1,5 @@
 ---
-description: Prometheus support in Calico Cloud.
+description: Reference for Prometheus support in Calico Cloud connected clusters covering the bundled operator-managed install and bring-your-own Prometheus deployment options.
 ---
 
 # Prometheus support

--- a/calico-cloud/operations/usage-metrics.mdx
+++ b/calico-cloud/operations/usage-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Where to find Calico Cloud usage metrics.
+description: Reference for finding Calico Cloud Pro usage and billing metrics, calculated as vCPU hours across all connected clusters each month.
 ---
 
 import IconUser from '/img/icons/user-icon.svg';

--- a/calico-cloud_versioned_docs/version-22-2/operations/cluster-management.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/cluster-management.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manage cluster storage, add new clusters, and configure alerts.
+description: Manage Calico Cloud connected clusters from the web console by adding clusters, removing managed clusters, and configuring cluster-wide alerts.
 ---
 
 # Manage clusters

--- a/calico-cloud_versioned_docs/version-22-2/operations/comms/apiserver-tls.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/comms/apiserver-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificates to secure access to the Calico Cloud API server.
+description: Provide TLS certificates that secure access to the Calico Cloud API server on a connected cluster as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for the API server

--- a/calico-cloud_versioned_docs/version-22-2/operations/comms/certificate-management.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/comms/certificate-management.mdx
@@ -1,5 +1,5 @@
 ---
-description: Control the issuer of certificates used by Calico Cloud.
+description: Manage TLS certificates for Calico Cloud components on a connected cluster by controlling the certificate issuer through the Kubernetes Certificates API.
 ---
 
 # Manage TLS certificates used by Calico Cloud

--- a/calico-cloud_versioned_docs/version-22-2/operations/comms/compliance-tls.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/comms/compliance-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificate to secure access to compliance.
+description: Provide TLS certificates that secure access to the Calico Cloud compliance components on a connected cluster as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for compliance

--- a/calico-cloud_versioned_docs/version-22-2/operations/comms/crypto-auth.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/comms/crypto-auth.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable TLS authentication and encryption for various Calico Cloud components.
+description: Configure TLS authentication and encryption across Calico Cloud components, the Kubernetes control plane, Typha, Node, and observability traffic on connected clusters.
 ---
 
 # Configure encryption and authentication to secure Calico Cloud components

--- a/calico-cloud_versioned_docs/version-22-2/operations/comms/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/comms/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Secure communications for Calico components.
+description: Secure communications between Calico Cloud components on a connected cluster with mutual TLS, including API server, log storage, web console, and BGP endpoints.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/operations/comms/log-storage-tls.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/comms/log-storage-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificate to secure access to log storage.
+description: Provide TLS certificates that secure access to Calico Cloud log storage on a connected cluster as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for log storage

--- a/calico-cloud_versioned_docs/version-22-2/operations/comms/manager-tls.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/comms/manager-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificates to secure access to the web console user interface.
+description: Provide TLS certificates that secure browser access to the Calico Cloud web console on a connected cluster in place of the default self-signed certificate.
 ---
 
 # Provide TLS certificates for the web console

--- a/calico-cloud_versioned_docs/version-22-2/operations/comms/packetcapture-tls.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/comms/packetcapture-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificate to secure access to PacketCapture APIs.
+description: Provide TLS certificates that secure access to the Calico Cloud PacketCapture APIs on a connected cluster as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for PacketCapture APIs

--- a/calico-cloud_versioned_docs/version-22-2/operations/comms/secure-bgp.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/comms/secure-bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP passwords to prevent attackers from injecting false routing information.
+description: Configure BGP session passwords on Calico Cloud BGP peers on a connected cluster to block attackers from injecting false routing information.
 ---
 
 # Secure BGP sessions

--- a/calico-cloud_versioned_docs/version-22-2/operations/comms/secure-metrics.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/comms/secure-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Limit access to Calico Cloud metric endpoints using network policy.
+description: Restrict access to Calico Cloud Prometheus metric endpoints on a connected cluster with network policy so only authorized scrapers can read component telemetry.
 ---
 
 # Secure Calico Cloud Prometheus endpoints

--- a/calico-cloud_versioned_docs/version-22-2/operations/comms/typha-node-tls.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/comms/typha-node-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificates to secure communications between if you are using Typha to scale your deployment.
+description: Provide a custom CA and TLS certificates for mutual TLS authentication between Calico Cloud Node and Typha components on a connected cluster at scale.
 ---
 
 # Provide TLS certificates for Typha and Node

--- a/calico-cloud_versioned_docs/version-22-2/operations/component-logs.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/component-logs.mdx
@@ -1,5 +1,5 @@
 ---
-description: Where to find component logs.
+description: Reference for locating and collecting Calico Cloud component logs including calico/node, Felix, Typha, and observability agents on connected clusters.
 ---
 
 # Component logs

--- a/calico-cloud_versioned_docs/version-22-2/operations/disconnect.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/disconnect.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to use migration script to uninstall Calico Cloud from a cluster.
+description: Disconnect a cluster from Calico Cloud with the migration script that uninstalls SaaS components and reverts the cluster to open-source Project Calico.
 ---
 
 # Uninstall Calico Cloud from a cluster

--- a/calico-cloud_versioned_docs/version-22-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/ebpf/enabling-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to enable the eBPF data plane on an existing cluster.
+description: Switch a Calico Cloud connected cluster to the eBPF data plane on an existing installation as an alternative to the iptables data plane.
 ---
 
 # Enable eBPF on an existing cluster

--- a/calico-cloud_versioned_docs/version-22-2/operations/ebpf/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/ebpf/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Documentation for eBPF data plane mode, including how to enable eBPF data plane mode.
+description: Reference index for the Calico Cloud eBPF data plane on connected clusters covering installation, runtime switching, troubleshooting, and use-case selection.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/operations/ebpf/troubleshoot-ebpf.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/ebpf/troubleshoot-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: How to troubleshoot when running in eBPF mode.
+description: Troubleshooting guide for the Calico Cloud eBPF data plane on a connected cluster covering verification logs, service connectivity, BPF map inspection, and failure modes.
 ---
 
 # Troubleshoot eBPF mode

--- a/calico-cloud_versioned_docs/version-22-2/operations/ebpf/use-cases-ebpf.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/ebpf/use-cases-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn when to use eBPF, and when not to.
+description: Guidance on when the Calico Cloud eBPF data plane on a connected cluster fits a workload compared to the standard iptables data plane, with trade-offs.
 ---
 
 # eBPF use cases

--- a/calico-cloud_versioned_docs/version-22-2/operations/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manage clusters and add new users.
+description: Day-2 operations for Calico Cloud connected clusters covering cluster management, secure component communications, monitoring, eBPF, and disconnection.
 ---
 
 import { DocCardLink, DocCardLinkLayout } from '/src/___new___/components';

--- a/calico-cloud_versioned_docs/version-22-2/operations/monitor/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/monitor/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Tools for scraping useful metrics.
+description: Reference index for monitoring Calico Cloud connected clusters with Prometheus metrics covering BGP, policy, log collection, and component health.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/operations/monitor/metrics/bgp-metrics.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/monitor/metrics/bgp-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor BGP peering and route exchange in your cluster and get alerts by defining rules and thresholds.
+description: Monitor BGP peering and route exchange in Calico Cloud connected clusters by defining Prometheus rules and thresholds for peer health and route counts.
 ---
 
 # BGP metrics

--- a/calico-cloud_versioned_docs/version-22-2/operations/monitor/metrics/elasticsearch-and-fluentd-metrics.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/monitor/metrics/elasticsearch-and-fluentd-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor Fluentd metrics and get alerts on log storage or collection issues.
+description: Track Calico Cloud Fluentd metrics in Prometheus to alert on flow, DNS, and audit log collection disruptions on connected clusters.
 ---
 
 # Fluentd metrics

--- a/calico-cloud_versioned_docs/version-22-2/operations/monitor/metrics/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/monitor/metrics/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Prometheus metrics.
+description: Reference index for Calico Cloud Prometheus metrics on connected clusters covering BGP, policy, log collection, and recommended dashboards.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/operations/monitor/metrics/policy-metrics.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/monitor/metrics/policy-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor the effects of policy in your cluster and received alerts by defining rules and thresholds.
+description: Monitor the runtime effect of policies on Calico Cloud connected clusters by defining Prometheus rules and thresholds that fire alerts on policy hits.
 ---
 
 # Policy metrics

--- a/calico-cloud_versioned_docs/version-22-2/operations/monitor/metrics/recommended-metrics.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/monitor/metrics/recommended-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Recommended Prometheus metrics for monitoring Calico Enterprise components.
+description: Recommended Prometheus metrics for Calico Cloud Typha, Felix, and policy components on connected clusters, covering the signals most critical to cluster health.
 ---
 
 # Recommended Prometheus metrics

--- a/calico-cloud_versioned_docs/version-22-2/operations/monitor/prometheus/alertmanager.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/monitor/prometheus/alertmanager.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Alertmanager, a Prometheus feature that routes alerts.
+description: Configure Alertmanager in a Calico Cloud connected cluster to route Prometheus alerts to operators with deduplication, grouping, silencing, and inhibition rules.
 ---
 
 # Configure Alertmanager

--- a/calico-cloud_versioned_docs/version-22-2/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/monitor/prometheus/byo-prometheus.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to get Calico Cloud metrics using your own Prometheus.
+description: Scrape Calico Cloud component metrics from an existing bring-your-own Prometheus deployment instead of the bundled operator-managed Prometheus on connected clusters.
 ---
 
 # Bring your own Prometheus

--- a/calico-cloud_versioned_docs/version-22-2/operations/monitor/prometheus/configure-prometheus.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/monitor/prometheus/configure-prometheus.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure rules for alerts and denied packets, for persistent storage.
+description: Configure Calico Cloud Prometheus rules for denied-packet alerts and persistent storage on connected clusters by editing PrometheusRule and StorageClass resources.
 ---
 
 # Configure Prometheus

--- a/calico-cloud_versioned_docs/version-22-2/operations/monitor/prometheus/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/monitor/prometheus/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure open-source toolkit for systems monitoring and alerting.
+description: Configure the open-source Prometheus monitoring and alerting toolkit bundled with Calico Cloud for component metrics, alerts, and persistent storage on connected clusters.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/operations/monitor/prometheus/support.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/monitor/prometheus/support.mdx
@@ -1,5 +1,5 @@
 ---
-description: Prometheus support in Calico Cloud.
+description: Reference for Prometheus support in Calico Cloud connected clusters covering the bundled operator-managed install and bring-your-own Prometheus deployment options.
 ---
 
 # Prometheus support

--- a/calico-cloud_versioned_docs/version-22-2/operations/usage-metrics.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/operations/usage-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Where to find Calico Cloud usage metrics.
+description: Reference for finding Calico Cloud Pro usage and billing metrics, calculated as vCPU hours across all connected clusters each month.
 ---
 
 import IconUser from '/img/icons/user-icon.svg';

--- a/calico-enterprise/operations/clis/calicoctl/configure/datastore.mdx
+++ b/calico-enterprise/operations/clis/calicoctl/configure/datastore.mdx
@@ -1,5 +1,5 @@
 ---
-description: Sample configuration files for the Kubernetes API datastore.
+description: Sample calicoctl configuration for connecting to the Kubernetes API datastore in a Calico Enterprise cluster, with kubeconfig credential settings.
 ---
 
 # Configure calicoctl to connect to the datastore

--- a/calico-enterprise/operations/clis/calicoctl/configure/index.mdx
+++ b/calico-enterprise/operations/clis/calicoctl/configure/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure the calicoctl to access your datastore.
+description: Configure calicoctl to reach the datastore backing a Calico Enterprise cluster through config files, environment variables, or kubeconfig credentials.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/operations/clis/calicoctl/configure/overview.mdx
+++ b/calico-enterprise/operations/clis/calicoctl/configure/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure calicoctl for datastore access.
+description: Overview reference for configuring calicoctl datastore access in Calico Enterprise, comparing config-file, environment-variable, and kubeconfig methods.
 ---
 
 # Configure calicoctl

--- a/calico-enterprise/operations/clis/calicoctl/index.mdx
+++ b/calico-enterprise/operations/clis/calicoctl/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install and configure the required CLI for managing Calico Enterprise resources.
+description: Install and configure calicoctl for managing Calico Enterprise resources from the command line against the Kubernetes API datastore.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/operations/clis/calicoctl/install.mdx
+++ b/calico-enterprise/operations/clis/calicoctl/install.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install the CLI for Calico.
+description: Install the calicoctl command-line tool as a binary, container, or kubectl plugin so administrators can manage Calico Enterprise resources from any workstation.
 ---
 
 # Install calicoctl

--- a/calico-enterprise/operations/clis/calicoq/configure/datastore.mdx
+++ b/calico-enterprise/operations/clis/calicoq/configure/datastore.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure CLI to connect to the Kubernetes API datastore.
+description: Sample calicoq configuration for connecting to the Kubernetes API datastore in a Calico Enterprise cluster, with kubeconfig credential settings.
 ---
 
 # Configure calicoq to connect to the datastore

--- a/calico-enterprise/operations/clis/calicoq/configure/index.mdx
+++ b/calico-enterprise/operations/clis/calicoq/configure/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure calicoq for Kubernetes API datastore.
+description: Configure calicoq to reach the Kubernetes API datastore backing a Calico Enterprise cluster through config files or environment variables.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/operations/clis/calicoq/configure/overview.mdx
+++ b/calico-enterprise/operations/clis/calicoq/configure/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure the CLI to connect to the Kubernetes API datastore.
+description: Overview reference for configuring calicoq datastore access in Calico Enterprise, covering config files, environment variables, and Kubernetes credentials.
 ---
 
 import CliConfigIntro from '@site/calico-enterprise/_includes/components/CliConfigIntro';

--- a/calico-enterprise/operations/clis/calicoq/index.mdx
+++ b/calico-enterprise/operations/clis/calicoq/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install and configure the required CLI for managing Calico Enterprise resources.
+description: Install and configure calicoq for querying policy and endpoint relationships in a Calico Enterprise cluster from the command line.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/operations/clis/calicoq/installing.mdx
+++ b/calico-enterprise/operations/clis/calicoq/installing.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install the CLI for Calico Enterprise.
+description: Install the calicoq command-line tool as a binary or container on any host with network access to the Calico Enterprise datastore.
 ---
 
 import MaintenanceClisCalicoqInstalling from '@site/calico-enterprise/_includes/components/MaintenanceClisCalicoqInstalling';

--- a/calico-enterprise/operations/clis/index.mdx
+++ b/calico-enterprise/operations/clis/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install and configure CLIs for manipulating and querying resources.
+description: Install and configure the Calico Enterprise command-line tools calicoctl and calicoq for managing and querying cluster resources.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/operations/cnx/access-the-manager.mdx
+++ b/calico-enterprise/operations/cnx/access-the-manager.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure access to the web console.
+description: Expose the Calico Enterprise web console outside the cluster through ingress, a load balancer service, or port forwarding for administrator access.
 ---
 
 # Configure access to the web console

--- a/calico-enterprise/operations/cnx/authentication-quickstart.mdx
+++ b/calico-enterprise/operations/cnx/authentication-quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use default token authentication to log in to the web console and Kibana.
+description: Sign in to the Calico Enterprise web console and Kibana with default service-account token authentication for a quick first-time setup.
 ---
 
 # Authentication quickstart

--- a/calico-enterprise/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise/operations/cnx/configure-identity-provider.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure an external identity provider for user access to Calico Enterprise Manager and Kibana.
+description: Connect an external identity provider to Calico Enterprise so users authenticate against an existing IdP when signing in to the web console and Kibana.
 ---
 
 # Configure an external identity provider

--- a/calico-enterprise/operations/cnx/index.mdx
+++ b/calico-enterprise/operations/cnx/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Get started using the web console.
+description: Start with the Calico Enterprise web console covering access exposure, authentication, identity-provider integration, and role-based permissions.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/operations/cnx/roles-and-permissions.mdx
+++ b/calico-enterprise/operations/cnx/roles-and-permissions.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure roles and permissions for Calico Enterprise features and functions.
+description: Configure Kubernetes RBAC roles and bindings to scope user access to Calico Enterprise features, tiered policies, observability views, and management plane APIs.
 ---
 
 # Configure user roles and permissions

--- a/calico-enterprise/operations/comms/apiserver-tls.mdx
+++ b/calico-enterprise/operations/comms/apiserver-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificates to secure access to the Calico Enterprise API server.
+description: Provide TLS certificates that secure access to the Calico Enterprise API server as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for the API server

--- a/calico-enterprise/operations/comms/certificate-management.mdx
+++ b/calico-enterprise/operations/comms/certificate-management.mdx
@@ -1,5 +1,5 @@
 ---
-description: Control the issuer of certificates used by Calico Enterprise.
+description: Manage TLS certificates for Calico Enterprise components by controlling the certificate issuer through the Kubernetes Certificates API and operator configuration.
 ---
 
 # Manage TLS certificates used by Calico Enterprise

--- a/calico-enterprise/operations/comms/compliance-tls.mdx
+++ b/calico-enterprise/operations/comms/compliance-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificate to secure access to compliance.
+description: Provide TLS certificates that secure access to the Calico Enterprise compliance components as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for compliance

--- a/calico-enterprise/operations/comms/crypto-auth.mdx
+++ b/calico-enterprise/operations/comms/crypto-auth.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable TLS authentication and encryption for various Calico Enterprise components.
+description: Configure TLS authentication and encryption across Calico Enterprise components, the Kubernetes control plane, Typha, Node, and shared observability traffic.
 ---
 
 # Configure encryption and authentication to secure Calico Enterprise components

--- a/calico-enterprise/operations/comms/index.mdx
+++ b/calico-enterprise/operations/comms/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Secure communications for Calico components.
+description: Secure communications between Calico Enterprise components with mutual TLS, including API server, log storage, web console, BGP, and observability stack endpoints.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/operations/comms/linseed-tls.mdx
+++ b/calico-enterprise/operations/comms/linseed-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificate to secure access to Linseed APIs.
+description: Provide TLS certificates that secure access to the Calico Enterprise Linseed APIs as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for Linseed APIs

--- a/calico-enterprise/operations/comms/log-storage-tls.mdx
+++ b/calico-enterprise/operations/comms/log-storage-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificate to secure access to log storage.
+description: Provide TLS certificates that secure access to Calico Enterprise log storage as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for log storage

--- a/calico-enterprise/operations/comms/manager-tls.mdx
+++ b/calico-enterprise/operations/comms/manager-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificates to secure access to Calico Enterprise Manager user interface.
+description: Provide TLS certificates that secure browser access to the Calico Enterprise web console user interface in place of the default self-signed certificate.
 ---
 
 # Provide TLS certificates for Calico Enterprise Manager

--- a/calico-enterprise/operations/comms/packetcapture-tls.mdx
+++ b/calico-enterprise/operations/comms/packetcapture-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificate to secure access to PacketCapture APIs.
+description: Provide TLS certificates that secure access to the Calico Enterprise PacketCapture APIs as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for PacketCapture APIs

--- a/calico-enterprise/operations/comms/secure-bgp.mdx
+++ b/calico-enterprise/operations/comms/secure-bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP passwords to prevent attackers from injecting false routing information.
+description: Configure BGP session passwords on Calico Enterprise BGP peers to block attackers from injecting false routing information into the cluster.
 ---
 
 # Secure BGP sessions

--- a/calico-enterprise/operations/comms/secure-metrics.mdx
+++ b/calico-enterprise/operations/comms/secure-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Limit access to Calico Enterprise metric endpoints using network policy.
+description: Restrict access to Calico Enterprise Prometheus metric endpoints with network policy so only authorized scrapers can read sensitive component telemetry.
 ---
 
 # Secure Calico Enterprise Prometheus endpoints

--- a/calico-enterprise/operations/comms/typha-node-tls.mdx
+++ b/calico-enterprise/operations/comms/typha-node-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificates to secure communications between if you are using Typha to scale your deployment.
+description: Provide a custom CA and TLS certificates for mutual TLS authentication between Calico Enterprise Node and Typha components at scale.
 ---
 
 # Provide TLS certificates for Typha and Node

--- a/calico-enterprise/operations/crd-migration.mdx
+++ b/calico-enterprise/operations/crd-migration.mdx
@@ -1,5 +1,5 @@
 ---
-description: Migrate Calico resources from the aggregated API server (v1 CRDs) to native v3 CRDs to remove the API server component.
+description: Migrate Calico Enterprise resources from the aggregated API server backing storage to native projectcalico.org/v3 CRDs so the API server component can be removed.
 ---
 
 # Migrate from API server to native CRDs

--- a/calico-enterprise/operations/decommissioning-a-node.mdx
+++ b/calico-enterprise/operations/decommissioning-a-node.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manually remove a node from a cluster that is installed with Calico.
+description: Manually decommission a node in a Calico Enterprise cluster, releasing IP allocations and BGP peers from the cluster datastore cleanly.
 ---
 
 # Decommission a node

--- a/calico-enterprise/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise/operations/ebpf/enabling-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to enable the eBPF data plane on an existing cluster.
+description: Switch a running Calico Enterprise cluster to the eBPF data plane on an existing installation as an alternative to the iptables data plane.
 ---
 
 # Enable eBPF on an existing cluster

--- a/calico-enterprise/operations/ebpf/index.mdx
+++ b/calico-enterprise/operations/ebpf/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Documentation for eBPF data plane mode, including how to enable eBPF data plane mode.
+description: Reference index for the Calico Enterprise eBPF data plane covering installation, runtime switching, troubleshooting, and use-case selection.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/operations/ebpf/install.mdx
+++ b/calico-enterprise/operations/ebpf/install.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install Calico Enterprise in eBPF mode.
+description: Install Calico Enterprise with the eBPF data plane during initial cluster setup as an alternative to the iptables data plane.
 ---
 
 # Install in eBPF mode

--- a/calico-enterprise/operations/ebpf/troubleshoot-ebpf.mdx
+++ b/calico-enterprise/operations/ebpf/troubleshoot-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: How to troubleshoot when running in eBPF mode.
+description: Troubleshooting guide for the Calico Enterprise eBPF data plane covering verification logs, service connectivity, BPF map inspection, and common failure modes.
 ---
 
 # Troubleshoot eBPF mode

--- a/calico-enterprise/operations/ebpf/use-cases-ebpf.mdx
+++ b/calico-enterprise/operations/ebpf/use-cases-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn when to use eBPF, and when not to.
+description: Guidance on when the Calico Enterprise eBPF data plane fits a workload compared to the standard iptables data plane, with trade-offs and feature comparisons.
 ---
 
 # eBPF use cases

--- a/calico-enterprise/operations/index.mdx
+++ b/calico-enterprise/operations/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Post-installation tasks for managing Calico including upgrading and troubleshooting.
+description: Day-2 operations for Calico Enterprise clusters covering upgrades, web console access, CLIs, certificate management, log storage, monitoring, eBPF, and troubleshooting.
 ---
 
 import { DocCardLink, DocCardLinkLayout } from '/src/___new___/components';

--- a/calico-enterprise/operations/license-options.mdx
+++ b/calico-enterprise/operations/license-options.mdx
@@ -1,5 +1,5 @@
 ---
-description: Review options to track your Calico Enterprise license expiration.
+description: Track Calico Enterprise license expiration through operator-exposed Prometheus metrics and renewal workflows to avoid unplanned cluster degradation.
 ---
 
 # License expiration and renewal

--- a/calico-enterprise/operations/logstorage/adjust-log-storage-size.mdx
+++ b/calico-enterprise/operations/logstorage/adjust-log-storage-size.mdx
@@ -1,5 +1,5 @@
 ---
-description: Adjust the log storage size during or after installation.
+description: Resize the Calico Enterprise log storage cluster by tuning node counts, replicas, CPU, and memory during or after installation for production workloads.
 ---
 
 # Adjust log storage size

--- a/calico-enterprise/operations/logstorage/advanced-node-scheduling.mdx
+++ b/calico-enterprise/operations/logstorage/advanced-node-scheduling.mdx
@@ -1,5 +1,5 @@
 ---
-description: Control where Elasticsearch pods and replicas are scheduled.
+description: Steer Calico Enterprise Elasticsearch pod and replica placement across Kubernetes nodes with data-node selectors and shard scheduling controls.
 ---
 
 # Advanced Node Scheduling

--- a/calico-enterprise/operations/logstorage/create-storage.mdx
+++ b/calico-enterprise/operations/logstorage/create-storage.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure persistent storage for flow logs, DNS logs, audit logs, and compliance reports.
+description: Configure persistent storage in Calico Enterprise for flow logs, DNS logs, audit logs, and compliance reports before installation.
 ---
 
 # Configure storage for logs and reports

--- a/calico-enterprise/operations/logstorage/index.mdx
+++ b/calico-enterprise/operations/logstorage/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure your log storage.
+description: Configure log storage for Calico Enterprise covering persistent volumes, node scheduling, sizing, and capacity recommendations.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/operations/logstorage/log-storage-recommendations.mdx
+++ b/calico-enterprise/operations/logstorage/log-storage-recommendations.mdx
@@ -1,5 +1,5 @@
 ---
-description: Guidelines for setting up your log storage.
+description: Reference recommendations for Calico Enterprise log storage covering Elastic Cloud on Kubernetes, StorageClasses, node sizing, and production capacity.
 ---
 
 # Log storage recommendations

--- a/calico-enterprise/operations/monitor/index.mdx
+++ b/calico-enterprise/operations/monitor/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Tools for scraping useful metrics.
+description: Reference index for monitoring Calico Enterprise clusters with the bundled Prometheus stack covering BGP, policy, log storage, and operator metrics.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/operations/monitor/metrics/bgp-metrics.mdx
+++ b/calico-enterprise/operations/monitor/metrics/bgp-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor BGP peering and route exchange in your cluster and get alerts by defining rules and thresholds.
+description: Monitor BGP peering and route exchange in Calico Enterprise clusters by defining Prometheus rules and thresholds for peer health and route counts.
 ---
 
 # BGP metrics

--- a/calico-enterprise/operations/monitor/metrics/elasticsearch-and-fluentd-metrics.mdx
+++ b/calico-enterprise/operations/monitor/metrics/elasticsearch-and-fluentd-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor Elasticsearch and Fluentd metrics, and get alerts on log storage or collection issues.
+description: Track Calico Enterprise Elasticsearch and Fluentd metrics in Prometheus to alert on flow, DNS, audit, and compliance log collection or storage disruptions.
 ---
 
 # Elasticsearch and Fluentd metrics

--- a/calico-enterprise/operations/monitor/metrics/index.mdx
+++ b/calico-enterprise/operations/monitor/metrics/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Prometheus metrics.
+description: Reference index for Calico Enterprise Prometheus metrics covering BGP, policy, log storage, and recommended dashboards.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/operations/monitor/metrics/policy-metrics.mdx
+++ b/calico-enterprise/operations/monitor/metrics/policy-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor the effects of policy in your cluster and received alerts by defining rules and thresholds.
+description: Monitor the runtime effect of Calico Enterprise policies on cluster traffic by defining Prometheus rules and thresholds that fire alerts on policy hits.
 ---
 
 # Policy metrics

--- a/calico-enterprise/operations/monitor/metrics/recommended-metrics.mdx
+++ b/calico-enterprise/operations/monitor/metrics/recommended-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Recommended Prometheus metrics for monitoring Calico Enterprise components.
+description: Recommended Prometheus metrics for Calico Enterprise Typha, Felix, and policy components, covering the signals most critical to cluster health.
 ---
 
 # Recommended Prometheus metrics

--- a/calico-enterprise/operations/monitor/prometheus/alertmanager.mdx
+++ b/calico-enterprise/operations/monitor/prometheus/alertmanager.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Alertmanager, a Prometheus feature that routes alerts.
+description: Configure Alertmanager in a Calico Enterprise cluster to route Prometheus alerts to operators with deduplication, grouping, silencing, and inhibition rules.
 ---
 
 # Configure Alertmanager

--- a/calico-enterprise/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-enterprise/operations/monitor/prometheus/byo-prometheus.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to get Calico Enterprise metrics using your own Prometheus.
+description: Scrape Calico Enterprise component metrics from an existing bring-your-own Prometheus deployment instead of the bundled operator-managed Prometheus.
 ---
 
 # Bring your own Prometheus

--- a/calico-enterprise/operations/monitor/prometheus/configure-prometheus.mdx
+++ b/calico-enterprise/operations/monitor/prometheus/configure-prometheus.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure rules for alerts and denied packets, for persistent storage.
+description: Configure Calico Enterprise Prometheus rules for denied-packet alerts and persistent storage by editing the bundled PrometheusRule and StorageClass resources.
 ---
 
 # Configure Prometheus

--- a/calico-enterprise/operations/monitor/prometheus/index.mdx
+++ b/calico-enterprise/operations/monitor/prometheus/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure open-source toolkit for systems monitoring and alerting.
+description: Configure the open-source Prometheus monitoring and alerting toolkit bundled with Calico Enterprise for component metrics, alerts, and persistent storage.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/operations/monitor/prometheus/support.mdx
+++ b/calico-enterprise/operations/monitor/prometheus/support.mdx
@@ -1,5 +1,5 @@
 ---
-description: Prometheus support in Calico Enterprise.
+description: Reference for Prometheus support in Calico Enterprise covering the bundled operator-managed install and bring-your-own Prometheus deployment options.
 ---
 
 # Prometheus support

--- a/calico-enterprise/operations/native-v3-crds.mdx
+++ b/calico-enterprise/operations/native-v3-crds.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable native projectcalico.org/v3 CRDs to use Calico resources directly as CRDs without the aggregation API server.
+description: Switch Calico Enterprise to native projectcalico.org/v3 CRDs so resources are stored directly as CRDs without the aggregated API server component.
 ---
 
 # Enable native v3 CRDs

--- a/calico-enterprise/operations/nftables.mdx
+++ b/calico-enterprise/operations/nftables.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install Calico Enterprise using the nftables data plane.
+description: Install Calico Enterprise on a cluster running kube-proxy in nftables mode for Kubernetes 1.31 or later, using the nftables Linux data plane.
 title: "nftables"
 ---
 

--- a/calico-enterprise/operations/troubleshoot/commands.mdx
+++ b/calico-enterprise/operations/troubleshoot/commands.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn basic commands to verify cluster and components are working.
+description: Reference of command-line tools and kubectl invocations for verifying cluster, routing, policy, and component health in Calico Enterprise.
 ---
 
 # Troubleshooting commands

--- a/calico-enterprise/operations/troubleshoot/component-logs.mdx
+++ b/calico-enterprise/operations/troubleshoot/component-logs.mdx
@@ -1,5 +1,5 @@
 ---
-description: Where to find component logs.
+description: Reference for locating and collecting Calico Enterprise component logs including calico/node, Felix, Typha, Linseed, and observability stack output.
 ---
 
 # Component logs

--- a/calico-enterprise/operations/troubleshoot/index.mdx
+++ b/calico-enterprise/operations/troubleshoot/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Troubleshooting, logs, and diagnostics.
+description: Troubleshooting guide for Calico Enterprise clusters covering diagnostic commands, component logs, and recovery procedures.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/operations/troubleshoot/troubleshooting.mdx
+++ b/calico-enterprise/operations/troubleshoot/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-description: View logs and diagnostics, common issues, and where to report issues in github.
+description: Troubleshooting guide for Calico Enterprise clusters covering kubectl-calico diagnostics bundles, log severity tuning, common failure patterns, and where to report issues.
 ---
 
 # Troubleshooting and diagnostics

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoctl/configure/datastore.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoctl/configure/datastore.mdx
@@ -1,5 +1,5 @@
 ---
-description: Sample configuration files for the Kubernetes API datastore.
+description: Sample calicoctl configuration for connecting to the Kubernetes API datastore in a Calico Enterprise cluster, with kubeconfig credential settings.
 ---
 
 # Configure calicoctl to connect to the datastore

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoctl/configure/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoctl/configure/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure the calicoctl to access your datastore.
+description: Configure calicoctl to reach the datastore backing a Calico Enterprise cluster through config files, environment variables, or kubeconfig credentials.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoctl/configure/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoctl/configure/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure calicoctl for datastore access.
+description: Overview reference for configuring calicoctl datastore access in Calico Enterprise, comparing config-file, environment-variable, and kubeconfig methods.
 ---
 
 # Configure calicoctl

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoctl/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoctl/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install and configure the required CLI for managing Calico Enterprise resources.
+description: Install and configure calicoctl for managing Calico Enterprise resources from the command line against the Kubernetes API datastore.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoctl/install.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoctl/install.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install the CLI for Calico.
+description: Install the calicoctl command-line tool as a binary, container, or kubectl plugin so administrators can manage Calico Enterprise resources from any workstation.
 ---
 
 # Install calicoctl

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoq/configure/datastore.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoq/configure/datastore.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure CLI to connect to the Kubernetes API datastore.
+description: Sample calicoq configuration for connecting to the Kubernetes API datastore in a Calico Enterprise cluster, with kubeconfig credential settings.
 ---
 
 # Configure calicoq to connect to the datastore

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoq/configure/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoq/configure/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure calicoq for Kubernetes API datastore.
+description: Configure calicoq to reach the Kubernetes API datastore backing a Calico Enterprise cluster through config files or environment variables.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoq/configure/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoq/configure/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure the CLI to connect to the Kubernetes API datastore.
+description: Overview reference for configuring calicoq datastore access in Calico Enterprise, covering config files, environment variables, and Kubernetes credentials.
 ---
 
 import CliConfigIntro from '@site/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/CliConfigIntro';

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoq/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoq/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install and configure the required CLI for managing Calico Enterprise resources.
+description: Install and configure calicoq for querying policy and endpoint relationships in a Calico Enterprise cluster from the command line.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoq/installing.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/calicoq/installing.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install the CLI for Calico Enterprise.
+description: Install the calicoq command-line tool as a binary or container on any host with network access to the Calico Enterprise datastore.
 ---
 
 import MaintenanceClisCalicoqInstalling from '@site/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/MaintenanceClisCalicoqInstalling';

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/clis/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install and configure CLIs for manipulating and querying resources.
+description: Install and configure the Calico Enterprise command-line tools calicoctl and calicoq for managing and querying cluster resources.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/cnx/access-the-manager.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/cnx/access-the-manager.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure access to the web console.
+description: Expose the Calico Enterprise web console outside the cluster through ingress, a load balancer service, or port forwarding for administrator access.
 ---
 
 # Configure access to the web console

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/cnx/authentication-quickstart.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/cnx/authentication-quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use default token authentication to log in to the web console and Kibana.
+description: Sign in to the Calico Enterprise web console and Kibana with default service-account token authentication for a quick first-time setup.
 ---
 
 # Authentication quickstart

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/cnx/configure-identity-provider.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure an external identity provider for user access to Calico Enterprise Manager and Kibana.
+description: Connect an external identity provider to Calico Enterprise so users authenticate against an existing IdP when signing in to the web console and Kibana.
 ---
 
 # Configure an external identity provider

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/cnx/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/cnx/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Get started using the web console.
+description: Start with the Calico Enterprise web console covering access exposure, authentication, identity-provider integration, and role-based permissions.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/cnx/roles-and-permissions.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/cnx/roles-and-permissions.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure roles and permissions for Calico Enterprise features and functions.
+description: Configure Kubernetes RBAC roles and bindings to scope user access to Calico Enterprise features, tiered policies, observability views, and management plane APIs.
 ---
 
 # Configure user roles and permissions

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/apiserver-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/apiserver-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificates to secure access to the Calico Enterprise API server.
+description: Provide TLS certificates that secure access to the Calico Enterprise API server as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for the API server

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/certificate-management.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/certificate-management.mdx
@@ -1,5 +1,5 @@
 ---
-description: Control the issuer of certificates used by Calico Enterprise.
+description: Manage TLS certificates for Calico Enterprise components by controlling the certificate issuer through the Kubernetes Certificates API and operator configuration.
 ---
 
 # Manage TLS certificates used by Calico Enterprise

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/compliance-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/compliance-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificate to secure access to compliance.
+description: Provide TLS certificates that secure access to the Calico Enterprise compliance components as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for compliance

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/crypto-auth.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/crypto-auth.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable TLS authentication and encryption for various Calico Enterprise components.
+description: Configure TLS authentication and encryption across Calico Enterprise components, the Kubernetes control plane, Typha, Node, and shared observability traffic.
 ---
 
 # Configure encryption and authentication to secure Calico Enterprise components

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Secure communications for Calico components.
+description: Secure communications between Calico Enterprise components with mutual TLS, including API server, log storage, web console, BGP, and observability stack endpoints.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/linseed-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/linseed-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificate to secure access to Linseed APIs.
+description: Provide TLS certificates that secure access to the Calico Enterprise Linseed APIs as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for Linseed APIs

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/log-storage-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/log-storage-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificate to secure access to log storage.
+description: Provide TLS certificates that secure access to Calico Enterprise log storage as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for log storage

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/manager-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/manager-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificates to secure access to Calico Enterprise Manager user interface.
+description: Provide TLS certificates that secure browser access to the Calico Enterprise web console user interface in place of the default self-signed certificate.
 ---
 
 # Provide TLS certificates for Calico Enterprise Manager

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/packetcapture-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/packetcapture-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificate to secure access to PacketCapture APIs.
+description: Provide TLS certificates that secure access to the Calico Enterprise PacketCapture APIs as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for PacketCapture APIs

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/secure-bgp.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/secure-bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP passwords to prevent attackers from injecting false routing information.
+description: Configure BGP session passwords on Calico Enterprise BGP peers to block attackers from injecting false routing information into the cluster.
 ---
 
 # Secure BGP sessions

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/secure-metrics.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/secure-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Limit access to Calico Enterprise metric endpoints using network policy.
+description: Restrict access to Calico Enterprise Prometheus metric endpoints with network policy so only authorized scrapers can read sensitive component telemetry.
 ---
 
 # Secure Calico Enterprise Prometheus endpoints

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/typha-node-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/comms/typha-node-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificates to secure communications between if you are using Typha to scale your deployment.
+description: Provide a custom CA and TLS certificates for mutual TLS authentication between Calico Enterprise Node and Typha components at scale.
 ---
 
 # Provide TLS certificates for Typha and Node

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/decommissioning-a-node.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/decommissioning-a-node.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manually remove a node from a cluster that is installed with Calico.
+description: Manually decommission a node in a Calico Enterprise cluster, releasing IP allocations and BGP peers from the cluster datastore cleanly.
 ---
 
 # Decommission a node

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/enabling-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to enable the eBPF data plane on an existing cluster.
+description: Switch a running Calico Enterprise cluster to the eBPF data plane on an existing installation as an alternative to the iptables data plane.
 ---
 
 # Enable eBPF on an existing cluster

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Documentation for eBPF data plane mode, including how to enable eBPF data plane mode.
+description: Reference index for the Calico Enterprise eBPF data plane covering installation, runtime switching, troubleshooting, and use-case selection.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/install.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/install.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install Calico Enterprise in eBPF mode.
+description: Install Calico Enterprise with the eBPF data plane during initial cluster setup as an alternative to the iptables data plane.
 ---
 
 # Install in eBPF mode

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/troubleshoot-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/troubleshoot-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: How to troubleshoot when running in eBPF mode.
+description: Troubleshooting guide for the Calico Enterprise eBPF data plane covering verification logs, service connectivity, BPF map inspection, and common failure modes.
 ---
 
 # Troubleshoot eBPF mode

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/use-cases-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/use-cases-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn when to use eBPF, and when not to.
+description: Guidance on when the Calico Enterprise eBPF data plane fits a workload compared to the standard iptables data plane, with trade-offs and feature comparisons.
 ---
 
 # eBPF use cases

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Post-installation tasks for managing Calico including upgrading and troubleshooting.
+description: Day-2 operations for Calico Enterprise clusters covering upgrades, web console access, CLIs, certificate management, log storage, monitoring, eBPF, and troubleshooting.
 ---
 
 import { DocCardLink, DocCardLinkLayout } from '/src/___new___/components';

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/license-options.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/license-options.mdx
@@ -1,5 +1,5 @@
 ---
-description: Review options to track your Calico Enterprise license expiration.
+description: Track Calico Enterprise license expiration through operator-exposed Prometheus metrics and renewal workflows to avoid unplanned cluster degradation.
 ---
 
 # License expiration and renewal

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/logstorage/adjust-log-storage-size.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/logstorage/adjust-log-storage-size.mdx
@@ -1,5 +1,5 @@
 ---
-description: Adjust the log storage size during or after installation.
+description: Resize the Calico Enterprise log storage cluster by tuning node counts, replicas, CPU, and memory during or after installation for production workloads.
 ---
 
 # Adjust log storage size

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/logstorage/advanced-node-scheduling.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/logstorage/advanced-node-scheduling.mdx
@@ -1,5 +1,5 @@
 ---
-description: Control where Elasticsearch pods and replicas are scheduled.
+description: Steer Calico Enterprise Elasticsearch pod and replica placement across Kubernetes nodes with data-node selectors and shard scheduling controls.
 ---
 
 # Advanced Node Scheduling

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/logstorage/create-storage.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/logstorage/create-storage.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure persistent storage for flow logs, DNS logs, audit logs, and compliance reports.
+description: Configure persistent storage in Calico Enterprise for flow logs, DNS logs, audit logs, and compliance reports before installation.
 ---
 
 # Configure storage for logs and reports

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/logstorage/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/logstorage/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure your log storage.
+description: Configure log storage for Calico Enterprise covering persistent volumes, node scheduling, sizing, and capacity recommendations.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/logstorage/log-storage-recommendations.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/logstorage/log-storage-recommendations.mdx
@@ -1,5 +1,5 @@
 ---
-description: Guidelines for setting up your log storage.
+description: Reference recommendations for Calico Enterprise log storage covering Elastic Cloud on Kubernetes, StorageClasses, node sizing, and production capacity.
 ---
 
 # Log storage recommendations

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Tools for scraping useful metrics.
+description: Reference index for monitoring Calico Enterprise clusters with the bundled Prometheus stack covering BGP, policy, log storage, and operator metrics.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/metrics/bgp-metrics.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/metrics/bgp-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor BGP peering and route exchange in your cluster and get alerts by defining rules and thresholds.
+description: Monitor BGP peering and route exchange in Calico Enterprise clusters by defining Prometheus rules and thresholds for peer health and route counts.
 ---
 
 # BGP metrics

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/metrics/elasticsearch-and-fluentd-metrics.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/metrics/elasticsearch-and-fluentd-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor Elasticsearch and Fluentd metrics, and get alerts on log storage or collection issues.
+description: Track Calico Enterprise Elasticsearch and Fluentd metrics in Prometheus to alert on flow, DNS, audit, and compliance log collection or storage disruptions.
 ---
 
 # Elasticsearch and Fluentd metrics

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/metrics/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/metrics/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Prometheus metrics.
+description: Reference index for Calico Enterprise Prometheus metrics covering BGP, policy, log storage, and recommended dashboards.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/metrics/policy-metrics.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/metrics/policy-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor the effects of policy in your cluster and received alerts by defining rules and thresholds.
+description: Monitor the runtime effect of Calico Enterprise policies on cluster traffic by defining Prometheus rules and thresholds that fire alerts on policy hits.
 ---
 
 # Policy metrics

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/metrics/recommended-metrics.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/metrics/recommended-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Recommended Prometheus metrics for monitoring Calico Enterprise components.
+description: Recommended Prometheus metrics for Calico Enterprise Typha, Felix, and policy components, covering the signals most critical to cluster health.
 ---
 
 # Recommended Prometheus metrics

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/prometheus/alertmanager.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/prometheus/alertmanager.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Alertmanager, a Prometheus feature that routes alerts.
+description: Configure Alertmanager in a Calico Enterprise cluster to route Prometheus alerts to operators with deduplication, grouping, silencing, and inhibition rules.
 ---
 
 # Configure Alertmanager

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/prometheus/byo-prometheus.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to get Calico Enterprise metrics using your own Prometheus.
+description: Scrape Calico Enterprise component metrics from an existing bring-your-own Prometheus deployment instead of the bundled operator-managed Prometheus.
 ---
 
 # Bring your own Prometheus

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/prometheus/configure-prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/prometheus/configure-prometheus.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure rules for alerts and denied packets, for persistent storage.
+description: Configure Calico Enterprise Prometheus rules for denied-packet alerts and persistent storage by editing the bundled PrometheusRule and StorageClass resources.
 ---
 
 # Configure Prometheus

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/prometheus/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/prometheus/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure open-source toolkit for systems monitoring and alerting.
+description: Configure the open-source Prometheus monitoring and alerting toolkit bundled with Calico Enterprise for component metrics, alerts, and persistent storage.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/prometheus/support.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/prometheus/support.mdx
@@ -1,5 +1,5 @@
 ---
-description: Prometheus support in Calico Enterprise.
+description: Reference for Prometheus support in Calico Enterprise covering the bundled operator-managed install and bring-your-own Prometheus deployment options.
 ---
 
 # Prometheus support

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/nftables.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/nftables.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install Calico Enterprise using the nftables data plane.
+description: Install Calico Enterprise on a cluster running kube-proxy in nftables mode for Kubernetes 1.31 or later, using the nftables Linux data plane.
 title: "nftables"
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/troubleshoot/commands.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/troubleshoot/commands.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn basic commands to verify cluster and components are working.
+description: Reference of command-line tools and kubectl invocations for verifying cluster, routing, policy, and component health in Calico Enterprise.
 ---
 
 # Troubleshooting commands

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/troubleshoot/component-logs.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/troubleshoot/component-logs.mdx
@@ -1,5 +1,5 @@
 ---
-description: Where to find component logs.
+description: Reference for locating and collecting Calico Enterprise component logs including calico/node, Felix, Typha, Linseed, and observability stack output.
 ---
 
 # Component logs

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/troubleshoot/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/troubleshoot/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Troubleshooting, logs, and diagnostics.
+description: Troubleshooting guide for Calico Enterprise clusters covering diagnostic commands, component logs, and recovery procedures.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/troubleshoot/troubleshooting.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/troubleshoot/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-description: View logs and diagnostics, common issues, and where to report issues in github.
+description: Troubleshooting guide for Calico Enterprise clusters covering kubectl-calico diagnostics bundles, log severity tuning, common failure patterns, and where to report issues.
 ---
 
 # Troubleshooting and diagnostics

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoctl/configure/datastore.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoctl/configure/datastore.mdx
@@ -1,5 +1,5 @@
 ---
-description: Sample configuration files for the Kubernetes API datastore.
+description: Sample calicoctl configuration for connecting to the Kubernetes API datastore in a Calico Enterprise cluster, with kubeconfig credential settings.
 ---
 
 # Configure calicoctl to connect to the datastore

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoctl/configure/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoctl/configure/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure the calicoctl to access your datastore.
+description: Configure calicoctl to reach the datastore backing a Calico Enterprise cluster through config files, environment variables, or kubeconfig credentials.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoctl/configure/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoctl/configure/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure calicoctl for datastore access.
+description: Overview reference for configuring calicoctl datastore access in Calico Enterprise, comparing config-file, environment-variable, and kubeconfig methods.
 ---
 
 # Configure calicoctl

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoctl/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoctl/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install and configure the required CLI for managing Calico Enterprise resources.
+description: Install and configure calicoctl for managing Calico Enterprise resources from the command line against the Kubernetes API datastore.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoctl/install.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoctl/install.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install the CLI for Calico.
+description: Install the calicoctl command-line tool as a binary, container, or kubectl plugin so administrators can manage Calico Enterprise resources from any workstation.
 ---
 
 # Install calicoctl

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoq/configure/datastore.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoq/configure/datastore.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure CLI to connect to the Kubernetes API datastore.
+description: Sample calicoq configuration for connecting to the Kubernetes API datastore in a Calico Enterprise cluster, with kubeconfig credential settings.
 ---
 
 # Configure calicoq to connect to the datastore

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoq/configure/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoq/configure/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure calicoq for Kubernetes API datastore.
+description: Configure calicoq to reach the Kubernetes API datastore backing a Calico Enterprise cluster through config files or environment variables.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoq/configure/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoq/configure/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure the CLI to connect to the Kubernetes API datastore.
+description: Overview reference for configuring calicoq datastore access in Calico Enterprise, covering config files, environment variables, and Kubernetes credentials.
 ---
 
 import CliConfigIntro from '@site/calico-enterprise_versioned_docs/version-3.23-1/_includes/components/CliConfigIntro';

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoq/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoq/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install and configure the required CLI for managing Calico Enterprise resources.
+description: Install and configure calicoq for querying policy and endpoint relationships in a Calico Enterprise cluster from the command line.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoq/installing.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/calicoq/installing.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install the CLI for Calico Enterprise.
+description: Install the calicoq command-line tool as a binary or container on any host with network access to the Calico Enterprise datastore.
 ---
 
 import MaintenanceClisCalicoqInstalling from '@site/calico-enterprise_versioned_docs/version-3.23-1/_includes/components/MaintenanceClisCalicoqInstalling';

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/clis/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install and configure CLIs for manipulating and querying resources.
+description: Install and configure the Calico Enterprise command-line tools calicoctl and calicoq for managing and querying cluster resources.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/cnx/access-the-manager.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/cnx/access-the-manager.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure access to the web console.
+description: Expose the Calico Enterprise web console outside the cluster through ingress, a load balancer service, or port forwarding for administrator access.
 ---
 
 # Configure access to the web console

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/cnx/authentication-quickstart.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/cnx/authentication-quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use default token authentication to log in to the web console and Kibana.
+description: Sign in to the Calico Enterprise web console and Kibana with default service-account token authentication for a quick first-time setup.
 ---
 
 # Authentication quickstart

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/cnx/configure-identity-provider.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure an external identity provider for user access to Calico Enterprise Manager and Kibana.
+description: Connect an external identity provider to Calico Enterprise so users authenticate against an existing IdP when signing in to the web console and Kibana.
 ---
 
 # Configure an external identity provider

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/cnx/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/cnx/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Get started using the web console.
+description: Start with the Calico Enterprise web console covering access exposure, authentication, identity-provider integration, and role-based permissions.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/cnx/roles-and-permissions.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/cnx/roles-and-permissions.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure roles and permissions for Calico Enterprise features and functions.
+description: Configure Kubernetes RBAC roles and bindings to scope user access to Calico Enterprise features, tiered policies, observability views, and management plane APIs.
 ---
 
 # Configure user roles and permissions

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/apiserver-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/apiserver-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificates to secure access to the Calico Enterprise API server.
+description: Provide TLS certificates that secure access to the Calico Enterprise API server as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for the API server

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/certificate-management.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/certificate-management.mdx
@@ -1,5 +1,5 @@
 ---
-description: Control the issuer of certificates used by Calico Enterprise.
+description: Manage TLS certificates for Calico Enterprise components by controlling the certificate issuer through the Kubernetes Certificates API and operator configuration.
 ---
 
 # Manage TLS certificates used by Calico Enterprise

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/compliance-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/compliance-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificate to secure access to compliance.
+description: Provide TLS certificates that secure access to the Calico Enterprise compliance components as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for compliance

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/crypto-auth.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/crypto-auth.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable TLS authentication and encryption for various Calico Enterprise components.
+description: Configure TLS authentication and encryption across Calico Enterprise components, the Kubernetes control plane, Typha, Node, and shared observability traffic.
 ---
 
 # Configure encryption and authentication to secure Calico Enterprise components

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Secure communications for Calico components.
+description: Secure communications between Calico Enterprise components with mutual TLS, including API server, log storage, web console, BGP, and observability stack endpoints.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/linseed-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/linseed-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificate to secure access to Linseed APIs.
+description: Provide TLS certificates that secure access to the Calico Enterprise Linseed APIs as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for Linseed APIs

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/log-storage-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/log-storage-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificate to secure access to log storage.
+description: Provide TLS certificates that secure access to Calico Enterprise log storage as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for log storage

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/manager-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/manager-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificates to secure access to Calico Enterprise Manager user interface.
+description: Provide TLS certificates that secure browser access to the Calico Enterprise web console user interface in place of the default self-signed certificate.
 ---
 
 # Provide TLS certificates for Calico Enterprise Manager

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/packetcapture-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/packetcapture-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificate to secure access to PacketCapture APIs.
+description: Provide TLS certificates that secure access to the Calico Enterprise PacketCapture APIs as part of a zero-trust deployment model.
 ---
 
 # Provide TLS certificates for PacketCapture APIs

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/secure-bgp.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/secure-bgp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure BGP passwords to prevent attackers from injecting false routing information.
+description: Configure BGP session passwords on Calico Enterprise BGP peers to block attackers from injecting false routing information into the cluster.
 ---
 
 # Secure BGP sessions

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/secure-metrics.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/secure-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Limit access to Calico Enterprise metric endpoints using network policy.
+description: Restrict access to Calico Enterprise Prometheus metric endpoints with network policy so only authorized scrapers can read sensitive component telemetry.
 ---
 
 # Secure Calico Enterprise Prometheus endpoints

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/typha-node-tls.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/comms/typha-node-tls.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add TLS certificates to secure communications between if you are using Typha to scale your deployment.
+description: Provide a custom CA and TLS certificates for mutual TLS authentication between Calico Enterprise Node and Typha components at scale.
 ---
 
 # Provide TLS certificates for Typha and Node

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/decommissioning-a-node.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/decommissioning-a-node.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manually remove a node from a cluster that is installed with Calico.
+description: Manually decommission a node in a Calico Enterprise cluster, releasing IP allocations and BGP peers from the cluster datastore cleanly.
 ---
 
 # Decommission a node

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/enabling-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to enable the eBPF data plane on an existing cluster.
+description: Switch a running Calico Enterprise cluster to the eBPF data plane on an existing installation as an alternative to the iptables data plane.
 ---
 
 # Enable eBPF on an existing cluster

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Documentation for eBPF data plane mode, including how to enable eBPF data plane mode.
+description: Reference index for the Calico Enterprise eBPF data plane covering installation, runtime switching, troubleshooting, and use-case selection.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/install.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/install.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install Calico Enterprise in eBPF mode.
+description: Install Calico Enterprise with the eBPF data plane during initial cluster setup as an alternative to the iptables data plane.
 ---
 
 # Install in eBPF mode

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/troubleshoot-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/troubleshoot-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: How to troubleshoot when running in eBPF mode.
+description: Troubleshooting guide for the Calico Enterprise eBPF data plane covering verification logs, service connectivity, BPF map inspection, and common failure modes.
 ---
 
 # Troubleshoot eBPF mode

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/use-cases-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/ebpf/use-cases-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn when to use eBPF, and when not to.
+description: Guidance on when the Calico Enterprise eBPF data plane fits a workload compared to the standard iptables data plane, with trade-offs and feature comparisons.
 ---
 
 # eBPF use cases

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Post-installation tasks for managing Calico including upgrading and troubleshooting.
+description: Day-2 operations for Calico Enterprise clusters covering upgrades, web console access, CLIs, certificate management, log storage, monitoring, eBPF, and troubleshooting.
 ---
 
 import { DocCardLink, DocCardLinkLayout } from '/src/___new___/components';

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/license-options.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/license-options.mdx
@@ -1,5 +1,5 @@
 ---
-description: Review options to track your Calico Enterprise license expiration.
+description: Track Calico Enterprise license expiration through operator-exposed Prometheus metrics and renewal workflows to avoid unplanned cluster degradation.
 ---
 
 # License expiration and renewal

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/logstorage/adjust-log-storage-size.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/logstorage/adjust-log-storage-size.mdx
@@ -1,5 +1,5 @@
 ---
-description: Adjust the log storage size during or after installation.
+description: Resize the Calico Enterprise log storage cluster by tuning node counts, replicas, CPU, and memory during or after installation for production workloads.
 ---
 
 # Adjust log storage size

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/logstorage/advanced-node-scheduling.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/logstorage/advanced-node-scheduling.mdx
@@ -1,5 +1,5 @@
 ---
-description: Control where Elasticsearch pods and replicas are scheduled.
+description: Steer Calico Enterprise Elasticsearch pod and replica placement across Kubernetes nodes with data-node selectors and shard scheduling controls.
 ---
 
 # Advanced Node Scheduling

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/logstorage/create-storage.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/logstorage/create-storage.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure persistent storage for flow logs, DNS logs, audit logs, and compliance reports.
+description: Configure persistent storage in Calico Enterprise for flow logs, DNS logs, audit logs, and compliance reports before installation.
 ---
 
 # Configure storage for logs and reports

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/logstorage/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/logstorage/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure your log storage.
+description: Configure log storage for Calico Enterprise covering persistent volumes, node scheduling, sizing, and capacity recommendations.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/logstorage/log-storage-recommendations.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/logstorage/log-storage-recommendations.mdx
@@ -1,5 +1,5 @@
 ---
-description: Guidelines for setting up your log storage.
+description: Reference recommendations for Calico Enterprise log storage covering Elastic Cloud on Kubernetes, StorageClasses, node sizing, and production capacity.
 ---
 
 # Log storage recommendations

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Tools for scraping useful metrics.
+description: Reference index for monitoring Calico Enterprise clusters with the bundled Prometheus stack covering BGP, policy, log storage, and operator metrics.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/metrics/bgp-metrics.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/metrics/bgp-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor BGP peering and route exchange in your cluster and get alerts by defining rules and thresholds.
+description: Monitor BGP peering and route exchange in Calico Enterprise clusters by defining Prometheus rules and thresholds for peer health and route counts.
 ---
 
 # BGP metrics

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/metrics/elasticsearch-and-fluentd-metrics.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/metrics/elasticsearch-and-fluentd-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor Elasticsearch and Fluentd metrics, and get alerts on log storage or collection issues.
+description: Track Calico Enterprise Elasticsearch and Fluentd metrics in Prometheus to alert on flow, DNS, audit, and compliance log collection or storage disruptions.
 ---
 
 # Elasticsearch and Fluentd metrics

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/metrics/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/metrics/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Prometheus metrics.
+description: Reference index for Calico Enterprise Prometheus metrics covering BGP, policy, log storage, and recommended dashboards.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/metrics/policy-metrics.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/metrics/policy-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor the effects of policy in your cluster and received alerts by defining rules and thresholds.
+description: Monitor the runtime effect of Calico Enterprise policies on cluster traffic by defining Prometheus rules and thresholds that fire alerts on policy hits.
 ---
 
 # Policy metrics

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/metrics/recommended-metrics.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/metrics/recommended-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Recommended Prometheus metrics for monitoring Calico Enterprise components.
+description: Recommended Prometheus metrics for Calico Enterprise Typha, Felix, and policy components, covering the signals most critical to cluster health.
 ---
 
 # Recommended Prometheus metrics

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/prometheus/alertmanager.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/prometheus/alertmanager.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Alertmanager, a Prometheus feature that routes alerts.
+description: Configure Alertmanager in a Calico Enterprise cluster to route Prometheus alerts to operators with deduplication, grouping, silencing, and inhibition rules.
 ---
 
 # Configure Alertmanager

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/prometheus/byo-prometheus.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to get Calico Enterprise metrics using your own Prometheus.
+description: Scrape Calico Enterprise component metrics from an existing bring-your-own Prometheus deployment instead of the bundled operator-managed Prometheus.
 ---
 
 # Bring your own Prometheus

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/prometheus/configure-prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/prometheus/configure-prometheus.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure rules for alerts and denied packets, for persistent storage.
+description: Configure Calico Enterprise Prometheus rules for denied-packet alerts and persistent storage by editing the bundled PrometheusRule and StorageClass resources.
 ---
 
 # Configure Prometheus

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/prometheus/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/prometheus/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure open-source toolkit for systems monitoring and alerting.
+description: Configure the open-source Prometheus monitoring and alerting toolkit bundled with Calico Enterprise for component metrics, alerts, and persistent storage.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/prometheus/support.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/monitor/prometheus/support.mdx
@@ -1,5 +1,5 @@
 ---
-description: Prometheus support in Calico Enterprise.
+description: Reference for Prometheus support in Calico Enterprise covering the bundled operator-managed install and bring-your-own Prometheus deployment options.
 ---
 
 # Prometheus support

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/nftables.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/nftables.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install Calico Enterprise using the nftables data plane.
+description: Install Calico Enterprise on a cluster running kube-proxy in nftables mode for Kubernetes 1.31 or later, using the nftables Linux data plane.
 title: "nftables"
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/troubleshoot/commands.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/troubleshoot/commands.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn basic commands to verify cluster and components are working.
+description: Reference of command-line tools and kubectl invocations for verifying cluster, routing, policy, and component health in Calico Enterprise.
 ---
 
 # Troubleshooting commands

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/troubleshoot/component-logs.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/troubleshoot/component-logs.mdx
@@ -1,5 +1,5 @@
 ---
-description: Where to find component logs.
+description: Reference for locating and collecting Calico Enterprise component logs including calico/node, Felix, Typha, Linseed, and observability stack output.
 ---
 
 # Component logs

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/troubleshoot/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/troubleshoot/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Troubleshooting, logs, and diagnostics.
+description: Troubleshooting guide for Calico Enterprise clusters covering diagnostic commands, component logs, and recovery procedures.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/troubleshoot/troubleshooting.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/troubleshoot/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-description: View logs and diagnostics, common issues, and where to report issues in github.
+description: Troubleshooting guide for Calico Enterprise clusters covering kubectl-calico diagnostics bundles, log severity tuning, common failure patterns, and where to report issues.
 ---
 
 # Troubleshooting and diagnostics

--- a/calico/operations/calicoctl/configure/etcd.mdx
+++ b/calico/operations/calicoctl/configure/etcd.mdx
@@ -1,5 +1,5 @@
 ---
-description: Sample configuration files etcd.
+description: Sample calicoctl configuration files for connecting to an etcdv3 datastore in a Calico Open Source cluster, with TLS, endpoints, and authentication settings.
 ---
 
 # Configure calicoctl to connect to an etcd datastore

--- a/calico/operations/calicoctl/configure/index.mdx
+++ b/calico/operations/calicoctl/configure/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure the calicoctl to access your datastore.
+description: Configure calicoctl to reach the datastore backing a Calico Open Source cluster through config files, environment variables, or kubeconfig credentials.
 hide_table_of_contents: true
 ---
 

--- a/calico/operations/calicoctl/configure/kdd.mdx
+++ b/calico/operations/calicoctl/configure/kdd.mdx
@@ -1,5 +1,5 @@
 ---
-description: Sample configuration files for kdd.
+description: Sample calicoctl configuration files for connecting to the Kubernetes API datastore in a Calico Open Source cluster using kubeconfig credentials.
 ---
 
 # Configure calicoctl to connect to the Kubernetes API datastore

--- a/calico/operations/calicoctl/configure/overview.mdx
+++ b/calico/operations/calicoctl/configure/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure calicoctl for datastore access.
+description: Overview reference for configuring calicoctl datastore access in Calico Open Source, comparing config-file, environment-variable, and kubeconfig credential methods.
 ---
 
 # Configure calicoctl

--- a/calico/operations/calicoctl/index.mdx
+++ b/calico/operations/calicoctl/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install and configure the Calico CLI for managing resources.
+description: Install and configure calicoctl, the command-line tool for managing Calico Open Source resources in Kubernetes API and etcdv3 datastores.
 hide_table_of_contents: true
 ---
 

--- a/calico/operations/calicoctl/install.mdx
+++ b/calico/operations/calicoctl/install.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install the CLI for Calico.
+description: Install the calicoctl command-line tool as a binary, container, or kubectl plugin so administrators can manage Calico Open Source resources from any workstation.
 ---
 
 # Install calicoctl

--- a/calico/operations/certificate-management.mdx
+++ b/calico/operations/certificate-management.mdx
@@ -1,5 +1,5 @@
 ---
-description: Control the issuer of certificates used by Calico
+description: Manage TLS certificates for Calico Open Source components by controlling the certificate issuer through the Kubernetes Certificates API and operator configuration.
 ---
 
 # Manage TLS certificates used by Calico

--- a/calico/operations/crd-migration.mdx
+++ b/calico/operations/crd-migration.mdx
@@ -1,5 +1,5 @@
 ---
-description: Migrate Calico resources from the aggregated API server (v1 CRDs) to native v3 CRDs to remove the API server component.
+description: Migrate Calico Open Source resources from the aggregated API server backing storage to native projectcalico.org/v3 CRDs so the API server component can be removed.
 ---
 
 # Migrate from API server to native CRDs

--- a/calico/operations/datastore-migration.mdx
+++ b/calico/operations/datastore-migration.mdx
@@ -1,5 +1,5 @@
 ---
-description: Migrate your cluster from using an etcdv3 datastore to a Kubernetes datastore.
+description: Migrate a Calico Open Source cluster from the etcdv3 datastore to the Kubernetes API datastore with calicoctl, preserving network and policy state on a live cluster.
 ---
 
 # Migrate Calico data from an etcdv3 datastore to a Kubernetes datastore

--- a/calico/operations/decommissioning-a-node.mdx
+++ b/calico/operations/decommissioning-a-node.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manually remove a node from a cluster that is installed with Calico.
+description: Manually decommission a node in a self-managed Calico Open Source cluster with calicoctl, releasing IP allocations and BGP peers from the datastore cleanly.
 ---
 
 # Decommission a node

--- a/calico/operations/ebpf/enabling-ebpf.mdx
+++ b/calico/operations/ebpf/enabling-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: Step-by-step instructions for enabling the eBPF data plane.
+description: Switch a running Calico Open Source cluster to the eBPF data plane through automatic Tigera Operator detection on kubeadm clusters or a manual configuration path.
 ---
 
 # Enabling the eBPF data plane

--- a/calico/operations/ebpf/index.mdx
+++ b/calico/operations/ebpf/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Documentation for eBPF data plane mode, including how to enable eBPF data plane mode.
+description: Reference index for the Calico Open Source eBPF data plane covering installation, runtime switching, troubleshooting, and use-case selection.
 hide_table_of_contents: true
 ---
 

--- a/calico/operations/ebpf/install.mdx
+++ b/calico/operations/ebpf/install.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install Calico in eBPF mode.
+description: Install Calico Open Source with the eBPF data plane during initial cluster setup as an alternative to the iptables data plane.
 ---
 
 # Install in eBPF mode

--- a/calico/operations/ebpf/troubleshoot-ebpf.mdx
+++ b/calico/operations/ebpf/troubleshoot-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: How to troubleshoot when running in eBPF mode.
+description: Troubleshooting guide for the Calico Open Source eBPF data plane covering verification logs, service connectivity, BPF map inspection, and common failure modes.
 ---
 
 # Troubleshoot eBPF mode

--- a/calico/operations/ebpf/use-cases-ebpf.mdx
+++ b/calico/operations/ebpf/use-cases-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn when to use eBPF, and when not to.
+description: Guidance on when the Calico Open Source eBPF data plane fits a workload compared to the standard iptables data plane, with trade-offs and feature comparisons.
 ---
 
 # eBPF use cases

--- a/calico/operations/fips.mdx
+++ b/calico/operations/fips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Run Calico using FIPS validated cryptography.
+description: Run Calico Open Source in FIPS 140-2 compliant mode using NIST-validated cryptographic modules and FIPS-approved algorithms across all data plane components.
 ---
 
 # FIPS mode

--- a/calico/operations/image-options/alternate-registry.mdx
+++ b/calico/operations/image-options/alternate-registry.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to pull images from a public or private registry.
+description: Configure Calico Open Source to pull operator and component images from a public or private container registry, including air-gapped and constrained networks.
 ---
 
 # Configure use of your image registry

--- a/calico/operations/image-options/imageset.mdx
+++ b/calico/operations/image-options/imageset.mdx
@@ -1,5 +1,5 @@
 ---
-description: Specify the digests for operator to use to deploy images.
+description: Pin Calico Open Source operator deployments to immutable image digests with an ImageSet resource so security teams can review and verify each image.
 ---
 
 # Install images by registry digest

--- a/calico/operations/image-options/index.mdx
+++ b/calico/operations/image-options/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install Calico using from a public or private registry, or by digest.
+description: Install Calico Open Source from a public or private container registry, or pin operator-managed components to specific image digests.
 hide_table_of_contents: true
 ---
 

--- a/calico/operations/index.mdx
+++ b/calico/operations/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Post-installation tasks for managing Calico including upgrading and troubleshooting.
+description: Day-2 operations for Calico Open Source clusters covering upgrades, calicoctl, certificate management, monitoring, image registries, eBPF, and troubleshooting.
 ---
 
 import { DocCardLink, DocCardLinkLayout } from '/src/___new___/components';

--- a/calico/operations/install-apiserver.mdx
+++ b/calico/operations/install-apiserver.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install the Calico API server on an existing Calico cluster
+description: Install the Calico Open Source aggregated API server on an existing cluster so kubectl can manage projectcalico.org/v3 resources without calicoctl.
 ---
 
 # Enable kubectl to manage Calico APIs

--- a/calico/operations/istio/about-istio-ambient.mdx
+++ b/calico/operations/istio/about-istio-ambient.mdx
@@ -1,5 +1,5 @@
 ---
-description: An overview of Calico's bundled version of Istio Ambient Mode
+description: Overview of the Istio ambient mode service mesh bundled with Calico Open Source, covering mTLS without sidecars and integration with Calico network policy.
 ---
 
 # Istio Ambient Mode

--- a/calico/operations/istio/deploy-istio-ambient.mdx
+++ b/calico/operations/istio/deploy-istio-ambient.mdx
@@ -1,5 +1,5 @@
 ---
-description: This page explains how to deploy Calico's bundled version of Istio in ambient mode.
+description: Deploy the Calico Open Source bundled Istio ambient mesh on an existing cluster to add mTLS to workloads without sidecars or Waypoint.
 ---
 
 # Deploy Istio Ambient Mode on your cluster

--- a/calico/operations/monitor/index.mdx
+++ b/calico/operations/monitor/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Tools for scraping useful metrics
+description: Reference index for scraping and visualizing Calico Open Source component metrics with the open-source Prometheus and Grafana stack.
 hide_table_of_contents: true
 ---
 

--- a/calico/operations/monitor/monitor-component-metrics.mdx
+++ b/calico/operations/monitor/monitor-component-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use open source Prometheus for monitoring and alerting on Calico components.
+description: Scrape Calico Open Source Felix, Typha, and kube-controllers metrics with open-source Prometheus and configure alerting rules from time-series data.
 ---
 
 # Monitor Calico component metrics

--- a/calico/operations/monitor/monitor-component-visual.mdx
+++ b/calico/operations/monitor/monitor-component-visual.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use open source Grafana for visualizing Calico components.
+description: Visualize Calico Open Source component metrics scraped by Prometheus on Grafana dashboards to spot anomalies in Felix, Typha, and node performance.
 ---
 
 # Visualizing metrics via Grafana

--- a/calico/operations/native-v3-crds.mdx
+++ b/calico/operations/native-v3-crds.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable native projectcalico.org/v3 CRDs to use Calico resources directly as CRDs without the aggregation API server.
+description: Switch Calico Open Source to native projectcalico.org/v3 CRDs so resources are stored directly as CRDs without the aggregated API server component.
 ---
 
 # Enable native v3 CRDs

--- a/calico/operations/operator-migration.mdx
+++ b/calico/operations/operator-migration.mdx
@@ -1,5 +1,5 @@
 ---
-description: Migrate Calico from manifest-based to operator-managed installation
+description: Migrate a Calico Open Source installation from manifest-based resources to an operator-managed install for automatic platform detection, simpler upgrades, and lifecycle management.
 ---
 
 # Migrate Calico to an operator-managed installation

--- a/calico/operations/troubleshoot/commands.mdx
+++ b/calico/operations/troubleshoot/commands.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn basic commands to verify cluster and components are working.
+description: Reference of command-line tools and kubectl invocations for verifying cluster, routing, and component health in a Calico Open Source installation.
 ---
 
 # Troubleshooting commands

--- a/calico/operations/troubleshoot/component-logs.mdx
+++ b/calico/operations/troubleshoot/component-logs.mdx
@@ -1,5 +1,5 @@
 ---
-description: Where to find component logs.
+description: Reference for locating and collecting Calico Open Source component logs including calico/node, Felix, Typha, kube-controllers, and CNI plugin output.
 ---
 
 # Component logs

--- a/calico/operations/troubleshoot/index.mdx
+++ b/calico/operations/troubleshoot/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Troubleshooting, logs, and diagnostics.
+description: Troubleshooting guide for Calico Open Source clusters covering diagnostic commands, component logs, and known issues for self-managed installations.
 hide_table_of_contents: true
 ---
 

--- a/calico/operations/troubleshoot/troubleshooting.mdx
+++ b/calico/operations/troubleshoot/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-description: View logs and diagnostics, common issues, and where to report issues in github.
+description: Troubleshooting guide for Calico Open Source clusters covering diagnostics, common failure patterns, log severity tuning, and where to file upstream issues.
 ---
 
 # Troubleshooting and diagnostics

--- a/calico/operations/troubleshoot/vpp.mdx
+++ b/calico/operations/troubleshoot/vpp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Specific troubleshooting steps for the VPP data plane.
+description: Troubleshooting guide for the Calico Open Source VPP data plane covering log collection, diagnostic helpers, and recovery from common VPP failure modes.
 ---
 
 # VPP data plane troubleshooting

--- a/calico/operations/upgrading/index.mdx
+++ b/calico/operations/upgrading/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Upgrade to a newer version of Calico.
+description: Upgrade options for Calico Open Source clusters covering Kubernetes, OpenShift, and OpenStack platforms with manifest, Helm, and operator install methods.
 hide_table_of_contents: true
 ---
 

--- a/calico/operations/upgrading/kubernetes-upgrade.mdx
+++ b/calico/operations/upgrading/kubernetes-upgrade.mdx
@@ -1,5 +1,5 @@
 ---
-description: Upgrade to a newer version of Calico for Kubernetes.
+description: Upgrade Calico Open Source on Kubernetes from v3.15 or later for Helm, operator-managed, and manifest-based installs on both Kubernetes API and etcd datastores.
 ---
 
 import AutoHostendpointsMigrate from '@site/calico/_includes/components/AutoHostendpointsMigrate';

--- a/calico/operations/upgrading/openshift-upgrade.mdx
+++ b/calico/operations/upgrading/openshift-upgrade.mdx
@@ -1,5 +1,5 @@
 ---
-description: Upgrade to a newer version of Calico for OpenShift.
+description: Upgrade Calico Open Source on OpenShift 4 by reapplying manifests and updating OwnerReferences for projectcalico.org/v3 resources.
 ---
 
 import AutoHostendpointsMigrate from '@site/calico/_includes/components/AutoHostendpointsMigrate';

--- a/calico/operations/upgrading/openstack-upgrade.mdx
+++ b/calico/operations/upgrading/openstack-upgrade.mdx
@@ -1,5 +1,5 @@
 ---
-description: Upgrade to a newer version of Calico for OpenStack.
+description: Upgrade Calico Open Source on OpenStack from v3.0 or later by updating system packages on CentOS or Ubuntu compute and control nodes.
 ---
 
 # Upgrade Calico on OpenStack

--- a/calico_versioned_docs/version-3.32/operations/calicoctl/configure/etcd.mdx
+++ b/calico_versioned_docs/version-3.32/operations/calicoctl/configure/etcd.mdx
@@ -1,5 +1,5 @@
 ---
-description: Sample configuration files etcd.
+description: Sample calicoctl configuration files for connecting to an etcdv3 datastore in a Calico Open Source cluster, with TLS, endpoints, and authentication settings.
 ---
 
 # Configure calicoctl to connect to an etcd datastore

--- a/calico_versioned_docs/version-3.32/operations/calicoctl/configure/index.mdx
+++ b/calico_versioned_docs/version-3.32/operations/calicoctl/configure/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure the calicoctl to access your datastore.
+description: Configure calicoctl to reach the datastore backing a Calico Open Source cluster through config files, environment variables, or kubeconfig credentials.
 hide_table_of_contents: true
 ---
 

--- a/calico_versioned_docs/version-3.32/operations/calicoctl/configure/kdd.mdx
+++ b/calico_versioned_docs/version-3.32/operations/calicoctl/configure/kdd.mdx
@@ -1,5 +1,5 @@
 ---
-description: Sample configuration files for kdd.
+description: Sample calicoctl configuration files for connecting to the Kubernetes API datastore in a Calico Open Source cluster using kubeconfig credentials.
 ---
 
 # Configure calicoctl to connect to the Kubernetes API datastore

--- a/calico_versioned_docs/version-3.32/operations/calicoctl/configure/overview.mdx
+++ b/calico_versioned_docs/version-3.32/operations/calicoctl/configure/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure calicoctl for datastore access.
+description: Overview reference for configuring calicoctl datastore access in Calico Open Source, comparing config-file, environment-variable, and kubeconfig credential methods.
 ---
 
 # Configure calicoctl

--- a/calico_versioned_docs/version-3.32/operations/calicoctl/index.mdx
+++ b/calico_versioned_docs/version-3.32/operations/calicoctl/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install and configure the Calico CLI for managing resources.
+description: Install and configure calicoctl, the command-line tool for managing Calico Open Source resources in Kubernetes API and etcdv3 datastores.
 hide_table_of_contents: true
 ---
 

--- a/calico_versioned_docs/version-3.32/operations/calicoctl/install.mdx
+++ b/calico_versioned_docs/version-3.32/operations/calicoctl/install.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install the CLI for Calico.
+description: Install the calicoctl command-line tool as a binary, container, or kubectl plugin so administrators can manage Calico Open Source resources from any workstation.
 ---
 
 # Install calicoctl

--- a/calico_versioned_docs/version-3.32/operations/certificate-management.mdx
+++ b/calico_versioned_docs/version-3.32/operations/certificate-management.mdx
@@ -1,5 +1,5 @@
 ---
-description: Control the issuer of certificates used by Calico
+description: Manage TLS certificates for Calico Open Source components by controlling the certificate issuer through the Kubernetes Certificates API and operator configuration.
 ---
 
 # Manage TLS certificates used by Calico

--- a/calico_versioned_docs/version-3.32/operations/crd-migration.mdx
+++ b/calico_versioned_docs/version-3.32/operations/crd-migration.mdx
@@ -1,5 +1,5 @@
 ---
-description: Migrate Calico resources from the aggregated API server (v1 CRDs) to native v3 CRDs to remove the API server component.
+description: Migrate Calico Open Source resources from the aggregated API server backing storage to native projectcalico.org/v3 CRDs so the API server component can be removed.
 ---
 
 # Migrate from API server to native CRDs

--- a/calico_versioned_docs/version-3.32/operations/datastore-migration.mdx
+++ b/calico_versioned_docs/version-3.32/operations/datastore-migration.mdx
@@ -1,5 +1,5 @@
 ---
-description: Migrate your cluster from using an etcdv3 datastore to a Kubernetes datastore.
+description: Migrate a Calico Open Source cluster from the etcdv3 datastore to the Kubernetes API datastore with calicoctl, preserving network and policy state on a live cluster.
 ---
 
 # Migrate Calico data from an etcdv3 datastore to a Kubernetes datastore

--- a/calico_versioned_docs/version-3.32/operations/decommissioning-a-node.mdx
+++ b/calico_versioned_docs/version-3.32/operations/decommissioning-a-node.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manually remove a node from a cluster that is installed with Calico.
+description: Manually decommission a node in a self-managed Calico Open Source cluster with calicoctl, releasing IP allocations and BGP peers from the datastore cleanly.
 ---
 
 # Decommission a node

--- a/calico_versioned_docs/version-3.32/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.32/operations/ebpf/enabling-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: Step-by-step instructions for enabling the eBPF data plane.
+description: Switch a running Calico Open Source cluster to the eBPF data plane through automatic Tigera Operator detection on kubeadm clusters or a manual configuration path.
 ---
 
 # Enabling the eBPF data plane

--- a/calico_versioned_docs/version-3.32/operations/ebpf/index.mdx
+++ b/calico_versioned_docs/version-3.32/operations/ebpf/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Documentation for eBPF data plane mode, including how to enable eBPF data plane mode.
+description: Reference index for the Calico Open Source eBPF data plane covering installation, runtime switching, troubleshooting, and use-case selection.
 hide_table_of_contents: true
 ---
 

--- a/calico_versioned_docs/version-3.32/operations/ebpf/install.mdx
+++ b/calico_versioned_docs/version-3.32/operations/ebpf/install.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install Calico in eBPF mode.
+description: Install Calico Open Source with the eBPF data plane during initial cluster setup as an alternative to the iptables data plane.
 ---
 
 # Install in eBPF mode

--- a/calico_versioned_docs/version-3.32/operations/ebpf/troubleshoot-ebpf.mdx
+++ b/calico_versioned_docs/version-3.32/operations/ebpf/troubleshoot-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: How to troubleshoot when running in eBPF mode.
+description: Troubleshooting guide for the Calico Open Source eBPF data plane covering verification logs, service connectivity, BPF map inspection, and common failure modes.
 ---
 
 # Troubleshoot eBPF mode

--- a/calico_versioned_docs/version-3.32/operations/ebpf/use-cases-ebpf.mdx
+++ b/calico_versioned_docs/version-3.32/operations/ebpf/use-cases-ebpf.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn when to use eBPF, and when not to.
+description: Guidance on when the Calico Open Source eBPF data plane fits a workload compared to the standard iptables data plane, with trade-offs and feature comparisons.
 ---
 
 # eBPF use cases

--- a/calico_versioned_docs/version-3.32/operations/fips.mdx
+++ b/calico_versioned_docs/version-3.32/operations/fips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Run Calico using FIPS validated cryptography.
+description: Run Calico Open Source in FIPS 140-2 compliant mode using NIST-validated cryptographic modules and FIPS-approved algorithms across all data plane components.
 ---
 
 # FIPS mode

--- a/calico_versioned_docs/version-3.32/operations/image-options/alternate-registry.mdx
+++ b/calico_versioned_docs/version-3.32/operations/image-options/alternate-registry.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to pull images from a public or private registry.
+description: Configure Calico Open Source to pull operator and component images from a public or private container registry, including air-gapped and constrained networks.
 ---
 
 # Configure use of your image registry

--- a/calico_versioned_docs/version-3.32/operations/image-options/imageset.mdx
+++ b/calico_versioned_docs/version-3.32/operations/image-options/imageset.mdx
@@ -1,5 +1,5 @@
 ---
-description: Specify the digests for operator to use to deploy images.
+description: Pin Calico Open Source operator deployments to immutable image digests with an ImageSet resource so security teams can review and verify each image.
 ---
 
 # Install images by registry digest

--- a/calico_versioned_docs/version-3.32/operations/image-options/index.mdx
+++ b/calico_versioned_docs/version-3.32/operations/image-options/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install Calico using from a public or private registry, or by digest.
+description: Install Calico Open Source from a public or private container registry, or pin operator-managed components to specific image digests.
 hide_table_of_contents: true
 ---
 

--- a/calico_versioned_docs/version-3.32/operations/index.mdx
+++ b/calico_versioned_docs/version-3.32/operations/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Post-installation tasks for managing Calico including upgrading and troubleshooting.
+description: Day-2 operations for Calico Open Source clusters covering upgrades, calicoctl, certificate management, monitoring, image registries, eBPF, and troubleshooting.
 ---
 
 import { DocCardLink, DocCardLinkLayout } from '/src/___new___/components';

--- a/calico_versioned_docs/version-3.32/operations/install-apiserver.mdx
+++ b/calico_versioned_docs/version-3.32/operations/install-apiserver.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install the Calico API server on an existing Calico cluster
+description: Install the Calico Open Source aggregated API server on an existing cluster so kubectl can manage projectcalico.org/v3 resources without calicoctl.
 ---
 
 # Enable kubectl to manage Calico APIs

--- a/calico_versioned_docs/version-3.32/operations/istio/about-istio-ambient.mdx
+++ b/calico_versioned_docs/version-3.32/operations/istio/about-istio-ambient.mdx
@@ -1,5 +1,5 @@
 ---
-description: An overview of Calico's bundled version of Istio Ambient Mode
+description: Overview of the Istio ambient mode service mesh bundled with Calico Open Source, covering mTLS without sidecars and integration with Calico network policy.
 ---
 
 # Istio Ambient Mode

--- a/calico_versioned_docs/version-3.32/operations/istio/deploy-istio-ambient.mdx
+++ b/calico_versioned_docs/version-3.32/operations/istio/deploy-istio-ambient.mdx
@@ -1,5 +1,5 @@
 ---
-description: This page explains how to deploy Calico's bundled version of Istio in ambient mode.
+description: Deploy the Calico Open Source bundled Istio ambient mesh on an existing cluster to add mTLS to workloads without sidecars or Waypoint.
 ---
 
 # Deploy Istio Ambient Mode on your cluster

--- a/calico_versioned_docs/version-3.32/operations/monitor/index.mdx
+++ b/calico_versioned_docs/version-3.32/operations/monitor/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Tools for scraping useful metrics
+description: Reference index for scraping and visualizing Calico Open Source component metrics with the open-source Prometheus and Grafana stack.
 hide_table_of_contents: true
 ---
 

--- a/calico_versioned_docs/version-3.32/operations/monitor/monitor-component-metrics.mdx
+++ b/calico_versioned_docs/version-3.32/operations/monitor/monitor-component-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use open source Prometheus for monitoring and alerting on Calico components.
+description: Scrape Calico Open Source Felix, Typha, and kube-controllers metrics with open-source Prometheus and configure alerting rules from time-series data.
 ---
 
 # Monitor Calico component metrics

--- a/calico_versioned_docs/version-3.32/operations/monitor/monitor-component-visual.mdx
+++ b/calico_versioned_docs/version-3.32/operations/monitor/monitor-component-visual.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use open source Grafana for visualizing Calico components.
+description: Visualize Calico Open Source component metrics scraped by Prometheus on Grafana dashboards to spot anomalies in Felix, Typha, and node performance.
 ---
 
 # Visualizing metrics via Grafana

--- a/calico_versioned_docs/version-3.32/operations/native-v3-crds.mdx
+++ b/calico_versioned_docs/version-3.32/operations/native-v3-crds.mdx
@@ -1,5 +1,5 @@
 ---
-description: Enable native projectcalico.org/v3 CRDs to use Calico resources directly as CRDs without the aggregation API server.
+description: Switch Calico Open Source to native projectcalico.org/v3 CRDs so resources are stored directly as CRDs without the aggregated API server component.
 ---
 
 # Enable native v3 CRDs

--- a/calico_versioned_docs/version-3.32/operations/operator-migration.mdx
+++ b/calico_versioned_docs/version-3.32/operations/operator-migration.mdx
@@ -1,5 +1,5 @@
 ---
-description: Migrate Calico from manifest-based to operator-managed installation
+description: Migrate a Calico Open Source installation from manifest-based resources to an operator-managed install for automatic platform detection, simpler upgrades, and lifecycle management.
 ---
 
 # Migrate Calico to an operator-managed installation

--- a/calico_versioned_docs/version-3.32/operations/troubleshoot/commands.mdx
+++ b/calico_versioned_docs/version-3.32/operations/troubleshoot/commands.mdx
@@ -1,5 +1,5 @@
 ---
-description: Learn basic commands to verify cluster and components are working.
+description: Reference of command-line tools and kubectl invocations for verifying cluster, routing, and component health in a Calico Open Source installation.
 ---
 
 # Troubleshooting commands

--- a/calico_versioned_docs/version-3.32/operations/troubleshoot/component-logs.mdx
+++ b/calico_versioned_docs/version-3.32/operations/troubleshoot/component-logs.mdx
@@ -1,5 +1,5 @@
 ---
-description: Where to find component logs.
+description: Reference for locating and collecting Calico Open Source component logs including calico/node, Felix, Typha, kube-controllers, and CNI plugin output.
 ---
 
 # Component logs

--- a/calico_versioned_docs/version-3.32/operations/troubleshoot/index.mdx
+++ b/calico_versioned_docs/version-3.32/operations/troubleshoot/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Troubleshooting, logs, and diagnostics.
+description: Troubleshooting guide for Calico Open Source clusters covering diagnostic commands, component logs, and known issues for self-managed installations.
 hide_table_of_contents: true
 ---
 

--- a/calico_versioned_docs/version-3.32/operations/troubleshoot/troubleshooting.mdx
+++ b/calico_versioned_docs/version-3.32/operations/troubleshoot/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-description: View logs and diagnostics, common issues, and where to report issues in github.
+description: Troubleshooting guide for Calico Open Source clusters covering diagnostics, common failure patterns, log severity tuning, and where to file upstream issues.
 ---
 
 # Troubleshooting and diagnostics

--- a/calico_versioned_docs/version-3.32/operations/troubleshoot/vpp.mdx
+++ b/calico_versioned_docs/version-3.32/operations/troubleshoot/vpp.mdx
@@ -1,5 +1,5 @@
 ---
-description: Specific troubleshooting steps for the VPP data plane.
+description: Troubleshooting guide for the Calico Open Source VPP data plane covering log collection, diagnostic helpers, and recovery from common VPP failure modes.
 ---
 
 # VPP data plane troubleshooting

--- a/calico_versioned_docs/version-3.32/operations/upgrading/index.mdx
+++ b/calico_versioned_docs/version-3.32/operations/upgrading/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Upgrade to a newer version of Calico.
+description: Upgrade options for Calico Open Source clusters covering Kubernetes, OpenShift, and OpenStack platforms with manifest, Helm, and operator install methods.
 hide_table_of_contents: true
 ---
 

--- a/calico_versioned_docs/version-3.32/operations/upgrading/kubernetes-upgrade.mdx
+++ b/calico_versioned_docs/version-3.32/operations/upgrading/kubernetes-upgrade.mdx
@@ -1,5 +1,5 @@
 ---
-description: Upgrade to a newer version of Calico for Kubernetes.
+description: Upgrade Calico Open Source on Kubernetes from v3.15 or later for Helm, operator-managed, and manifest-based installs on both Kubernetes API and etcd datastores.
 ---
 
 import AutoHostendpointsMigrate from '@site/calico_versioned_docs/version-3.32/_includes/components/AutoHostendpointsMigrate';

--- a/calico_versioned_docs/version-3.32/operations/upgrading/openshift-upgrade.mdx
+++ b/calico_versioned_docs/version-3.32/operations/upgrading/openshift-upgrade.mdx
@@ -1,5 +1,5 @@
 ---
-description: Upgrade to a newer version of Calico for OpenShift.
+description: Upgrade Calico Open Source on OpenShift 4 by reapplying manifests and updating OwnerReferences for projectcalico.org/v3 resources.
 ---
 
 import AutoHostendpointsMigrate from '@site/calico_versioned_docs/version-3.32/_includes/components/AutoHostendpointsMigrate';

--- a/calico_versioned_docs/version-3.32/operations/upgrading/openstack-upgrade.mdx
+++ b/calico_versioned_docs/version-3.32/operations/upgrading/openstack-upgrade.mdx
@@ -1,5 +1,5 @@
 ---
-description: Upgrade to a newer version of Calico for OpenStack.
+description: Upgrade Calico Open Source on OpenStack from v3.0 or later by updating system packages on CentOS or Ubuntu compute and control nodes.
 ---
 
 # Upgrade Calico on OpenStack


### PR DESCRIPTION
## Summary

Rewrites the `description` frontmatter on every page in the operations book across the three unversioned (next-release) source trees — 127 files, 1-line replacement each. Same rule set as #2696, #2697, #2708, #2709, #2710, #2711.

| Tree | Files |
|------|--:|
| `calico/operations/` | 37 |
| `calico-enterprise/operations/` | 59 |
| `calico-cloud/operations/` | 31 |
| **Total** | **127** |

**Next-only on purpose.** Landing on unversioned source first so descriptions can get review without pre-mirroring to versioned snapshots that would all need amending if anything changes. Mirror to published latest-version snapshots in a follow-up.

## What every new description follows

1. Names exactly one canonical product (`Calico Open Source`, `Calico Enterprise`, `Calico Cloud`).
2. ≤ 200 characters.
3. Action-led on procedural pages; noun-led on reference, troubleshooting, and overview pages per the `docs-frontmatter-description` skill's content-type rules.
4. No `enable`, `disable`, or `teaching`.
5. Unique across products.
6. Vale-clean on line 2 (frontmatter description line).

## What was wrong before

Pre-fix snapshot of the same 127 files:

- **9 forbidden-word hits** — all `enable` (TLS authentication, eBPF data plane, native v3 CRDs across three products).
- **0 descriptions over 200 chars**.
- **0 colons**.
- **Many descriptions used the bare word "Calico"** instead of the canonical product names. Rewrites use the explicit canonical product everywhere.
- **Cross-product literal duplicates** — features that exist in all three products (eBPF data plane, calicoctl configuration, TLS certificate management, Prometheus monitoring, troubleshooting commands, BGP metrics, secure-bgp, log-storage TLS, manager TLS, typha-node TLS, etc.) had identical or near-identical descriptions across product directories. Now disambiguated by deployment context — Calico Open Source's self-managed/CLI framing, Calico Enterprise's cluster/management-UI framing, Calico Cloud's connected-cluster framing.

## Verification

Run from repo root on this branch:

```
grep -nEri "^description:.*\b(enable|disable|teaching)\b" \
  calico/operations calico-enterprise/operations calico-cloud/operations
```

Length, canonical-name presence, and cross-product-uniqueness checks are equivalent one-liners over the same three directories. All four return empty post-fix.

## Test plan

- [ ] Run the forbidden-word grep above and confirm empty.
- [ ] Spot-check cross-product triples (`*/operations/ebpf/enabling-ebpf.mdx`, `*/operations/comms/secure-bgp.mdx`, `*/operations/monitor/metrics/bgp-metrics.mdx`, `*/operations/ebpf/use-cases-ebpf.mdx`) for distinguishability.
- [ ] Spot-check 5 random rewrites against page bodies for accuracy.
- [ ] After review, mirror to latest-version snapshots in a follow-up PR.