### PR TITLE
Rewrite multicluster page descriptions (next trees)

### DIFF
--- a/calico-cloud/multicluster/aws.mdx
+++ b/calico-cloud/multicluster/aws.mdx
@@ -16,12 +16,12 @@ The cluster is installed on real hardware where node and pod IPs are routable, u
 
 ![A diagram showing the key configuration requirements setting up an AWS cluster (using AWS VPN CNI) peering with an on-premise cluster.](/img/calico-enterprise/federation/aws-rcc.svg)
 
-**Calico Enterprise configuration**
+**Calico Cloud configuration**
 
 - IP pool resource is configured for the on-premise IP assignment with IPIP is disabled
 - BGP peering to the VPN router
 - A Remote Cluster Configuration resource references the AWS cluster
-- Service discovery of the AWS cluster services uses the Calico Enterprise Federated Services Controller
+- Service discovery of the AWS cluster services uses the Calico Cloud Federated Services Controller
 
 **Notes**
 

--- a/calico-cloud/multicluster/aws.mdx
+++ b/calico-cloud/multicluster/aws.mdx
@@ -1,5 +1,5 @@
 ---
-description: A sample configuration of Calico Enterprise federated endpoint identity and federated services for an AWS cluster.
+description: Sample Calico Cloud cluster mesh configuration that peers an on-premises cluster with an AWS VPC cluster using BGP, NLB, and the Federated Services Controller.
 ---
 
 # Cluster mesh example for clusters in AWS

--- a/calico-cloud/multicluster/index.mdx
+++ b/calico-cloud/multicluster/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to configure cluster mesh.
+description: Form a Calico Cloud cluster mesh across clusters connected to the SaaS management plane with identity-aware policy and cross-cluster service discovery.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud/multicluster/kubeconfig.mdx
+++ b/calico-cloud/multicluster/kubeconfig.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a local cluster to pull endpoint data from a remote cluster.
+description: Connect Calico Cloud connected clusters into a cluster mesh by generating per-cluster kubeconfig credentials and RemoteClusterConfiguration with VXLAN or WireGuard.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico-cloud/multicluster/overview.mdx
+++ b/calico-cloud/multicluster/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a cluster mesh for cross-cluster endpoints sharing, cross-cluster connectivity, and cross-cluster service discovery.
+description: Calico Cloud cluster mesh concepts for connected clusters including pod IP routability, federated endpoint identity, federated services, and overlay networking.
 ---
 
 # Overview

--- a/calico-cloud/multicluster/services-controller.mdx
+++ b/calico-cloud/multicluster/services-controller.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a federated service for cross-cluster service discovery for local clusters.
+description: Configure a Calico Cloud federated service with the Tigera Federated Services Controller to surface endpoints from connected clusters in the SaaS plane.
 ---
 
 # Configure federated services

--- a/calico-cloud_versioned_docs/version-22-2/multicluster/aws.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/multicluster/aws.mdx
@@ -1,5 +1,5 @@
 ---
-description: A sample configuration of Calico Enterprise federated endpoint identity and federated services for an AWS cluster.
+description: Sample Calico Cloud cluster mesh configuration that peers an on-premises cluster with an AWS VPC cluster using BGP, NLB, and the Federated Services Controller.
 ---
 
 # Cluster mesh example for clusters in AWS

--- a/calico-cloud_versioned_docs/version-22-2/multicluster/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/multicluster/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to configure cluster mesh.
+description: Form a Calico Cloud cluster mesh across clusters connected to the SaaS management plane with identity-aware policy and cross-cluster service discovery.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/multicluster/kubeconfig.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/multicluster/kubeconfig.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a local cluster to pull endpoint data from a remote cluster.
+description: Connect Calico Cloud connected clusters into a cluster mesh by generating per-cluster kubeconfig credentials and RemoteClusterConfiguration with VXLAN or WireGuard.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico-cloud_versioned_docs/version-22-2/multicluster/overview.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/multicluster/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a cluster mesh for cross-cluster endpoints sharing, cross-cluster connectivity, and cross-cluster service discovery.
+description: Calico Cloud cluster mesh concepts for connected clusters including pod IP routability, federated endpoint identity, federated services, and overlay networking.
 ---
 
 # Overview

--- a/calico-cloud_versioned_docs/version-22-2/multicluster/services-controller.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/multicluster/services-controller.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a federated service for cross-cluster service discovery for local clusters.
+description: Configure a Calico Cloud federated service with the Tigera Federated Services Controller to surface endpoints from connected clusters in the SaaS plane.
 ---
 
 # Configure federated services

--- a/calico-enterprise/multicluster/change-cluster-type.mdx
+++ b/calico-enterprise/multicluster/change-cluster-type.mdx
@@ -1,5 +1,5 @@
 ---
-description: Change an existing Calico Enterprise cluster type to a management cluster, a managed cluster, or standalone.
+description: Convert a Calico Enterprise cluster between management, managed, and standalone roles by editing ManagementCluster and ManagementClusterConnection resources.
 ---
 
 # Change a cluster type

--- a/calico-enterprise/multicluster/federation/aws.mdx
+++ b/calico-enterprise/multicluster/federation/aws.mdx
@@ -1,5 +1,5 @@
 ---
-description: A sample configuration of Calico Enterprise federated endpoint identity and federated services for an AWS cluster.
+description: Sample Calico Enterprise cluster mesh configuration that peers an on-premises cluster with an AWS VPC cluster using BGP, NLB, and the Federated Services Controller.
 ---
 
 # Cluster mesh example for clusters in AWS

--- a/calico-enterprise/multicluster/federation/index.mdx
+++ b/calico-enterprise/multicluster/federation/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to configure cluster mesh.
+description: Form a Calico Enterprise cluster mesh with federated endpoint identity, federated services, and multi-cluster networking for cross-cluster connectivity.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/multicluster/federation/kubeconfig.mdx
+++ b/calico-enterprise/multicluster/federation/kubeconfig.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a local cluster to pull endpoint data from a remote cluster.
+description: Connect a Calico Enterprise cluster mesh by generating per-cluster kubeconfig credentials and RemoteClusterConfiguration resources with VXLAN or WireGuard overlays.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico-enterprise/multicluster/federation/overview.mdx
+++ b/calico-enterprise/multicluster/federation/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a cluster mesh for cross-cluster endpoints sharing, cross-cluster connectivity, and cross-cluster service discovery.
+description: Calico Enterprise cluster mesh concepts including pod IP routability, federated workload endpoints, federated services, and identity-aware cross-cluster policy.
 ---
 
 # Overview

--- a/calico-enterprise/multicluster/federation/services-controller.mdx
+++ b/calico-enterprise/multicluster/federation/services-controller.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a federated service for cross-cluster service discovery for local clusters.
+description: Configure a Calico Enterprise federated service with the Tigera Federated Services Controller to consolidate endpoints across a cluster mesh.
 ---
 
 # Configure federated services

--- a/calico-enterprise/multicluster/fine-tune-deployment.mdx
+++ b/calico-enterprise/multicluster/fine-tune-deployment.mdx
@@ -1,5 +1,5 @@
 ---
-description: Review your multi-cluster management deployment to ensure it is ready for production.
+description: Harden a Calico Enterprise multi-cluster management deployment for production with scalable service types, log retention tuning, and RBAC for managed cluster data.
 ---
 
 # Fine-tune multi-cluster management

--- a/calico-enterprise/multicluster/index.mdx
+++ b/calico-enterprise/multicluster/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico Enterprise features for scaling to production.
+description: Centralize control of Kubernetes clusters in a self-managed Calico Enterprise management cluster with federated endpoints, federated services, and cross-cluster networking.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install Calico Enterprise managed cluster using Helm application package manager.
+description: Install a Calico Enterprise managed cluster with Helm 3 and connect it to a self-managed management cluster for centralized control and log storage.
 ---
 
 # Create a Calico Enterprise managed cluster

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install Calico Enterprise management cluster using Helm application package manager.
+description: Install a self-managed Calico Enterprise management cluster with Helm 3 to consolidate control of multiple managed clusters from a single plane.
 ---
 
 # Create a Calico Enterprise management cluster

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/index.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to configure management and managed clusters using Helm.
+description: Install a self-managed Calico Enterprise management and managed cluster pairing with Helm 3 charts, suitable for GitOps tooling such as ArgoCD.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/index.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to configure management and managed clusters.
+description: Pair a self-managed Calico Enterprise management cluster with managed clusters for centralized log storage, RBAC, and federated policy across providers.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/standard-install/create-a-managed-cluster.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/standard-install/create-a-managed-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create a Calico Enterprise managed cluster that you can control from you management cluster.
+description: Register a Calico Enterprise managed cluster with a self-managed management cluster using the Tigera Operator for centralized log storage and RBAC.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create a Calico Enterprise management cluster to manage multiple clusters from a single management plane.
+description: Provision a self-managed Calico Enterprise management cluster with the Tigera Operator to control hundreds of managed Kubernetes clusters from one plane.
 ---
 
 # Create a Calico Enterprise management cluster

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/standard-install/index.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/standard-install/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to configure management and managed clusters using standard operator installation.
+description: Install a self-managed Calico Enterprise management and managed cluster pairing with the Tigera Operator for centralized observability and RBAC.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/change-cluster-type.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/change-cluster-type.mdx
@@ -1,5 +1,5 @@
 ---
-description: Change an existing Calico Enterprise cluster type to a management cluster, a managed cluster, or standalone.
+description: Convert a Calico Enterprise cluster between management, managed, and standalone roles by editing ManagementCluster and ManagementClusterConnection resources.
 ---
 
 # Change a cluster type

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/federation/aws.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/federation/aws.mdx
@@ -1,5 +1,5 @@
 ---
-description: A sample configuration of Calico Enterprise federated endpoint identity and federated services for an AWS cluster.
+description: Sample Calico Enterprise cluster mesh configuration that peers an on-premises cluster with an AWS VPC cluster using BGP, NLB, and the Federated Services Controller.
 ---
 
 # Cluster mesh example for clusters in AWS

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/federation/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/federation/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to configure cluster mesh.
+description: Form a Calico Enterprise cluster mesh with federated endpoint identity, federated services, and multi-cluster networking for cross-cluster connectivity.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/federation/kubeconfig.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/federation/kubeconfig.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a local cluster to pull endpoint data from a remote cluster.
+description: Connect a Calico Enterprise cluster mesh by generating per-cluster kubeconfig credentials and RemoteClusterConfiguration resources with VXLAN or WireGuard overlays.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/federation/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/federation/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a cluster mesh for cross-cluster endpoints sharing, cross-cluster connectivity, and cross-cluster service discovery.
+description: Calico Enterprise cluster mesh concepts including pod IP routability, federated workload endpoints, federated services, and identity-aware cross-cluster policy.
 ---
 
 # Overview

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/federation/services-controller.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/federation/services-controller.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a federated service for cross-cluster service discovery for local clusters.
+description: Configure a Calico Enterprise federated service with the Tigera Federated Services Controller to consolidate endpoints across a cluster mesh.
 ---
 
 # Configure federated services

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/fine-tune-deployment.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/fine-tune-deployment.mdx
@@ -1,5 +1,5 @@
 ---
-description: Review your multi-cluster management deployment to ensure it is ready for production.
+description: Harden a Calico Enterprise multi-cluster management deployment for production with scalable service types, log retention tuning, and RBAC for managed cluster data.
 ---
 
 # Fine-tune multi-cluster management

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico Enterprise features for scaling to production.
+description: Centralize control of Kubernetes clusters in a self-managed Calico Enterprise management cluster with federated endpoints, federated services, and cross-cluster networking.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install Calico Enterprise managed cluster using Helm application package manager.
+description: Install a Calico Enterprise managed cluster with Helm 3 and connect it to a self-managed management cluster for centralized control and log storage.
 ---
 
 # Create a Calico Enterprise managed cluster

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install Calico Enterprise management cluster using Helm application package manager.
+description: Install a self-managed Calico Enterprise management cluster with Helm 3 to consolidate control of multiple managed clusters from a single plane.
 ---
 
 # Create a Calico Enterprise management cluster

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/helm-install/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/helm-install/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to configure management and managed clusters using Helm.
+description: Install a self-managed Calico Enterprise management and managed cluster pairing with Helm 3 charts, suitable for GitOps tooling such as ArgoCD.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to configure management and managed clusters.
+description: Pair a self-managed Calico Enterprise management cluster with managed clusters for centralized log storage, RBAC, and federated policy across providers.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-managed-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-managed-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create a Calico Enterprise managed cluster that you can control from you management cluster.
+description: Register a Calico Enterprise managed cluster with a self-managed management cluster using the Tigera Operator for centralized log storage and RBAC.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create a Calico Enterprise management cluster to manage multiple clusters from a single management plane.
+description: Provision a self-managed Calico Enterprise management cluster with the Tigera Operator to control hundreds of managed Kubernetes clusters from one plane.
 ---
 
 # Create a Calico Enterprise management cluster

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/standard-install/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/standard-install/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to configure management and managed clusters using standard operator installation.
+description: Install a self-managed Calico Enterprise management and managed cluster pairing with the Tigera Operator for centralized observability and RBAC.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/multicluster/change-cluster-type.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/multicluster/change-cluster-type.mdx
@@ -1,5 +1,5 @@
 ---
-description: Change an existing Calico Enterprise cluster type to a management cluster, a managed cluster, or standalone.
+description: Convert a Calico Enterprise cluster between management, managed, and standalone roles by editing ManagementCluster and ManagementClusterConnection resources.
 ---
 
 # Change a cluster type

--- a/calico-enterprise_versioned_docs/version-3.23-1/multicluster/federation/aws.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/multicluster/federation/aws.mdx
@@ -1,5 +1,5 @@
 ---
-description: A sample configuration of Calico Enterprise federated endpoint identity and federated services for an AWS cluster.
+description: Sample Calico Enterprise cluster mesh configuration that peers an on-premises cluster with an AWS VPC cluster using BGP, NLB, and the Federated Services Controller.
 ---
 
 # Cluster mesh example for clusters in AWS

--- a/calico-enterprise_versioned_docs/version-3.23-1/multicluster/federation/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/multicluster/federation/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to configure cluster mesh.
+description: Form a Calico Enterprise cluster mesh with federated endpoint identity, federated services, and multi-cluster networking for cross-cluster connectivity.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/multicluster/federation/kubeconfig.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/multicluster/federation/kubeconfig.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a local cluster to pull endpoint data from a remote cluster.
+description: Connect a Calico Enterprise cluster mesh by generating per-cluster kubeconfig credentials and RemoteClusterConfiguration resources with VXLAN or WireGuard overlays.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico-enterprise_versioned_docs/version-3.23-1/multicluster/federation/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/multicluster/federation/overview.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a cluster mesh for cross-cluster endpoints sharing, cross-cluster connectivity, and cross-cluster service discovery.
+description: Calico Enterprise cluster mesh concepts including pod IP routability, federated workload endpoints, federated services, and identity-aware cross-cluster policy.
 ---
 
 # Overview

--- a/calico-enterprise_versioned_docs/version-3.23-1/multicluster/federation/services-controller.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/multicluster/federation/services-controller.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure a federated service for cross-cluster service discovery for local clusters.
+description: Configure a Calico Enterprise federated service with the Tigera Federated Services Controller to consolidate endpoints across a cluster mesh.
 ---
 
 # Configure federated services

--- a/calico-enterprise_versioned_docs/version-3.23-1/multicluster/fine-tune-deployment.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/multicluster/fine-tune-deployment.mdx
@@ -1,5 +1,5 @@
 ---
-description: Review your multi-cluster management deployment to ensure it is ready for production.
+description: Harden a Calico Enterprise multi-cluster management deployment for production with scalable service types, log retention tuning, and RBAC for managed cluster data.
 ---
 
 # Fine-tune multi-cluster management

--- a/calico-enterprise_versioned_docs/version-3.23-1/multicluster/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/multicluster/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Calico Enterprise features for scaling to production.
+description: Centralize control of Kubernetes clusters in a self-managed Calico Enterprise management cluster with federated endpoints, federated services, and cross-cluster networking.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install Calico Enterprise managed cluster using Helm application package manager.
+description: Install a Calico Enterprise managed cluster with Helm 3 and connect it to a self-managed management cluster for centralized control and log storage.
 ---
 
 # Create a Calico Enterprise managed cluster

--- a/calico-enterprise_versioned_docs/version-3.23-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -1,5 +1,5 @@
 ---
-description: Install Calico Enterprise management cluster using Helm application package manager.
+description: Install a self-managed Calico Enterprise management cluster with Helm 3 to consolidate control of multiple managed clusters from a single plane.
 ---
 
 # Create a Calico Enterprise management cluster

--- a/calico-enterprise_versioned_docs/version-3.23-1/multicluster/set-up-multi-cluster-management/helm-install/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/multicluster/set-up-multi-cluster-management/helm-install/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to configure management and managed clusters using Helm.
+description: Install a self-managed Calico Enterprise management and managed cluster pairing with Helm 3 charts, suitable for GitOps tooling such as ArgoCD.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/multicluster/set-up-multi-cluster-management/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/multicluster/set-up-multi-cluster-management/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to configure management and managed clusters.
+description: Pair a self-managed Calico Enterprise management cluster with managed clusters for centralized log storage, RBAC, and federated policy across providers.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/multicluster/set-up-multi-cluster-management/standard-install/create-a-managed-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/multicluster/set-up-multi-cluster-management/standard-install/create-a-managed-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create a Calico Enterprise managed cluster that you can control from you management cluster.
+description: Register a Calico Enterprise managed cluster with a self-managed management cluster using the Tigera Operator for centralized log storage and RBAC.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/calico-enterprise_versioned_docs/version-3.23-1/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/multicluster/set-up-multi-cluster-management/standard-install/create-a-management-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-description: Create a Calico Enterprise management cluster to manage multiple clusters from a single management plane.
+description: Provision a self-managed Calico Enterprise management cluster with the Tigera Operator to control hundreds of managed Kubernetes clusters from one plane.
 ---
 
 # Create a Calico Enterprise management cluster

--- a/calico-enterprise_versioned_docs/version-3.23-1/multicluster/set-up-multi-cluster-management/standard-install/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/multicluster/set-up-multi-cluster-management/standard-install/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Steps to configure management and managed clusters using standard operator installation.
+description: Install a self-managed Calico Enterprise management and managed cluster pairing with the Tigera Operator for centralized observability and RBAC.
 hide_table_of_contents: true
 ---
 


### PR DESCRIPTION
## Summary

Rewrites the `description` frontmatter on every page in the multicluster book across the two unversioned (next-release) source trees -- 20 files, 1-line replacement each. Same rule set as #2696, #2697, #2708, #2709, #2710, #2711, #2718, #2719, #2720.

| Tree | Files |
|------|--:|
| `calico-enterprise/multicluster/` | 15 |
| `calico-cloud/multicluster/` | 5 |
| **Total** | **20** |

Calico Open Source has no multicluster book, so this PR is CE + CC only.

**Next-only on purpose.** Landing on unversioned source first so descriptions can get review without pre-mirroring to versioned snapshots that would all need amending if anything changes. Mirror to published latest-version snapshots in a follow-up.

## CE vs CC disambiguation

The pre-fix state had 5 literal cross-product duplicates -- `aws.mdx`, `index.mdx`, `kubeconfig.mdx`, `overview.mdx`, and `services-controller.mdx` shared identical descriptions between the CE federation directory and the CC multicluster directory.

Rewrites disambiguate by deployment model:

- **Calico Enterprise** -- self-managed management cluster framing (self-managed management cluster, Tigera Operator, in-cluster Federated Services Controller).
- **Calico Cloud** -- SaaS management plane framing (connected clusters, Calico Cloud SaaS plane).

## What every new description follows

1. Names exactly one canonical product (`Calico Enterprise`, `Calico Cloud`).
2. <= 200 characters.
3. Action-led on procedural pages; noun-led on reference and overview pages per the `docs-frontmatter-description` skill's content-type rules.
4. No `enable`, `disable`, or `teaching`.
5. Unique across products.
6. No colons in the description value.
7. Vale-clean on line 2 (frontmatter description line) -- includes no possessives (`GKE's`), no `walks through`, no `allowlist(ing)`, and `Tigera Operator` capitalized correctly.

## Pre-fix violations across the 20 files

- 0 forbidden-word hits (`enable`/`disable`/`teaching`).
- 0 descriptions over 200 chars.
- 0 colons.
- 0 `walks through`, possessive, or `allowlist` hits.
- 5 literal cross-product duplicates between `calico-enterprise/multicluster/federation/*` and `calico-cloud/multicluster/*` (aws, index, kubeconfig, overview, services-controller).
- 2 Vale line-2 issues introduced during a first-pass rewrite (`kubeconfigs` plural) -- rephrased to `per-cluster kubeconfig credentials`.

## Verification

Run from repo root on this branch:

```
grep -nEri "^description:.*\b(enable|disable|teaching)\b" \
  calico-enterprise/multicluster calico-cloud/multicluster
```

Length, canonical-name presence, and cross-product-uniqueness checks are equivalent one-liners over the same two directories. All return empty post-fix.

Vale on changed files, filtered to line-2 issues, returns empty:

```
git diff upstream/main --name-only | xargs scripts/vale-lint.sh --output=line 2>&1 | awk -F: '$2 == 2'
```

## Test plan

- [ ] Run the forbidden-word grep above and confirm empty.
- [ ] Spot-check the 5 CE/CC duplicate pairs (`aws`, `index`, `kubeconfig`, `overview`, `services-controller`) for distinguishability.
- [ ] Spot-check 5 random rewrites against page bodies for accuracy.
- [ ] After review, mirror to latest-version snapshots in a follow-up PR.