### PR TITLE
Rewrite threat-defense page descriptions (next trees)

### DIFF
--- a/calico-cloud/threat/configuring-webhooks.mdx
+++ b/calico-cloud/threat/configuring-webhooks.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use webhooks to send security event alerts to third-party systems.
+description: Configure Calico Cloud webhooks from the web console to post security event alerts to Slack, Jira, Alertmanager, or generic JSON endpoints.
 title: Webhooks for security events
 ---
 

--- a/calico-cloud/threat/container-threat-detection.mdx
+++ b/calico-cloud/threat/container-threat-detection.mdx
@@ -1,5 +1,5 @@
 ---
-description: Threat detection for containerized workloads.
+description: Detect malware hashes and suspicious container activity such as privilege escalation and command-and-control in Calico Cloud connected clusters with the managed eBPF threat detection engine.
 redirect_from:
   - /threat/malware-detection
 ---

--- a/calico-cloud/threat/deeppacketinspection.mdx
+++ b/calico-cloud/threat/deeppacketinspection.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor live traffic for malicious activities.
+description: Run deep packet inspection on selected workloads in Calico Cloud connected clusters with Snort community rules to alert on suspected malicious traffic.
 ---
 
 # Deep packet inspection

--- a/calico-cloud/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-cloud/threat/deploying-waf-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Deploy WAF with ingress gateways
+description: Step-by-step tutorial for deploying a Calico Cloud web application firewall with the Calico Ingress Gateway to protect publicly exposed services from Layer 7 attacks.
 ---
 
 # Deploy a web application firewall with Calico Ingress Gateway

--- a/calico-cloud/threat/index.mdx
+++ b/calico-cloud/threat/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Detect and respond to threats in Calico Cloud connected clusters with container threat detection, managed threat-intel feed updates, deep packet inspection, and WAF.
+description: Detect and respond to threats in Calico Cloud connected clusters with container threat detection, threat intelligence feeds, deep packet inspection, and WAF.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud/threat/index.mdx
+++ b/calico-cloud/threat/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Trace, analyze, and block malicious threats using intelligent feeds and alerts.
+description: Detect and respond to threats in Calico Cloud connected clusters with container threat detection, managed threat-intel feed updates, deep packet inspection, and WAF.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud/threat/security-event-management.mdx
+++ b/calico-cloud/threat/security-event-management.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manage security events from your cluster in a single place.
+description: Triage and manage security events from Calico Cloud connected clusters in the Security Events Dashboard, with filtering, exceptions, and recommended remediation.
 ---
 
 # Security event management

--- a/calico-cloud/threat/suspicious-domains.mdx
+++ b/calico-cloud/threat/suspicious-domains.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use managed threat-intelligence feeds in Calico Cloud to detect DNS queries to suspicious domains and surface impacted pods in the anomaly dashboard.
+description: Add threat intelligence feeds to Calico Cloud to detect DNS queries to suspicious domains from connected clusters and surface impacted pods in the anomaly dashboard.
 ---
 
 # Trace and alert on suspicious domains

--- a/calico-cloud/threat/suspicious-domains.mdx
+++ b/calico-cloud/threat/suspicious-domains.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add threat intelligence feeds to trace DNS queries that involve suspicious domains.
+description: Use managed threat-intelligence feeds in Calico Cloud to detect DNS queries to suspicious domains and surface impacted pods in the anomaly dashboard.
 ---
 
 # Trace and alert on suspicious domains

--- a/calico-cloud/threat/suspicious-ips.mdx
+++ b/calico-cloud/threat/suspicious-ips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use managed threat-intelligence feeds in Calico Cloud to alert on flows to suspicious IP addresses and optionally block them with a dynamic deny-list policy.
+description: Add threat intelligence feeds to Calico Cloud to alert on flows to suspicious IPs in connected clusters and optionally block them with a dynamic deny-list policy.
 ---
 
 # Trace and block suspicious IPs

--- a/calico-cloud/threat/suspicious-ips.mdx
+++ b/calico-cloud/threat/suspicious-ips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add threat intelligence feeds to trace network flows of suspicious IP addresses, and optionally block traffic to them.
+description: Use managed threat-intelligence feeds in Calico Cloud to alert on flows to suspicious IP addresses and optionally block them with a dynamic deny-list policy.
 ---
 
 # Trace and block suspicious IPs

--- a/calico-cloud/threat/tor-vpn-feed-and-dashboard.mdx
+++ b/calico-cloud/threat/tor-vpn-feed-and-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-description: Detect anonymization activity in Calico Cloud connected clusters with managed Tor bulk exit and X4B VPN feeds, and investigate findings in the Tor-VPN dashboard.
+description: Detect anonymization activity in Calico Cloud connected clusters with Tor bulk exit and X4B VPN feeds, and investigate findings in the Tor-VPN dashboard in the web console.
 ---
 
 # Anonymization attacks

--- a/calico-cloud/threat/tor-vpn-feed-and-dashboard.mdx
+++ b/calico-cloud/threat/tor-vpn-feed-and-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-description: Detect and analyze malicious anonymization activity using Tor-VPN feeds.
+description: Detect anonymization activity in Calico Cloud connected clusters with managed Tor bulk exit and X4B VPN feeds, and investigate findings in the Tor-VPN dashboard.
 ---
 
 # Anonymization attacks

--- a/calico-cloud/threat/web-application-firewall.mdx
+++ b/calico-cloud/threat/web-application-firewall.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to use with Layer 7 Web Application Firewall.
+description: Protect cluster workloads from Layer 7 attacks with the Calico Cloud workload-based WAF, powered by Envoy sidecars and the OWASP ModSecurity Core Rule Set.
 ---
 
 # Workload-based Web Application Firewall (WAF)

--- a/calico-cloud_versioned_docs/version-22-2/threat/configuring-webhooks.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/threat/configuring-webhooks.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use webhooks to send security event alerts to third-party systems.
+description: Configure Calico Cloud webhooks from the web console to post security event alerts to Slack, Jira, Alertmanager, or generic JSON endpoints.
 title: Webhooks for security events
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/threat/container-threat-detection.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/threat/container-threat-detection.mdx
@@ -1,5 +1,5 @@
 ---
-description: Threat detection for containerized workloads.
+description: Detect malware hashes and suspicious container activity such as privilege escalation and command-and-control in Calico Cloud connected clusters with the managed eBPF threat detection engine.
 redirect_from:
   - /threat/malware-detection
 ---

--- a/calico-cloud_versioned_docs/version-22-2/threat/deeppacketinspection.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/threat/deeppacketinspection.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor live traffic for malicious activities.
+description: Run deep packet inspection on selected workloads in Calico Cloud connected clusters with Snort community rules to alert on suspected malicious traffic.
 ---
 
 # Deep packet inspection

--- a/calico-cloud_versioned_docs/version-22-2/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/threat/deploying-waf-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Deploy WAF with ingress gateways
+description: Step-by-step tutorial for deploying a Calico Cloud web application firewall with the Calico Ingress Gateway to protect publicly exposed services from Layer 7 attacks.
 ---
 
 # Deploy a web application firewall with Calico Ingress Gateway

--- a/calico-cloud_versioned_docs/version-22-2/threat/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/threat/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Trace, analyze, and block malicious threats using intelligent feeds and alerts.
+description: Detect and respond to threats in Calico Cloud connected clusters with container threat detection, threat intelligence feeds, deep packet inspection, and WAF.
 hide_table_of_contents: true
 ---
 

--- a/calico-cloud_versioned_docs/version-22-2/threat/security-event-management.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/threat/security-event-management.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manage security events from your cluster in a single place.
+description: Triage and manage security events from Calico Cloud connected clusters in the Security Events Dashboard, with filtering, exceptions, and recommended remediation.
 ---
 
 # Security event management

--- a/calico-cloud_versioned_docs/version-22-2/threat/suspicious-domains.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/threat/suspicious-domains.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add threat intelligence feeds to trace DNS queries that involve suspicious domains.
+description: Add threat intelligence feeds to Calico Cloud to detect DNS queries to suspicious domains from connected clusters and surface impacted pods in the anomaly dashboard.
 ---
 
 # Trace and alert on suspicious domains

--- a/calico-cloud_versioned_docs/version-22-2/threat/suspicious-ips.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/threat/suspicious-ips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add threat intelligence feeds to trace network flows of suspicious IP addresses, and optionally block traffic to them.
+description: Add threat intelligence feeds to Calico Cloud to alert on flows to suspicious IPs in connected clusters and optionally block them with a dynamic deny-list policy.
 ---
 
 # Trace and block suspicious IPs

--- a/calico-cloud_versioned_docs/version-22-2/threat/tor-vpn-feed-and-dashboard.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/threat/tor-vpn-feed-and-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-description: Detect and analyze malicious anonymization activity using Tor-VPN feeds.
+description: Detect anonymization activity in Calico Cloud connected clusters with Tor bulk exit and X4B VPN feeds, and investigate findings in the Tor-VPN dashboard in the web console.
 ---
 
 # Anonymization attacks

--- a/calico-cloud_versioned_docs/version-22-2/threat/web-application-firewall.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/threat/web-application-firewall.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to use with Layer 7 Web Application Firewall.
+description: Protect cluster workloads from Layer 7 attacks with the Calico Cloud workload-based WAF, powered by Envoy sidecars and the OWASP ModSecurity Core Rule Set.
 ---
 
 # Workload-based Web Application Firewall (WAF)

--- a/calico-enterprise/threat/configuring-webhooks.mdx
+++ b/calico-enterprise/threat/configuring-webhooks.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use webhooks to send security event alerts to third-party systems.
+description: Configure Calico Enterprise webhooks to post security event alerts to Slack, Jira, Alertmanager, or generic JSON endpoints from your self-hosted cluster.
 title: Webhooks for security events
 ---
 

--- a/calico-enterprise/threat/deeppacketinspection.mdx
+++ b/calico-enterprise/threat/deeppacketinspection.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor live traffic for malicious activities.
+description: Run deep packet inspection on selected workloads in your Calico Enterprise cluster with Snort community rules to alert on suspected malicious traffic.
 ---
 
 # Deep packet inspection

--- a/calico-enterprise/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-enterprise/threat/deploying-waf-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Deploy WAF with ingress gateways
+description: Step-by-step tutorial for deploying a Calico Enterprise web application firewall with the Calico Ingress Gateway to protect publicly exposed services from Layer 7 attacks.
 ---
 
 # Deploy a web application firewall with Calico Ingress Gateway

--- a/calico-enterprise/threat/index.mdx
+++ b/calico-enterprise/threat/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Detect, analyze, and block threats in your Calico Enterprise cluster with intrusion detection, threat-intel feeds, deep packet inspection, and a workload-based WAF.
+description: Detect, analyze, and block threats in your Calico Enterprise cluster with intrusion detection, threat intelligence feeds, deep packet inspection, and a workload-based WAF.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/threat/index.mdx
+++ b/calico-enterprise/threat/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Trace, analyze, and block malicious threats using intelligent feeds and alerts.
+description: Detect, analyze, and block threats in your Calico Enterprise cluster with intrusion detection, threat-intel feeds, deep packet inspection, and a workload-based WAF.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise/threat/security-event-management.mdx
+++ b/calico-enterprise/threat/security-event-management.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manage security events from your cluster in a single place.
+description: Triage and manage security events from your Calico Enterprise cluster in the Security Events Dashboard, with filtering, exceptions, and recommended remediation.
 ---
 
 # Security event management

--- a/calico-enterprise/threat/suspicious-domains.mdx
+++ b/calico-enterprise/threat/suspicious-domains.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add threat intelligence feeds to trace DNS queries that involve suspicious domains.
+description: Add threat intelligence feeds to Calico Enterprise to detect DNS queries to suspicious domains and surface impacted pods in the anomaly dashboard.
 ---
 
 # Trace and alert on suspicious domains

--- a/calico-enterprise/threat/suspicious-ips.mdx
+++ b/calico-enterprise/threat/suspicious-ips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add threat intelligence feeds to trace network flows of suspicious IP addresses, and optionally block traffic to them.
+description: Add threat intelligence feeds to Calico Enterprise to alert on flows to suspicious IP addresses and optionally block them with a dynamic deny-list policy.
 ---
 
 # Trace and block suspicious IPs

--- a/calico-enterprise/threat/tor-vpn-feed-and-dashboard.mdx
+++ b/calico-enterprise/threat/tor-vpn-feed-and-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-description: Detect and analyze malicious anonymization activity using Tor-VPN feeds.
+description: Detect anonymization activity in your Calico Enterprise cluster with Tor bulk exit and X4B VPN feeds, and investigate findings in the Tor-VPN Kibana dashboard.
 ---
 
 # Anonymization attacks

--- a/calico-enterprise/threat/web-application-firewall.mdx
+++ b/calico-enterprise/threat/web-application-firewall.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to use with Layer 7 Web Application Firewall.
+description: Protect cluster workloads from Layer 7 attacks with the Calico Enterprise workload-based WAF, powered by Envoy sidecars and the OWASP ModSecurity Core Rule Set.
 ---
 
 # Workload-based Web Application Firewall (WAF)

--- a/calico-enterprise_versioned_docs/version-3.22-2/threat/configuring-webhooks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/threat/configuring-webhooks.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use webhooks to send security event alerts to third-party systems.
+description: Configure Calico Enterprise webhooks to post security event alerts to Slack, Jira, Alertmanager, or generic JSON endpoints from your self-hosted cluster.
 title: Webhooks for security events
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/threat/deeppacketinspection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/threat/deeppacketinspection.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor live traffic for malicious activities.
+description: Run deep packet inspection on selected workloads in your Calico Enterprise cluster with Snort community rules to alert on suspected malicious traffic.
 ---
 
 # Deep packet inspection

--- a/calico-enterprise_versioned_docs/version-3.22-2/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/threat/deploying-waf-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Deploy WAF with ingress gateways
+description: Step-by-step tutorial for deploying a Calico Enterprise web application firewall with the Calico Ingress Gateway to protect publicly exposed services from Layer 7 attacks.
 ---
 
 # Deploy a web application firewall with Calico Ingress Gateway

--- a/calico-enterprise_versioned_docs/version-3.22-2/threat/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/threat/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Trace, analyze, and block malicious threats using intelligent feeds and alerts.
+description: Detect, analyze, and block threats in your Calico Enterprise cluster with intrusion detection, threat intelligence feeds, deep packet inspection, and a workload-based WAF.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/threat/security-event-management.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/threat/security-event-management.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manage security events from your cluster in a single place.
+description: Triage and manage security events from your Calico Enterprise cluster in the Security Events Dashboard, with filtering, exceptions, and recommended remediation.
 ---
 
 # Security event management

--- a/calico-enterprise_versioned_docs/version-3.22-2/threat/suspicious-domains.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/threat/suspicious-domains.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add threat intelligence feeds to trace DNS queries that involve suspicious domains.
+description: Add threat intelligence feeds to Calico Enterprise to detect DNS queries to suspicious domains and surface impacted pods in the anomaly dashboard.
 ---
 
 # Trace and alert on suspicious domains

--- a/calico-enterprise_versioned_docs/version-3.22-2/threat/suspicious-ips.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/threat/suspicious-ips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add threat intelligence feeds to trace network flows of suspicious IP addresses, and optionally block traffic to them.
+description: Add threat intelligence feeds to Calico Enterprise to alert on flows to suspicious IP addresses and optionally block them with a dynamic deny-list policy.
 ---
 
 # Trace and block suspicious IPs

--- a/calico-enterprise_versioned_docs/version-3.22-2/threat/tor-vpn-feed-and-dashboard.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/threat/tor-vpn-feed-and-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-description: Detect and analyze malicious anonymization activity using Tor-VPN feeds.
+description: Detect anonymization activity in your Calico Enterprise cluster with Tor bulk exit and X4B VPN feeds, and investigate findings in the Tor-VPN Kibana dashboard.
 ---
 
 # Anonymization attacks

--- a/calico-enterprise_versioned_docs/version-3.22-2/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/threat/web-application-firewall.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to use with Layer 7 Web Application Firewall.
+description: Protect cluster workloads from Layer 7 attacks with the Calico Enterprise workload-based WAF, powered by Envoy sidecars and the OWASP ModSecurity Core Rule Set.
 ---
 
 # Workload-based Web Application Firewall (WAF)

--- a/calico-enterprise_versioned_docs/version-3.23-1/threat/configuring-webhooks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/threat/configuring-webhooks.mdx
@@ -1,5 +1,5 @@
 ---
-description: Use webhooks to send security event alerts to third-party systems.
+description: Configure Calico Enterprise webhooks to post security event alerts to Slack, Jira, Alertmanager, or generic JSON endpoints from your self-hosted cluster.
 title: Webhooks for security events
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/threat/deeppacketinspection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/threat/deeppacketinspection.mdx
@@ -1,5 +1,5 @@
 ---
-description: Monitor live traffic for malicious activities.
+description: Run deep packet inspection on selected workloads in your Calico Enterprise cluster with Snort community rules to alert on suspected malicious traffic.
 ---
 
 # Deep packet inspection

--- a/calico-enterprise_versioned_docs/version-3.23-1/threat/deploying-waf-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/threat/deploying-waf-ingress-gateway.mdx
@@ -1,5 +1,5 @@
 ---
-description: Deploy WAF with ingress gateways
+description: Step-by-step tutorial for deploying a Calico Enterprise web application firewall with the Calico Ingress Gateway to protect publicly exposed services from Layer 7 attacks.
 ---
 
 # Deploy a web application firewall with Calico Ingress Gateway

--- a/calico-enterprise_versioned_docs/version-3.23-1/threat/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/threat/index.mdx
@@ -1,5 +1,5 @@
 ---
-description: Trace, analyze, and block malicious threats using intelligent feeds and alerts.
+description: Detect, analyze, and block threats in your Calico Enterprise cluster with intrusion detection, threat intelligence feeds, deep packet inspection, and a workload-based WAF.
 hide_table_of_contents: true
 ---
 

--- a/calico-enterprise_versioned_docs/version-3.23-1/threat/security-event-management.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/threat/security-event-management.mdx
@@ -1,5 +1,5 @@
 ---
-description: Manage security events from your cluster in a single place.
+description: Triage and manage security events from your Calico Enterprise cluster in the Security Events Dashboard, with filtering, exceptions, and recommended remediation.
 ---
 
 # Security event management

--- a/calico-enterprise_versioned_docs/version-3.23-1/threat/suspicious-domains.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/threat/suspicious-domains.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add threat intelligence feeds to trace DNS queries that involve suspicious domains.
+description: Add threat intelligence feeds to Calico Enterprise to detect DNS queries to suspicious domains and surface impacted pods in the anomaly dashboard.
 ---
 
 # Trace and alert on suspicious domains

--- a/calico-enterprise_versioned_docs/version-3.23-1/threat/suspicious-ips.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/threat/suspicious-ips.mdx
@@ -1,5 +1,5 @@
 ---
-description: Add threat intelligence feeds to trace network flows of suspicious IP addresses, and optionally block traffic to them.
+description: Add threat intelligence feeds to Calico Enterprise to alert on flows to suspicious IP addresses and optionally block them with a dynamic deny-list policy.
 ---
 
 # Trace and block suspicious IPs

--- a/calico-enterprise_versioned_docs/version-3.23-1/threat/tor-vpn-feed-and-dashboard.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/threat/tor-vpn-feed-and-dashboard.mdx
@@ -1,5 +1,5 @@
 ---
-description: Detect and analyze malicious anonymization activity using Tor-VPN feeds.
+description: Detect anonymization activity in your Calico Enterprise cluster with Tor bulk exit and X4B VPN feeds, and investigate findings in the Tor-VPN Kibana dashboard.
 ---
 
 # Anonymization attacks

--- a/calico-enterprise_versioned_docs/version-3.23-1/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/threat/web-application-firewall.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure Calico to use with Layer 7 Web Application Firewall.
+description: Protect cluster workloads from Layer 7 attacks with the Calico Enterprise workload-based WAF, powered by Envoy sidecars and the OWASP ModSecurity Core Rule Set.
 ---
 
 # Workload-based Web Application Firewall (WAF)


### PR DESCRIPTION
## Summary

Rewrites the `description` frontmatter on every page in the threat-defense book across the two unversioned (next-release) source trees that have one — 19 files, 1-line replacement each. Same rule set as #2696, #2697, #2708, #2709, #2710, #2711, #2718, #2719, #2720.

| Tree | Files |
|------|--:|
| `calico-enterprise/threat/` | 9 |
| `calico-cloud/threat/` | 10 |
| **Total** | **19** |

**Next-only on purpose.** Landing on unversioned source first so descriptions can get review without pre-mirroring to versioned snapshots that would all need amending if anything changes. Mirror to published latest-version snapshots in a follow-up.

## What every new description follows

1. Names exactly one canonical product (`Calico Enterprise` or `Calico Cloud`). Calico Open Source has no threat-defense book.
2. ≤ 200 characters.
3. Action-led on procedural pages, tutorial-led on the WAF-with-ingress-gateway guides, noun-led on overview and dashboard pages per the `docs-frontmatter-description` skill's content-type rules.
4. No `enable`, `disable`, or `teaching`.
5. Unique across products.
6. Vale-clean on line 2 (frontmatter description line).

## What was wrong before

Pre-fix snapshot of the same 19 files:

- **0 forbidden-word hits** in descriptions (`enable`/`disable`/`teaching`).
- **0 descriptions over 200 chars**.
- **0 colons** in description values.
- **7 cross-product literal duplicates** — feeds, DPI, security-event management, webhooks, WAF, ingress-gateway WAF, and Tor-VPN pages all shared identical descriptions across the two product trees. Now disambiguated by deployment context — Calico Enterprise's self-hosted cluster framing vs. Calico Cloud's connected-cluster and managed-feed framing.
- **Several fragments** — `Deploy WAF with ingress gateways`, `Threat detection for containerized workloads`, `Configure Calico to use with Layer 7 Web Application Firewall`, `Monitor live traffic for malicious activities` are short, non-canonical, or omit the product name entirely. Rewrites use complete sentences with the canonical product name and Threat covers anomaly detection, container threat detection, IDS, threat-intel feeds, alerts, and malware detection.

## Verification

Run from repo root on this branch:

```
grep -nEri "^description:.*\b(enable|disable|teaching)\b" \
  calico-enterprise/threat calico-cloud/threat
```

Length, canonical-name presence, and cross-product-uniqueness checks are equivalent one-liners over the same two directories. All four return empty post-fix.

## Test plan

- [ ] Run the forbidden-word grep above and confirm empty.
- [ ] Spot-check cross-product pairs (`*/threat/suspicious-ips.mdx`, `*/threat/web-application-firewall.mdx`, `*/threat/tor-vpn-feed-and-dashboard.mdx`, `*/threat/deeppacketinspection.mdx`) for distinguishability.
- [ ] Spot-check 5 random rewrites against page bodies for accuracy.
- [ ] After review, mirror to latest-version snapshots in a follow-up PR.