### PR TITLE
Update Calico Enterprise releases.json (3.21-2, 3.22-2, 3.23-1)

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.21-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.21-2/releases.json
@@ -35,6 +35,10 @@
         "version": "v3.21.7",
         "image": "tigera/cnx-manager"
       },
+      "cnx-manager-proxy": {
+        "version": "v3.21.7",
+        "image": "tigera/cnx-manager-proxy"
+      },
       "cnx-node": {
         "version": "v3.21.7",
         "image": "tigera/cnx-node"

--- a/calico-enterprise_versioned_docs/version-3.22-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.22-2/releases.json
@@ -15,6 +15,10 @@
         "version": "v3.22.4",
         "image": "tigera/alertmanager"
       },
+      "apiserver": {
+        "version": "v3.22.4",
+        "image": "tigera/apiserver"
+      },
       "calicoctl": {
         "version": "v3.22.4",
         "image": "tigera/calicoctl"
@@ -22,30 +26,6 @@
       "calicoq": {
         "version": "v3.22.4",
         "image": "tigera/calicoq"
-      },
-      "apiserver": {
-        "version": "v3.22.4",
-        "image": "tigera/apiserver"
-      },
-      "kube-controllers": {
-        "version": "v3.22.4",
-        "image": "tigera/kube-controllers"
-      },
-      "manager": {
-        "version": "v3.22.4",
-        "image": "tigera/manager"
-      },
-      "node": {
-        "version": "v3.22.4",
-        "image": "tigera/node"
-      },
-      "node-windows": {
-        "version": "v3.22.4",
-        "image": "tigera/node-windows"
-      },
-      "queryserver": {
-        "version": "v3.22.4",
-        "image": "tigera/queryserver"
       },
       "compliance-benchmarker": {
         "version": "v3.22.4",
@@ -78,9 +58,6 @@
       },
       "coreos-fluentd": {
         "version": "1.19.2"
-      },
-      "upstream-istio": {
-        "version": "1.28.1"
       },
       "coreos-prometheus": {
         "version": "v3.11.1"
@@ -173,6 +150,10 @@
         "version": "v3.22.4",
         "image": "tigera/envoy-ratelimit"
       },
+      "gateway-l7-collector": {
+        "version": "v3.22.4",
+        "image": "tigera/gateway-l7-collector"
+      },
       "guardian": {
         "version": "v3.22.4",
         "image": "tigera/guardian"
@@ -185,6 +166,22 @@
         "version": "v3.22.4",
         "image": "tigera/intrusion-detection-controller"
       },
+      "istio-install-cni": {
+        "version": "v3.22.4",
+        "image": "tigera/istio-install-cni"
+      },
+      "istio-pilot": {
+        "version": "v3.22.4",
+        "image": "tigera/istio-pilot"
+      },
+      "istio-proxyv2": {
+        "version": "v3.22.4",
+        "image": "tigera/istio-proxyv2"
+      },
+      "istio-ztunnel": {
+        "version": "v3.22.4",
+        "image": "tigera/istio-ztunnel"
+      },
       "key-cert-provisioner": {
         "version": "v3.22.4",
         "image": "tigera/key-cert-provisioner"
@@ -192,6 +189,10 @@
       "kibana": {
         "version": "v3.22.4",
         "image": "tigera/kibana"
+      },
+      "kube-controllers": {
+        "version": "v3.22.4",
+        "image": "tigera/kube-controllers"
       },
       "l7-admission-controller": {
         "version": "v3.22.4",
@@ -208,6 +209,22 @@
       "linseed": {
         "version": "v3.22.4",
         "image": "tigera/linseed"
+      },
+      "manager": {
+        "version": "v3.22.4",
+        "image": "tigera/manager"
+      },
+      "manager-proxy": {
+        "version": "v3.22.4",
+        "image": "tigera/manager-proxy"
+      },
+      "node": {
+        "version": "v3.22.4",
+        "image": "tigera/node"
+      },
+      "node-windows": {
+        "version": "v3.22.4",
+        "image": "tigera/node-windows"
       },
       "packetcapture": {
         "version": "v3.22.4",
@@ -229,6 +246,10 @@
         "version": "v3.22.4",
         "image": "tigera/prometheus-operator"
       },
+      "queryserver": {
+        "version": "v3.22.4",
+        "image": "tigera/queryserver"
+      },
       "tigera-cni": {
         "version": "v3.22.4",
         "image": "tigera/cni"
@@ -248,6 +269,9 @@
       "ui-apis": {
         "version": "v3.22.4",
         "image": "tigera/ui-apis"
+      },
+      "upstream-istio": {
+        "version": "1.28.1"
       },
       "voltron": {
         "version": "v3.22.4",

--- a/calico-enterprise_versioned_docs/version-3.23-1/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.23-1/releases.json
@@ -1,5 +1,5 @@
 [
-    {
+  {
     "title": "v3.23.0-1.0",
     "tigera-operator": {
       "version": "v1.41.1",
@@ -15,6 +15,10 @@
         "version": "v3.23.0-1.0",
         "image": "tigera/alertmanager"
       },
+      "apiserver": {
+        "version": "v3.23.0-1.0",
+        "image": "tigera/apiserver"
+      },
       "calicoctl": {
         "version": "v3.23.0-1.0",
         "image": "tigera/calicoctl"
@@ -22,30 +26,6 @@
       "calicoq": {
         "version": "v3.23.0-1.0",
         "image": "tigera/calicoq"
-      },
-      "apiserver": {
-        "version": "v3.23.0-1.0",
-        "image": "tigera/apiserver"
-      },
-      "kube-controllers": {
-        "version": "v3.23.0-1.0",
-        "image": "tigera/kube-controllers"
-      },
-      "manager": {
-        "version": "v3.23.0-1.0",
-        "image": "tigera/manager"
-      },
-      "node": {
-        "version": "v3.23.0-1.0",
-        "image": "tigera/node"
-      },
-      "node-windows": {
-        "version": "v3.23.0-1.0",
-        "image": "tigera/node-windows"
-      },
-      "queryserver": {
-        "version": "v3.23.0-1.0",
-        "image": "tigera/queryserver"
       },
       "compliance-benchmarker": {
         "version": "v3.23.0-1.0",
@@ -68,25 +48,22 @@
         "image": "tigera/compliance-snapshotter"
       },
       "coreos-alertmanager": {
-        "version": "v0.28.1"
+        "version": "v0.30.1"
       },
       "coreos-config-reloader": {
-        "version": "v0.84.0"
+        "version": "v0.88.0"
       },
       "coreos-dex": {
         "version": "v2.41.1"
       },
       "coreos-fluentd": {
-        "version": "1.18.0"
-      },
-      "upstream-istio": {
-        "version": "1.28.1"
+        "version": "1.19.1"
       },
       "coreos-prometheus": {
-        "version": "v3.4.1"
+        "version": "v3.9.1"
       },
       "coreos-prometheus-operator": {
-        "version": "v0.84.0"
+        "version": "v0.88.0"
       },
       "csi": {
         "version": "v3.23.0-1.0",
@@ -109,13 +86,13 @@
         "image": "tigera/dikastes"
       },
       "eck-elasticsearch": {
-        "version": "8.19.8"
+        "version": "8.19.10"
       },
       "eck-elasticsearch-operator": {
-        "version": "2.16.1"
+        "version": "2.16.0"
       },
       "eck-kibana": {
-        "version": "8.19.8"
+        "version": "8.19.10"
       },
       "egress-gateway": {
         "version": "v3.23.0-1.0",
@@ -173,6 +150,10 @@
         "version": "v3.23.0-1.0",
         "image": "tigera/envoy-ratelimit"
       },
+      "gateway-l7-collector": {
+        "version": "v3.23.0-1.0",
+        "image": "tigera/gateway-l7-collector"
+      },
       "guardian": {
         "version": "v3.23.0-1.0",
         "image": "tigera/guardian"
@@ -185,6 +166,22 @@
         "version": "v3.23.0-1.0",
         "image": "tigera/intrusion-detection-controller"
       },
+      "istio-install-cni": {
+        "version": "v3.23.0-1.0",
+        "image": "tigera/istio-install-cni"
+      },
+      "istio-pilot": {
+        "version": "v3.23.0-1.0",
+        "image": "tigera/istio-pilot"
+      },
+      "istio-proxyv2": {
+        "version": "v3.23.0-1.0",
+        "image": "tigera/istio-proxyv2"
+      },
+      "istio-ztunnel": {
+        "version": "v3.23.0-1.0",
+        "image": "tigera/istio-ztunnel"
+      },
       "key-cert-provisioner": {
         "version": "v3.23.0-1.0",
         "image": "tigera/key-cert-provisioner"
@@ -192,6 +189,10 @@
       "kibana": {
         "version": "v3.23.0-1.0",
         "image": "tigera/kibana"
+      },
+      "kube-controllers": {
+        "version": "v3.23.0-1.0",
+        "image": "tigera/kube-controllers"
       },
       "l7-admission-controller": {
         "version": "v3.23.0-1.0",
@@ -208,6 +209,22 @@
       "linseed": {
         "version": "v3.23.0-1.0",
         "image": "tigera/linseed"
+      },
+      "manager": {
+        "version": "v3.23.0-1.0",
+        "image": "tigera/manager"
+      },
+      "manager-proxy": {
+        "version": "v3.23.0-1.0",
+        "image": "tigera/manager-proxy"
+      },
+      "node": {
+        "version": "v3.23.0-1.0",
+        "image": "tigera/node"
+      },
+      "node-windows": {
+        "version": "v3.23.0-1.0",
+        "image": "tigera/node-windows"
       },
       "packetcapture": {
         "version": "v3.23.0-1.0",
@@ -228,6 +245,14 @@
       "prometheus-operator": {
         "version": "v3.23.0-1.0",
         "image": "tigera/prometheus-operator"
+      },
+      "queryserver": {
+        "version": "v3.23.0-1.0",
+        "image": "tigera/queryserver"
+      },
+      "test-signer": {
+        "version": "v3.23.0-1.0",
+        "image": "tigera/test-signer"
       },
       "tigera-cni": {
         "version": "v3.23.0-1.0",


### PR DESCRIPTION
## Summary

- Refreshes `releases.json` for CE 3.21-2, 3.22-2, and 3.23-1 via `make version/updateall`. Source: `release-calient-v3.21-2/-v3.22-2/-v3.23-1` branches of `tigera/calico-private` `calico/_data/versions.yml`.
- 3.23-1: adds `test-signer`, `manager-proxy`, `gateway-l7-collector`, and the new `istio-install-cni / istio-pilot / istio-proxyv2 / istio-ztunnel` family. Removes the consolidated `upstream-istio` entry. ECK Elasticsearch/Kibana bumped 8.19.8 → 8.19.10.
- 3.23-1: **10 components were hand-patched to restore the `tigera/` image prefix.** Upstream `versions.yml` for v3.23.0-1.0 has those entries unprefixed: `cni`, `cni-windows`, `eck-operator`, `envoy-gateway`, `envoy-proxy`, `envoy-ratelimit`, `node-driver-registrar`, `intrusion-detection-job-installer`, `pod2daemon-flexvol`, `prometheus-service`. Verified against quay.io: `quay.io/<unprefixed>:v3.23.0-1.0` returns 404; `quay.io/tigera/<unprefixed>:v3.23.0-1.0` exists (200 public / 401 private). Without the prefix, the private-registry doc would render broken `docker pull` commands. **Follow-up: `tigera/calico-private` `release-calient-v3.23-1/calico/_data/versions.yml` needs a fix to drop this divergence on the next regen.**

## Test plan

- [ ] `git diff` only touches `releases.json` files (no `variables.js` / template churn).
- [ ] Spot-check the rendered CE 3.23 private-registry page locally; confirm `docker pull` commands point to real `quay.io/tigera/...` paths.
- [ ] Confirm `eck-elasticsearch-operator 2.16.0` (down from 2.16.1) matches upstream intent — verified against `release-calient-v3.23-1/versions.yml`.
- [ ] Spot-check CE 3.21 and 3.22 private-registry pages render unchanged (no prefix-loss in those streams).

🤖 Generated with [Claude Code](https://claude.com/claude-code)