### PR TITLE
Add a note to Ingress Gateway docs re global default deny

### DIFF
--- a/calico-cloud/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico-cloud/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -29,6 +29,10 @@ You need to do the following:
 
 ## Create an ingress gateway
 
+1. If you are using a [global default deny policy](../../network-policy/beginners/kubernetes-default-deny.mdx),
+   allow traffic through the gateway by adding the `tigera-gateway` namespace to the list of excluded namespaces in the
+   `namespaceSelector` field.
+
 1. To enable Gateway API support, create a `GatewayAPI` resource with the name `tigera-secure`:
 
    ```bash

--- a/calico-cloud_versioned_docs/version-22-2/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -29,6 +29,10 @@ You need to do the following:
 
 ## Create an ingress gateway
 
+1. If you are using a [global default deny policy](../../network-policy/beginners/kubernetes-default-deny.mdx),
+   allow traffic through the gateway by adding the `tigera-gateway` namespace to the list of excluded namespaces in the
+   `namespaceSelector` field.
+
 1. To enable Gateway API support, create a `GatewayAPI` resource with the name `tigera-secure`:
 
    ```bash

--- a/calico-enterprise/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico-enterprise/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -29,6 +29,10 @@ You need to do the following:
 
 ## Create an ingress gateway
 
+1. If you are using a [global default deny policy](../../network-policy/beginners/kubernetes-default-deny.mdx),
+   allow traffic through the gateway by adding the `tigera-gateway` namespace to the list of excluded namespaces in the
+   `namespaceSelector` field.
+
 1. To enable Gateway API support, create a `GatewayAPI` resource with the name `tigera-secure`:
 
    ```bash

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -29,6 +29,10 @@ You need to do the following:
 
 ## Create an ingress gateway
 
+1. If you are using a [global default deny policy](../../network-policy/beginners/kubernetes-default-deny.mdx),
+   allow traffic through the gateway by adding the `tigera-gateway` namespace to the list of excluded namespaces in the
+   `namespaceSelector` field.
+
 1. To enable Gateway API support, create a `GatewayAPI` resource with the name `tigera-secure`:
 
    ```bash

--- a/calico-enterprise_versioned_docs/version-3.23-1/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -29,6 +29,10 @@ You need to do the following:
 
 ## Create an ingress gateway
 
+1. If you are using a [global default deny policy](../../network-policy/beginners/kubernetes-default-deny.mdx),
+   allow traffic through the gateway by adding the `tigera-gateway` namespace to the list of excluded namespaces in the
+   `namespaceSelector` field.
+
 1. To enable Gateway API support, create a `GatewayAPI` resource with the name `tigera-secure`:
 
    ```bash

--- a/calico/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -29,6 +29,10 @@ You need to do the following:
 
 ## Create an ingress gateway
 
+1. If you are using a [global default deny policy](../../network-policy/get-started/kubernetes-default-deny.mdx),
+   allow traffic through the gateway by adding the `tigera-gateway` namespace to the list of excluded namespaces in the
+   `namespaceSelector` field.
+
 1. To enable Gateway API support, create a `GatewayAPI` resource with the name `default`:
 
    ```bash

--- a/calico_versioned_docs/version-3.31/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico_versioned_docs/version-3.31/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -29,6 +29,10 @@ You need to do the following:
 
 ## Create an ingress gateway
 
+1. If you are using a [global default deny policy](../../network-policy/get-started/kubernetes-default-deny.mdx),
+   allow traffic through the gateway by adding the `tigera-gateway` namespace to the list of excluded namespaces in the
+   `namespaceSelector` field.
+
 1. To enable Gateway API support, create a `GatewayAPI` resource with the name `default`:
 
    ```bash

--- a/calico_versioned_docs/version-3.32/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -29,6 +29,10 @@ You need to do the following:
 
 ## Create an ingress gateway
 
+1. If you are using a [global default deny policy](../../network-policy/get-started/kubernetes-default-deny.mdx),
+   allow traffic through the gateway by adding the `tigera-gateway` namespace to the list of excluded namespaces in the
+   `namespaceSelector` field.
+
 1. To enable Gateway API support, create a `GatewayAPI` resource with the name `default`:
 
    ```bash


### PR DESCRIPTION
Ingress Gateway fails to start when a default deny rule is applied to the tigera-gateway namespace. Add a note to the ingress gateway setup docs to exclude it from the deny rules.

Product Version(s):
* Calico 3.31
* Calico Enterprise 3.22-2, 3.23-1
* Calico Cloud 22-2

Issue:
https://tigera.atlassian.net/browse/EV-6476

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->