### PR TITLE
docs: note Kibana 7→8 migration known issue on 3.21 and 3.22 release notes

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -272,6 +272,12 @@ To update an existing installation of Calico Enterprise 3.21, see [Install a pat
 
 May 25, 2026
 
+:::note[Upgrading from Calico Enterprise 3.20 or earlier]
+
+Calico Enterprise 3.21 and later upgrade Kibana from 7.x to 8.x, and there is a known issue with the Kibana 7 → 8 saved-object migration when upgrading from Calico Enterprise 3.20 or earlier. This release includes the fix — upgrade directly to 3.21.8 or later to avoid it.
+
+:::
+
 #### Bug fixes
 
 * Fixes an issue where `HostEndpoint` policies block UDP return traffic for SNAT'd pod egress when using the eBPF dataplane.

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -369,6 +369,12 @@ To update an existing installation of Calico Enterprise 3.22, see [Install a pat
 
 May 20, 2026
 
+:::note[Upgrading from Calico Enterprise 3.20 or earlier]
+
+Calico Enterprise 3.21 and later upgrade Kibana from 7.x to 8.x, and there is a known issue with the Kibana 7 → 8 saved-object migration when upgrading from Calico Enterprise 3.20 or earlier. This release includes the fix — upgrade directly to 3.22.5 or later to avoid it.
+
+:::
+
 #### Enhancements
 
 * Added a named "https" port on the calico-manager Service and, when the OpenShift IDP is configured, publish a `tigera-ca-public` Secret in the `calico-system` namespace so that OpenShift's Ingress→Route conversion can produce a reencrypt Route fronting the manager.


### PR DESCRIPTION
## Summary

- Add an upgrade note on the 3.21.8 and 3.22.5 release sections calling out the known Kibana 7→8 saved-object migration issue when upgrading from Calico Enterprise 3.20 or earlier.
- The fix shipped in 3.21.8 and 3.22.5 — the note is placed on those releases to direct readers to use them (or later).

## Test plan

- [ ] Verify the rendered note appears on the 3.21.8 section on the 3.21 release-notes page.
- [ ] Verify the rendered note appears on the 3.22.5 section on the 3.22 release-notes page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)