### PR TITLE
[DOCS#EV-6623]: Fill HEP policy recommendation docs gaps — selector syntax and status lifecycle

### DIFF
--- a/calico-enterprise/network-policy/recommendations/hep-policy-recommendations.mdx
+++ b/calico-enterprise/network-policy/recommendations/hep-policy-recommendations.mdx
@@ -118,33 +118,31 @@ See [Manage the life cycle of recommendations](#manage-the-life-cycle-of-recomme
 
 ### Scope recommendations to specific hosts
 
-By default, every HostEndpoint in the cluster is eligible for
+By default, every host endpoint in the cluster is eligible for
 recommendations. To restrict the engine to a subset, set
 `hostEndpointSpec.selector` to a Calico label-selector expression that
-matches the HostEndpoint labels you want to cover.
+matches the labels of the host endpoints you want to cover.
 
 ```bash
-# Generate recommendations only for HostEndpoints labelled
-# `environment=prod`.
-kubectl patch policyrecommendationscope default --type=merge -p '{
-  "spec": {
-    "hostEndpointSpec": {
-      "recommendationStatus": "Enabled",
-      "selector": "environment == '\''prod'\''"
-    }
-  }
-}'
+# Recommend policies only for host endpoints labelled environment=prod.
+kubectl patch policyrecommendationscope default --type=merge --patch-file=/dev/stdin <<'EOF'
+spec:
+  hostEndpointSpec:
+    recommendationStatus: Enabled
+    selector: environment == 'prod'
+EOF
 ```
 
-A few common patterns:
+This table shows common selector patterns for host endpoint policy
+recommendations:
 
-| Goal                                        | Expression                                                            |
-| ------------------------------------------- | --------------------------------------------------------------------- |
-| All HostEndpoints                           | `all()` (or omit `selector`)                                          |
-| Single label value                          | `role == 'edge'`                                                      |
-| Any of several values                       | `role in { 'edge', 'gateway' }`                                       |
-| Label present, any value                    | `has(zone)`                                                           |
-| Combined conditions                         | <code>environment == 'prod' && !has(quarantined)</code>               |
+| Goal                                             | Expression                                                       |
+| ------------------------------------------------ | ---------------------------------------------------------------- |
+| Match all host endpoints                         | `all()` (or omit `selector`)                                     |
+| Match a single label value                       | `role == 'edge'`                                                 |
+| Match any of several values                      | `role in { 'edge', 'gateway' }`                                  |
+| Match host endpoints that carry a given label    | `has(zone)`                                                      |
+| Combine conditions with boolean operators        | <code>environment == 'prod' && !has(quarantined)</code>          |
 
 For the full operator reference — comparison, set membership,
 substring, and boolean composition — see
@@ -324,21 +322,23 @@ recommendation in `Learn`.
 In addition to the `stagedAction` lifecycle described above (which **you**
 control), the engine reports its own view of each recommendation through
 the `policyrecommendation.tigera.io/status` annotation on the staged
-global network policy. Use it to know when a recommendation has settled
-down enough to enforce.
+global network policy. Use it to know when a recommendation has stopped
+changing long enough to be ready to enforce.
+
+This table describes the values the engine assigns to the
+`policyrecommendation.tigera.io/status` annotation:
 
 | Value         | Meaning                                                                                                                      |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `Learning`    | Engine is still actively adding or modifying rules from flow logs. This is the initial value and is reset whenever the engine changes the recommendation. |
-| `Stabilizing` | Engine has not modified the recommendation for longer than `2 × interval`, but less than `stabilizationPeriod`. Rules look settled but the engine is still watching. |
+| `Stabilizing` | Engine has not modified the recommendation for longer than `2 × interval`, but no more than `stabilizationPeriod`. Rules look settled but the engine is still watching. |
 | `Stable`      | Engine has not modified the recommendation for longer than `stabilizationPeriod`. The recommendation is considered ready to enforce. |
 
 The status transitions are driven by the time since the engine last
 modified the recommendation, not by elapsed time alone:
 
-- A host that suddenly sends new traffic mid-`Stabilizing` will be
-  knocked back to `Learning` while the engine incorporates the new
-  rules.
+- A host that suddenly sends new traffic during a `Stabilizing` period
+  returns to `Learning` while the engine incorporates the new rules.
 - The `stabilizationPeriod` and `interval` values in
   [Tune global settings](#tune-global-settings) directly control how
   quickly a recommendation can reach `Stable`.
@@ -363,7 +363,7 @@ kubectl get stagedglobalnetworkpolicies.projectcalico.org \
 Wait for `Stable` before
 [accepting](#activate-a-recommendation) and
 [enforcing](#enforce-a-recommendation) a recommendation. Accepting a
-recommendation while it is still `Learning` or `Stabilizing` pins the
+recommendation while it is still learning or stabilizing pins the
 current — possibly incomplete — set of rules and stops the engine from
 refining it further.
 

--- a/calico-enterprise/network-policy/recommendations/hep-policy-recommendations.mdx
+++ b/calico-enterprise/network-policy/recommendations/hep-policy-recommendations.mdx
@@ -66,8 +66,10 @@ to the staged and enforced global network policies in that tier.
 
 - [Enable host-policy recommendations](#enable-host-policy-recommendations)
 - [View recommended policies](#view-recommended-policies)
+- [Scope recommendations to specific hosts](#scope-recommendations-to-specific-hosts)
 - [Tune global settings](#tune-global-settings)
 - [Manage the life cycle of recommendations](#manage-the-life-cycle-of-recommendations)
+- [Track recommendation readiness](#track-recommendation-readiness)
 - [Confirm a recommendation is matching real traffic](#confirm-a-recommendation-is-matching-real-traffic)
 - [Disable host-policy recommendations](#disable-host-policy-recommendations)
 
@@ -113,6 +115,40 @@ matches the selector. Each recommended policy has one of three states
 you can set — `Learn`, `Set`, or `Ignore` — tracked by the
 `projectcalico.org/spec.stagedAction` label and `spec.stagedAction` field.
 See [Manage the life cycle of recommendations](#manage-the-life-cycle-of-recommendations).
+
+### Scope recommendations to specific hosts
+
+By default, every HostEndpoint in the cluster is eligible for
+recommendations. To restrict the engine to a subset, set
+`hostEndpointSpec.selector` to a Calico label-selector expression that
+matches the HostEndpoint labels you want to cover.
+
+```bash
+# Generate recommendations only for HostEndpoints labelled
+# `environment=prod`.
+kubectl patch policyrecommendationscope default --type=merge -p '{
+  "spec": {
+    "hostEndpointSpec": {
+      "recommendationStatus": "Enabled",
+      "selector": "environment == '\''prod'\''"
+    }
+  }
+}'
+```
+
+A few common patterns:
+
+| Goal                                        | Expression                                                            |
+| ------------------------------------------- | --------------------------------------------------------------------- |
+| All HostEndpoints                           | `all()` (or omit `selector`)                                          |
+| Single label value                          | `role == 'edge'`                                                      |
+| Any of several values                       | `role in { 'edge', 'gateway' }`                                       |
+| Label present, any value                    | `has(zone)`                                                           |
+| Combined conditions                         | <code>environment == 'prod' && !has(quarantined)</code>               |
+
+For the full operator reference — comparison, set membership,
+substring, and boolean composition — see
+[label selectors](../../reference/resources/policyrecommendations.mdx#selectors).
 
 ### Tune global settings
 
@@ -282,6 +318,56 @@ kubectl delete globalnetworkpolicy.projectcalico.org <name>
 
 On the next processing cycle, the engine creates a fresh staged
 recommendation in `Learn`.
+
+### Track recommendation readiness
+
+In addition to the `stagedAction` lifecycle described above (which **you**
+control), the engine reports its own view of each recommendation through
+the `policyrecommendation.tigera.io/status` annotation on the staged
+global network policy. Use it to know when a recommendation has settled
+down enough to enforce.
+
+| Value         | Meaning                                                                                                                      |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `Learning`    | Engine is still actively adding or modifying rules from flow logs. This is the initial value and is reset whenever the engine changes the recommendation. |
+| `Stabilizing` | Engine has not modified the recommendation for longer than `2 × interval`, but less than `stabilizationPeriod`. Rules look settled but the engine is still watching. |
+| `Stable`      | Engine has not modified the recommendation for longer than `stabilizationPeriod`. The recommendation is considered ready to enforce. |
+
+The status transitions are driven by the time since the engine last
+modified the recommendation, not by elapsed time alone:
+
+- A host that suddenly sends new traffic mid-`Stabilizing` will be
+  knocked back to `Learning` while the engine incorporates the new
+  rules.
+- The `stabilizationPeriod` and `interval` values in
+  [Tune global settings](#tune-global-settings) directly control how
+  quickly a recommendation can reach `Stable`.
+
+Read the annotation with `kubectl`:
+
+```bash
+kubectl get stagedglobalnetworkpolicy.projectcalico.org <name> \
+  -o jsonpath='{.metadata.annotations.policyrecommendation\.tigera\.io/status}{"\n"}'
+```
+
+List the status of every host-policy recommendation at once:
+
+```bash
+kubectl get stagedglobalnetworkpolicies.projectcalico.org \
+  -l projectcalico.org/tier=hostendpoint-isolation \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.annotations.policyrecommendation\.tigera\.io/status}{"\n"}{end}'
+```
+
+:::tip
+
+Wait for `Stable` before
+[accepting](#activate-a-recommendation) and
+[enforcing](#enforce-a-recommendation) a recommendation. Accepting a
+recommendation while it is still `Learning` or `Stabilizing` pins the
+current — possibly incomplete — set of rules and stops the engine from
+refining it further.
+
+:::
 
 ### Confirm a recommendation is matching real traffic
 

--- a/calico-enterprise/reference/resources/policyrecommendations.mdx
+++ b/calico-enterprise/reference/resources/policyrecommendations.mdx
@@ -52,7 +52,7 @@ $ kubectl patch policyrecommendationscope default -p '{"spec":{"<parameter>":"<v
 | Field                              | Description                                                  | Accepted Values | Schema | Default        |
 | ---------------------------------- | ------------------------------------------------------------ | --------------- | ------ | -------------- |
 | `recStatus`                        | Defines the namespace policy recommendation engine status.   | Enabled/Disabled |        | Disabled       |
-| `selector`                         | Selects the namespaces for generating recommendations.       |                 |        | `!(projectcalico.org/name starts with ''tigera-'') && !(projectcalico.org/name starts with ''calico-'') && !(projectcalico.org/name starts with ''kube-'')` |
+| `selector`                         | Selects the namespaces for generating recommendations. Accepts any [label selector](#selectors) expression. |                 |        | `!(projectcalico.org/name starts with ''tigera-'') && !(projectcalico.org/name starts with ''calico-'') && !(projectcalico.org/name starts with ''kube-'')` |
 | `intraNamespacePassThroughTraffic` | When true, sets all intra-namespace traffic to Pass          | true/false |        | false |
 | `tierName`                         | Tier where the generated staged network policies are created. The tier must already exist. | | string | `namespace-isolation` |
 
@@ -74,7 +74,7 @@ without re-reading the spec. Annotations live under the
 | Annotation                                   | Description                                                                                                                                                                                                                                       |
 | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `policyrecommendation.tigera.io/status`      | Engine's readiness signal for this recommendation. See [Recommendation status lifecycle](#recommendation-status-lifecycle) below.                                                                                                                |
-| `policyrecommendation.tigera.io/lastUpdated` | RFC 3339 timestamp of the engine's last modification to the recommendation's spec. Drives the `Learning → Stabilizing → Stable` transitions.                                                                                                      |
+| `policyrecommendation.tigera.io/lastUpdated` | RFC 3339 timestamp of the engine's last modification to the generated staged policy's spec (the recommendation itself, not the PolicyRecommendationScope spec). Drives the `Learning → Stabilizing → Stable` transitions.                          |
 | `policyrecommendation.tigera.io/scope`       | Scope the recommendation was generated for. One of `namespace` (namespace recommendations) or `hostEndpoint` (host recommendations). Individual rules can also carry per-rule `scope` annotations such as `Domains`, `Private`, `Public`, `Service`, `NetworkSet`. |
 | `policyrecommendation.tigera.io/name`        | Name of the source object (namespace for namespace recommendations, HostEndpoint for host recommendations).                                                                                                                                       |
 | `policyrecommendation.tigera.io/namespace`   | For namespace recommendations: the namespace the recommendation applies to.                                                                                                                                                                       |
@@ -83,8 +83,9 @@ without re-reading the spec. Annotations live under the
 
 The `policyrecommendation.tigera.io/status` annotation moves through
 the following values as the engine refines a recommendation. The
-transitions are driven by `lastUpdated`: the longer the spec has
-remained unchanged, the further the recommendation has progressed.
+transitions are driven by `lastUpdated`: the longer the generated
+staged policy's spec has remained unchanged, the further the
+recommendation has progressed.
 
 | Status        | When it is set                                                                                                                                  |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/calico-enterprise/reference/resources/policyrecommendations.mdx
+++ b/calico-enterprise/reference/resources/policyrecommendations.mdx
@@ -61,5 +61,50 @@ $ kubectl patch policyrecommendationscope default -p '{"spec":{"<parameter>":"<v
 | Field                    | Description                                                  | Accepted Values  | Schema | Default                 |
 | ------------------------ | ------------------------------------------------------------ | ---------------- | ------ | ----------------------- |
 | `recommendationStatus`   | Defines the host policy recommendation engine status.        | Enabled/Disabled |        | Disabled                |
-| `selector`               | Selects which HostEndpoints the engine generates recommendations for. If omitted, every HostEndpoint is eligible. | | string | (all HostEndpoints)     |
+| `selector`               | Selects which HostEndpoints the engine generates recommendations for. If omitted, every HostEndpoint is eligible. Accepts any [label selector](#selectors) expression. | | string | (all HostEndpoints)     |
 | `tierName`               | Tier where the generated staged global network policies are created. The tier must already exist. | | string | `hostendpoint-isolation` |
+
+## Annotations on generated recommendations
+
+The engine annotates each staged network policy and staged global
+network policy it generates so you can inspect its progress and source
+without re-reading the spec. Annotations live under the
+`policyrecommendation.tigera.io/` prefix.
+
+| Annotation                                   | Description                                                                                                                                                                                                                                       |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `policyrecommendation.tigera.io/status`      | Engine's readiness signal for this recommendation. See [Recommendation status lifecycle](#recommendation-status-lifecycle) below.                                                                                                                |
+| `policyrecommendation.tigera.io/lastUpdated` | RFC 3339 timestamp of the engine's last modification to the recommendation's spec. Drives the `Learning → Stabilizing → Stable` transitions.                                                                                                      |
+| `policyrecommendation.tigera.io/scope`       | Scope the recommendation was generated for. One of `namespace` (namespace recommendations) or `hostEndpoint` (host recommendations). Individual rules can also carry per-rule `scope` annotations such as `Domains`, `Private`, `Public`, `Service`, `NetworkSet`. |
+| `policyrecommendation.tigera.io/name`        | Name of the source object (namespace for namespace recommendations, HostEndpoint for host recommendations).                                                                                                                                       |
+| `policyrecommendation.tigera.io/namespace`   | For namespace recommendations: the namespace the recommendation applies to.                                                                                                                                                                       |
+
+### Recommendation status lifecycle
+
+The `policyrecommendation.tigera.io/status` annotation moves through
+the following values as the engine refines a recommendation. The
+transitions are driven by `lastUpdated`: the longer the spec has
+remained unchanged, the further the recommendation has progressed.
+
+| Status        | When it is set                                                                                                                                  |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Learning`    | Initial value for every new recommendation. Reset to this whenever the engine modifies the spec.                                                |
+| `Stabilizing` | Set when the spec has been unchanged for more than `2 × interval` but no more than `stabilizationPeriod`. Rules look settled but are still being watched. |
+| `Stable`      | Set when the spec has been unchanged for more than `stabilizationPeriod`. Treat as ready to accept and enforce.                                 |
+
+`interval` and `stabilizationPeriod` are the top-level fields on this
+resource. Adjusting them directly controls how quickly a recommendation
+can reach `Stable`. See [Spec](#spec).
+
+The engine resets the status to `Learning` and bumps `lastUpdated` any
+time it adds, removes, or changes a rule, so a recommendation that
+absorbs new traffic late in its life cycle returns to `Learning` until
+it next stabilizes.
+
+## Selectors
+
+The `selector` fields on `namespaceSpec` and `hostEndpointSpec` accept
+the same label-selector expression language used elsewhere in Calico
+network policy.
+
+<Selectors />


### PR DESCRIPTION
Product Version(s):
Calico Enterprise (next / unreleased — applies to the docs merged in #2658).

Issue:
- Jira: [EV-6623](https://tigera.atlassian.net/browse/EV-6623)
- Follow-up to merged PR #2658 (Patrick Zhan / @xiumozhan)

Link to docs preview:
Once Netlify builds, the two updated pages are:
- `/calico-enterprise/next/network-policy/recommendations/hep-policy-recommendations`
- `/calico-enterprise/next/reference/resources/policyrecommendations`

## Summary

Backfills two release-blocking gaps surfaced during the CNX-R1355 / CNX-T5996 manual test cycle audit of #2658.

### 1. `hostEndpointSpec.selector` had no operator syntax reference

Neither the HEP page nor the PolicyRecommendationScope reference page documented the Calico label-selector syntax (`==`, `in {…}`, `has()`, `all()`, boolean composition, …) that the field accepts. A user landing on `hostEndpointSpec.selector` for the first time had no path to the operator reference.

Changes:
- HEP page: new ``### Scope recommendations to specific hosts`` section with a worked example (`environment == 'prod'`) and a common-pattern table, linking to the new selectors anchor on the reference page.
- Reference page: new ``## Selectors`` section that renders the ``<Selectors />`` partial — the import was already at the top of the file but never rendered.
- Reference page: ``selector`` row in the HostEndpointSpec table now points at ``#selectors``.

### 2. `policyrecommendation.tigera.io/status` lifecycle was undocumented

The HEP page describes the user-controlled ``stagedAction`` lifecycle (``Learn`` / ``Set`` / ``Ignore``), and mentions ``stabilizationPeriod`` only as a config knob. The engine's own readiness signal — the ``policyrecommendation.tigera.io/status`` annotation moving through ``Learning → Stabilizing → Stable`` — wasn't documented anywhere. Users had no way to answer ``when is my recommendation ready to enforce?``.

Verified against source: `policy-recommendation/pkg/calico-resources/stagednetworkpolicy.go:53-57` and `pkg/engine/recommendation.go:493-534`.

Changes:
- HEP page: new ``### Track recommendation readiness`` section with the status table, the exact transition conditions (`> 2 × interval`, `> stabilizationPeriod`), the reset-on-modify behavior, two `kubectl` one-liners (single + bulk) for reading the annotation, and a tip to wait for ``Stable`` before accepting/enforcing.
- Reference page: new ``## Annotations on generated recommendations`` section documenting the full ``policyrecommendation.tigera.io/*`` annotation family (`status`, `lastUpdated`, `scope`, `name`, `namespace`), plus a ``### Recommendation status lifecycle`` subsection that the HEP page cross-links to.

## Not in scope

The reference page imports several other partials (``Servicematch``, ``Serviceaccountmatch``, ``Ports``, ``Entityrule``, ``Icmp``, ``Rule``) that are never rendered — the page truncates at the HostEndpointSpec table. Looks like a separate gap from the original fork of `globalnetworkpolicy.mdx`. Leaving for a follow-up so this PR stays focused on EV-6623.

## SME review

- [ ] @xiumozhan — original author of #2658, please confirm the status lifecycle description matches the implementation you wired.

## Merge checklist

- [ ] Deploy preview inspected
- [x] Local build passes (`BUILD_NEXT=true yarn build` produced no new broken-link errors against the two changed pages)
- [ ] Test have passed

[EV-6623]: https://tigera.atlassian.net/browse/EV-6623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ