### PR TITLE
Publish Calico Enterprise 3.21.8

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -268,3 +268,13 @@ May 13, 2026
 
 To update an existing installation of Calico Enterprise 3.21, see [Install a patch release](../getting-started/manifest-archive.mdx).
 
+### Calico Enterprise 3.21.8 bug fix release
+
+May 22, 2026
+
+#### Bug fixes
+
+* TBD
+
+To update an existing installation of Calico Enterprise 3.21, see [Install a patch release](../getting-started/manifest-archive.mdx).
+

--- a/calico-enterprise_versioned_docs/version-3.21-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.21-2/releases.json
@@ -1,5 +1,270 @@
 [
   {
+    "title": "v3.21.8",
+    "tigera-operator": {
+      "version": "v1.38.14",
+      "image": "tigera/operator",
+      "registry": "quay.io"
+    },
+    "calico": {
+      "minor_version": "v3.30",
+      "archive_path": "archive"
+    },
+    "components": {
+      "alertmanager": {
+        "version": "v3.21.8",
+        "image": "tigera/alertmanager"
+      },
+      "calicoctl": {
+        "version": "v3.21.8",
+        "image": "tigera/calicoctl"
+      },
+      "calicoq": {
+        "version": "v3.21.8",
+        "image": "tigera/calicoq"
+      },
+      "cnx-apiserver": {
+        "version": "v3.21.8",
+        "image": "tigera/cnx-apiserver"
+      },
+      "cnx-kube-controllers": {
+        "version": "v3.21.8",
+        "image": "tigera/kube-controllers"
+      },
+      "cnx-manager": {
+        "version": "v3.21.8",
+        "image": "tigera/cnx-manager"
+      },
+      "cnx-manager-proxy": {
+        "version": "v3.21.8",
+        "image": "tigera/cnx-manager-proxy"
+      },
+      "cnx-node": {
+        "version": "v3.21.8",
+        "image": "tigera/cnx-node"
+      },
+      "cnx-node-windows": {
+        "version": "v3.21.8",
+        "image": "tigera/cnx-node-windows"
+      },
+      "cnx-queryserver": {
+        "version": "v3.21.8",
+        "image": "tigera/cnx-queryserver"
+      },
+      "compliance-benchmarker": {
+        "version": "v3.21.8",
+        "image": "tigera/compliance-benchmarker"
+      },
+      "compliance-controller": {
+        "version": "v3.21.8",
+        "image": "tigera/compliance-controller"
+      },
+      "compliance-reporter": {
+        "version": "v3.21.8",
+        "image": "tigera/compliance-reporter"
+      },
+      "compliance-server": {
+        "version": "v3.21.8",
+        "image": "tigera/compliance-server"
+      },
+      "compliance-snapshotter": {
+        "version": "v3.21.8",
+        "image": "tigera/compliance-snapshotter"
+      },
+      "coreos-alertmanager": {
+        "version": "v0.28.1"
+      },
+      "coreos-config-reloader": {
+        "version": "v0.91.0"
+      },
+      "coreos-dex": {
+        "version": "v2.41.1"
+      },
+      "coreos-fluentd": {
+        "version": "1.19.2"
+      },
+      "coreos-prometheus": {
+        "version": "v2.55.1"
+      },
+      "coreos-prometheus-operator": {
+        "version": "v0.91.0"
+      },
+      "csi": {
+        "version": "v3.21.8",
+        "image": "tigera/csi"
+      },
+      "csi-node-driver-registrar": {
+        "version": "v3.21.8",
+        "image": "tigera/node-driver-registrar"
+      },
+      "deep-packet-inspection": {
+        "version": "v3.21.8",
+        "image": "tigera/deep-packet-inspection"
+      },
+      "dex": {
+        "version": "v3.21.8",
+        "image": "tigera/dex"
+      },
+      "dikastes": {
+        "version": "v3.21.8",
+        "image": "tigera/dikastes"
+      },
+      "eck-elasticsearch": {
+        "version": "8.19.15"
+      },
+      "eck-elasticsearch-operator": {
+        "version": "2.16.1"
+      },
+      "eck-kibana": {
+        "version": "8.19.15"
+      },
+      "egress-gateway": {
+        "version": "v3.21.8",
+        "image": "tigera/egress-gateway"
+      },
+      "elastic-tsee-installer": {
+        "version": "v3.21.8",
+        "image": "tigera/intrusion-detection-job-installer"
+      },
+      "elasticsearch": {
+        "version": "v3.21.8",
+        "image": "tigera/elasticsearch"
+      },
+      "elasticsearch-metrics": {
+        "version": "v3.21.8",
+        "image": "tigera/elasticsearch-metrics"
+      },
+      "elasticsearch-operator": {
+        "version": "v3.21.8",
+        "image": "tigera/eck-operator"
+      },
+      "envoy": {
+        "version": "v3.21.8",
+        "image": "tigera/envoy"
+      },
+      "envoy-init": {
+        "version": "v3.21.8",
+        "image": "tigera/envoy-init"
+      },
+      "es-gateway": {
+        "version": "v3.21.8",
+        "image": "tigera/es-gateway"
+      },
+      "firewall-integration": {
+        "version": "v3.21.8",
+        "image": "tigera/firewall-integration"
+      },
+      "flexvol": {
+        "version": "v3.21.8",
+        "image": "tigera/pod2daemon-flexvol"
+      },
+      "fluentd": {
+        "version": "v3.21.8",
+        "image": "tigera/fluentd"
+      },
+      "fluentd-windows": {
+        "version": "v3.21.8",
+        "image": "tigera/fluentd-windows"
+      },
+      "gateway-api-envoy-gateway": {
+        "version": "v3.21.8",
+        "image": "tigera/envoy-gateway"
+      },
+      "gateway-api-envoy-proxy": {
+        "version": "v3.21.8",
+        "image": "tigera/envoy-proxy"
+      },
+      "gateway-api-envoy-ratelimit": {
+        "version": "v3.21.8",
+        "image": "tigera/envoy-ratelimit"
+      },
+      "guardian": {
+        "version": "v3.21.8",
+        "image": "tigera/guardian"
+      },
+      "ingress-collector": {
+        "version": "v3.21.8",
+        "image": "tigera/ingress-collector"
+      },
+      "intrusion-detection-controller": {
+        "version": "v3.21.8",
+        "image": "tigera/intrusion-detection-controller"
+      },
+      "key-cert-provisioner": {
+        "version": "v3.21.8",
+        "image": "tigera/key-cert-provisioner"
+      },
+      "kibana": {
+        "version": "v3.21.8",
+        "image": "tigera/kibana"
+      },
+      "l7-admission-controller": {
+        "version": "v3.21.8",
+        "image": "tigera/l7-admission-controller"
+      },
+      "l7-collector": {
+        "version": "v3.21.8",
+        "image": "tigera/l7-collector"
+      },
+      "license-agent": {
+        "version": "v3.21.8",
+        "image": "tigera/license-agent"
+      },
+      "linseed": {
+        "version": "v3.21.8",
+        "image": "tigera/linseed"
+      },
+      "packetcapture": {
+        "version": "v3.21.8",
+        "image": "tigera/packetcapture"
+      },
+      "policy-recommendation": {
+        "version": "v3.21.8",
+        "image": "tigera/policy-recommendation"
+      },
+      "prometheus": {
+        "version": "v3.21.8",
+        "image": "tigera/prometheus"
+      },
+      "prometheus-config-reloader": {
+        "version": "v3.21.8",
+        "image": "tigera/prometheus-config-reloader"
+      },
+      "prometheus-operator": {
+        "version": "v3.21.8",
+        "image": "tigera/prometheus-operator"
+      },
+      "tigera-cni": {
+        "version": "v3.21.8",
+        "image": "tigera/cni"
+      },
+      "tigera-cni-windows": {
+        "version": "v3.21.8",
+        "image": "tigera/cni-windows"
+      },
+      "tigera-prometheus-service": {
+        "version": "v3.21.8",
+        "image": "tigera/prometheus-service"
+      },
+      "typha": {
+        "version": "v3.21.8",
+        "image": "tigera/typha"
+      },
+      "ui-apis": {
+        "version": "v3.21.8",
+        "image": "tigera/ui-apis"
+      },
+      "voltron": {
+        "version": "v3.21.8",
+        "image": "tigera/voltron"
+      },
+      "webhooks-processor": {
+        "version": "v3.21.8",
+        "image": "tigera/webhooks-processor"
+      }
+    }
+  },
+  {
     "title": "v3.21.7",
     "tigera-operator": {
       "version": "v1.38.14",

--- a/calico-enterprise_versioned_docs/version-3.21-2/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/variables.js
@@ -2,13 +2,13 @@ const releases = require('./releases.json');
 const componentImage = require('../../src/components/utils/componentImage');
 
 const variables = {
-  releaseTitle: 'v3.21.7',
+  releaseTitle: 'v3.21.8',
   prodname: 'Calico Enterprise',
   prodnamedash: 'calico-enterprise',
   version: 'v3.21',
   openSourceVersion: releases[0].calico.minor_version.slice(1),
   baseUrl: '/calico-enterprise/3.21',
-  filesUrl: 'https://downloads.tigera.io/ee/v3.21.7',
+  filesUrl: 'https://downloads.tigera.io/ee/v3.21.8',
   rpmsUrl: 'https://downloads.tigera.io/ee/rpms/' + releases[0].title.slice(0, 5),
   tutorialFilesURL: 'https://docs.tigera.io/files',
   tmpScriptsURL: 'https://docs.tigera.io/calico-enterprise/3.21',
@@ -20,7 +20,7 @@ const variables = {
   rootDirWindows: 'C:\\TigeraCalico',
   registry: 'quay.io/',
   envoyVersion: '1.3.2',
-  chart_version_name: 'v3.21.7-0',
+  chart_version_name: 'v3.21.8-0',
   tigeraOperator: releases[0]['tigera-operator'],
   dikastesVersion: releases[0].components.dikastes.version,
   releases,


### PR DESCRIPTION
## Summary
- Add `v3.21.8` entry to `calico-enterprise_versioned_docs/version-3.21-2/releases.json` (operator `v1.38.14`, component list mirrored from v3.21.7)
- Bump `releaseTitle`, `filesUrl`, and `chart_version_name` to `v3.21.8` in `variables.js`
- Add a `Calico Enterprise 3.21.8 bug fix release` scaffold (May 22, 2026, TBD bullet) to the release notes

Bug-fix bullets and the final operator/CoreOS/ECK pins will be filled in during release cutting.

cc @danudey

## Test plan
- [ ] Confirm operator version and component versions match the cut artifacts
- [ ] Populate the \`TBD\` bug-fix bullet(s) once release notes are finalised
- [ ] Visual check of release notes page once published

🤖 Generated with [Claude Code](https://claude.com/claude-code)