### PR TITLE
DOCS-2939: Publish Calico Enterprise 3.21.8

### DIFF
--- a/calico-enterprise/reference/installation/_api.mdx
+++ b/calico-enterprise/reference/installation/_api.mdx
@@ -819,6 +819,7 @@ _Appears in:_
 | `hostPorts` _[HostPortsType](#hostportstype)_ | (Optional) HostPorts configures whether or not Calico will support Kubernetes HostPorts. Valid only when using the Calico CNI plugin.<br />Default: Enabled |
 | `multiInterfaceMode` _[MultiInterfaceMode](#multiinterfacemode)_ | (Optional) MultiInterfaceMode configures what will configure multiple interface per pod. Only valid for Calico Enterprise installations using the Calico CNI plugin.<br />Default: None |
 | `containerIPForwarding` _[ContainerIPForwardingType](#containeripforwardingtype)_ | (Optional) ContainerIPForwarding configures whether ip forwarding will be enabled for containers in the CNI configuration.<br />Default: Disabled |
+| `linuxPodInterfaceType` _[LinuxPodInterfaceType](#linuxpodinterfacetype)_ | (Optional) LinuxPodInterfaceType selects the virtual device type the Calico CNI plugin creates for each pod's interface on Linux nodes. When set to Netkit, the CNI plugin creates a netkit L2 pair on kernels that support it (Linux 6.7+) and falls back to a veth pair on older kernels. Netkit is recommended for the BPF dataplane, where it allows BPF programs to attach via BPF_NETKIT_PRIMARY for improved throughput and tail-latency under contention; for non-BPF dataplanes it is functionally equivalent to veth. Only valid when using the Calico CNI plugin.<br />Default: Veth |
 | `sysctl` _[Sysctl](#sysctl) array_ | (Optional) Sysctl configures sysctl parameters for tuning plugin |
 | `linuxPolicySetupTimeoutSeconds` _integer_ | (Optional) LinuxPolicySetupTimeoutSeconds delays new pods from running containers until their policy has been programmed in the dataplane. The specified delay defines the maximum amount of time that the Calico CNI plugin will wait for policy to be programmed. Only applies to pods created on Linux nodes. * A value of 0 disables pod startup delays.<br />Default: 0 |
 
@@ -3253,6 +3254,7 @@ _Appears in:_
 | `allocateLoadBalancerNodePorts` _boolean_ | (Optional)  |
 | `loadBalancerSourceRanges` _string array_ | (Optional)  |
 | `loadBalancerIP` _string_ | (Optional)  |
+| `patch` _[KubernetesPatchSpec](#kubernetespatchspec)_ | (Optional) Patch allows the Service for a gateway to be patched in ways that aren't more explicitly supported by the fields above.  For example, the following YAML could be used to set the Service's healthCheckNodePort:   patch:     type: StrategicMerge     value:       spec:         healthCheckNodePort: 12345 |
 
 
 ### Goldmane
@@ -3756,6 +3758,7 @@ _Appears in:_
 | `imagePath` _string_ | (Optional) ImagePath allows for the path part of an image to be specified. If specified then the specified value will be used as the image path for each image. If not specified or empty, the default for each image will be used. A special case value, UseDefault, is supported to explicitly specify the default image path will be used for each image. Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>` This option allows configuring the `<imagePath>` portion of the above format. |
 | `imagePrefix` _string_ | (Optional) ImagePrefix allows for the prefix part of an image to be specified. If specified then the given value will be used as a prefix on each image. If not specified or empty, no prefix will be used. A special case value, UseDefault, is supported to explicitly specify the default image prefix will be used for each image. Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>` This option allows configuring the `<imagePrefix>` portion of the above format. |
 | `imagePullSecrets` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#localobjectreference-v1-core) array_ | (Optional) ImagePullSecrets is an array of references to container registry pull secrets to use. These are applied to all images to be pulled. |
+| `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#pullpolicy-v1-core)_ | (Optional) ImagePullPolicy is the pull policy applied to containers in pods rendered by the operator that do not explicitly set their own pull policy. If unset, defaults to IfNotPresent. This is useful in air-gapped environments where images are pre-loaded onto nodes and must not be re-pulled from a remote registry. |
 | `kubernetesProvider` _[Provider](#provider)_ | (Optional) KubernetesProvider specifies a particular provider of the Kubernetes platform and enables provider-specific configuration. If the specified value is empty, the Operator will attempt to automatically determine the current provider. If the specified value is not empty, the Operator will still attempt auto-detection, but will additionally compare the auto-detected value to the specified value to confirm they match. |
 | `cni` _[CNISpec](#cnispec)_ | (Optional) CNI specifies the CNI that will be used by this installation. |
 | `calicoNetwork` _[CalicoNetworkSpec](#caliconetworkspec)_ | (Optional) CalicoNetwork specifies networking configuration options for Calico. |
@@ -4455,6 +4458,28 @@ _Appears in:_
 | `BPF` |  |
 | `VPP` |  |
 | `Nftables` |  |
+
+
+### LinuxPodInterfaceType
+
+_Underlying type:_ _string_
+
+LinuxPodInterfaceType specifies the type of virtual device the Calico CNI plugin
+creates for the pod-side interface on Linux nodes.
+
+One of: Veth, Netkit
+
+_Validation:_
+- Enum: [Veth Netkit]
+
+
+_Appears in:_
+- [CalicoNetworkSpec](#caliconetworkspec)
+
+| Value | Description |
+| --- | --- |
+| `Veth` |  |
+| `Netkit` |  |
 
 
 ### LogCollectionSpec

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/installation/_api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/installation/_api.mdx
@@ -1976,7 +1976,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name is an enum which identifies the EGW Deployment container by name.<br />Supported values are: calico-egw |
+| `name` _string_ | Name is an enum which identifies the EGW Deployment container by name.<br />Supported values are: egress-gateway |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | (Optional) Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named EGW Deployment container's resources. If omitted, the EGW Deployment will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence. |
 
 
@@ -3453,7 +3453,7 @@ _Appears in:_
 | `nodeUpdateStrategy` _[DaemonSetUpdateStrategy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#daemonsetupdatestrategy-v1-apps)_ | (Optional) NodeUpdateStrategy can be used to customize the desired update strategy, such as the MaxUnavailable field. |
 | `componentResources` _[ComponentResource](#componentresource) array_ | (Optional) Deprecated. Please use CalicoNodeDaemonSet, TyphaDeployment, and KubeControllersDeployment. ComponentResources can be used to customize the resource requirements for each component. Node, Typha, and KubeControllers are supported for installations. |
 | `certificateManagement` _[CertificateManagement](#certificatemanagement)_ | (Optional) CertificateManagement configures pods to submit a CertificateSigningRequest to the certificates.k8s.io/v1beta1 API in order to obtain TLS certificates. This feature requires that you bring your own CSR signing and approval process, otherwise pods will be stuck during initialization. |
-| `nonPrivileged` _[NonPrivilegedType](#nonprivilegedtype)_ | (Optional) NonPrivileged configures Calico to be run in non-privileged containers as non-root users where possible. |
+| `nonPrivileged` _[NonPrivilegedType](#nonprivilegedtype)_ | (Optional) Deprecated. NonPrivileged is deprecated and will be removed from the API in a future release. Enabling this field is not supported and will cause errors. NonPrivileged configures Calico to be run in non-privileged containers as non-root users where possible. |
 | `calicoNodeDaemonSet` _[CalicoNodeDaemonSet](#caliconodedaemonset)_ | CalicoNodeDaemonSet configures the calico-node DaemonSet. If used in conjunction with the deprecated ComponentResources, then these overrides take precedence. |
 | `csiNodeDriverDaemonSet` _[CSINodeDriverDaemonSet](#csinodedriverdaemonset)_ | CSINodeDriverDaemonSet configures the csi-node-driver DaemonSet. |
 | `calicoKubeControllersDeployment` _[CalicoKubeControllersDeployment](#calicokubecontrollersdeployment)_ | CalicoKubeControllersDeployment configures the calico-kube-controllers Deployment. If used in conjunction with the deprecated ComponentResources, then these overrides take precedence. |

--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -268,13 +268,14 @@ May 13, 2026
 
 To update an existing installation of Calico Enterprise 3.21, see [Install a patch release](../getting-started/manifest-archive.mdx).
 
-### Calico Enterprise 3.21.8 bug fix release
+### Calico Enterprise 3.21.8 hotfix release
 
 May 22, 2026
 
 #### Bug fixes
 
-* TBD
+* Fixes an issue where `HostEndpoint` policies block UDP return traffic for SNAT'd pod egress when using the eBPF dataplane.
+* Fix Kibana crashloop when upgrading from Calico Enterprise 3.20 or earlier to 3.21. The orphan `ingest_manager_settings` saved object left by Fleet 7.17 is now discarded during Kibana 8.x saved-object migration.
 
 To update an existing installation of Calico Enterprise 3.21, see [Install a patch release](../getting-started/manifest-archive.mdx).
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -270,7 +270,7 @@ To update an existing installation of Calico Enterprise 3.21, see [Install a pat
 
 ### Calico Enterprise 3.21.8 hotfix release
 
-May 22, 2026
+May 25, 2026
 
 #### Bug fixes
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -268,3 +268,13 @@ May 13, 2026
 
 To update an existing installation of Calico Enterprise 3.21, see [Install a patch release](../getting-started/manifest-archive.mdx).
 
+### Calico Enterprise 3.21.8 bug fix release
+
+May 22, 2026
+
+#### Bug fixes
+
+* TBD
+
+To update an existing installation of Calico Enterprise 3.21, see [Install a patch release](../getting-started/manifest-archive.mdx).
+

--- a/calico-enterprise_versioned_docs/version-3.21-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.21-2/releases.json
@@ -1,5 +1,270 @@
 [
   {
+    "title": "v3.21.8",
+    "tigera-operator": {
+      "version": "v1.38.14",
+      "image": "tigera/operator",
+      "registry": "quay.io"
+    },
+    "calico": {
+      "minor_version": "v3.30",
+      "archive_path": "archive"
+    },
+    "components": {
+      "alertmanager": {
+        "version": "v3.21.8",
+        "image": "tigera/alertmanager"
+      },
+      "calicoctl": {
+        "version": "v3.21.8",
+        "image": "tigera/calicoctl"
+      },
+      "calicoq": {
+        "version": "v3.21.8",
+        "image": "tigera/calicoq"
+      },
+      "cnx-apiserver": {
+        "version": "v3.21.8",
+        "image": "tigera/cnx-apiserver"
+      },
+      "cnx-kube-controllers": {
+        "version": "v3.21.8",
+        "image": "tigera/kube-controllers"
+      },
+      "cnx-manager": {
+        "version": "v3.21.8",
+        "image": "tigera/cnx-manager"
+      },
+      "cnx-manager-proxy": {
+        "version": "v3.21.8",
+        "image": "tigera/cnx-manager-proxy"
+      },
+      "cnx-node": {
+        "version": "v3.21.8",
+        "image": "tigera/cnx-node"
+      },
+      "cnx-node-windows": {
+        "version": "v3.21.8",
+        "image": "tigera/cnx-node-windows"
+      },
+      "cnx-queryserver": {
+        "version": "v3.21.8",
+        "image": "tigera/cnx-queryserver"
+      },
+      "compliance-benchmarker": {
+        "version": "v3.21.8",
+        "image": "tigera/compliance-benchmarker"
+      },
+      "compliance-controller": {
+        "version": "v3.21.8",
+        "image": "tigera/compliance-controller"
+      },
+      "compliance-reporter": {
+        "version": "v3.21.8",
+        "image": "tigera/compliance-reporter"
+      },
+      "compliance-server": {
+        "version": "v3.21.8",
+        "image": "tigera/compliance-server"
+      },
+      "compliance-snapshotter": {
+        "version": "v3.21.8",
+        "image": "tigera/compliance-snapshotter"
+      },
+      "coreos-alertmanager": {
+        "version": "v0.28.1"
+      },
+      "coreos-config-reloader": {
+        "version": "v0.91.0"
+      },
+      "coreos-dex": {
+        "version": "v2.41.1"
+      },
+      "coreos-fluentd": {
+        "version": "1.19.2"
+      },
+      "coreos-prometheus": {
+        "version": "v2.55.1"
+      },
+      "coreos-prometheus-operator": {
+        "version": "v0.91.0"
+      },
+      "csi": {
+        "version": "v3.21.8",
+        "image": "tigera/csi"
+      },
+      "csi-node-driver-registrar": {
+        "version": "v3.21.8",
+        "image": "tigera/node-driver-registrar"
+      },
+      "deep-packet-inspection": {
+        "version": "v3.21.8",
+        "image": "tigera/deep-packet-inspection"
+      },
+      "dex": {
+        "version": "v3.21.8",
+        "image": "tigera/dex"
+      },
+      "dikastes": {
+        "version": "v3.21.8",
+        "image": "tigera/dikastes"
+      },
+      "eck-elasticsearch": {
+        "version": "8.19.15"
+      },
+      "eck-elasticsearch-operator": {
+        "version": "2.16.1"
+      },
+      "eck-kibana": {
+        "version": "8.19.15"
+      },
+      "egress-gateway": {
+        "version": "v3.21.8",
+        "image": "tigera/egress-gateway"
+      },
+      "elastic-tsee-installer": {
+        "version": "v3.21.8",
+        "image": "tigera/intrusion-detection-job-installer"
+      },
+      "elasticsearch": {
+        "version": "v3.21.8",
+        "image": "tigera/elasticsearch"
+      },
+      "elasticsearch-metrics": {
+        "version": "v3.21.8",
+        "image": "tigera/elasticsearch-metrics"
+      },
+      "elasticsearch-operator": {
+        "version": "v3.21.8",
+        "image": "tigera/eck-operator"
+      },
+      "envoy": {
+        "version": "v3.21.8",
+        "image": "tigera/envoy"
+      },
+      "envoy-init": {
+        "version": "v3.21.8",
+        "image": "tigera/envoy-init"
+      },
+      "es-gateway": {
+        "version": "v3.21.8",
+        "image": "tigera/es-gateway"
+      },
+      "firewall-integration": {
+        "version": "v3.21.8",
+        "image": "tigera/firewall-integration"
+      },
+      "flexvol": {
+        "version": "v3.21.8",
+        "image": "tigera/pod2daemon-flexvol"
+      },
+      "fluentd": {
+        "version": "v3.21.8",
+        "image": "tigera/fluentd"
+      },
+      "fluentd-windows": {
+        "version": "v3.21.8",
+        "image": "tigera/fluentd-windows"
+      },
+      "gateway-api-envoy-gateway": {
+        "version": "v3.21.8",
+        "image": "tigera/envoy-gateway"
+      },
+      "gateway-api-envoy-proxy": {
+        "version": "v3.21.8",
+        "image": "tigera/envoy-proxy"
+      },
+      "gateway-api-envoy-ratelimit": {
+        "version": "v3.21.8",
+        "image": "tigera/envoy-ratelimit"
+      },
+      "guardian": {
+        "version": "v3.21.8",
+        "image": "tigera/guardian"
+      },
+      "ingress-collector": {
+        "version": "v3.21.8",
+        "image": "tigera/ingress-collector"
+      },
+      "intrusion-detection-controller": {
+        "version": "v3.21.8",
+        "image": "tigera/intrusion-detection-controller"
+      },
+      "key-cert-provisioner": {
+        "version": "v3.21.8",
+        "image": "tigera/key-cert-provisioner"
+      },
+      "kibana": {
+        "version": "v3.21.8",
+        "image": "tigera/kibana"
+      },
+      "l7-admission-controller": {
+        "version": "v3.21.8",
+        "image": "tigera/l7-admission-controller"
+      },
+      "l7-collector": {
+        "version": "v3.21.8",
+        "image": "tigera/l7-collector"
+      },
+      "license-agent": {
+        "version": "v3.21.8",
+        "image": "tigera/license-agent"
+      },
+      "linseed": {
+        "version": "v3.21.8",
+        "image": "tigera/linseed"
+      },
+      "packetcapture": {
+        "version": "v3.21.8",
+        "image": "tigera/packetcapture"
+      },
+      "policy-recommendation": {
+        "version": "v3.21.8",
+        "image": "tigera/policy-recommendation"
+      },
+      "prometheus": {
+        "version": "v3.21.8",
+        "image": "tigera/prometheus"
+      },
+      "prometheus-config-reloader": {
+        "version": "v3.21.8",
+        "image": "tigera/prometheus-config-reloader"
+      },
+      "prometheus-operator": {
+        "version": "v3.21.8",
+        "image": "tigera/prometheus-operator"
+      },
+      "tigera-cni": {
+        "version": "v3.21.8",
+        "image": "tigera/cni"
+      },
+      "tigera-cni-windows": {
+        "version": "v3.21.8",
+        "image": "tigera/cni-windows"
+      },
+      "tigera-prometheus-service": {
+        "version": "v3.21.8",
+        "image": "tigera/prometheus-service"
+      },
+      "typha": {
+        "version": "v3.21.8",
+        "image": "tigera/typha"
+      },
+      "ui-apis": {
+        "version": "v3.21.8",
+        "image": "tigera/ui-apis"
+      },
+      "voltron": {
+        "version": "v3.21.8",
+        "image": "tigera/voltron"
+      },
+      "webhooks-processor": {
+        "version": "v3.21.8",
+        "image": "tigera/webhooks-processor"
+      }
+    }
+  },
+  {
     "title": "v3.21.7",
     "tigera-operator": {
       "version": "v1.38.14",

--- a/calico-enterprise_versioned_docs/version-3.21-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.21-2/releases.json
@@ -2,7 +2,7 @@
   {
     "title": "v3.21.8",
     "tigera-operator": {
-      "version": "v1.38.14",
+      "version": "v1.38.15",
       "image": "tigera/operator",
       "registry": "quay.io"
     },

--- a/calico-enterprise_versioned_docs/version-3.21-2/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/variables.js
@@ -2,13 +2,13 @@ const releases = require('./releases.json');
 const componentImage = require('../../src/components/utils/componentImage');
 
 const variables = {
-  releaseTitle: 'v3.21.7',
+  releaseTitle: 'v3.21.8',
   prodname: 'Calico Enterprise',
   prodnamedash: 'calico-enterprise',
   version: 'v3.21',
   openSourceVersion: releases[0].calico.minor_version.slice(1),
   baseUrl: '/calico-enterprise/3.21',
-  filesUrl: 'https://downloads.tigera.io/ee/v3.21.7',
+  filesUrl: 'https://downloads.tigera.io/ee/v3.21.8',
   rpmsUrl: 'https://downloads.tigera.io/ee/rpms/' + releases[0].title.slice(0, 5),
   tutorialFilesURL: 'https://docs.tigera.io/files',
   tmpScriptsURL: 'https://docs.tigera.io/calico-enterprise/3.21',
@@ -20,7 +20,7 @@ const variables = {
   rootDirWindows: 'C:\\TigeraCalico',
   registry: 'quay.io/',
   envoyVersion: '1.3.2',
-  chart_version_name: 'v3.21.7-0',
+  chart_version_name: 'v3.21.8-0',
   tigeraOperator: releases[0]['tigera-operator'],
   dikastesVersion: releases[0].components.dikastes.version,
   releases,


### PR DESCRIPTION
## Summary
- Add `v3.21.8` entry to `calico-enterprise_versioned_docs/version-3.21-2/releases.json` (operator `v1.38.14`, component list mirrored from v3.21.7)
- Bump `releaseTitle`, `filesUrl`, and `chart_version_name` to `v3.21.8` in `variables.js`
- Add a `Calico Enterprise 3.21.8 bug fix release` scaffold (May 22, 2026, TBD bullet) to the release notes

Bug-fix bullets and the final operator/CoreOS/ECK pins will be filled in during release cutting.

cc @danudey

Tracked in [DOCS-2939](https://tigera.atlassian.net/browse/DOCS-2939).

## Test plan
- [ ] Confirm operator version and component versions match the cut artifacts
- [ ] Populate the \`TBD\` bug-fix bullet(s) once release notes are finalised
- [ ] Visual check of release notes page once published

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-2939]: https://tigera.atlassian.net/browse/DOCS-2939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ