### PR TITLE
Rectify RN message for Openshift IdP

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -247,7 +247,7 @@ May 13, 2026
   ...
   ```
 
-* Added a named "https" port on the calico-manager Service and, when the OpenShift IDP is configured, publish a `tigera-ca-public` Secret in the `calico-system` namespace so that OpenShift's Ingress→Route conversion can produce a reencrypt Route fronting the manager.
+* Added a named "https" port on the calico-manager Service and, when the OpenShift IDP is configured, publish a `tigera-ca-public` Secret in the `tigera-manager` namespace so that OpenShift's Ingress→Route conversion can produce a reencrypt Route fronting the manager.
 
 #### Bug fixes
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -369,6 +369,10 @@ To update an existing installation of Calico Enterprise 3.22, see [Install a pat
 
 May 20, 2026
 
+#### Enhancements
+
+* Added a named "https" port on the calico-manager Service and, when the OpenShift IDP is configured, publish a `tigera-ca-public` Secret in the `calico-system` namespace so that OpenShift's Ingress→Route conversion can produce a reencrypt Route fronting the manager.
+
 #### Bug fixes
 
 * Fixes an issue where `HostEndpoint` policies block UDP return traffic for SNAT'd pod egress when using the eBPF dataplane.


### PR DESCRIPTION
Correct the namespace for the v3.21 pages where the manager is installed in the tigera-manager namespace.