### PR TITLE
Add missing custom-resources step to native v3 CRDs install docs

### DIFF
--- a/calico-enterprise/operations/native-v3-crds.mdx
+++ b/calico-enterprise/operations/native-v3-crds.mdx
@@ -106,10 +106,16 @@ Select the method below based on your preferred installation method.
 
    :::
 
-1. Install the Tigera Operator and custom resources:
+1. Install the Tigera Operator:
 
    ```bash
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
+   ```
+
+1. Install $[prodname] by creating the necessary custom resources:
+
+   ```bash
+   kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml
    ```
 
 </TabItem>


### PR DESCRIPTION
The Manifest install tab for Calico Enterprise's native v3 CRDs page was missing the `kubectl create -f .../custom-resources.yaml` step. Without it, following the docs leaves you with an operator running but no Installation CR, so nothing actually gets installed.

Fixes [CORE-12826](https://tigera.atlassian.net/browse/CORE-12826).

Note: that ticket also calls out that Calico Cloud is missing the Operations/CRD-mode docs entirely. That's left for a separate PR.

[CORE-12826]: https://tigera.atlassian.net/browse/CORE-12826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ