### PR TITLE
Document Kubernetes 1.34+ requirement for native v3 CRDs

### DIFF
--- a/calico-enterprise/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise/operations/cnx/configure-identity-provider.mdx
@@ -186,7 +186,7 @@ When configuring your cluster, you may be asked for the following inputs:
 </TabItem>
 <TabItem label="OpenShift" value="OpenShift-2">
 
-1. Install the [OpenShift CLI (oc)](https://docs.okd.io/4.9/cli_reference/openshift_cli/getting-started-cli.html).
+1. Install the [OpenShift CLI (oc)](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html).
 
 1. Create values for some required variables. `MANAGER_URL` is the URL where the $[prodname] web console will be accessed,
    `CLUSTER_DOMAIN` is the domain (excl. port) where your OpenShift cluster is accessed (run `oc status` to get it) and `CLIENT_SECRET` is a value of your choosing.

--- a/calico-enterprise/operations/native-v3-crds.mdx
+++ b/calico-enterprise/operations/native-v3-crds.mdx
@@ -36,12 +36,12 @@ When using native `projectcalico.org/v3` CRDs:
 
 ### Validation and defaulting
 
-When using native `projectcalico.org/v3` CRDs, resource validation and defaulting are handled by native CRD validation and defaulting, as well as ValidatingAdmissionPolicies and MutatingAdmissionPolicies. $[prodname] uses [MutatingAdmissionPolicies](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) for defaulting, which are currently a **beta** Kubernetes feature. You must ensure that the `MutatingAdmissionPolicy` feature gate is enabled on your Kubernetes API server before using native `projectcalico.org/v3` CRDs.
+When using native `projectcalico.org/v3` CRDs, resource validation and defaulting are handled by native CRD validation and defaulting, as well as ValidatingAdmissionPolicies and MutatingAdmissionPolicies. $[prodname] uses [MutatingAdmissionPolicies](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) for defaulting, which require the beta `admissionregistration.k8s.io/v1beta1` API. That API is available in **Kubernetes 1.34 and later**. On Kubernetes 1.33 and earlier, MutatingAdmissionPolicy is only available as an alpha API (`v1alpha1`), which $[prodname] does not support. On Kubernetes 1.34 and 1.35, you must enable the `MutatingAdmissionPolicy` feature gate on your Kubernetes API server before using native `projectcalico.org/v3` CRDs, as it is not enabled by default. On Kubernetes 1.36 and later, the feature is GA and enabled by default.
 
 ## Before you begin
 
 - A Kubernetes cluster **without** $[prodname] installed, or a cluster where you are performing a fresh install. To migrate an existing cluster from API server mode, see [Migrate from API server to native CRDs](crd-migration.mdx).
-- The `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) must be enabled on the Kubernetes API server. This feature is beta in Kubernetes and is not enabled by default.
+- **Kubernetes 1.34 or later.** $[prodname] uses the beta `admissionregistration.k8s.io/v1beta1` MutatingAdmissionPolicy API for defaulting, which is not available on Kubernetes 1.33 and earlier (where MutatingAdmissionPolicy is alpha only). On Kubernetes 1.34 and 1.35, the `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) must be enabled on the API server, as it is not enabled by default. On Kubernetes 1.36 and later, the feature is GA and enabled by default.
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/calico-enterprise_versioned_docs/version-3.20-2/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/operations/cnx/configure-identity-provider.mdx
@@ -123,7 +123,7 @@ When configuring your cluster, you may be asked for the following inputs:
 </TabItem>
 <TabItem label="OpenShift" value="OpenShift-2">
 
-1. Install the [OpenShift CLI (oc)](https://docs.okd.io/4.9/cli_reference/openshift_cli/getting-started-cli.html).
+1. Install the [OpenShift CLI (oc)](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html).
 
 1. Create values for some required variables. `MANAGER_URL` is the URL where the $[prodname] web console will be accessed,
    `CLUSTER_DOMAIN` is the domain (excl. port) where your OpenShift cluster is accessed (run `oc status` to get it) and `CLIENT_SECRET` is a value of your choosing.

--- a/calico-enterprise_versioned_docs/version-3.21-2/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/operations/cnx/configure-identity-provider.mdx
@@ -123,7 +123,7 @@ When configuring your cluster, you may be asked for the following inputs:
 </TabItem>
 <TabItem label="OpenShift" value="OpenShift-2">
 
-1. Install the [OpenShift CLI (oc)](https://docs.okd.io/4.9/cli_reference/openshift_cli/getting-started-cli.html).
+1. Install the [OpenShift CLI (oc)](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html).
 
 1. Create values for some required variables. `MANAGER_URL` is the URL where the $[prodname] web console will be accessed,
    `CLUSTER_DOMAIN` is the domain (excl. port) where your OpenShift cluster is accessed (run `oc status` to get it) and `CLIENT_SECRET` is a value of your choosing.

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/cnx/configure-identity-provider.mdx
@@ -186,7 +186,7 @@ When configuring your cluster, you may be asked for the following inputs:
 </TabItem>
 <TabItem label="OpenShift" value="OpenShift-2">
 
-1. Install the [OpenShift CLI (oc)](https://docs.okd.io/4.9/cli_reference/openshift_cli/getting-started-cli.html).
+1. Install the [OpenShift CLI (oc)](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html).
 
 1. Create values for some required variables. `MANAGER_URL` is the URL where the $[prodname] web console will be accessed,
    `CLUSTER_DOMAIN` is the domain (excl. port) where your OpenShift cluster is accessed (run `oc status` to get it) and `CLIENT_SECRET` is a value of your choosing.

--- a/calico-enterprise_versioned_docs/version-3.23-1/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-1/operations/cnx/configure-identity-provider.mdx
@@ -186,7 +186,7 @@ When configuring your cluster, you may be asked for the following inputs:
 </TabItem>
 <TabItem label="OpenShift" value="OpenShift-2">
 
-1. Install the [OpenShift CLI (oc)](https://docs.okd.io/4.9/cli_reference/openshift_cli/getting-started-cli.html).
+1. Install the [OpenShift CLI (oc)](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html).
 
 1. Create values for some required variables. `MANAGER_URL` is the URL where the $[prodname] web console will be accessed,
    `CLUSTER_DOMAIN` is the domain (excl. port) where your OpenShift cluster is accessed (run `oc status` to get it) and `CLIENT_SECRET` is a value of your choosing.

--- a/calico-enterprise_versioned_docs/version-3.23-2/operations/cnx/configure-identity-provider.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/operations/cnx/configure-identity-provider.mdx
@@ -186,7 +186,7 @@ When configuring your cluster, you may be asked for the following inputs:
 </TabItem>
 <TabItem label="OpenShift" value="OpenShift-2">
 
-1. Install the [OpenShift CLI (oc)](https://docs.okd.io/4.9/cli_reference/openshift_cli/getting-started-cli.html).
+1. Install the [OpenShift CLI (oc)](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html).
 
 1. Create values for some required variables. `MANAGER_URL` is the URL where the $[prodname] web console will be accessed,
    `CLUSTER_DOMAIN` is the domain (excl. port) where your OpenShift cluster is accessed (run `oc status` to get it) and `CLIENT_SECRET` is a value of your choosing.

--- a/calico-enterprise_versioned_docs/version-3.23-2/operations/native-v3-crds.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/operations/native-v3-crds.mdx
@@ -36,12 +36,12 @@ When using native `projectcalico.org/v3` CRDs:
 
 ### Validation and defaulting
 
-When using native `projectcalico.org/v3` CRDs, resource validation and defaulting are handled by native CRD validation and defaulting, as well as ValidatingAdmissionPolicies and MutatingAdmissionPolicies. $[prodname] uses [MutatingAdmissionPolicies](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) for defaulting, which are currently a **beta** Kubernetes feature. You must ensure that the `MutatingAdmissionPolicy` feature gate is enabled on your Kubernetes API server before using native `projectcalico.org/v3` CRDs.
+When using native `projectcalico.org/v3` CRDs, resource validation and defaulting are handled by native CRD validation and defaulting, as well as ValidatingAdmissionPolicies and MutatingAdmissionPolicies. $[prodname] uses [MutatingAdmissionPolicies](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) for defaulting, which require the beta `admissionregistration.k8s.io/v1beta1` API. That API is available in **Kubernetes 1.34 and later**. On Kubernetes 1.33 and earlier, MutatingAdmissionPolicy is only available as an alpha API (`v1alpha1`), which $[prodname] does not support. On Kubernetes 1.34 and 1.35, you must enable the `MutatingAdmissionPolicy` feature gate on your Kubernetes API server before using native `projectcalico.org/v3` CRDs, as it is not enabled by default. On Kubernetes 1.36 and later, the feature is GA and enabled by default.
 
 ## Before you begin
 
 - A Kubernetes cluster **without** $[prodname] installed, or a cluster where you are performing a fresh install. To migrate an existing cluster from API server mode, see [Migrate from API server to native CRDs](crd-migration.mdx).
-- The `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) must be enabled on the Kubernetes API server. This feature is beta in Kubernetes and is not enabled by default.
+- **Kubernetes 1.34 or later.** $[prodname] uses the beta `admissionregistration.k8s.io/v1beta1` MutatingAdmissionPolicy API for defaulting, which is not available on Kubernetes 1.33 and earlier (where MutatingAdmissionPolicy is alpha only). On Kubernetes 1.34 and 1.35, the `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) must be enabled on the API server, as it is not enabled by default. On Kubernetes 1.36 and later, the feature is GA and enabled by default.
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
+++ b/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
@@ -135,7 +135,7 @@ If you're setting up a new cluster and don't need to customize the underlying Ku
 
 :::
 
-Before installing, enable the `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) on the Kubernetes API server. Native `projectcalico.org/v3` CRDs rely on MutatingAdmissionPolicies for defaulting, which are currently a **beta** Kubernetes feature and are not enabled by default.
+Native `projectcalico.org/v3` CRDs rely on MutatingAdmissionPolicies for defaulting, which require the beta `admissionregistration.k8s.io/v1beta1` API. That API is available in **Kubernetes 1.34 and later**; on Kubernetes 1.33 and earlier, MutatingAdmissionPolicy is only available as an alpha API and is not supported. On Kubernetes 1.34 and 1.35, enable the `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) on the Kubernetes API server before installing, as it is not enabled by default. On Kubernetes 1.36 and later, the feature is GA and enabled by default.
 
 1. Download the $[prodname] v3 CRD manifest.
 
@@ -223,7 +223,7 @@ If you have an existing manifest-based $[prodname] install using the legacy `crd
 - $[prodname] installed via `calico.yaml` manifest (not operator)
 - `kubectl` access to the cluster
 - A recent $[prodname] version that includes the migration controller
-- The `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) must be enabled on the Kubernetes API server before starting the migration. Native `projectcalico.org/v3` CRDs rely on MutatingAdmissionPolicies for defaulting, which are currently a **beta** Kubernetes feature and are not enabled by default.
+- **Kubernetes 1.34 or later.** Native `projectcalico.org/v3` CRDs rely on MutatingAdmissionPolicies for defaulting, which require the beta `admissionregistration.k8s.io/v1beta1` API. That API is not available on Kubernetes 1.33 and earlier, where MutatingAdmissionPolicy is alpha only. On Kubernetes 1.34 and 1.35, the `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) must be enabled on the Kubernetes API server before starting the migration, as it is not enabled by default. On Kubernetes 1.36 and later, the feature is GA and enabled by default.
 
 #### Migration steps
 

--- a/calico/operations/crd-migration.mdx
+++ b/calico/operations/crd-migration.mdx
@@ -53,7 +53,7 @@ The locked window is typically short (seconds to a few minutes depending on clus
 
 - $[prodname] v3.32+ (or the release that includes the migration controller)
 - Cluster is currently running in API server mode (the aggregated API server is deployed)
-- The `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) must be enabled on the Kubernetes API server before starting the migration. Native `projectcalico.org/v3` CRDs rely on MutatingAdmissionPolicies for defaulting, which are currently a **beta** Kubernetes feature and are not enabled by default.
+- **Kubernetes 1.34 or later.** Native `projectcalico.org/v3` CRDs rely on MutatingAdmissionPolicies for defaulting, which require the beta `admissionregistration.k8s.io/v1beta1` API. That API is not available on Kubernetes 1.33 and earlier, where MutatingAdmissionPolicy is alpha only. On Kubernetes 1.34 and 1.35, the `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) must be enabled on the Kubernetes API server before starting the migration, as it is not enabled by default. On Kubernetes 1.36 and later, the feature is GA and enabled by default.
 - **If using GitOps (ArgoCD, Flux):** pause sync before starting the migration. These tools may interfere with the API group switchover. You'll update your manifests to use `projectcalico.org/v3` after migration completes.
 
 ## How to

--- a/calico/operations/native-v3-crds.mdx
+++ b/calico/operations/native-v3-crds.mdx
@@ -36,12 +36,12 @@ When using native `projectcalico.org/v3` CRDs:
 
 ### Validation and defaulting
 
-When using native `projectcalico.org/v3` CRDs, resource validation and defaulting are handled by native CRD validation and defaulting, as well as ValidatingAdmissionPolicies and MutatingAdmissionPolicies. $[prodname] uses [MutatingAdmissionPolicies](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) for defaulting, which are currently a **beta** Kubernetes feature. You must ensure that the `MutatingAdmissionPolicy` feature gate is enabled on your Kubernetes API server before using native `projectcalico.org/v3` CRDs.
+When using native `projectcalico.org/v3` CRDs, resource validation and defaulting are handled by native CRD validation and defaulting, as well as ValidatingAdmissionPolicies and MutatingAdmissionPolicies. $[prodname] uses [MutatingAdmissionPolicies](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) for defaulting, which require the beta `admissionregistration.k8s.io/v1beta1` API. That API is available in **Kubernetes 1.34 and later**. On Kubernetes 1.33 and earlier, MutatingAdmissionPolicy is only available as an alpha API (`v1alpha1`), which $[prodname] does not support. On Kubernetes 1.34 and 1.35, you must enable the `MutatingAdmissionPolicy` feature gate on your Kubernetes API server before using native `projectcalico.org/v3` CRDs, as it is not enabled by default. On Kubernetes 1.36 and later, the feature is GA and enabled by default.
 
 ## Before you begin
 
 - A Kubernetes cluster **without** $[prodname] installed, or a cluster where you are performing a fresh install. To migrate an existing cluster from API server mode, see [Migrate from API server to native CRDs](crd-migration.mdx).
-- The `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) must be enabled on the Kubernetes API server. This feature is beta in Kubernetes and is not enabled by default.
+- **Kubernetes 1.34 or later.** $[prodname] uses the beta `admissionregistration.k8s.io/v1beta1` MutatingAdmissionPolicy API for defaulting, which is not available on Kubernetes 1.33 and earlier (where MutatingAdmissionPolicy is alpha only). On Kubernetes 1.34 and 1.35, the `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) must be enabled on the API server, as it is not enabled by default. On Kubernetes 1.36 and later, the feature is GA and enabled by default.
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
@@ -135,7 +135,7 @@ If you're setting up a new cluster and don't need to customize the underlying Ku
 
 :::
 
-Before installing, enable the `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) on the Kubernetes API server. Native `projectcalico.org/v3` CRDs rely on MutatingAdmissionPolicies for defaulting, which are currently a **beta** Kubernetes feature and are not enabled by default.
+Native `projectcalico.org/v3` CRDs rely on MutatingAdmissionPolicies for defaulting, which require the beta `admissionregistration.k8s.io/v1beta1` API. That API is available in **Kubernetes 1.34 and later**; on Kubernetes 1.33 and earlier, MutatingAdmissionPolicy is only available as an alpha API and is not supported. On Kubernetes 1.34 and 1.35, enable the `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) on the Kubernetes API server before installing, as it is not enabled by default. On Kubernetes 1.36 and later, the feature is GA and enabled by default.
 
 1. Download the $[prodname] v3 CRD manifest.
 
@@ -223,7 +223,7 @@ If you have an existing manifest-based $[prodname] install using the legacy `crd
 - $[prodname] installed via `calico.yaml` manifest (not operator)
 - `kubectl` access to the cluster
 - A recent $[prodname] version that includes the migration controller
-- The `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) must be enabled on the Kubernetes API server before starting the migration. Native `projectcalico.org/v3` CRDs rely on MutatingAdmissionPolicies for defaulting, which are currently a **beta** Kubernetes feature and are not enabled by default.
+- **Kubernetes 1.34 or later.** Native `projectcalico.org/v3` CRDs rely on MutatingAdmissionPolicies for defaulting, which require the beta `admissionregistration.k8s.io/v1beta1` API. That API is not available on Kubernetes 1.33 and earlier, where MutatingAdmissionPolicy is alpha only. On Kubernetes 1.34 and 1.35, the `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) must be enabled on the Kubernetes API server before starting the migration, as it is not enabled by default. On Kubernetes 1.36 and later, the feature is GA and enabled by default.
 
 #### Migration steps
 

--- a/calico_versioned_docs/version-3.32/operations/crd-migration.mdx
+++ b/calico_versioned_docs/version-3.32/operations/crd-migration.mdx
@@ -53,7 +53,7 @@ The locked window is typically short (seconds to a few minutes depending on clus
 
 - $[prodname] v3.32+ (or the release that includes the migration controller)
 - Cluster is currently running in API server mode (the aggregated API server is deployed)
-- The `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) must be enabled on the Kubernetes API server before starting the migration. Native `projectcalico.org/v3` CRDs rely on MutatingAdmissionPolicies for defaulting, which are currently a **beta** Kubernetes feature and are not enabled by default.
+- **Kubernetes 1.34 or later.** Native `projectcalico.org/v3` CRDs rely on MutatingAdmissionPolicies for defaulting, which require the beta `admissionregistration.k8s.io/v1beta1` API. That API is not available on Kubernetes 1.33 and earlier, where MutatingAdmissionPolicy is alpha only. On Kubernetes 1.34 and 1.35, the `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) must be enabled on the Kubernetes API server before starting the migration, as it is not enabled by default. On Kubernetes 1.36 and later, the feature is GA and enabled by default.
 - **If using GitOps (ArgoCD, Flux):** pause sync before starting the migration. These tools may interfere with the API group switchover. You'll update your manifests to use `projectcalico.org/v3` after migration completes.
 
 ## How to

--- a/calico_versioned_docs/version-3.32/operations/native-v3-crds.mdx
+++ b/calico_versioned_docs/version-3.32/operations/native-v3-crds.mdx
@@ -36,12 +36,12 @@ When using native `projectcalico.org/v3` CRDs:
 
 ### Validation and defaulting
 
-When using native `projectcalico.org/v3` CRDs, resource validation and defaulting are handled by native CRD validation and defaulting, as well as ValidatingAdmissionPolicies and MutatingAdmissionPolicies. $[prodname] uses [MutatingAdmissionPolicies](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) for defaulting, which are currently a **beta** Kubernetes feature. You must ensure that the `MutatingAdmissionPolicy` feature gate is enabled on your Kubernetes API server before using native `projectcalico.org/v3` CRDs.
+When using native `projectcalico.org/v3` CRDs, resource validation and defaulting are handled by native CRD validation and defaulting, as well as ValidatingAdmissionPolicies and MutatingAdmissionPolicies. $[prodname] uses [MutatingAdmissionPolicies](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) for defaulting, which require the beta `admissionregistration.k8s.io/v1beta1` API. That API is available in **Kubernetes 1.34 and later**. On Kubernetes 1.33 and earlier, MutatingAdmissionPolicy is only available as an alpha API (`v1alpha1`), which $[prodname] does not support. On Kubernetes 1.34 and 1.35, you must enable the `MutatingAdmissionPolicy` feature gate on your Kubernetes API server before using native `projectcalico.org/v3` CRDs, as it is not enabled by default. On Kubernetes 1.36 and later, the feature is GA and enabled by default.
 
 ## Before you begin
 
 - A Kubernetes cluster **without** $[prodname] installed, or a cluster where you are performing a fresh install. To migrate an existing cluster from API server mode, see [Migrate from API server to native CRDs](crd-migration.mdx).
-- The `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) must be enabled on the Kubernetes API server. This feature is beta in Kubernetes and is not enabled by default.
+- **Kubernetes 1.34 or later.** $[prodname] uses the beta `admissionregistration.k8s.io/v1beta1` MutatingAdmissionPolicy API for defaulting, which is not available on Kubernetes 1.33 and earlier (where MutatingAdmissionPolicy is alpha only). On Kubernetes 1.34 and 1.35, the `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) must be enabled on the API server, as it is not enabled by default. On Kubernetes 1.36 and later, the feature is GA and enabled by default.
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';


### PR DESCRIPTION
The native `projectcalico.org/v3` CRD docs said enabling the `MutatingAdmissionPolicy` feature gate was all you needed, but left out the Kubernetes version floor. MutatingAdmissionPolicy is only available as the beta `admissionregistration.k8s.io/v1beta1` API on Kubernetes 1.34 and later. On 1.33 and earlier it exists only as alpha (`v1alpha1`), which the operator and webhooks don't support, so the install/migration fails with a `ResourceReadError` on the `Installation`.

Updated the install, migration, and reference pages (Calico and Calico Enterprise, including the versioned snapshots) to call out the 1.34+ requirement, that 1.34/1.35 still need the feature gate enabled, and that the feature is GA and on by default in 1.36+.

Also a drive-by fix: the OpenShift CLI install link in the identity provider docs pointed at docs.okd.io, whose TLS certificate has expired and was failing the link check. Repointed it to the equivalent docs.openshift.com page.

Fixes https://github.com/projectcalico/calico/issues/12863
