### PR TITLE
[CORE-12848] OpenStack doc fixes

### DIFF
--- a/__tests__/crawler.test.js
+++ b/__tests__/crawler.test.js
@@ -116,6 +116,7 @@ test('Crawl the docs and execute tests', async () => {
     'http://www.iana.org/assignments/service-names', //==>Origin: https://downloads.tigera.io/ee/v3.14.4/manifests/tigera-operator.yaml
     'http://docs.openstack.org/',
     'http://docs.openstack.org', //This seems to be temporarily down.
+    'https://docs.openstack.org/install-guide/environment-etcd.html', // 403 from OpenStack docs WAF in Netlify build environment
     'https://tools.ietf.org/html/rfc5925',
     'https://datatracker.ietf.org/doc/html/rfc1149',
     'https://datatracker.ietf.org/doc/html/rfc7938',

--- a/calico/_includes/partials/_system-requirements.mdx
+++ b/calico/_includes/partials/_system-requirements.mdx
@@ -5,9 +5,14 @@ import Link from '@docusaurus/Link';
 
 * x86-64, arm64, ppc64le, or s390x processor
 
+<If condition={props.platform !== 'openstack'}>
 * Calico must be able to manage `cali*` interfaces on the host.
   When IPIP is enabled (the default), Calico also needs to be able to manage `tunl*` interfaces.
   When VXLAN is enabled, Calico also needs to be able to manage the `vxlan.calico` interface.
+</If>
+<If condition={props.platform === 'openstack'}>
+* Calico must be able to manage `tap*` interfaces on the host.
+</If>
 
 * Linux kernel 5.10 or later with [required dependencies](#kernel-dependencies).
   The following distributions have the required kernel, its dependencies, and are known to work well with $[prodname].
@@ -226,9 +231,9 @@ $[prodname] supports the [OpenShift Container Platform](https://docs.openshift.c
 ## OpenStack requirements
 
 The Calico Neutron driver is written in Python 3 and so requires an OpenStack release that runs with Python 3.
-Subject to that, we aim to develop and maintain the Neutron driver for Calico (networking-calico) so that its master code works with OpenStack master or any previous Python 3 release, on any operating system, independently of the deployment mechanism that is used to install it.
+Subject to that, we aim to develop and maintain the Neutron driver for Calico so that its master code works with OpenStack master or any previous Python 3 release, on any operating system, independently of the deployment mechanism that is used to install it.
 
-However, we recommend using OpenStack Caracal or later, and our active support and testing of Calico v3.30 with OpenStack is with Caracal.
+However, we recommend using OpenStack Caracal or later, and our active support and testing of Calico v3.30+ with OpenStack is with Caracal.
 </If>
 
 ## Kernel dependencies

--- a/calico/_includes/partials/_system-requirements.mdx
+++ b/calico/_includes/partials/_system-requirements.mdx
@@ -233,7 +233,7 @@ $[prodname] supports the [OpenShift Container Platform](https://docs.openshift.c
 The Calico Neutron driver is written in Python 3 and so requires an OpenStack release that runs with Python 3.
 Subject to that, we aim to develop and maintain the Neutron driver for Calico so that its master code works with OpenStack master or any previous Python 3 release, on any operating system, independently of the deployment mechanism that is used to install it.
 
-However, we recommend using OpenStack Caracal or later, and our active support and testing of Calico v3.30+ with OpenStack is with Caracal.
+However, we recommend using OpenStack Caracal or later, and our active support and testing of Calico $[version] with OpenStack is with Caracal.
 </If>
 
 ## Kernel dependencies

--- a/calico/getting-started/openstack/installation/devstack.mdx
+++ b/calico/getting-started/openstack/installation/devstack.mdx
@@ -4,13 +4,13 @@ description: Quickstart that wires Calico Open Source into a DevStack OpenStack 
 
 # DevStack
 
-The networking-calico project provides a DevStack plugin. The following
+$[prodname] provides a DevStack plugin. The following
 instructions explain how to set up a single or multiple node DevStack/$[prodname]
 system, and then how to see $[prodname] connectivity in action.
 
 :::note
 
-networking-calico includes a
+$[prodname] includes a
 [shell script](https://github.com/projectcalico/calico/blob/master/networking-calico/devstack/bootstrap.sh)
 that implements the following setup instructions. You are welcome to use it,
 but we recommend that you read the following description first anyway, and
@@ -29,7 +29,7 @@ and compute functions running on the same node:
 2. Add to your DevStack local.conf file:
 
    ```bash
-   enable_plugin networking-calico https://github.com/projectcalico/networking-calico
+   enable_plugin calico https://github.com/projectcalico/calico
    ```
 
 3. Run `stack.sh`.

--- a/calico/getting-started/openstack/overview.mdx
+++ b/calico/getting-started/openstack/overview.mdx
@@ -4,7 +4,8 @@ description: Components and topology used when running Calico Open Source as the
 
 # Calico for OpenStack
 
-$[prodname]'s integration with OpenStack consists of the following pieces.
+$[prodname]'s integration with OpenStack involves the following software
+components.
 
 - etcd, providing a distributed key/value database that is accessible from all
   compute hosts and Neutron servers.
@@ -15,8 +16,9 @@ $[prodname]'s integration with OpenStack consists of the following pieces.
   them. Felix also reports its own agent status, and the programming status
   for each workload, through etcd.
 
-- BIRD, also running on each compute host, to propagate local workload routes
-  to other compute hosts and infrastructure routers.
+- BIRD, or some equivalent routing daemon, also running on each compute host,
+  to propagate local workload routes to other compute hosts and infrastructure
+  routers.
 
 - The $[prodname] driver for Neutron, that runs as part of the Neutron server on
   each machine where the Neutron server runs. (There can be just one Neutron
@@ -32,11 +34,18 @@ $[prodname]'s integration with OpenStack consists of the following pieces.
   the key difference is that it gets its information from Etcd instead of by
   RPC from the Neutron server, as we have found this to be more scalable.
 
-The Etcd, Felix and BIRD pieces are the same as in other $[prodname] integrations,
-and so independent of OpenStack. The $[prodname] Neutron driver and DHCP agent are
-specific to OpenStack, and are provided by the [networking-calico](https://github.com/projectcalico/networking-calico/) project.
+Some of these pieces are Calico deliverables.  Others must be provisioned
+separately, as explained by the following table.
 
-From an OpenStack point of view, networking-calico is just one of many possible
+| Component                      | Provisioning                                                                                                                                                                             |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| etcd                           | Must be provisioned by the user before installing Calico deliverables.  Typically now covered by OpenStack install - see https://docs.openstack.org/install-guide/environment-etcd.html. |
+| Felix                          | Calico deliverable, provided by the `calico-felix` package.                                                                                                                              |
+| BIRD (or equivalent)           | Must be provisioned and configured by the user.  See guidance on our [install pages](installation).                                                                                      |
+| $[prodname] driver for Neutron | Calico deliverable, provided by the `calico-control` package.                                                                                                                            |
+| $[prodname] DHCP agent         | Calico deliverable, provided by the `calico-dhcp-agent` package.                                                                                                                         |
+
+From an OpenStack point of view, Calico is just one of many possible
 Neutron drivers that provide connectivity between instances (VMs) as specified
 by the Neutron API. Refer to [$[prodname]'s interpretation of Neutron API calls](../../networking/openstack/neutron-api.mdx) for more detail about the
-parts of the Neutron API that the networking-calico provides.
+parts of the Neutron API that Calico provides.

--- a/calico/networking/openstack/floating-ips.mdx
+++ b/calico/networking/openstack/floating-ips.mdx
@@ -4,7 +4,7 @@ description: Allocate Neutron floating IPs against a Calico Open Source OpenStac
 
 # Floating IPs
 
-networking-calico includes support for floating IPs.
+Calico includes support for floating IPs.
 
 To set up a floating IP, you need the same pattern of Neutron data model
 objects as you do for Neutron in general, which means:

--- a/calico/networking/openstack/host-routes.mdx
+++ b/calico/networking/openstack/host-routes.mdx
@@ -15,7 +15,7 @@ via DHCP, that the instance's routing table gets those routes.
 
 ## With $[prodname], a host route's next hop IP should be the local host
 
-networking-calico supports host routes, but it's important to note that a host
+Calico supports host routes, but it's important to note that a host
 route is only consistent with $[prodname] when its next hop IP represents the local
 hypervisor. This is because the local hypervisor, in a $[prodname] setup, _always_
 routes all data from an instance and so is always the next hop IP for data to
@@ -28,13 +28,13 @@ its next IP hop from there.
 Specifically, each host route's next hop IP should be the gateway IP of the
 subnet that the desired instance NIC is attached to, and from which it got its
 IP address - where 'desired instance NIC' means the one that you want data for
-that host route to go through. In networking-calico's usage, subnet gateway
+that host route to go through. In Calico's usage, subnet gateway
 IPs represent the local hypervisor, because data sent by an instance is always
 routed there.
 
 :::note
 
-networking-calico avoids unnecessary IP usage by using the subnet
+Calico avoids unnecessary IP usage by using the subnet
 gateway IP to represent the local compute host, on every compute host where
 that subnet is being used. Although that might initially sound odd, it works
 because no data is ever sent to or from the gateway IP address; the gateway

--- a/calico/networking/openstack/kuryr.mdx
+++ b/calico/networking/openstack/kuryr.mdx
@@ -1,10 +1,10 @@
 ---
-description: Use Kuryr together with the networking-calico ML2 driver in Calico Open Source so Neutron provides networking for container workloads.
+description: Use Kuryr together with the Calico ML2 driver in Calico Open Source so Neutron provides networking for container workloads.
 ---
 
 # Kuryr
 
-networking-calico works with Kuryr; this means using Neutron, with the $[prodname]
+$[prodname] works with Kuryr; this means using Neutron, with the $[prodname]
 core plugin, to provide networking for container workloads.
 
 You can use DevStack to install a single node $[prodname]/Kuryr system, with a
@@ -18,7 +18,7 @@ RABBIT_PASSWORD=6366743536a8216bde26
 SERVICE_PASSWORD=91eb72bcafb4ddf246ab
 SERVICE_TOKEN=c5680feca5e2c9c8f820
 
-enable_plugin networking-calico git://git.openstack.org/openstack/networking-calico
+enable_plugin calico https://github.com/projectcalico/calico
 enable_plugin kuryr git://git.openstack.org/openstack/kuryr
 enable_service kuryr
 enable_service etcd-server

--- a/calico/networking/openstack/semantics.mdx
+++ b/calico/networking/openstack/semantics.mdx
@@ -117,6 +117,6 @@ OpenStack release, we hope to make this explicit, by arranging for $[prodname]
 networks to report `l2_adjacency False`.
 
 Subject to those restrictions and understandings, we believe that
-networking-calico fully implements Neutron semantics, i.e. that it provides the
+Calico fully implements Neutron semantics, i.e. that it provides the
 connectivity that an operator would expect for a given sequence of Neutron API
 setup calls.

--- a/calico_versioned_docs/version-3.29/_includes/partials/_system-requirements.mdx
+++ b/calico_versioned_docs/version-3.29/_includes/partials/_system-requirements.mdx
@@ -5,9 +5,14 @@ import Link from '@docusaurus/Link';
 
 * x86-64, arm64, ppc64le, or s390x processor
 
+<If condition={props.platform !== 'openstack'}>
 * Calico must be able to manage `cali*` interfaces on the host.
   When IPIP is enabled (the default), Calico also needs to be able to manage `tunl*` interfaces.
   When VXLAN is enabled, Calico also needs to be able to manage the `vxlan.calico` interface.
+</If>
+<If condition={props.platform === 'openstack'}>
+* Calico must be able to manage `tap*` interfaces on the host.
+</If>
 
 * Linux kernel 5.10 or later with [required dependencies](#kernel-dependencies).
   The following distributions have the required kernel, its dependencies, and are known to work well with $[prodname].
@@ -227,9 +232,9 @@ $[prodname] supports the [OpenShift Container Platform](https://docs.openshift.c
 ## OpenStack requirements
 
 The Calico Neutron driver is written in Python 3 and so requires an OpenStack release that runs with Python 3.
-Subject to that, we aim to develop and maintain the Neutron driver for Calico (networking-calico) so that its master code works with OpenStack master or any previous Python 3 release, on any operating system, independently of the deployment mechanism that is used to install it.
+Subject to that, we aim to develop and maintain the Neutron driver for Calico so that its master code works with OpenStack master or any previous Python 3 release, on any operating system, independently of the deployment mechanism that is used to install it.
 
-However, we recommend using OpenStack Yoga or later, and our active support and testing of Calico v3.29 with OpenStack is with Yoga.
+However, we recommend using OpenStack Yoga or later, and our active support and testing of Calico $[version] with OpenStack is with Yoga.
 </If>
 
 ## Kernel dependencies

--- a/calico_versioned_docs/version-3.29/getting-started/openstack/installation/devstack.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/openstack/installation/devstack.mdx
@@ -4,13 +4,13 @@ description: Quickstart to show connectivity between DevStack and Calico.
 
 # DevStack
 
-The networking-calico project provides a DevStack plugin. The following
+$[prodname] provides a DevStack plugin. The following
 instructions explain how to set up a single or multiple node DevStack/$[prodname]
 system, and then how to see $[prodname] connectivity in action.
 
 :::note
 
-networking-calico includes a
+$[prodname] includes a
 [shell script](https://github.com/projectcalico/calico/blob/master/networking-calico/devstack/bootstrap.sh)
 that implements the following setup instructions. You are welcome to use it,
 but we recommend that you read the following description first anyway, and
@@ -29,7 +29,7 @@ and compute functions running on the same node:
 2. Add to your DevStack local.conf file:
 
    ```bash
-   enable_plugin networking-calico https://github.com/projectcalico/networking-calico
+   enable_plugin calico https://github.com/projectcalico/calico
    ```
 
 3. Run `stack.sh`.

--- a/calico_versioned_docs/version-3.29/getting-started/openstack/overview.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/openstack/overview.mdx
@@ -4,7 +4,8 @@ description: Review the Calico components used in an OpenStack deployment.
 
 # Calico for OpenStack
 
-$[prodname]'s integration with OpenStack consists of the following pieces.
+$[prodname]'s integration with OpenStack involves the following software
+components.
 
 - etcd, providing a distributed key/value database that is accessible from all
   compute hosts and Neutron servers.
@@ -15,8 +16,9 @@ $[prodname]'s integration with OpenStack consists of the following pieces.
   them. Felix also reports its own agent status, and the programming status
   for each workload, through etcd.
 
-- BIRD, also running on each compute host, to propagate local workload routes
-  to other compute hosts and infrastructure routers.
+- BIRD, or some equivalent routing daemon, also running on each compute host,
+  to propagate local workload routes to other compute hosts and infrastructure
+  routers.
 
 - The $[prodname] driver for Neutron, that runs as part of the Neutron server on
   each machine where the Neutron server runs. (There can be just one Neutron
@@ -32,11 +34,18 @@ $[prodname]'s integration with OpenStack consists of the following pieces.
   the key difference is that it gets its information from Etcd instead of by
   RPC from the Neutron server, as we have found this to be more scalable.
 
-The Etcd, Felix and BIRD pieces are the same as in other $[prodname] integrations,
-and so independent of OpenStack. The $[prodname] Neutron driver and DHCP agent are
-specific to OpenStack, and are provided by the [networking-calico](https://github.com/projectcalico/networking-calico/) project.
+Some of these pieces are Calico deliverables.  Others must be provisioned
+separately, as explained by the following table.
 
-From an OpenStack point of view, networking-calico is just one of many possible
+| Component                      | Provisioning                                                                                                                                                                             |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| etcd                           | Must be provisioned by the user before installing Calico deliverables.  Typically now covered by OpenStack install - see https://docs.openstack.org/install-guide/environment-etcd.html. |
+| Felix                          | Calico deliverable, provided by the `calico-felix` package.                                                                                                                              |
+| BIRD (or equivalent)           | Must be provisioned and configured by the user.  See guidance on our [install pages](installation).                                                                                      |
+| $[prodname] driver for Neutron | Calico deliverable, provided by the `calico-control` package.                                                                                                                            |
+| $[prodname] DHCP agent         | Calico deliverable, provided by the `calico-dhcp-agent` package.                                                                                                                         |
+
+From an OpenStack point of view, Calico is just one of many possible
 Neutron drivers that provide connectivity between instances (VMs) as specified
 by the Neutron API. Refer to [$[prodname]'s interpretation of Neutron API calls](../../networking/openstack/neutron-api.mdx) for more detail about the
-parts of the Neutron API that the networking-calico provides.
+parts of the Neutron API that Calico provides.

--- a/calico_versioned_docs/version-3.29/networking/openstack/floating-ips.mdx
+++ b/calico_versioned_docs/version-3.29/networking/openstack/floating-ips.mdx
@@ -4,7 +4,7 @@ description: Configure floating IPs in Calico for OpenStack.
 
 # Floating IPs
 
-networking-calico includes beta support for floating IPs. Currently this
+Calico includes beta support for floating IPs. Currently this
 requires running $[prodname] as a Neutron core plugin (i.e. `core_plugin = calico`) instead of as an ML2 mechanism driver.
 
 :::note

--- a/calico_versioned_docs/version-3.29/networking/openstack/host-routes.mdx
+++ b/calico_versioned_docs/version-3.29/networking/openstack/host-routes.mdx
@@ -15,7 +15,7 @@ via DHCP, that the instance's routing table gets those routes.
 
 ## With $[prodname], a host route's next hop IP should be the local host
 
-networking-calico supports host routes, but it's important to note that a host
+Calico supports host routes, but it's important to note that a host
 route is only consistent with $[prodname] when its next hop IP represents the local
 hypervisor. This is because the local hypervisor, in a $[prodname] setup, _always_
 routes all data from an instance and so is always the next hop IP for data to
@@ -28,13 +28,13 @@ its next IP hop from there.
 Specifically, each host route's next hop IP should be the gateway IP of the
 subnet that the desired instance NIC is attached to, and from which it got its
 IP address - where 'desired instance NIC' means the one that you want data for
-that host route to go through. In networking-calico's usage, subnet gateway
+that host route to go through. In Calico's usage, subnet gateway
 IPs represent the local hypervisor, because data sent by an instance is always
 routed there.
 
 :::note
 
-networking-calico avoids unnecessary IP usage by using the subnet
+Calico avoids unnecessary IP usage by using the subnet
 gateway IP to represent the local compute host, on every compute host where
 that subnet is being used. Although that might initially sound odd, it works
 because no data is ever sent to or from the gateway IP address; the gateway

--- a/calico_versioned_docs/version-3.29/networking/openstack/kuryr.mdx
+++ b/calico_versioned_docs/version-3.29/networking/openstack/kuryr.mdx
@@ -4,7 +4,7 @@ description: Use Kuryr with Calico networking.
 
 # Kuryr
 
-networking-calico works with Kuryr; this means using Neutron, with the $[prodname]
+Calico works with Kuryr; this means using Neutron, with the $[prodname]
 ML2 driver, to provide networking for container workloads.
 
 You can use DevStack to install a single node $[prodname]/Kuryr system, with a
@@ -18,7 +18,7 @@ RABBIT_PASSWORD=6366743536a8216bde26
 SERVICE_PASSWORD=91eb72bcafb4ddf246ab
 SERVICE_TOKEN=c5680feca5e2c9c8f820
 
-enable_plugin networking-calico git://git.openstack.org/openstack/networking-calico
+enable_plugin calico https://github.com/projectcalico/calico
 enable_plugin kuryr git://git.openstack.org/openstack/kuryr
 enable_service kuryr
 enable_service etcd-server

--- a/calico_versioned_docs/version-3.29/networking/openstack/semantics.mdx
+++ b/calico_versioned_docs/version-3.29/networking/openstack/semantics.mdx
@@ -117,6 +117,6 @@ OpenStack release, we hope to make this explicit, by arranging for $[prodname]
 networks to report `l2_adjacency False`.
 
 Subject to those restrictions and understandings, we believe that
-networking-calico fully implements Neutron semantics, i.e. that it provides the
+Calico fully implements Neutron semantics, i.e. that it provides the
 connectivity that an operator would expect for a given sequence of Neutron API
 setup calls.

--- a/calico_versioned_docs/version-3.30/_includes/partials/_system-requirements.mdx
+++ b/calico_versioned_docs/version-3.30/_includes/partials/_system-requirements.mdx
@@ -5,9 +5,14 @@ import Link from '@docusaurus/Link';
 
 * x86-64, arm64, ppc64le, or s390x processor
 
+<If condition={props.platform !== 'openstack'}>
 * Calico must be able to manage `cali*` interfaces on the host.
   When IPIP is enabled (the default), Calico also needs to be able to manage `tunl*` interfaces.
   When VXLAN is enabled, Calico also needs to be able to manage the `vxlan.calico` interface.
+</If>
+<If condition={props.platform === 'openstack'}>
+* Calico must be able to manage `tap*` interfaces on the host.
+</If>
 
 * Linux kernel 5.10 or later with [required dependencies](#kernel-dependencies).
   The following distributions have the required kernel, its dependencies, and are known to work well with $[prodname].
@@ -228,9 +233,9 @@ $[prodname] supports the [OpenShift Container Platform](https://docs.openshift.c
 ## OpenStack requirements
 
 The Calico Neutron driver is written in Python 3 and so requires an OpenStack release that runs with Python 3.
-Subject to that, we aim to develop and maintain the Neutron driver for Calico (networking-calico) so that its master code works with OpenStack master or any previous Python 3 release, on any operating system, independently of the deployment mechanism that is used to install it.
+Subject to that, we aim to develop and maintain the Neutron driver for Calico so that its master code works with OpenStack master or any previous Python 3 release, on any operating system, independently of the deployment mechanism that is used to install it.
 
-However, we recommend using OpenStack Caracal or later, and our active support and testing of Calico v3.30 with OpenStack is with Caracal.
+However, we recommend using OpenStack Caracal or later, and our active support and testing of Calico $[version] with OpenStack is with Caracal.
 </If>
 
 ## Kernel dependencies

--- a/calico_versioned_docs/version-3.30/getting-started/openstack/installation/devstack.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/openstack/installation/devstack.mdx
@@ -4,13 +4,13 @@ description: Quickstart to show connectivity between DevStack and Calico.
 
 # DevStack
 
-The networking-calico project provides a DevStack plugin. The following
+$[prodname] provides a DevStack plugin. The following
 instructions explain how to set up a single or multiple node DevStack/$[prodname]
 system, and then how to see $[prodname] connectivity in action.
 
 :::note
 
-networking-calico includes a
+$[prodname] includes a
 [shell script](https://github.com/projectcalico/calico/blob/master/networking-calico/devstack/bootstrap.sh)
 that implements the following setup instructions. You are welcome to use it,
 but we recommend that you read the following description first anyway, and
@@ -29,7 +29,7 @@ and compute functions running on the same node:
 2. Add to your DevStack local.conf file:
 
    ```bash
-   enable_plugin networking-calico https://github.com/projectcalico/networking-calico
+   enable_plugin calico https://github.com/projectcalico/calico
    ```
 
 3. Run `stack.sh`.

--- a/calico_versioned_docs/version-3.30/getting-started/openstack/overview.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/openstack/overview.mdx
@@ -4,7 +4,8 @@ description: Review the Calico components used in an OpenStack deployment.
 
 # Calico for OpenStack
 
-$[prodname]'s integration with OpenStack consists of the following pieces.
+$[prodname]'s integration with OpenStack involves the following software
+components.
 
 - etcd, providing a distributed key/value database that is accessible from all
   compute hosts and Neutron servers.
@@ -15,8 +16,9 @@ $[prodname]'s integration with OpenStack consists of the following pieces.
   them. Felix also reports its own agent status, and the programming status
   for each workload, through etcd.
 
-- BIRD, also running on each compute host, to propagate local workload routes
-  to other compute hosts and infrastructure routers.
+- BIRD, or some equivalent routing daemon, also running on each compute host,
+  to propagate local workload routes to other compute hosts and infrastructure
+  routers.
 
 - The $[prodname] driver for Neutron, that runs as part of the Neutron server on
   each machine where the Neutron server runs. (There can be just one Neutron
@@ -32,11 +34,18 @@ $[prodname]'s integration with OpenStack consists of the following pieces.
   the key difference is that it gets its information from Etcd instead of by
   RPC from the Neutron server, as we have found this to be more scalable.
 
-The Etcd, Felix and BIRD pieces are the same as in other $[prodname] integrations,
-and so independent of OpenStack. The $[prodname] Neutron driver and DHCP agent are
-specific to OpenStack, and are provided by the [networking-calico](https://github.com/projectcalico/networking-calico/) project.
+Some of these pieces are Calico deliverables.  Others must be provisioned
+separately, as explained by the following table.
 
-From an OpenStack point of view, networking-calico is just one of many possible
+| Component                      | Provisioning                                                                                                                                                                             |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| etcd                           | Must be provisioned by the user before installing Calico deliverables.  Typically now covered by OpenStack install - see https://docs.openstack.org/install-guide/environment-etcd.html. |
+| Felix                          | Calico deliverable, provided by the `calico-felix` package.                                                                                                                              |
+| BIRD (or equivalent)           | Must be provisioned and configured by the user.  See guidance on our [install pages](installation).                                                                                      |
+| $[prodname] driver for Neutron | Calico deliverable, provided by the `calico-control` package.                                                                                                                            |
+| $[prodname] DHCP agent         | Calico deliverable, provided by the `calico-dhcp-agent` package.                                                                                                                         |
+
+From an OpenStack point of view, Calico is just one of many possible
 Neutron drivers that provide connectivity between instances (VMs) as specified
 by the Neutron API. Refer to [$[prodname]'s interpretation of Neutron API calls](../../networking/openstack/neutron-api.mdx) for more detail about the
-parts of the Neutron API that the networking-calico provides.
+parts of the Neutron API that Calico provides.

--- a/calico_versioned_docs/version-3.30/networking/openstack/floating-ips.mdx
+++ b/calico_versioned_docs/version-3.30/networking/openstack/floating-ips.mdx
@@ -4,7 +4,7 @@ description: Configure floating IPs in Calico for OpenStack.
 
 # Floating IPs
 
-networking-calico includes beta support for floating IPs. Currently this
+Calico includes beta support for floating IPs. Currently this
 requires running $[prodname] as a Neutron core plugin (i.e. `core_plugin = calico`) instead of as an ML2 mechanism driver.
 
 :::note

--- a/calico_versioned_docs/version-3.30/networking/openstack/host-routes.mdx
+++ b/calico_versioned_docs/version-3.30/networking/openstack/host-routes.mdx
@@ -15,7 +15,7 @@ via DHCP, that the instance's routing table gets those routes.
 
 ## With $[prodname], a host route's next hop IP should be the local host
 
-networking-calico supports host routes, but it's important to note that a host
+Calico supports host routes, but it's important to note that a host
 route is only consistent with $[prodname] when its next hop IP represents the local
 hypervisor. This is because the local hypervisor, in a $[prodname] setup, _always_
 routes all data from an instance and so is always the next hop IP for data to
@@ -28,13 +28,13 @@ its next IP hop from there.
 Specifically, each host route's next hop IP should be the gateway IP of the
 subnet that the desired instance NIC is attached to, and from which it got its
 IP address - where 'desired instance NIC' means the one that you want data for
-that host route to go through. In networking-calico's usage, subnet gateway
+that host route to go through. In Calico's usage, subnet gateway
 IPs represent the local hypervisor, because data sent by an instance is always
 routed there.
 
 :::note
 
-networking-calico avoids unnecessary IP usage by using the subnet
+Calico avoids unnecessary IP usage by using the subnet
 gateway IP to represent the local compute host, on every compute host where
 that subnet is being used. Although that might initially sound odd, it works
 because no data is ever sent to or from the gateway IP address; the gateway

--- a/calico_versioned_docs/version-3.30/networking/openstack/kuryr.mdx
+++ b/calico_versioned_docs/version-3.30/networking/openstack/kuryr.mdx
@@ -4,7 +4,7 @@ description: Use Kuryr with Calico networking.
 
 # Kuryr
 
-networking-calico works with Kuryr; this means using Neutron, with the $[prodname]
+Calico works with Kuryr; this means using Neutron, with the $[prodname]
 ML2 driver, to provide networking for container workloads.
 
 You can use DevStack to install a single node $[prodname]/Kuryr system, with a
@@ -18,7 +18,7 @@ RABBIT_PASSWORD=6366743536a8216bde26
 SERVICE_PASSWORD=91eb72bcafb4ddf246ab
 SERVICE_TOKEN=c5680feca5e2c9c8f820
 
-enable_plugin networking-calico git://git.openstack.org/openstack/networking-calico
+enable_plugin calico https://github.com/projectcalico/calico
 enable_plugin kuryr git://git.openstack.org/openstack/kuryr
 enable_service kuryr
 enable_service etcd-server

--- a/calico_versioned_docs/version-3.30/networking/openstack/semantics.mdx
+++ b/calico_versioned_docs/version-3.30/networking/openstack/semantics.mdx
@@ -117,6 +117,6 @@ OpenStack release, we hope to make this explicit, by arranging for $[prodname]
 networks to report `l2_adjacency False`.
 
 Subject to those restrictions and understandings, we believe that
-networking-calico fully implements Neutron semantics, i.e. that it provides the
+Calico fully implements Neutron semantics, i.e. that it provides the
 connectivity that an operator would expect for a given sequence of Neutron API
 setup calls.

--- a/calico_versioned_docs/version-3.31/_includes/partials/_system-requirements.mdx
+++ b/calico_versioned_docs/version-3.31/_includes/partials/_system-requirements.mdx
@@ -5,9 +5,14 @@ import Link from '@docusaurus/Link';
 
 * x86-64, arm64, ppc64le, or s390x processor
 
+<If condition={props.platform !== 'openstack'}>
 * Calico must be able to manage `cali*` interfaces on the host.
   When IPIP is enabled (the default), Calico also needs to be able to manage `tunl*` interfaces.
   When VXLAN is enabled, Calico also needs to be able to manage the `vxlan.calico` interface.
+</If>
+<If condition={props.platform === 'openstack'}>
+* Calico must be able to manage `tap*` interfaces on the host.
+</If>
 
 * Linux kernel 5.10 or later with [required dependencies](#kernel-dependencies).
   The following distributions have the required kernel, its dependencies, and are known to work well with $[prodname].
@@ -227,9 +232,9 @@ $[prodname] supports the [OpenShift Container Platform](https://docs.openshift.c
 ## OpenStack requirements
 
 The Calico Neutron driver is written in Python 3 and so requires an OpenStack release that runs with Python 3.
-Subject to that, we aim to develop and maintain the Neutron driver for Calico (networking-calico) so that its master code works with OpenStack master or any previous Python 3 release, on any operating system, independently of the deployment mechanism that is used to install it.
+Subject to that, we aim to develop and maintain the Neutron driver for Calico so that its master code works with OpenStack master or any previous Python 3 release, on any operating system, independently of the deployment mechanism that is used to install it.
 
-However, we recommend using OpenStack Caracal or later, and our active support and testing of Calico v3.30 with OpenStack is with Caracal.
+However, we recommend using OpenStack Caracal or later, and our active support and testing of Calico $[version] with OpenStack is with Caracal.
 </If>
 
 ## Kernel dependencies

--- a/calico_versioned_docs/version-3.31/getting-started/openstack/installation/devstack.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/openstack/installation/devstack.mdx
@@ -4,13 +4,13 @@ description: Quickstart to show connectivity between DevStack and Calico.
 
 # DevStack
 
-The networking-calico project provides a DevStack plugin. The following
+$[prodname] provides a DevStack plugin. The following
 instructions explain how to set up a single or multiple node DevStack/$[prodname]
 system, and then how to see $[prodname] connectivity in action.
 
 :::note
 
-networking-calico includes a
+$[prodname] includes a
 [shell script](https://github.com/projectcalico/calico/blob/master/networking-calico/devstack/bootstrap.sh)
 that implements the following setup instructions. You are welcome to use it,
 but we recommend that you read the following description first anyway, and
@@ -29,7 +29,7 @@ and compute functions running on the same node:
 2. Add to your DevStack local.conf file:
 
    ```bash
-   enable_plugin networking-calico https://github.com/projectcalico/networking-calico
+   enable_plugin calico https://github.com/projectcalico/calico
    ```
 
 3. Run `stack.sh`.

--- a/calico_versioned_docs/version-3.31/getting-started/openstack/overview.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/openstack/overview.mdx
@@ -4,7 +4,8 @@ description: Review the Calico components used in an OpenStack deployment.
 
 # Calico for OpenStack
 
-$[prodname]'s integration with OpenStack consists of the following pieces.
+$[prodname]'s integration with OpenStack involves the following software
+components.
 
 - etcd, providing a distributed key/value database that is accessible from all
   compute hosts and Neutron servers.
@@ -15,8 +16,9 @@ $[prodname]'s integration with OpenStack consists of the following pieces.
   them. Felix also reports its own agent status, and the programming status
   for each workload, through etcd.
 
-- BIRD, also running on each compute host, to propagate local workload routes
-  to other compute hosts and infrastructure routers.
+- BIRD, or some equivalent routing daemon, also running on each compute host,
+  to propagate local workload routes to other compute hosts and infrastructure
+  routers.
 
 - The $[prodname] driver for Neutron, that runs as part of the Neutron server on
   each machine where the Neutron server runs. (There can be just one Neutron
@@ -32,11 +34,18 @@ $[prodname]'s integration with OpenStack consists of the following pieces.
   the key difference is that it gets its information from Etcd instead of by
   RPC from the Neutron server, as we have found this to be more scalable.
 
-The Etcd, Felix and BIRD pieces are the same as in other $[prodname] integrations,
-and so independent of OpenStack. The $[prodname] Neutron driver and DHCP agent are
-specific to OpenStack, and are provided by the [networking-calico](https://github.com/projectcalico/networking-calico/) project.
+Some of these pieces are Calico deliverables.  Others must be provisioned
+separately, as explained by the following table.
 
-From an OpenStack point of view, networking-calico is just one of many possible
+| Component                      | Provisioning                                                                                                                                                                             |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| etcd                           | Must be provisioned by the user before installing Calico deliverables.  Typically now covered by OpenStack install - see https://docs.openstack.org/install-guide/environment-etcd.html. |
+| Felix                          | Calico deliverable, provided by the `calico-felix` package.                                                                                                                              |
+| BIRD (or equivalent)           | Must be provisioned and configured by the user.  See guidance on our [install pages](installation).                                                                                      |
+| $[prodname] driver for Neutron | Calico deliverable, provided by the `calico-control` package.                                                                                                                            |
+| $[prodname] DHCP agent         | Calico deliverable, provided by the `calico-dhcp-agent` package.                                                                                                                         |
+
+From an OpenStack point of view, Calico is just one of many possible
 Neutron drivers that provide connectivity between instances (VMs) as specified
 by the Neutron API. Refer to [$[prodname]'s interpretation of Neutron API calls](../../networking/openstack/neutron-api.mdx) for more detail about the
-parts of the Neutron API that the networking-calico provides.
+parts of the Neutron API that Calico provides.

--- a/calico_versioned_docs/version-3.31/networking/openstack/floating-ips.mdx
+++ b/calico_versioned_docs/version-3.31/networking/openstack/floating-ips.mdx
@@ -4,7 +4,7 @@ description: Configure floating IPs in Calico for OpenStack.
 
 # Floating IPs
 
-networking-calico includes beta support for floating IPs. Currently this
+Calico includes beta support for floating IPs. Currently this
 requires running $[prodname] as a Neutron core plugin (i.e. `core_plugin = calico`) instead of as an ML2 mechanism driver.
 
 :::note

--- a/calico_versioned_docs/version-3.31/networking/openstack/host-routes.mdx
+++ b/calico_versioned_docs/version-3.31/networking/openstack/host-routes.mdx
@@ -15,7 +15,7 @@ via DHCP, that the instance's routing table gets those routes.
 
 ## With $[prodname], a host route's next hop IP should be the local host
 
-networking-calico supports host routes, but it's important to note that a host
+Calico supports host routes, but it's important to note that a host
 route is only consistent with $[prodname] when its next hop IP represents the local
 hypervisor. This is because the local hypervisor, in a $[prodname] setup, _always_
 routes all data from an instance and so is always the next hop IP for data to
@@ -28,13 +28,13 @@ its next IP hop from there.
 Specifically, each host route's next hop IP should be the gateway IP of the
 subnet that the desired instance NIC is attached to, and from which it got its
 IP address - where 'desired instance NIC' means the one that you want data for
-that host route to go through. In networking-calico's usage, subnet gateway
+that host route to go through. In Calico's usage, subnet gateway
 IPs represent the local hypervisor, because data sent by an instance is always
 routed there.
 
 :::note
 
-networking-calico avoids unnecessary IP usage by using the subnet
+Calico avoids unnecessary IP usage by using the subnet
 gateway IP to represent the local compute host, on every compute host where
 that subnet is being used. Although that might initially sound odd, it works
 because no data is ever sent to or from the gateway IP address; the gateway

--- a/calico_versioned_docs/version-3.31/networking/openstack/kuryr.mdx
+++ b/calico_versioned_docs/version-3.31/networking/openstack/kuryr.mdx
@@ -4,7 +4,7 @@ description: Use Kuryr with Calico networking.
 
 # Kuryr
 
-networking-calico works with Kuryr; this means using Neutron, with the $[prodname]
+Calico works with Kuryr; this means using Neutron, with the $[prodname]
 ML2 driver, to provide networking for container workloads.
 
 You can use DevStack to install a single node $[prodname]/Kuryr system, with a
@@ -18,7 +18,7 @@ RABBIT_PASSWORD=6366743536a8216bde26
 SERVICE_PASSWORD=91eb72bcafb4ddf246ab
 SERVICE_TOKEN=c5680feca5e2c9c8f820
 
-enable_plugin networking-calico git://git.openstack.org/openstack/networking-calico
+enable_plugin calico https://github.com/projectcalico/calico
 enable_plugin kuryr git://git.openstack.org/openstack/kuryr
 enable_service kuryr
 enable_service etcd-server

--- a/calico_versioned_docs/version-3.31/networking/openstack/semantics.mdx
+++ b/calico_versioned_docs/version-3.31/networking/openstack/semantics.mdx
@@ -117,6 +117,6 @@ OpenStack release, we hope to make this explicit, by arranging for $[prodname]
 networks to report `l2_adjacency False`.
 
 Subject to those restrictions and understandings, we believe that
-networking-calico fully implements Neutron semantics, i.e. that it provides the
+Calico fully implements Neutron semantics, i.e. that it provides the
 connectivity that an operator would expect for a given sequence of Neutron API
 setup calls.

--- a/calico_versioned_docs/version-3.32/_includes/partials/_system-requirements.mdx
+++ b/calico_versioned_docs/version-3.32/_includes/partials/_system-requirements.mdx
@@ -5,9 +5,14 @@ import Link from '@docusaurus/Link';
 
 * x86-64, arm64, ppc64le, or s390x processor
 
+<If condition={props.platform !== 'openstack'}>
 * Calico must be able to manage `cali*` interfaces on the host.
   When IPIP is enabled (the default), Calico also needs to be able to manage `tunl*` interfaces.
   When VXLAN is enabled, Calico also needs to be able to manage the `vxlan.calico` interface.
+</If>
+<If condition={props.platform === 'openstack'}>
+* Calico must be able to manage `tap*` interfaces on the host.
+</If>
 
 * Linux kernel 5.10 or later with [required dependencies](#kernel-dependencies).
   The following distributions have the required kernel, its dependencies, and are known to work well with $[prodname].
@@ -226,9 +231,9 @@ $[prodname] supports the [OpenShift Container Platform](https://docs.openshift.c
 ## OpenStack requirements
 
 The Calico Neutron driver is written in Python 3 and so requires an OpenStack release that runs with Python 3.
-Subject to that, we aim to develop and maintain the Neutron driver for Calico (networking-calico) so that its master code works with OpenStack master or any previous Python 3 release, on any operating system, independently of the deployment mechanism that is used to install it.
+Subject to that, we aim to develop and maintain the Neutron driver for Calico so that its master code works with OpenStack master or any previous Python 3 release, on any operating system, independently of the deployment mechanism that is used to install it.
 
-However, we recommend using OpenStack Caracal or later, and our active support and testing of Calico v3.30 with OpenStack is with Caracal.
+However, we recommend using OpenStack Caracal or later, and our active support and testing of Calico $[version] with OpenStack is with Caracal.
 </If>
 
 ## Kernel dependencies

--- a/calico_versioned_docs/version-3.32/getting-started/openstack/installation/devstack.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/openstack/installation/devstack.mdx
@@ -4,13 +4,13 @@ description: Quickstart that wires Calico Open Source into a DevStack OpenStack 
 
 # DevStack
 
-The networking-calico project provides a DevStack plugin. The following
+$[prodname] provides a DevStack plugin. The following
 instructions explain how to set up a single or multiple node DevStack/$[prodname]
 system, and then how to see $[prodname] connectivity in action.
 
 :::note
 
-networking-calico includes a
+$[prodname] includes a
 [shell script](https://github.com/projectcalico/calico/blob/master/networking-calico/devstack/bootstrap.sh)
 that implements the following setup instructions. You are welcome to use it,
 but we recommend that you read the following description first anyway, and
@@ -29,7 +29,7 @@ and compute functions running on the same node:
 2. Add to your DevStack local.conf file:
 
    ```bash
-   enable_plugin networking-calico https://github.com/projectcalico/networking-calico
+   enable_plugin calico https://github.com/projectcalico/calico
    ```
 
 3. Run `stack.sh`.

--- a/calico_versioned_docs/version-3.32/getting-started/openstack/overview.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/openstack/overview.mdx
@@ -4,7 +4,8 @@ description: Components and topology used when running Calico Open Source as the
 
 # Calico for OpenStack
 
-$[prodname]'s integration with OpenStack consists of the following pieces.
+$[prodname]'s integration with OpenStack involves the following software
+components.
 
 - etcd, providing a distributed key/value database that is accessible from all
   compute hosts and Neutron servers.
@@ -15,8 +16,9 @@ $[prodname]'s integration with OpenStack consists of the following pieces.
   them. Felix also reports its own agent status, and the programming status
   for each workload, through etcd.
 
-- BIRD, also running on each compute host, to propagate local workload routes
-  to other compute hosts and infrastructure routers.
+- BIRD, or some equivalent routing daemon, also running on each compute host,
+  to propagate local workload routes to other compute hosts and infrastructure
+  routers.
 
 - The $[prodname] driver for Neutron, that runs as part of the Neutron server on
   each machine where the Neutron server runs. (There can be just one Neutron
@@ -32,11 +34,18 @@ $[prodname]'s integration with OpenStack consists of the following pieces.
   the key difference is that it gets its information from Etcd instead of by
   RPC from the Neutron server, as we have found this to be more scalable.
 
-The Etcd, Felix and BIRD pieces are the same as in other $[prodname] integrations,
-and so independent of OpenStack. The $[prodname] Neutron driver and DHCP agent are
-specific to OpenStack, and are provided by the [networking-calico](https://github.com/projectcalico/networking-calico/) project.
+Some of these pieces are Calico deliverables.  Others must be provisioned
+separately, as explained by the following table.
 
-From an OpenStack point of view, networking-calico is just one of many possible
+| Component                      | Provisioning                                                                                                                                                                             |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| etcd                           | Must be provisioned by the user before installing Calico deliverables.  Typically now covered by OpenStack install - see https://docs.openstack.org/install-guide/environment-etcd.html. |
+| Felix                          | Calico deliverable, provided by the `calico-felix` package.                                                                                                                              |
+| BIRD (or equivalent)           | Must be provisioned and configured by the user.  See guidance on our [install pages](installation).                                                                                      |
+| $[prodname] driver for Neutron | Calico deliverable, provided by the `calico-control` package.                                                                                                                            |
+| $[prodname] DHCP agent         | Calico deliverable, provided by the `calico-dhcp-agent` package.                                                                                                                         |
+
+From an OpenStack point of view, Calico is just one of many possible
 Neutron drivers that provide connectivity between instances (VMs) as specified
 by the Neutron API. Refer to [$[prodname]'s interpretation of Neutron API calls](../../networking/openstack/neutron-api.mdx) for more detail about the
-parts of the Neutron API that the networking-calico provides.
+parts of the Neutron API that Calico provides.

--- a/calico_versioned_docs/version-3.32/networking/openstack/floating-ips.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/floating-ips.mdx
@@ -4,7 +4,7 @@ description: Allocate Neutron floating IPs against a Calico Open Source OpenStac
 
 # Floating IPs
 
-networking-calico includes support for floating IPs.
+Calico includes support for floating IPs.
 
 To set up a floating IP, you need the same pattern of Neutron data model
 objects as you do for Neutron in general, which means:

--- a/calico_versioned_docs/version-3.32/networking/openstack/host-routes.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/host-routes.mdx
@@ -15,7 +15,7 @@ via DHCP, that the instance's routing table gets those routes.
 
 ## With $[prodname], a host route's next hop IP should be the local host
 
-networking-calico supports host routes, but it's important to note that a host
+Calico supports host routes, but it's important to note that a host
 route is only consistent with $[prodname] when its next hop IP represents the local
 hypervisor. This is because the local hypervisor, in a $[prodname] setup, _always_
 routes all data from an instance and so is always the next hop IP for data to
@@ -28,13 +28,13 @@ its next IP hop from there.
 Specifically, each host route's next hop IP should be the gateway IP of the
 subnet that the desired instance NIC is attached to, and from which it got its
 IP address - where 'desired instance NIC' means the one that you want data for
-that host route to go through. In networking-calico's usage, subnet gateway
+that host route to go through. In Calico's usage, subnet gateway
 IPs represent the local hypervisor, because data sent by an instance is always
 routed there.
 
 :::note
 
-networking-calico avoids unnecessary IP usage by using the subnet
+Calico avoids unnecessary IP usage by using the subnet
 gateway IP to represent the local compute host, on every compute host where
 that subnet is being used. Although that might initially sound odd, it works
 because no data is ever sent to or from the gateway IP address; the gateway

--- a/calico_versioned_docs/version-3.32/networking/openstack/kuryr.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/kuryr.mdx
@@ -1,10 +1,10 @@
 ---
-description: Use Kuryr together with the networking-calico ML2 driver in Calico Open Source so Neutron provides networking for container workloads.
+description: Use Kuryr together with the Calico ML2 driver in Calico Open Source so Neutron provides networking for container workloads.
 ---
 
 # Kuryr
 
-networking-calico works with Kuryr; this means using Neutron, with the $[prodname]
+$[prodname] works with Kuryr; this means using Neutron, with the $[prodname]
 core plugin, to provide networking for container workloads.
 
 You can use DevStack to install a single node $[prodname]/Kuryr system, with a
@@ -18,7 +18,7 @@ RABBIT_PASSWORD=6366743536a8216bde26
 SERVICE_PASSWORD=91eb72bcafb4ddf246ab
 SERVICE_TOKEN=c5680feca5e2c9c8f820
 
-enable_plugin networking-calico git://git.openstack.org/openstack/networking-calico
+enable_plugin calico https://github.com/projectcalico/calico
 enable_plugin kuryr git://git.openstack.org/openstack/kuryr
 enable_service kuryr
 enable_service etcd-server

--- a/calico_versioned_docs/version-3.32/networking/openstack/semantics.mdx
+++ b/calico_versioned_docs/version-3.32/networking/openstack/semantics.mdx
@@ -117,6 +117,6 @@ OpenStack release, we hope to make this explicit, by arranging for $[prodname]
 networks to report `l2_adjacency False`.
 
 Subject to those restrictions and understandings, we believe that
-networking-calico fully implements Neutron semantics, i.e. that it provides the
+Calico fully implements Neutron semantics, i.e. that it provides the
 connectivity that an operator would expect for a given sequence of Neutron API
 setup calls.


### PR DESCRIPTION
- System requirements should say "tap*" instead of "cali*"

- System requirements should say "v3.30+" instead of just "v3.30"

- In the discussion of software components, clarify that some of them need to be provisioned by the user, and that an alternative routing daemon may be used instead of BIRD

- Update uses of `networking-calico` as a Git repository to say   `projectcalico/calico` instead.  `networking-calico` in this sense has been incorrect since we created the OSS monorepo.

- Update other remaining uses of "networking-calico" to just "Calico".  The history of the "networking-calico" term is not of interest to our readers, and there is no useful distinction to be implied by saying "networking-calico" instead of just "Calico".
