### PR TITLE
flannel migration: document removing leftover flannel iptables rules

### DIFF
--- a/calico/getting-started/kubernetes/flannel/migration-from-flannel.mdx
+++ b/calico/getting-started/kubernetes/flannel/migration-from-flannel.mdx
@@ -92,6 +92,39 @@ There are two ways to switch your cluster to use $[prodname] networking. Both me
    kubectl delete -f $[manifestsUrl]/manifests/flannel-migration/migration-job.yaml
    ```
 
+1. Remove leftover flannel `iptables` rules from each node.
+
+   The migration controller removes the flannel daemonset and deletes the flannel
+   network devices (`flannel.<vni>` and `cni0`), but it does not remove the
+   `iptables` chains that flannel programs: `FLANNEL-POSTRTG` in the `nat` table and
+   `FLANNEL-FWD` in the `filter` table. These chains survive the migration.
+
+   This matters once you start using Kubernetes `NetworkPolicy`. The masquerade rule
+   in `FLANNEL-POSTRTG` keeps SNAT-ing cross-node pod-to-pod traffic to the node's
+   tunnel IP, so the source address no longer matches pod-selector rules and Calico
+   drops the traffic. The symptom is that cross-node connections to policy-selected
+   pods time out after an otherwise successful migration, while same-node traffic
+   keeps working. Remove the leftover chains so that Calico is the only owner of pod
+   masquerading.
+
+   Run the following on every node. It covers both the legacy and nft `iptables`
+   backends and is safe to re-run:
+
+   ```bash
+   for ipt in iptables-legacy iptables-nft ip6tables-legacy ip6tables-nft; do
+     command -v "$ipt" >/dev/null 2>&1 || continue
+     "$ipt" -w -t nat -D POSTROUTING -j FLANNEL-POSTRTG 2>/dev/null
+     "$ipt" -w -t nat -F FLANNEL-POSTRTG 2>/dev/null
+     "$ipt" -w -t nat -X FLANNEL-POSTRTG 2>/dev/null
+     "$ipt" -w -t filter -D FORWARD -j FLANNEL-FWD 2>/dev/null
+     "$ipt" -w -t filter -F FLANNEL-FWD 2>/dev/null
+     "$ipt" -w -t filter -X FLANNEL-FWD 2>/dev/null
+   done
+   ```
+
+   Alternatively, reboot each node during a drained maintenance window to clear the
+   leftover rules.
+
 ### Modify flannel configuration
 
 The migration controller autodetects your flannel configuration, and in most cases, does not require

--- a/calico/getting-started/kubernetes/flannel/migration-from-flannel.mdx
+++ b/calico/getting-started/kubernetes/flannel/migration-from-flannel.mdx
@@ -94,35 +94,15 @@ There are two ways to switch your cluster to use $[prodname] networking. Both me
 
 1. Remove leftover flannel `iptables` rules from each node.
 
-   The migration controller removes the flannel daemonset and deletes the flannel
-   network devices (`flannel.<vni>` and `cni0`), but it does not remove the
-   `iptables` chains that flannel programs: `FLANNEL-POSTRTG` in the `nat` table and
-   `FLANNEL-FWD` in the `filter` table. These chains survive the migration.
+   The migration controller deletes the flannel network devices but leaves flannel's `iptables` chains (`FLANNEL-POSTRTG` in `nat`, `FLANNEL-FWD` in `filter`) in place. Their masquerade rule SNATs cross-node pod traffic, which breaks Kubernetes `NetworkPolicy` for policy-selected pods. Because flannel is no longer running, you only need to clear the chains once. Use either method:
 
-   This matters once you start using Kubernetes `NetworkPolicy`. The masquerade rule
-   in `FLANNEL-POSTRTG` keeps SNAT-ing cross-node pod-to-pod traffic to the node's
-   tunnel IP, so the source address no longer matches pod-selector rules and Calico
-   drops the traffic. The symptom is that cross-node connections to policy-selected
-   pods time out after an otherwise successful migration, while same-node traffic
-   keeps working. Remove the leftover chains so that Calico is the only owner of pod
-   masquerading.
+   **Method 1: Reboot or replace nodes**
 
-   Because flannel is no longer running, nothing re-creates these chains, so you only
-   need to clear them once. Choose whichever of the following approaches fits your
-   cluster.
+   Perform a rolling reboot (drain, reboot, uncordon each node in turn), or replace the nodes if you use immutable or managed node pools. The rules do not persist across a reboot, so no work on the nodes is needed.
 
-   **If you can reboot or replace nodes**
+   **Method 2: Remove the chains in place**
 
-   Perform a rolling reboot of the cluster nodes (drain, reboot, uncordon each node
-   in turn), or replace the nodes entirely if you use immutable or managed node
-   pools. The leftover rules do not persist across a reboot, so no manual work on
-   the nodes is needed.
-
-   **If rebooting nodes is undesirable**
-
-   Remove the chains in place by running the following on every node. It takes
-   effect immediately without disrupting workloads, covers both the legacy and nft
-   `iptables` backends, and is safe to re-run:
+   Run the following on every node. It takes effect immediately without disrupting workloads, covers both the legacy and nft backends, and is safe to re-run:
 
    ```bash
    for ipt in iptables-legacy iptables-nft ip6tables-legacy ip6tables-nft; do

--- a/calico/getting-started/kubernetes/flannel/migration-from-flannel.mdx
+++ b/calico/getting-started/kubernetes/flannel/migration-from-flannel.mdx
@@ -107,8 +107,22 @@ There are two ways to switch your cluster to use $[prodname] networking. Both me
    keeps working. Remove the leftover chains so that Calico is the only owner of pod
    masquerading.
 
-   Run the following on every node. It covers both the legacy and nft `iptables`
-   backends and is safe to re-run:
+   Because flannel is no longer running, nothing re-creates these chains, so you only
+   need to clear them once. Choose whichever of the following approaches fits your
+   cluster.
+
+   **If you can reboot or replace nodes**
+
+   Perform a rolling reboot of the cluster nodes (drain, reboot, uncordon each node
+   in turn), or replace the nodes entirely if you use immutable or managed node
+   pools. The leftover rules do not persist across a reboot, so no manual work on
+   the nodes is needed.
+
+   **If rebooting nodes is undesirable**
+
+   Remove the chains in place by running the following on every node. It takes
+   effect immediately without disrupting workloads, covers both the legacy and nft
+   `iptables` backends, and is safe to re-run:
 
    ```bash
    for ipt in iptables-legacy iptables-nft ip6tables-legacy ip6tables-nft; do
@@ -121,9 +135,6 @@ There are two ways to switch your cluster to use $[prodname] networking. Both me
      "$ipt" -w -t filter -X FLANNEL-FWD 2>/dev/null
    done
    ```
-
-   Alternatively, reboot each node during a drained maintenance window to clear the
-   leftover rules.
 
 ### Modify flannel configuration
 

--- a/calico/getting-started/kubernetes/flannel/migration-from-flannel.mdx
+++ b/calico/getting-started/kubernetes/flannel/migration-from-flannel.mdx
@@ -92,30 +92,6 @@ There are two ways to switch your cluster to use $[prodname] networking. Both me
    kubectl delete -f $[manifestsUrl]/manifests/flannel-migration/migration-job.yaml
    ```
 
-1. Remove leftover flannel `iptables` rules from each node.
-
-   The migration controller deletes the flannel network devices but leaves flannel's `iptables` chains (`FLANNEL-POSTRTG` in `nat`, `FLANNEL-FWD` in `filter`) in place. Their masquerade rule SNATs cross-node pod traffic, which breaks Kubernetes `NetworkPolicy` for policy-selected pods. Because flannel is no longer running, you only need to clear the chains once. Use either method:
-
-   **Method 1: Reboot or replace nodes**
-
-   Perform a rolling reboot (drain, reboot, uncordon each node in turn), or replace the nodes if you use immutable or managed node pools. The rules do not persist across a reboot, so no work on the nodes is needed.
-
-   **Method 2: Remove the chains in place**
-
-   Run the following on every node. It takes effect immediately without disrupting workloads, covers both the legacy and nft backends, and is safe to re-run:
-
-   ```bash
-   for ipt in iptables-legacy iptables-nft ip6tables-legacy ip6tables-nft; do
-     command -v "$ipt" >/dev/null 2>&1 || continue
-     "$ipt" -w -t nat -D POSTROUTING -j FLANNEL-POSTRTG 2>/dev/null
-     "$ipt" -w -t nat -F FLANNEL-POSTRTG 2>/dev/null
-     "$ipt" -w -t nat -X FLANNEL-POSTRTG 2>/dev/null
-     "$ipt" -w -t filter -D FORWARD -j FLANNEL-FWD 2>/dev/null
-     "$ipt" -w -t filter -F FLANNEL-FWD 2>/dev/null
-     "$ipt" -w -t filter -X FLANNEL-FWD 2>/dev/null
-   done
-   ```
-
 ### Modify flannel configuration
 
 The migration controller autodetects your flannel configuration, and in most cases, does not require

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/flannel/migration-from-flannel.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/flannel/migration-from-flannel.mdx
@@ -92,6 +92,30 @@ There are two ways to switch your cluster to use $[prodname] networking. Both me
    kubectl delete -f $[manifestsUrl]/manifests/flannel-migration/migration-job.yaml
    ```
 
+1. Remove leftover flannel `iptables` rules from each node.
+
+   The migration controller deletes the flannel network devices but leaves flannel's `iptables` chains (`FLANNEL-POSTRTG` in `nat`, `FLANNEL-FWD` in `filter`) in place. Their masquerade rule SNATs cross-node pod traffic, which breaks Kubernetes `NetworkPolicy` for policy-selected pods. Because flannel is no longer running, you only need to clear the chains once. Use either method:
+
+   **Method 1: Reboot or replace nodes**
+
+   Perform a rolling reboot (drain, reboot, uncordon each node in turn), or replace the nodes if you use immutable or managed node pools. The rules do not persist across a reboot, so no work on the nodes is needed.
+
+   **Method 2: Remove the chains in place**
+
+   Run the following on every node. It takes effect immediately without disrupting workloads, covers both the legacy and nft backends, and is safe to re-run:
+
+   ```bash
+   for ipt in iptables-legacy iptables-nft ip6tables-legacy ip6tables-nft; do
+     command -v "$ipt" >/dev/null 2>&1 || continue
+     "$ipt" -w -t nat -D POSTROUTING -j FLANNEL-POSTRTG 2>/dev/null
+     "$ipt" -w -t nat -F FLANNEL-POSTRTG 2>/dev/null
+     "$ipt" -w -t nat -X FLANNEL-POSTRTG 2>/dev/null
+     "$ipt" -w -t filter -D FORWARD -j FLANNEL-FWD 2>/dev/null
+     "$ipt" -w -t filter -F FLANNEL-FWD 2>/dev/null
+     "$ipt" -w -t filter -X FLANNEL-FWD 2>/dev/null
+   done
+   ```
+
 ### Modify flannel configuration
 
 The migration controller autodetects your flannel configuration, and in most cases, does not require

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/flannel/migration-from-flannel.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/flannel/migration-from-flannel.mdx
@@ -92,6 +92,30 @@ There are two ways to switch your cluster to use $[prodname] networking. Both me
    kubectl delete -f $[manifestsUrl]/manifests/flannel-migration/migration-job.yaml
    ```
 
+1. Remove leftover flannel `iptables` rules from each node.
+
+   The migration controller deletes the flannel network devices but leaves flannel's `iptables` chains (`FLANNEL-POSTRTG` in `nat`, `FLANNEL-FWD` in `filter`) in place. Their masquerade rule SNATs cross-node pod traffic, which breaks Kubernetes `NetworkPolicy` for policy-selected pods. Because flannel is no longer running, you only need to clear the chains once. Use either method:
+
+   **Method 1: Reboot or replace nodes**
+
+   Perform a rolling reboot (drain, reboot, uncordon each node in turn), or replace the nodes if you use immutable or managed node pools. The rules do not persist across a reboot, so no work on the nodes is needed.
+
+   **Method 2: Remove the chains in place**
+
+   Run the following on every node. It takes effect immediately without disrupting workloads, covers both the legacy and nft backends, and is safe to re-run:
+
+   ```bash
+   for ipt in iptables-legacy iptables-nft ip6tables-legacy ip6tables-nft; do
+     command -v "$ipt" >/dev/null 2>&1 || continue
+     "$ipt" -w -t nat -D POSTROUTING -j FLANNEL-POSTRTG 2>/dev/null
+     "$ipt" -w -t nat -F FLANNEL-POSTRTG 2>/dev/null
+     "$ipt" -w -t nat -X FLANNEL-POSTRTG 2>/dev/null
+     "$ipt" -w -t filter -D FORWARD -j FLANNEL-FWD 2>/dev/null
+     "$ipt" -w -t filter -F FLANNEL-FWD 2>/dev/null
+     "$ipt" -w -t filter -X FLANNEL-FWD 2>/dev/null
+   done
+   ```
+
 ### Modify flannel configuration
 
 The migration controller autodetects your flannel configuration, and in most cases, does not require

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/flannel/migration-from-flannel.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/flannel/migration-from-flannel.mdx
@@ -92,6 +92,30 @@ There are two ways to switch your cluster to use $[prodname] networking. Both me
    kubectl delete -f $[manifestsUrl]/manifests/flannel-migration/migration-job.yaml
    ```
 
+1. Remove leftover flannel `iptables` rules from each node.
+
+   The migration controller deletes the flannel network devices but leaves flannel's `iptables` chains (`FLANNEL-POSTRTG` in `nat`, `FLANNEL-FWD` in `filter`) in place. Their masquerade rule SNATs cross-node pod traffic, which breaks Kubernetes `NetworkPolicy` for policy-selected pods. Because flannel is no longer running, you only need to clear the chains once. Use either method:
+
+   **Method 1: Reboot or replace nodes**
+
+   Perform a rolling reboot (drain, reboot, uncordon each node in turn), or replace the nodes if you use immutable or managed node pools. The rules do not persist across a reboot, so no work on the nodes is needed.
+
+   **Method 2: Remove the chains in place**
+
+   Run the following on every node. It takes effect immediately without disrupting workloads, covers both the legacy and nft backends, and is safe to re-run:
+
+   ```bash
+   for ipt in iptables-legacy iptables-nft ip6tables-legacy ip6tables-nft; do
+     command -v "$ipt" >/dev/null 2>&1 || continue
+     "$ipt" -w -t nat -D POSTROUTING -j FLANNEL-POSTRTG 2>/dev/null
+     "$ipt" -w -t nat -F FLANNEL-POSTRTG 2>/dev/null
+     "$ipt" -w -t nat -X FLANNEL-POSTRTG 2>/dev/null
+     "$ipt" -w -t filter -D FORWARD -j FLANNEL-FWD 2>/dev/null
+     "$ipt" -w -t filter -F FLANNEL-FWD 2>/dev/null
+     "$ipt" -w -t filter -X FLANNEL-FWD 2>/dev/null
+   done
+   ```
+
 ### Modify flannel configuration
 
 The migration controller autodetects your flannel configuration, and in most cases, does not require

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/flannel/migration-from-flannel.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/flannel/migration-from-flannel.mdx
@@ -92,6 +92,30 @@ There are two ways to switch your cluster to use $[prodname] networking. Both me
    kubectl delete -f $[manifestsUrl]/manifests/flannel-migration/migration-job.yaml
    ```
 
+1. Remove leftover flannel `iptables` rules from each node.
+
+   The migration controller deletes the flannel network devices but leaves flannel's `iptables` chains (`FLANNEL-POSTRTG` in `nat`, `FLANNEL-FWD` in `filter`) in place. Their masquerade rule SNATs cross-node pod traffic, which breaks Kubernetes `NetworkPolicy` for policy-selected pods. Because flannel is no longer running, you only need to clear the chains once. Use either method:
+
+   **Method 1: Reboot or replace nodes**
+
+   Perform a rolling reboot (drain, reboot, uncordon each node in turn), or replace the nodes if you use immutable or managed node pools. The rules do not persist across a reboot, so no work on the nodes is needed.
+
+   **Method 2: Remove the chains in place**
+
+   Run the following on every node. It takes effect immediately without disrupting workloads, covers both the legacy and nft backends, and is safe to re-run:
+
+   ```bash
+   for ipt in iptables-legacy iptables-nft ip6tables-legacy ip6tables-nft; do
+     command -v "$ipt" >/dev/null 2>&1 || continue
+     "$ipt" -w -t nat -D POSTROUTING -j FLANNEL-POSTRTG 2>/dev/null
+     "$ipt" -w -t nat -F FLANNEL-POSTRTG 2>/dev/null
+     "$ipt" -w -t nat -X FLANNEL-POSTRTG 2>/dev/null
+     "$ipt" -w -t filter -D FORWARD -j FLANNEL-FWD 2>/dev/null
+     "$ipt" -w -t filter -F FLANNEL-FWD 2>/dev/null
+     "$ipt" -w -t filter -X FLANNEL-FWD 2>/dev/null
+   done
+   ```
+
 ### Modify flannel configuration
 
 The migration controller autodetects your flannel configuration, and in most cases, does not require


### PR DESCRIPTION
### Description

The live-migration guide tells you to delete the migration controller once migration completes, but it does not mention that **flannel leaves iptables rules behind** on every node.

The migration controller removes the flannel daemonset and deletes the flannel network devices (`flannel.<vni>`, `cni0`), but it does **not** remove the iptables chains flannel programs: `FLANNEL-POSTRTG` (nat) and `FLANNEL-FWD` (filter). These survive the migration.

The masquerade rule in `FLANNEL-POSTRTG` keeps SNAT-ing **cross-node** pod-to-pod traffic to the node's tunnel IP. This is invisible until you use `NetworkPolicy`: the SNAT'd source no longer matches pod-selector rules, so Calico's default-deny drops the traffic. Symptom after an otherwise successful migration: cross-node connections to policy-selected pods silently time out, while same-node traffic keeps working.

This PR adds a cleanup step after "Delete the migration controller" with an idempotent flush command (legacy + nft backends) and a reboot alternative.

### Notes

- Applies to the current docs (`calico/...`); maintainers may want to backport to the versioned snapshots.
- A complementary controller-side fix that performs this cleanup automatically is proposed in projectcalico/calico#12920. Until that ships (and for already-migrated clusters), this manual step is needed.

### Reproduction

After migrating, on any node: `nft list chain ip nat POSTROUTING` still shows `jump FLANNEL-POSTRTG` with non-zero counters; a cross-node listener sees the client's source as the sender node's tunnel IP (`<block>.0`) rather than the pod IP, and NetworkPolicy-selected pods become unreachable cross-node.
