### PR TITLE
DE-4285: update CE 3.23 compatibility matrix (kubeadm, OpenShift, RKE2)

### DIFF
--- a/calico-enterprise/getting-started/compatibility.mdx
+++ b/calico-enterprise/getting-started/compatibility.mdx
@@ -90,7 +90,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | $[prodname] version | OpenShift versions for Kubernetes | $[prodname] support                 |
 | -------------------- | --------------------------------- | ------------------------------------ |
-| 3.23                 | 4.18 - 4.20                       | $[prodname] CNI with network policy |
+| 3.23                 | 4.19 - 4.21                       | $[prodname] CNI with network policy |
 | 3.22                 | 4.17 - 4.20                       | $[prodname] CNI with network policy |
 | 3.21                 | 4.16 - 4.18                       | $[prodname] CNI with network policy |
 | 3.20                 | 4.15 - 4.17                       | $[prodname] CNI with network policy |
@@ -108,7 +108,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | $[prodname] version | $[prodname] support                 | Kubernetes versions |
 | -------------------- | ------------------------------------ | ------------------- |
-| 3.23                 | $[prodname] CNI with network policy | 1.33 - 1.34         |
+| 3.23                 | $[prodname] CNI with network policy | 1.33 - 1.35         |
 | 3.22                 | $[prodname] CNI with network policy | 1.31 - 1.34         |
 | 3.21                 | $[prodname] CNI with network policy | 1.31 - 1.33         |
 | 3.20                 | $[prodname] CNI with network policy | 1.29 - 1.31         |

--- a/calico-enterprise_versioned_docs/version-3.23-2/getting-started/compatibility.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/getting-started/compatibility.mdx
@@ -64,7 +64,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | $[prodname] version | Kubernetes/kubeadm versions | $[prodname] support                 |
 | -------------------- | --------------------------- | ------------------------------------ |
-| 3.23                 | 1.33 - 1.35                 | $[prodname] CNI with network policy |
+| 3.23                 | 1.33 - 1.36                 | $[prodname] CNI with network policy |
 | 3.22                 | 1.31 - 1.34                 | $[prodname] CNI with network policy |
 | 3.21                 | 1.31 - 1.33                 | $[prodname] CNI with network policy |
 | 3.20                 | 1.29 - 1.31                 | $[prodname] CNI with network policy |
@@ -90,7 +90,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | $[prodname] version | OpenShift versions for Kubernetes | $[prodname] support                 |
 | -------------------- | --------------------------------- | ------------------------------------ |
-| 3.23                 | 4.18 - 4.20                       | $[prodname] CNI with network policy |
+| 3.23                 | 4.19 - 4.21                       | $[prodname] CNI with network policy |
 | 3.22                 | 4.17 - 4.20                       | $[prodname] CNI with network policy |
 | 3.21                 | 4.16 - 4.18                       | $[prodname] CNI with network policy |
 | 3.20                 | 4.15 - 4.17                       | $[prodname] CNI with network policy |
@@ -108,7 +108,7 @@ Kubernetes version support aligns with [upstream Kubernetes](#kubernetes-kubeadm
 
 | $[prodname] version | $[prodname] support                 | Kubernetes versions |
 | -------------------- | ------------------------------------ | ------------------- |
-| 3.23                 | $[prodname] CNI with network policy | 1.33 - 1.34         |
+| 3.23                 | $[prodname] CNI with network policy | 1.33 - 1.35         |
 | 3.22                 | $[prodname] CNI with network policy | 1.31 - 1.34         |
 | 3.21                 | $[prodname] CNI with network policy | 1.31 - 1.33         |
 | 3.20                 | $[prodname] CNI with network policy | 1.29 - 1.31         |


### PR DESCRIPTION
## What

Update the **Calico Enterprise 3.23** rows in the compatibility matrix:

| Section | Before | After |
|---|---|---|
| Kubernetes-kubeadm | 1.33 - 1.35 | **1.33 - 1.36** |
| OpenShift | 4.18 - 4.20 | **4.19 - 4.21** |
| RKE2 | 1.33 - 1.34 | **1.33 - 1.35** |

## Where

- `calico-enterprise_versioned_docs/version-3.23-2/getting-started/compatibility.mdx` (kubeadm + OpenShift + RKE2)
- `calico-enterprise/getting-started/compatibility.mdx` — current/non-versioned (OpenShift + RKE2; kubeadm was already 1.33 - 1.36)

Only the 3.23 rows changed; table alignment preserved. Other 3.23 entries (kOps, MKE, RKE, Charmed Kubernetes) were left unchanged.

Jira: DE-4285