### PR TITLE
release-notes(3.23-2): add Multi-VRF, KubeVirt live migration, v3 native CRDs as TP

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -110,6 +110,9 @@ The following features are available as technology previews. Tech preview featur
 | [Istio Ambient Mode](../compliance/istio/about-istio-ambient.mdx) | – | TP | TP |
 | [Built-in observability dashboards](../observability/dashboards.mdx) | – | TP | TP |
 | [Calico Ingress Gateway](../networking/ingress-gateway/about-calico-ingress-gateway.mdx) | TP | GA | GA |
+| [KubeVirt live migration](../networking/kubevirt/index.mdx) | – | – | TP |
+| [Multi-VRF](../networking/configuring/multi-vrf.mdx) | – | – | TP |
+| [v3 native CRDs](../operations/native-v3-crds.mdx) | – | – | TP |
 
 Legend: **TP** = technology preview · **GA** = generally available · **–** = not yet introduced.
 

--- a/calico-enterprise_versioned_docs/version-3.23-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.23-2/releases.json
@@ -7,7 +7,7 @@
       "registry": "quay.io"
     },
     "calico": {
-      "minor_version": "v3.31",
+      "minor_version": "v3.32",
       "archive_path": "archive"
     },
     "components": {


### PR DESCRIPTION
## What

Add three technology-preview features to the **Calico Enterprise 3.23-2** release notes Technology Preview table. Each is **TP** in 3.23 and not yet introduced (`–`) in 3.21/3.22:

| Feature | 3.21 | 3.22 | 3.23 |
|---|---|---|---|
| KubeVirt live migration | – | – | TP |
| Multi-VRF | – | – | TP |
| v3 native CRDs | – | – | TP |

## Where

- `calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx`

Links resolve to:
- KubeVirt: `networking/kubevirt/`
- Multi-VRF: `networking/configuring/multi-vrf`
- v3 native CRDs: `operations/native-v3-crds`