### PR TITLE
release-notes(3.23-2): add Multi-VRF networking feature write-up

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -53,6 +53,14 @@ This lets platform teams drain nodes for upgrades, repairs, or capacity changes 
 
 For more information, see [Mark a load balancer node for maintenance](../networking/configuring/mark-lb-node-for-maintenance.mdx).
 
+### Multi-VRF networking (tech preview)
+
+You can now attach pods to one or more virtual routing and forwarding (VRF) domains. Traffic from a VRF-attached pod is routed in a dedicated routing table on the node, peered with a dedicated upstream fabric over BGP, and isolated from pods on other VRFs and from the default flat pod network.
+
+Use this to reach tenant networks that have overlapping external IPs, to enforce an in-cluster routing boundary between tenants, or to map workloads onto an existing multi-tenant fabric. The nftables data plane is required, and a pod can be attached to up to nine VRFs.
+
+For more information, see [Configure multi-VRF networking](../networking/configuring/multi-vrf.mdx).
+
 {/* End 3.23.0-2.0 features */}
 
 {/* Start 3.23.0-1.0 features */}
@@ -111,7 +119,7 @@ The following features are available as technology previews. Tech preview featur
 | [Built-in observability dashboards](../observability/dashboards.mdx) | – | TP | TP |
 | [Calico Ingress Gateway](../networking/ingress-gateway/about-calico-ingress-gateway.mdx) | TP | GA | GA |
 | [KubeVirt live migration](../networking/kubevirt/index.mdx) | – | – | TP |
-| [Multi-VRF](../networking/configuring/multi-vrf.mdx) | – | – | TP |
+| [Multi-VRF networking](../networking/configuring/multi-vrf.mdx) | – | – | TP |
 | [v3 native CRDs](../operations/native-v3-crds.mdx) | – | – | TP |
 
 Legend: **TP** = technology preview · **GA** = generally available · **–** = not yet introduced.


### PR DESCRIPTION
## Summary

- Adds a tech-preview feature write-up for Multi-VRF networking under the 3.23.0-2.0 features block in the CE 3.23-2 release notes.
- Renames the existing TP table row from "Multi-VRF" to "Multi-VRF networking" so the heading and table label match.

Tracked by PMREQ-812 (Multi-VRF Support, CE 3.23 EP2).

## Test plan

- [ ] Local docs build renders the new section under 3.23.0-2.0 features
- [ ] TP table contains a single "Multi-VRF networking" row
- [ ] Link to `multi-vrf.mdx` resolves in the versioned 3.23-2 site

🤖 Generated with [Claude Code](https://claude.com/claude-code)