### PR TITLE
release-notes(3.23-2): add Native v3 CRDs feature write-up

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -61,6 +61,19 @@ Use this to reach tenant networks that have overlapping external IPs, to enforce
 
 For more information, see [Configure multi-VRF networking](../networking/configuring/multi-vrf.mdx).
 
+### Native v3 CRDs (tech preview)
+
+$[prodname] now supports installation with native `projectcalico.org/v3` CRDs as an alternative to the aggregated API server.
+The Tigera Operator registers `projectcalico.org/v3` resources directly as native Kubernetes CRDs — no host-network pods, no ordering dependencies between CRDs and the API server, and `kubectl` manages v3 resources without an extra install step.
+This removes a long-standing source of installation friction on managed Kubernetes platforms like EKS and AKS.
+For existing clusters, a new `DatastoreMigration` controller copies resources from the aggregated API server to native CRDs in place; the datastore is briefly locked but workload connectivity is preserved through the migration window.
+
+Native v3 CRDs require Kubernetes 1.34 or later with the `MutatingAdmissionPolicy` feature gate enabled. The gate is GA and on by default in Kubernetes 1.36; on 1.34 and 1.35 it must be enabled explicitly on the API server.
+
+This is the first phase of phasing out the aggregated API server: in a future release, native v3 CRDs will become the default install mode, and in a later release the aggregated API server will be removed entirely.
+
+For more information, see [Enable native v3 CRDs](../operations/native-v3-crds.mdx) and [Migrate from API server to native CRDs](../operations/crd-migration.mdx).
+
 {/* End 3.23.0-2.0 features */}
 
 {/* Start 3.23.0-1.0 features */}
@@ -120,7 +133,7 @@ The following features are available as technology previews. Tech preview featur
 | [Calico Ingress Gateway](../networking/ingress-gateway/about-calico-ingress-gateway.mdx) | TP | GA | GA |
 | [KubeVirt live migration](../networking/kubevirt/index.mdx) | – | – | TP |
 | [Multi-VRF networking](../networking/configuring/multi-vrf.mdx) | – | – | TP |
-| [v3 native CRDs](../operations/native-v3-crds.mdx) | – | – | TP |
+| [Native v3 CRDs](../operations/native-v3-crds.mdx) | – | – | TP |
 
 Legend: **TP** = technology preview · **GA** = generally available · **–** = not yet introduced.
 


### PR DESCRIPTION
## Summary

- Add a tech-preview feature entry for native `projectcalico.org/v3` CRDs to the CE 3.23.0-2.0 release notes, mirroring the OSS Calico 3.32 release note for the same feature ([calico#10447](https://github.com/projectcalico/calico/pull/10447), @caseydavenport).
- Adapt the K8s prerequisite wording to reflect the CE 3.23-2 docs, which require Kubernetes 1.34+ with the `MutatingAdmissionPolicy` feature gate enabled.
- Link to the existing CE docs at `operations/native-v3-crds.mdx` and `operations/crd-migration.mdx`.
- Normalize the tech-preview table row label from "v3 native CRDs" to "Native v3 CRDs" so the table and the new heading match.

Context: Phil suggested in Slack that the API server change in OSS 3.32 deserves a special call-out in the Enterprise release notes; this PR adds that call-out as the Native v3 CRDs feature write-up.

## Test plan

- [ ] Render the 3.23-2 release notes page locally and confirm the new section appears under the 3.23.0-2.0 features block.
- [ ] Confirm both `Enable native v3 CRDs` and `Migrate from API server to native CRDs` links resolve.
- [ ] Confirm the TP table row label change does not break any anchor links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)