### PR TITLE
update v3.23.0-2.0: Operator version; helm pull for pre-release

### DIFF
--- a/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -35,8 +35,8 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 ```bash
 helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[releaseTitle]
-helm pull tigera-ee/crd.projectcalico.org.v1 --version $[releaseTitle]
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]$[helmPre]
+helm pull tigera-ee/crd.projectcalico.org.v1 --version $[releaseTitle]$[helmPre]
 ```
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -35,8 +35,8 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 ```bash
 helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[releaseTitle]
-helm pull tigera-ee/crd.projectcalico.org.v1 --version $[releaseTitle]
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]$[helmPre]
+helm pull tigera-ee/crd.projectcalico.org.v1 --version $[releaseTitle]$[helmPre]
 ```
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise/variables.js
+++ b/calico-enterprise/variables.js
@@ -3,6 +3,7 @@ const componentImage = require('../src/components/utils/componentImage');
 
 const variables = {
   releaseTitle: 'master',
+  helmPre: 'master'.includes('-') ? ' --devel' : '',
   prodname: 'Calico Enterprise',
   prodnamedash: 'calico-enterprise',
   version: 'master',

--- a/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -35,8 +35,8 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 ```bash
 helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[releaseTitle]
-helm pull tigera-ee/crd.projectcalico.org.v1 --version $[releaseTitle]
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]$[helmPre]
+helm pull tigera-ee/crd.projectcalico.org.v1 --version $[releaseTitle]$[helmPre]
 ```
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.23-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -35,8 +35,8 @@ In this guide, you install the Tigera Calico operator and custom resource defini
 ```bash
 helm repo add tigera-ee https://downloads.tigera.io/ee/charts
 helm repo update
-helm pull tigera-ee/tigera-operator --version $[releaseTitle]
-helm pull tigera-ee/crd.projectcalico.org.v1 --version $[releaseTitle]
+helm pull tigera-ee/tigera-operator --version $[releaseTitle]$[helmPre]
+helm pull tigera-ee/crd.projectcalico.org.v1 --version $[releaseTitle]$[helmPre]
 ```
 
 ### Prepare the Installation Configuration

--- a/calico-enterprise_versioned_docs/version-3.23-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.23-2/releases.json
@@ -2,7 +2,7 @@
   {
     "title": "v3.23.0-2.0",
     "tigera-operator": {
-      "version": "v1.42.1",
+      "version": "v1.42.2",
       "image": "tigera/operator",
       "registry": "quay.io"
     },

--- a/calico-enterprise_versioned_docs/version-3.23-2/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.23-2/variables.js
@@ -3,6 +3,7 @@ const componentImage = require('../../src/components/utils/componentImage');
 
 const variables = {
   releaseTitle: 'v3.23.0-2.0',
+  helmPre: 'v3.23.0-2.0'.includes('-') ? ' --devel' : '',
   prodname: 'Calico Enterprise',
   prodnamedash: 'calico-enterprise',
   version: 'v3.23',
@@ -21,7 +22,7 @@ const variables = {
   rootDirWindows: 'C:\\TigeraCalico',
   registry: 'quay.io/',
   envoyVersion: '1.5.0',
-  chart_version_name: 'v3.23.0-2.0-1',
+  chart_version_name: 'v3.23.0-2.0-0',
   tigeraOperator: releases[0]['tigera-operator'],
   dikastesVersion: releases[0].components.dikastes.version,
   releases,


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s): v3.23.0-2.0
Issue: Update operator version to v1.42.2

Updates the operator to v1.42.2 and appends `--devel` to the `helm pull` commands
so the pre-release charts resolve (the `-2.0` suffix makes them SemVer pre-releases,
which `helm pull` filters by default). Driven by a computed `helmPre` in variables.js.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->