### PR TITLE
test(crawler): skip 503ing amd64.ocp.releases.ci.openshift.org

### DIFF
--- a/__tests__/crawler.test.js
+++ b/__tests__/crawler.test.js
@@ -100,6 +100,7 @@ test('Crawl the docs and execute tests', async () => {
     'http://dpdk.org/git/dpdk-kmods', //==>Origin: https://raw.githubusercontent.com/projectcalico/vpp-dataplane/master/scripts/init_eks.sh
     //For frustrating 503 errors:
     'https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator',
+    /^https:\/\/amd64\.ocp\.releases\.ci\.openshift\.org\/?$/, //==>Origin: http://localhost:4242/calico-enterprise/latest/getting-started/install-on-clusters/openshift/hostedcontrolplanes
     //temp
     /^https:\/\/v1-21\.docs\.kubernetes\.io\/docs\/reference\/generated\/kubernetes-api\/v1\.21\//,
     'https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm',


### PR DESCRIPTION
## Summary
- Production deploy [6a2bb09c](https://app.netlify.com/projects/tigera/deploys/6a2bb09c2451a3000848e586) is failing on dead-link checks for `https://amd64.ocp.releases.ci.openshift.org` (and `/` variant), both returning 503 from the upstream OpenShift CI service.
- Origin page: `calico-enterprise/latest/getting-started/install-on-clusters/openshift/hostedcontrolplanes`.
- Adds a regex skip entry in the existing 503-skip group in `__tests__/crawler.test.js` so deploys can proceed.

## Test plan
- [ ] Verify production Netlify build succeeds with this change
- [ ] Revisit the skip once `amd64.ocp.releases.ci.openshift.org` is stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)