### PR TITLE
DOCS-2961: Publish Calico Enterprise 3.22.6

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -365,7 +365,7 @@ May 6, 2026
 
 To update an existing installation of Calico Enterprise 3.22, see [Install a patch release](../getting-started/manifest-archive.mdx).
 
-### Calico Enterprise 3.22.5
+### Calico Enterprise 3.22.5 bug fix release
 
 May 20, 2026
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -382,12 +382,13 @@ May 20, 2026
 
 To update an existing installation of Calico Enterprise 3.22, see [Install a patch release](../getting-started/manifest-archive.mdx).
 
-### Calico Enterprise 3.22.6
+### Calico Enterprise 3.22.6 bug fix release
 
 June 17, 2026
 
 #### Bug fixes
 
+* Fixed an RBAC error that could prevent the operator from creating secrets in the `tigera-manager` namespace on fresh installs with the `Authentication` resource configured.
 * Security updates.
 
 To update an existing installation of Calico Enterprise 3.22, see [Install a patch release](../getting-started/manifest-archive.mdx).

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -388,6 +388,6 @@ June 15, 2026
 
 #### Bug fixes
 
-* TBD
+* Security updates.
 
 To update an existing installation of Calico Enterprise 3.22, see [Install a patch release](../getting-started/manifest-archive.mdx).

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -384,7 +384,7 @@ To update an existing installation of Calico Enterprise 3.22, see [Install a pat
 
 ### Calico Enterprise 3.22.6
 
-June 15, 2026
+June 17, 2026
 
 #### Bug fixes
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -381,3 +381,13 @@ May 20, 2026
 * Fixes an issue where Felix makes unnecessary calls to nft when running in iptables mode.
 
 To update an existing installation of Calico Enterprise 3.22, see [Install a patch release](../getting-started/manifest-archive.mdx).
+
+### Calico Enterprise 3.22.6
+
+June 15, 2026
+
+#### Bug fixes
+
+* TBD
+
+To update an existing installation of Calico Enterprise 3.22, see [Install a patch release](../getting-started/manifest-archive.mdx).

--- a/calico-enterprise_versioned_docs/version-3.22-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.22-2/releases.json
@@ -1,5 +1,289 @@
 [
   {
+    "title": "v3.22.6",
+    "tigera-operator": {
+      "version": "v1.40.11",
+      "image": "tigera/operator",
+      "registry": "quay.io"
+    },
+    "calico": {
+      "minor_version": "v3.31",
+      "archive_path": "archive"
+    },
+    "components": {
+      "alertmanager": {
+        "version": "v3.22.6",
+        "image": "tigera/alertmanager"
+      },
+      "apiserver": {
+        "version": "v3.22.6",
+        "image": "tigera/apiserver"
+      },
+      "calicoctl": {
+        "version": "v3.22.6",
+        "image": "tigera/calicoctl"
+      },
+      "calicoq": {
+        "version": "v3.22.6",
+        "image": "tigera/calicoq"
+      },
+      "compliance-benchmarker": {
+        "version": "v3.22.6",
+        "image": "tigera/compliance-benchmarker"
+      },
+      "compliance-controller": {
+        "version": "v3.22.6",
+        "image": "tigera/compliance-controller"
+      },
+      "compliance-reporter": {
+        "version": "v3.22.6",
+        "image": "tigera/compliance-reporter"
+      },
+      "compliance-server": {
+        "version": "v3.22.6",
+        "image": "tigera/compliance-server"
+      },
+      "compliance-snapshotter": {
+        "version": "v3.22.6",
+        "image": "tigera/compliance-snapshotter"
+      },
+      "coreos-alertmanager": {
+        "version": "v0.32.0"
+      },
+      "coreos-config-reloader": {
+        "version": "v0.90.1"
+      },
+      "coreos-dex": {
+        "version": "v2.45.1"
+      },
+      "coreos-fluentd": {
+        "version": "1.19.2"
+      },
+      "coreos-prometheus": {
+        "version": "v3.11.1"
+      },
+      "coreos-prometheus-operator": {
+        "version": "v0.90.1"
+      },
+      "csi": {
+        "version": "v3.22.6",
+        "image": "tigera/csi"
+      },
+      "csi-node-driver-registrar": {
+        "version": "v3.22.6",
+        "image": "tigera/node-driver-registrar"
+      },
+      "deep-packet-inspection": {
+        "version": "v3.22.6",
+        "image": "tigera/deep-packet-inspection"
+      },
+      "dex": {
+        "version": "v3.22.6",
+        "image": "tigera/dex"
+      },
+      "dikastes": {
+        "version": "v3.22.6",
+        "image": "tigera/dikastes"
+      },
+      "eck-elasticsearch": {
+        "version": "8.19.15"
+      },
+      "eck-elasticsearch-operator": {
+        "version": "2.16.1"
+      },
+      "eck-kibana": {
+        "version": "8.19.15"
+      },
+      "egress-gateway": {
+        "version": "v3.22.6",
+        "image": "tigera/egress-gateway"
+      },
+      "elastic-tsee-installer": {
+        "version": "v3.22.6",
+        "image": "tigera/intrusion-detection-job-installer"
+      },
+      "elasticsearch": {
+        "version": "v3.22.6",
+        "image": "tigera/elasticsearch"
+      },
+      "elasticsearch-metrics": {
+        "version": "v3.22.6",
+        "image": "tigera/elasticsearch-metrics"
+      },
+      "elasticsearch-operator": {
+        "version": "v3.22.6",
+        "image": "tigera/eck-operator"
+      },
+      "envoy": {
+        "version": "v3.22.6",
+        "image": "tigera/envoy"
+      },
+      "es-gateway": {
+        "version": "v3.22.6",
+        "image": "tigera/es-gateway"
+      },
+      "firewall-integration": {
+        "version": "v3.22.6",
+        "image": "tigera/firewall-integration"
+      },
+      "flexvol": {
+        "version": "v3.22.6",
+        "image": "tigera/pod2daemon-flexvol"
+      },
+      "fluentd": {
+        "version": "v3.22.6",
+        "image": "tigera/fluentd"
+      },
+      "fluentd-windows": {
+        "version": "v3.22.6",
+        "image": "tigera/fluentd-windows"
+      },
+      "gateway-api-envoy-gateway": {
+        "version": "v3.22.6",
+        "image": "tigera/envoy-gateway"
+      },
+      "gateway-api-envoy-proxy": {
+        "version": "v3.22.6",
+        "image": "tigera/envoy-proxy"
+      },
+      "gateway-api-envoy-ratelimit": {
+        "version": "v3.22.6",
+        "image": "tigera/envoy-ratelimit"
+      },
+      "gateway-l7-collector": {
+        "version": "v3.22.6",
+        "image": "tigera/gateway-l7-collector"
+      },
+      "guardian": {
+        "version": "v3.22.6",
+        "image": "tigera/guardian"
+      },
+      "ingress-collector": {
+        "version": "v3.22.6",
+        "image": "tigera/ingress-collector"
+      },
+      "intrusion-detection-controller": {
+        "version": "v3.22.6",
+        "image": "tigera/intrusion-detection-controller"
+      },
+      "istio-install-cni": {
+        "version": "v3.22.6",
+        "image": "tigera/istio-install-cni"
+      },
+      "istio-pilot": {
+        "version": "v3.22.6",
+        "image": "tigera/istio-pilot"
+      },
+      "istio-proxyv2": {
+        "version": "v3.22.6",
+        "image": "tigera/istio-proxyv2"
+      },
+      "istio-ztunnel": {
+        "version": "v3.22.6",
+        "image": "tigera/istio-ztunnel"
+      },
+      "key-cert-provisioner": {
+        "version": "v3.22.6",
+        "image": "tigera/key-cert-provisioner"
+      },
+      "kibana": {
+        "version": "v3.22.6",
+        "image": "tigera/kibana"
+      },
+      "kube-controllers": {
+        "version": "v3.22.6",
+        "image": "tigera/kube-controllers"
+      },
+      "l7-admission-controller": {
+        "version": "v3.22.6",
+        "image": "tigera/l7-admission-controller"
+      },
+      "l7-collector": {
+        "version": "v3.22.6",
+        "image": "tigera/l7-collector"
+      },
+      "license-agent": {
+        "version": "v3.22.6",
+        "image": "tigera/license-agent"
+      },
+      "linseed": {
+        "version": "v3.22.6",
+        "image": "tigera/linseed"
+      },
+      "manager": {
+        "version": "v3.22.6",
+        "image": "tigera/manager"
+      },
+      "node": {
+        "version": "v3.22.6",
+        "image": "tigera/node"
+      },
+      "node-windows": {
+        "version": "v3.22.6",
+        "image": "tigera/node-windows"
+      },
+      "packetcapture": {
+        "version": "v3.22.6",
+        "image": "tigera/packetcapture"
+      },
+      "policy-recommendation": {
+        "version": "v3.22.6",
+        "image": "tigera/policy-recommendation"
+      },
+      "prometheus": {
+        "version": "v3.22.6",
+        "image": "tigera/prometheus"
+      },
+      "prometheus-config-reloader": {
+        "version": "v3.22.6",
+        "image": "tigera/prometheus-config-reloader"
+      },
+      "prometheus-operator": {
+        "version": "v3.22.6",
+        "image": "tigera/prometheus-operator"
+      },
+      "queryserver": {
+        "version": "v3.22.6",
+        "image": "tigera/queryserver"
+      },
+      "tigera-cni": {
+        "version": "v3.22.6",
+        "image": "tigera/cni"
+      },
+      "tigera-cni-windows": {
+        "version": "v3.22.6",
+        "image": "tigera/cni-windows"
+      },
+      "tigera-prometheus-service": {
+        "version": "v3.22.6",
+        "image": "tigera/prometheus-service"
+      },
+      "typha": {
+        "version": "v3.22.6",
+        "image": "tigera/typha"
+      },
+      "ui-apis": {
+        "version": "v3.22.6",
+        "image": "tigera/ui-apis"
+      },
+      "upstream-istio": {
+        "version": "1.28.1"
+      },
+      "voltron": {
+        "version": "v3.22.6",
+        "image": "tigera/voltron"
+      },
+      "waf-http-filter": {
+        "version": "v3.22.6",
+        "image": "tigera/waf-http-filter"
+      },
+      "webhooks-processor": {
+        "version": "v3.22.6",
+        "image": "tigera/webhooks-processor"
+      }
+    }
+  },
+  {
     "title": "v3.22.5",
     "tigera-operator": {
       "version": "v1.40.11",

--- a/calico-enterprise_versioned_docs/version-3.22-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.22-2/releases.json
@@ -2,7 +2,7 @@
   {
     "title": "v3.22.6",
     "tigera-operator": {
-      "version": "v1.40.11",
+      "version": "v1.40.12",
       "image": "tigera/operator",
       "registry": "quay.io"
     },

--- a/calico-enterprise_versioned_docs/version-3.22-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.22-2/releases.json
@@ -86,13 +86,13 @@
         "image": "tigera/dikastes"
       },
       "eck-elasticsearch": {
-        "version": "8.19.15"
+        "version": "8.19.16"
       },
       "eck-elasticsearch-operator": {
         "version": "2.16.1"
       },
       "eck-kibana": {
-        "version": "8.19.15"
+        "version": "8.19.16"
       },
       "egress-gateway": {
         "version": "v3.22.6",

--- a/calico-enterprise_versioned_docs/version-3.22-2/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.22-2/variables.js
@@ -2,13 +2,13 @@ const releases = require('./releases.json');
 const componentImage = require('../../src/components/utils/componentImage');
 
 const variables = {
-  releaseTitle: 'v3.22.5',
+  releaseTitle: 'v3.22.6',
   prodname: 'Calico Enterprise',
   prodnamedash: 'calico-enterprise',
   version: 'v3.22',
   openSourceVersion: releases[0].calico.minor_version.slice(1),
   baseUrl: '/calico-enterprise/latest',
-  filesUrl: 'https://downloads.tigera.io/ee/v3.22.5',
+  filesUrl: 'https://downloads.tigera.io/ee/v3.22.6',
   rpmsUrl: 'https://downloads.tigera.io/ee/rpms/' + releases[0].title.slice(0, 5),
   tutorialFilesURL: 'https://docs.tigera.io/files',
   tmpScriptsURL: 'https://docs.tigera.io/calico-enterprise/3.22',
@@ -20,7 +20,7 @@ const variables = {
   rootDirWindows: 'C:\\TigeraCalico',
   registry: 'quay.io/',
   envoyVersion: '1.5.0',
-  chart_version_name: 'v3.22.5-0',
+  chart_version_name: 'v3.22.6-0',
   tigeraOperator: releases[0]['tigera-operator'],
   dikastesVersion: releases[0].components.dikastes.version,
   releases,


### PR DESCRIPTION
## Summary

- Scaffolding for Calico Enterprise 3.22.6 patch release (target: June 15, 2026)
- Adds placeholder release notes entry dated June 15, 2026
- Bumps `releaseTitle`, `filesUrl`, and `chart_version_name` to v3.22.6 in `variables.js`
- Prepends new v3.22.6 entry to `releases.json` (component versions copied from v3.22.5)
- Operator number left as-is, will be updated when actual release content lands

Tracks [DOCS-2961](https://tigera.atlassian.net/browse/DOCS-2961).

## Test plan

- [ ] Replace placeholder bug fixes with actual release notes before merge
- [ ] Update component versions in `releases.json` if any differ from the v3.22.5 copy
- [ ] Update operator version when known
- [ ] Verify site build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-2961]: https://tigera.atlassian.net/browse/DOCS-2961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ