### PR TITLE
DOCS-2905: Publish Calico Open Source 3.32.1

### DIFF
--- a/calico_versioned_docs/version-3.32/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.32/release-notes/index.mdx
@@ -243,8 +243,45 @@ Calico Open Source release 3.32.0 is now generally available.
 
 To update a previous version of Calico, see [our upgrade guides](../operations/upgrading/index.mdx).
 
-{/*
 ### Calico Open Source 3.32.1 bug fix release
+
+24 Jun 2026
+
+#### Bug fixes
+
+- HELM: Fixes the tigera-operator chart install instructions, which omitted the step to install Calico CRDs from the separate crd.projectcalico.org.v1 chart. [calico 13043](https://github.com/projectcalico/calico/pull/13043) (@caseydavenport)
+- Fix manifest-based installs missing kubevirt.io RBAC rules on the calico-cni-plugin and calico-kube-controllers ClusterRoles, which caused KubeVirt VM networking and IPAM garbage collection failures. [calico 12996](https://github.com/projectcalico/calico/pull/12996) (@song-jiang)
+- Fixed a bug where Felix's periodic route resync did not detect (and repair) Calico-owned routes that had been modified in place by another process. Fixed unnecessary reprogramming of unchanged IPv6 multi-path routes on resync, and a corner case where removing an IPAM block route could trigger a spurious conntrack cleanup for a workload owning the block's network address. [calico 12958](https://github.com/projectcalico/calico/pull/12958) (@fasaxc)
+- [v3.32] fix(felix): exclude LB-only IPPools from BPF in-pool route flag [calico 12953](https://github.com/projectcalico/calico/pull/12953) (@defo89)
+- Fixes a NotFound error when using server-side apply (including Helm 4) to create Calico network policies that don't already exist. [calico 12906](https://github.com/projectcalico/calico/pull/12906) (@caseydavenport)
+- Fixes a bug in the eBPF dataplane in which deleting and restoring the local Node resource and restarting Felix could leave the node unable to handle network traffic. [calico 12874](https://github.com/projectcalico/calico/pull/12874) (@tomastigera)
+- Fix SNAT being skipped for traffic destined to LoadBalancer-only IPPools by excluding them from the all-ipam-pools ipset. [calico 12858](https://github.com/projectcalico/calico/pull/12858) (@defo89)
+- ebpf - Fix kube-proxy losing the NodePort externalTrafficPolicy=Local route-fixup trigger after a syncer swap, which could cause stale NAT entries on remote backends. [calico 12743](https://github.com/projectcalico/calico/pull/12743) (@tomastigera)
+- Fixes nft binary segfaults in calico/node and the Istio CNI install image when newer nftables is in use elsewhere on the host. [calico 12712](https://github.com/projectcalico/calico/pull/12712) (@caseydavenport)
+- Fixed a regression introduced in v3.30 where `RouteSyncDisabled` flag was not being honored by `LinkAddressManager`. [calico 12707](https://github.com/projectcalico/calico/pull/12707) (@mazdakn)
+- Fix server-side apply (FluxCD, ArgoCD, `kubectl apply --server-side`) failures on BGPConfiguration resources that set serviceLoadBalancerIPs, serviceExternalIPs, serviceClusterIPs, communities, or prefixAdvertisements. [calico 12705](https://github.com/projectcalico/calico/pull/12705) (@caseydavenport)
+- ebpf - Fix transient NodePort connection failures when Felix restarts on a node receiving external NodePort traffic. [calico 12694](https://github.com/projectcalico/calico/pull/12694) (@tomastigera)
+- Fixes a Felix panic that could occur when an IP set selector matched both a NetworkSet CIDR and workload IPs contained within it, with nftables as the active dataplane. [calico 12671](https://github.com/projectcalico/calico/pull/12671) (@caseydavenport)
+- Fix that certain internal API key types were non-comparable, requiring workarounds in various places. [calico 11958](https://github.com/projectcalico/calico/pull/11958) (@fasaxc)
+- Fix panic in calico/node on s390x architecture. [calico 11312](https://github.com/projectcalico/calico/pull/11312) (@vivkong)
+
+#### Other changes
+
+- Bump bundled third-party images (Envoy Gateway to v1.8.0, Envoy proxy, Envoy ratelimit, node-driver-registrar, Istio to 1.29.4) and their golang.org/x and spdystream dependencies to remediate CVE-2026-33814 and CVE-2026-35469. [calico 13030](https://github.com/projectcalico/calico/pull/13030) (@lucastigera)
+- Prevent deletion of built-in tiers in CRD mode. [calico 12982](https://github.com/projectcalico/calico/pull/12982) (@caseydavenport)
+- calico/node now refreshes the CNI plugin's kubeconfig immediately when the pod's projected ServiceAccount token is rotated, closing a 6-12h window where an externally-invalidated token could cause CNI ADD to fail with "Unauthorized" until the calico-node pod was restarted. [calico 12940](https://github.com/projectcalico/calico/pull/12940) (@skoryk-oleksandr)
+- HELM: Detect the served MutatingAdmissionPolicy API version and render MutatingAdmissionPolicy/MutatingAdmissionPolicyBinding accordingly (v1 on Kubernetes 1.36+, v1alpha1 when only the alpha API is served), defaulting to v1beta1. [calico 12877](https://github.com/projectcalico/calico/pull/12877) (@caseydavenport)
+- Support CGO Enabled builds for ppc64le [calico 12768](https://github.com/projectcalico/calico/pull/12768) (@kishen-v)
+- kube-controllers, goldmane: use default secure pprof server (localhost only). Use `kubectl port-forward` for remote access. [calico 12633](https://github.com/projectcalico/calico/pull/12633) (@Behnam-Shobiri)
+- Felix: reduce memory used for handling Typha reconnection.  Avoid converting all datastore keys to string, store the already-used key structs instead. [calico 11947](https://github.com/projectcalico/calico/pull/11947) (@fasaxc)
+- Deprecating HostMetadataUpdate, HostMetadataRemove, HostMetadataV6Update, and HostMetadataV6Remove internal protobuf messages in favor of HostMedataV4V6Update and HostMetadaV4V6 messages. [calico 11284](https://github.com/projectcalico/calico/pull/11284) (@mazdakn)
+
+#### Updating
+
+To update a previous version of Calico, see [our upgrade guides](../operations/upgrading/index.mdx).
+
+{/*
+### Calico Open Source 3.32.2 bug fix release
 
 DD MMMM YYYY
 

--- a/calico_versioned_docs/version-3.32/releases.json
+++ b/calico_versioned_docs/version-3.32/releases.json
@@ -1,4 +1,102 @@
 [
+    {
+    "title": "v3.32.1",
+    "tigera-operator": {
+      "image": "tigera/operator",
+      "registry": "quay.io",
+      "version": "v1.42.3"
+    },
+    "components": {
+      "calico/typha": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "calico/ctl": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "calico/node": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "calico/node-windows": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "calico/cni": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "calico/cni-windows": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "calico/apiserver": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "calico/kube-controllers": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "calico/envoy-gateway": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "calico/envoy-proxy": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "calico/envoy-ratelimit": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "calico/flannel-migration-controller": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "flannel": {
+        "version": "v0.24.4",
+        "registry": "docker.io"
+      },
+      "calico/dikastes": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "flexvol": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "calico/csi": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "calico/node-driver-registrar": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "calico/pod2daemon-flexvol": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "calico/key-cert-provisioner": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "calico/goldmane": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "calico/whisker": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      },
+      "calico/whisker-backend": {
+        "version": "v3.32.1",
+        "registry": "quay.io"
+      }
+    }
+  },
   {
     "title": "v3.32.0",
     "tigera-operator": {

--- a/calico_versioned_docs/version-3.32/variables.js
+++ b/calico_versioned_docs/version-3.32/variables.js
@@ -1,7 +1,7 @@
 const releases = require('./releases.json');
 
 const variables = {
-  releaseTitle: 'v3.32.0',
+  releaseTitle: 'v3.32.1',
   prodname: 'Calico',
   prodnamedash: 'calico',
   version: 'v3.32',
@@ -16,11 +16,11 @@ const variables = {
   noderunning: 'calico-node',
   rootDirWindows: 'C:\\CalicoWindows',
   ppa_repo_name: 'calico-3.32',
-  manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.32.0',
+  manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.32.1',
   releases,
   registry: '',
   vppbranch: 'v3.32.0',
-  envoyVersion: '1.5.6',
+  envoyVersion: '1.8.0',
   tigeraOperator: releases[0]['tigera-operator'],
   tigeraOperatorVersionShort: releases[0]['tigera-operator'].version.split('.').slice(0, 2).join('.'),
   imageNames: {


### PR DESCRIPTION
## Summary

- Scaffolding for Calico Open Source 3.32.1 patch release (target: June 17, 2026)
- Adds placeholder release notes entry dated June 17, 2026
- Bumps `releaseTitle` and `manifestsUrl` to v3.32.1 in `variables.js`
- Prepends new v3.32.1 entry to `releases.json` (component versions copied from v3.31.5)
- Operator number left as-is, will be updated when actual release content lands

Tracks [DOCS-2905](https://tigera.atlassian.net/browse/DOCS-2905).

## Test plan

- [ ] Replace placeholder bug fixes with actual release notes before merge
- [ ] Update component versions in `releases.json` if any differ from the v3.31.5 copy
- [ ] Update operator version when known
- [ ] Verify site build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-2905]: https://tigera.atlassian.net/browse/DOCS-2905