### PR TITLE
DOCS-2906: Publish Calico Open Source 3.31.6

### DIFF
--- a/calico_versioned_docs/version-3.31/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.31/release-notes/index.mdx
@@ -342,3 +342,15 @@ April 14, 2026
 #### Updating
 
 To update a previous version of Calico, see [our upgrade guides](../operations/upgrading/index.mdx).
+
+### Calico Open Source 3.31.6 bug fix release
+
+June 17, 2026
+
+#### Bug fixes
+
+- TBD
+
+#### Updating
+
+To update a previous version of Calico, see [our upgrade guides](../operations/upgrading/index.mdx).

--- a/calico_versioned_docs/version-3.31/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.31/release-notes/index.mdx
@@ -345,12 +345,32 @@ To update a previous version of Calico, see [our upgrade guides](../operations/u
 
 ### Calico Open Source 3.31.6 bug fix release
 
-June 17, 2026
+June 18, 2026
 
 #### Bug fixes
 
-- TBD
+- calico/node now refreshes the CNI plugin's kubeconfig immediately when the pod's projected ServiceAccount token is rotated, closing a 6-12h window where an externally-invalidated token could cause CNI ADD to fail with "Unauthorized" until the calico-node pod was restarted. [calico 12941](https://github.com/projectcalico/calico/pull/12941) (@skoryk-oleksandr)
+- Fix SNAT being skipped for traffic destined to LoadBalancer-only IPPools by excluding them from the all-ipam-pools ipset. [calico 12857](https://github.com/projectcalico/calico/pull/12857) (@defo89)
+- Fix calico-kube-controllers IPAM GC controller getting stuck when cleaning up nodes during rapid scale-down. [calico 12746](https://github.com/projectcalico/calico/pull/12746) (@haojiwu)
+- ebpf - Fix kube-proxy losing the NodePort externalTrafficPolicy=Local route-fixup trigger after a syncer swap, which could cause stale NAT entries on remote backends. [calico 12744](https://github.com/projectcalico/calico/pull/12744) (@tomastigera)
+- Fixes nft binary segfaults in calico/node when newer nftables is in use elsewhere on the host. [calico 12714](https://github.com/projectcalico/calico/pull/12714) (@caseydavenport)
+- ebpf - Fix transient NodePort connection failures when Felix restarts on a node receiving external NodePort traffic. [calico 12693](https://github.com/projectcalico/calico/pull/12693) (@tomastigera)
+- Fixes a Felix panic that could occur when an IP set selector matched both a NetworkSet CIDR and workload IPs contained within it, with nftables as the active dataplane. [calico 12672](https://github.com/projectcalico/calico/pull/12672) (@caseydavenport)
+- Typha now rejects oversized inbound client gob frames before reading them, preventing a potential denial-of-service caused by excessive memory allocation. [calico 12591](https://github.com/projectcalico/calico/pull/12591) (@Behnam-Shobiri)
+- Fix LoadBalancer IPAM race on kube-controllers startup that could assign multiple addresses to a Service. [calico 12569](https://github.com/projectcalico/calico/pull/12569) (@MichalFupso)
+- Fixed a Felix eBPF cleanup race condition that could cause a nil-pointer panic when an interface disappeared during TC qdisc cleanup. [calico 12481](https://github.com/projectcalico/calico/pull/12481) (@Behnam-Shobiri)
+- Fix nftables segfault on systems with newer nft versions (Debian Trixie, Fedora 42+) by bumping knftables to v0.0.21. [calico 12470](https://github.com/projectcalico/calico/pull/12470) (@caseydavenport)
 
+#### Other changes
+
+- Upgrade bundled Envoy Gateway to v1.8.0 (adds ListenerSet support) and bump bundled envoy-proxy, envoy-ratelimit, and node-driver-registrar images. [calico 12933](https://github.com/projectcalico/calico/pull/12933) (@lucastigera)
+- Updates LoadBalancer controller to not run when not explicitly configured as part of ENABLED_CONTROLLERS [calico 12932](https://github.com/projectcalico/calico/pull/12932) (@MichalFupso)
+- kube-controllers, goldmane: use default secure pprof server (localhost only). Use `kubectl port-forward` for remote access. [calico 12634](https://github.com/projectcalico/calico/pull/12634) (@Behnam-Shobiri)
+- Sanitize log output [calico 12606](https://github.com/projectcalico/calico/pull/12606) (@Behnam-Shobiri)
+- Sanitize calicoctl log output [calico 12537](https://github.com/projectcalico/calico/pull/12537) (@Behnam-Shobiri)
+- app-policy (Dikastes): normalize HTTP request-target before evaluating Application Layer Policy path rules, and reject shapes whose resolved form depends on upstream-specific decoding. Request paths are now RFC 3986 / RFC 7230 normalized (decode percent-escapes once, resolve dot-segments and repeated slashes, fold backslashes, strip matrix parameters per segment) and prefix matches are anchored to path-segment boundaries. Paths whose decoded form still contains percent-encoded path separators (%2e / %2f / %5c), or contains a null byte, are rejected. [calico 12533](https://github.com/projectcalico/calico/pull/12533) (@electricjesus)
+- Sanitize CNI plugin log output. [calico 12527](https://github.com/projectcalico/calico/pull/12527) (@Behnam-Shobiri)
+- Use cryptographically secure random number generator for X.509 certificate serial numbers. [calico 12467](https://github.com/projectcalico/calico/pull/12467) (@Behnam-Shobiri)
 #### Updating
 
 To update a previous version of Calico, see [our upgrade guides](../operations/upgrading/index.mdx).

--- a/calico_versioned_docs/version-3.31/releases.json
+++ b/calico_versioned_docs/version-3.31/releases.json
@@ -4,7 +4,7 @@
     "tigera-operator": {
       "image": "tigera/operator",
       "registry": "quay.io",
-      "version": "v1.40.8"
+      "version": "v1.40.13"
     },
     "components": {
       "calico/typha": {

--- a/calico_versioned_docs/version-3.31/releases.json
+++ b/calico_versioned_docs/version-3.31/releases.json
@@ -1,5 +1,103 @@
 [
   {
+    "title": "v3.31.6",
+    "tigera-operator": {
+      "image": "tigera/operator",
+      "registry": "quay.io",
+      "version": "v1.40.8"
+    },
+    "components": {
+      "calico/typha": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "calico/ctl": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "calico/node": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "calico/node-windows": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "calico/cni": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "calico/cni-windows": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "calico/apiserver": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "calico/kube-controllers": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "calico/envoy-gateway": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "calico/envoy-proxy": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "calico/envoy-ratelimit": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "calico/flannel-migration-controller": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "flannel": {
+        "version": "v0.24.4",
+        "registry": "docker.io"
+      },
+      "calico/dikastes": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "flexvol": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "calico/csi": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "calico/node-driver-registrar": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "calico/pod2daemon-flexvol": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "calico/key-cert-provisioner": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "calico/goldmane": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "calico/whisker": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      },
+      "calico/whisker-backend": {
+        "version": "v3.31.6",
+        "registry": "quay.io"
+      }
+    }
+  },
+  {
     "title": "v3.31.5",
     "tigera-operator": {
       "image": "tigera/operator",

--- a/calico_versioned_docs/version-3.31/variables.js
+++ b/calico_versioned_docs/version-3.31/variables.js
@@ -1,7 +1,7 @@
 const releases = require('./releases.json');
 
 const variables = {
-  releaseTitle: 'v3.31.5',
+  releaseTitle: 'v3.31.6',
   prodname: 'Calico',
   prodnamedash: 'calico',
   version: 'v3.31',
@@ -16,7 +16,7 @@ const variables = {
   noderunning: 'calico-node',
   rootDirWindows: 'C:\\CalicoWindows',
   ppa_repo_name: 'calico-3.31',
-  manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.31.5',
+  manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.31.6',
   releases,
   registry: '',
   vppbranch: 'v3.31.0',


### PR DESCRIPTION
## Summary

- Scaffolding for Calico Open Source 3.31.6 patch release (target: June 24, 2026)
- Uncomments the 3.31.6 placeholder block in release notes and dates it June 24, 2026
- Bumps `releaseTitle` and `manifestsUrl` to v3.31.6 in `variables.js`
- Prepends new v3.31.6 entry to `releases.json` (component versions copied from v3.31.5)
- Operator number left as-is, will be updated when actual release content lands

Tracks [DOCS-2906](https://tigera.atlassian.net/browse/DOCS-2906).

## Test plan

- [ ] Replace placeholder bug fixes with actual release notes before merge
- [ ] Update component versions in `releases.json` if any differ from the v3.32.0 copy
- [ ] Update operator version when known
- [ ] Verify site build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-2906]: https://tigera.atlassian.net/browse/DOCS-2906