### PR TITLE
Add note on supported data planes for non-cluster hosts

### DIFF
--- a/calico-enterprise/getting-started/bare-metal/about.mdx
+++ b/calico-enterprise/getting-started/bare-metal/about.mdx
@@ -58,6 +58,19 @@ To learn how to restrict traffic to/from hosts and VMs using Calico network poli
   - Your operating system includes the `ipset` and `conntrack` kernel dependencies.
 - For everything else, your non-cluster host or VM meets $[prodname] [system requirements](../install-on-clusters/requirements.mdx)
 
+### Supported Data Planes
+
+BPF is not supported on a non-cluster host, but non-cluster hosts are able to
+connect to a BPF cluster. By default a non-cluster host connecting to a BPF
+cluster will use nftables, but can be configured to use iptables.
+
+|   OS    | Cluster Data Plane |  Non-Cluster Host Data Plane  |
+| :-----: | :----------------: | :---------------------------: |
+| RHEL 8  |         Any         |           iptables            |
+| RHEL 9+ |         Any         | nftables (default) / iptables |
+| Ubuntu  |         Any         | nftables (default) / iptables |
+| Debian  |         Any         | nftables (default) / iptables |
+
 ## How to
 
 ### Set up your Kubernetes cluster to work with a non-cluster host or VM


### PR DESCRIPTION
Product Version(s):
Calico Enterprise v3.24+

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:

Adds a note on the supported data planes for non-cluster hosts.

We never explicitly called out the data plane supported by non cluster hosts, and https://github.com/tigera/calico-private/pull/12294 now sets up the packages to handle it properly.

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->