### PR TITLE
[DE-4331] Publish Calico Enterprise 3.21.9 hotfix release

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -279,3 +279,13 @@ May 25, 2026
 
 To update an existing installation of Calico Enterprise 3.21, see [Install a patch release](../getting-started/manifest-archive.mdx).
 
+### Calico Enterprise 3.21.9 hotfix release
+
+June 18, 2026
+
+#### Bug fixes
+
+* Security updates.
+
+To update an existing installation of Calico Enterprise 3.21, see [Install a patch release](../getting-started/manifest-archive.mdx).
+

--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -285,6 +285,9 @@ June 18, 2026
 
 #### Bug fixes
 
+* Fixed Felix not programming DNS snoop rules (causing FQDN/domain egress policy to silently fail) when a Kubernetes Service trusted DNS server could not be resolved at Felix start-of-day. Trusted servers are now re-resolved from Service updates without requiring a `calico-node` restart.
+* Fixed Felix permanently losing its NFQUEUE listener (DNS policy modes `DelayDeniedPacket`/`DelayDNSResponse`) after a transient netlink socket error, which caused denied packets awaiting domain programming to be dropped until `calico-node` was restarted.
+* Fixed an RBAC error that could prevent the operator from creating secrets in the `tigera-manager` namespace on fresh installs with the `Authentication` resource configured.
 * Security updates.
 
 To update an existing installation of Calico Enterprise 3.21, see [Install a patch release](../getting-started/manifest-archive.mdx).

--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -281,7 +281,7 @@ To update an existing installation of Calico Enterprise 3.21, see [Install a pat
 
 ### Calico Enterprise 3.21.9 hotfix release
 
-June 18, 2026
+June 19, 2026
 
 #### Bug fixes
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.21-2/releases.json
@@ -1,5 +1,266 @@
 [
   {
+    "title": "v3.21.9",
+    "tigera-operator": {
+      "version": "v1.38.16",
+      "image": "tigera/operator",
+      "registry": "quay.io"
+    },
+    "calico": {
+      "minor_version": "v3.30",
+      "archive_path": "archive"
+    },
+    "components": {
+      "alertmanager": {
+        "version": "v3.21.9",
+        "image": "tigera/alertmanager"
+      },
+      "calicoctl": {
+        "version": "v3.21.9",
+        "image": "tigera/calicoctl"
+      },
+      "calicoq": {
+        "version": "v3.21.9",
+        "image": "tigera/calicoq"
+      },
+      "cnx-apiserver": {
+        "version": "v3.21.9",
+        "image": "tigera/cnx-apiserver"
+      },
+      "cnx-kube-controllers": {
+        "version": "v3.21.9",
+        "image": "tigera/kube-controllers"
+      },
+      "cnx-manager": {
+        "version": "v3.21.9",
+        "image": "tigera/cnx-manager"
+      },
+      "cnx-node": {
+        "version": "v3.21.9",
+        "image": "tigera/cnx-node"
+      },
+      "cnx-node-windows": {
+        "version": "v3.21.9",
+        "image": "tigera/cnx-node-windows"
+      },
+      "cnx-queryserver": {
+        "version": "v3.21.9",
+        "image": "tigera/cnx-queryserver"
+      },
+      "compliance-benchmarker": {
+        "version": "v3.21.9",
+        "image": "tigera/compliance-benchmarker"
+      },
+      "compliance-controller": {
+        "version": "v3.21.9",
+        "image": "tigera/compliance-controller"
+      },
+      "compliance-reporter": {
+        "version": "v3.21.9",
+        "image": "tigera/compliance-reporter"
+      },
+      "compliance-server": {
+        "version": "v3.21.9",
+        "image": "tigera/compliance-server"
+      },
+      "compliance-snapshotter": {
+        "version": "v3.21.9",
+        "image": "tigera/compliance-snapshotter"
+      },
+      "coreos-alertmanager": {
+        "version": "v0.28.1"
+      },
+      "coreos-config-reloader": {
+        "version": "v0.91.0"
+      },
+      "coreos-dex": {
+        "version": "v2.41.1"
+      },
+      "coreos-fluentd": {
+        "version": "1.19.2"
+      },
+      "coreos-prometheus": {
+        "version": "v2.55.1"
+      },
+      "coreos-prometheus-operator": {
+        "version": "v0.91.0"
+      },
+      "csi": {
+        "version": "v3.21.9",
+        "image": "tigera/csi"
+      },
+      "csi-node-driver-registrar": {
+        "version": "v3.21.9",
+        "image": "tigera/node-driver-registrar"
+      },
+      "deep-packet-inspection": {
+        "version": "v3.21.9",
+        "image": "tigera/deep-packet-inspection"
+      },
+      "dex": {
+        "version": "v3.21.9",
+        "image": "tigera/dex"
+      },
+      "dikastes": {
+        "version": "v3.21.9",
+        "image": "tigera/dikastes"
+      },
+      "eck-elasticsearch": {
+        "version": "8.19.15"
+      },
+      "eck-elasticsearch-operator": {
+        "version": "2.16.1"
+      },
+      "eck-kibana": {
+        "version": "8.19.15"
+      },
+      "egress-gateway": {
+        "version": "v3.21.9",
+        "image": "tigera/egress-gateway"
+      },
+      "elastic-tsee-installer": {
+        "version": "v3.21.9",
+        "image": "tigera/intrusion-detection-job-installer"
+      },
+      "elasticsearch": {
+        "version": "v3.21.9",
+        "image": "tigera/elasticsearch"
+      },
+      "elasticsearch-metrics": {
+        "version": "v3.21.9",
+        "image": "tigera/elasticsearch-metrics"
+      },
+      "elasticsearch-operator": {
+        "version": "v3.21.9",
+        "image": "tigera/eck-operator"
+      },
+      "envoy": {
+        "version": "v3.21.9",
+        "image": "tigera/envoy"
+      },
+      "envoy-init": {
+        "version": "v3.21.9",
+        "image": "tigera/envoy-init"
+      },
+      "es-gateway": {
+        "version": "v3.21.9",
+        "image": "tigera/es-gateway"
+      },
+      "firewall-integration": {
+        "version": "v3.21.9",
+        "image": "tigera/firewall-integration"
+      },
+      "flexvol": {
+        "version": "v3.21.9",
+        "image": "tigera/pod2daemon-flexvol"
+      },
+      "fluentd": {
+        "version": "v3.21.9",
+        "image": "tigera/fluentd"
+      },
+      "fluentd-windows": {
+        "version": "v3.21.9",
+        "image": "tigera/fluentd-windows"
+      },
+      "gateway-api-envoy-gateway": {
+        "version": "v3.21.9",
+        "image": "tigera/envoy-gateway"
+      },
+      "gateway-api-envoy-proxy": {
+        "version": "v3.21.9",
+        "image": "tigera/envoy-proxy"
+      },
+      "gateway-api-envoy-ratelimit": {
+        "version": "v3.21.9",
+        "image": "tigera/envoy-ratelimit"
+      },
+      "guardian": {
+        "version": "v3.21.9",
+        "image": "tigera/guardian"
+      },
+      "ingress-collector": {
+        "version": "v3.21.9",
+        "image": "tigera/ingress-collector"
+      },
+      "intrusion-detection-controller": {
+        "version": "v3.21.9",
+        "image": "tigera/intrusion-detection-controller"
+      },
+      "key-cert-provisioner": {
+        "version": "v3.21.9",
+        "image": "tigera/key-cert-provisioner"
+      },
+      "kibana": {
+        "version": "v3.21.9",
+        "image": "tigera/kibana"
+      },
+      "l7-admission-controller": {
+        "version": "v3.21.9",
+        "image": "tigera/l7-admission-controller"
+      },
+      "l7-collector": {
+        "version": "v3.21.9",
+        "image": "tigera/l7-collector"
+      },
+      "license-agent": {
+        "version": "v3.21.9",
+        "image": "tigera/license-agent"
+      },
+      "linseed": {
+        "version": "v3.21.9",
+        "image": "tigera/linseed"
+      },
+      "packetcapture": {
+        "version": "v3.21.9",
+        "image": "tigera/packetcapture"
+      },
+      "policy-recommendation": {
+        "version": "v3.21.9",
+        "image": "tigera/policy-recommendation"
+      },
+      "prometheus": {
+        "version": "v3.21.9",
+        "image": "tigera/prometheus"
+      },
+      "prometheus-config-reloader": {
+        "version": "v3.21.9",
+        "image": "tigera/prometheus-config-reloader"
+      },
+      "prometheus-operator": {
+        "version": "v3.21.9",
+        "image": "tigera/prometheus-operator"
+      },
+      "tigera-cni": {
+        "version": "v3.21.9",
+        "image": "tigera/cni"
+      },
+      "tigera-cni-windows": {
+        "version": "v3.21.9",
+        "image": "tigera/cni-windows"
+      },
+      "tigera-prometheus-service": {
+        "version": "v3.21.9",
+        "image": "tigera/prometheus-service"
+      },
+      "typha": {
+        "version": "v3.21.9",
+        "image": "tigera/typha"
+      },
+      "ui-apis": {
+        "version": "v3.21.9",
+        "image": "tigera/ui-apis"
+      },
+      "voltron": {
+        "version": "v3.21.9",
+        "image": "tigera/voltron"
+      },
+      "webhooks-processor": {
+        "version": "v3.21.9",
+        "image": "tigera/webhooks-processor"
+      }
+    }
+  },
+  {
     "title": "v3.21.8",
     "tigera-operator": {
       "version": "v1.38.15",

--- a/calico-enterprise_versioned_docs/version-3.21-2/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/variables.js
@@ -2,13 +2,13 @@ const releases = require('./releases.json');
 const componentImage = require('../../src/components/utils/componentImage');
 
 const variables = {
-  releaseTitle: 'v3.21.8',
+  releaseTitle: 'v3.21.9',
   prodname: 'Calico Enterprise',
   prodnamedash: 'calico-enterprise',
   version: 'v3.21',
   openSourceVersion: releases[0].calico.minor_version.slice(1),
   baseUrl: '/calico-enterprise/3.21',
-  filesUrl: 'https://downloads.tigera.io/ee/v3.21.8',
+  filesUrl: 'https://downloads.tigera.io/ee/v3.21.9',
   rpmsUrl: 'https://downloads.tigera.io/ee/rpms/' + releases[0].title.slice(0, 5),
   tutorialFilesURL: 'https://docs.tigera.io/files',
   tmpScriptsURL: 'https://docs.tigera.io/calico-enterprise/3.21',
@@ -20,7 +20,7 @@ const variables = {
   rootDirWindows: 'C:\\TigeraCalico',
   registry: 'quay.io/',
   envoyVersion: '1.3.2',
-  chart_version_name: 'v3.21.8-0',
+  chart_version_name: 'v3.21.9-0',
   tigeraOperator: releases[0]['tigera-operator'],
   dikastesVersion: releases[0].components.dikastes.version,
   releases,


### PR DESCRIPTION
## Summary

Publishes the **Calico Enterprise 3.21.9** hotfix release docs (modeled on #2747, the 3.21.8 publish). Limited to the release-metadata + release-notes files — none of the API-reference changes from the reference PR.

### Changes (`calico-enterprise_versioned_docs/version-3.21-2/`)

- **`releases.json`** — new `v3.21.9` release block prepended. All `tigera/*` component versions at `v3.21.9`; `tigera-operator` at **`v1.38.16`**.
- **`variables.js`** — `releaseTitle`, `filesUrl`, `chart_version_name` bumped to `v3.21.9`.
- **`release-notes/index.mdx`** — new `3.21.9 hotfix release` section, dated **June 18, 2026**, Bug fixes: *Security updates.*

### Notes for reviewers

- `v3.21.9` is **not yet tagged** in `tigera/calico-private`, and `v1.38.16` is **not yet tagged** in `tigera/operator` (latest is `v1.38.15`) — both versions are set per the planned hotfix. Operator `v1.38.16` was specified explicitly.
- **Third-party component versions** (coreos-*, eck-*, upstream-istio) mirror **3.21.8** since 3.21.9 is not cut; update if the hotfix bumps any dependency.