### PR TITLE
Add known issue for ECK CA-rotation cert mismatch (3.21, 3.22)

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -290,5 +290,12 @@ June 19, 2026
 * Fixed an RBAC error that could prevent the operator from creating secrets in the `tigera-manager` namespace on fresh installs with the `Authentication` resource configured.
 * Security updates.
 
+#### Known issues
+
+* After an automatic Elasticsearch CA rotation, Elasticsearch nodes may fail to rejoin the cluster (and Kibana may fail to connect) with `PKIX path validation failed: Path does not chain with any of the trust anchors` errors in the logs.
+  This is caused by an upstream ECK issue where a renewed certificate authority is assigned a new Subject Key Identifier, breaking the certificate trust chain across pods that have not yet restarted.
+  To resolve or prevent the issue, delete the Elasticsearch transport (and, if Kibana is affected, HTTP) certificate secrets so that ECK regenerates all certificates under the current CA; Elasticsearch hot-reloads them without a pod restart.
+  For detection and exact remediation steps, see [this Elastic support article](https://support.elastic.co/knowledge/5198af8e).
+
 To update an existing installation of Calico Enterprise 3.21, see [Install a patch release](../getting-started/manifest-archive.mdx).
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -391,4 +391,12 @@ June 17, 2026
 * Fixed an RBAC error that could prevent the operator from creating secrets in the `tigera-manager` namespace on fresh installs with the `Authentication` resource configured.
 * Security updates.
 
+#### Known issues
+
+* After an automatic Elasticsearch CA rotation, Elasticsearch nodes may fail to rejoin the cluster (and Kibana may fail to connect) with `PKIX path validation failed: Path does not chain with any of the trust anchors` errors in the logs.
+  This is caused by an upstream ECK issue where a renewed certificate authority is assigned a new Subject Key Identifier, breaking the certificate trust chain across pods that have not yet restarted.
+  To resolve or prevent the issue, delete the Elasticsearch transport (and, if Kibana is affected, HTTP) certificate secrets so that ECK regenerates all certificates under the current CA; Elasticsearch hot-reloads them without a pod restart.
+  For detection and exact remediation steps, see [this Elastic support article](https://support.elastic.co/knowledge/5198af8e).
+  A fix is included in Calico Enterprise 3.22.7.
+
 To update an existing installation of Calico Enterprise 3.22, see [Install a patch release](../getting-started/manifest-archive.mdx).


### PR DESCRIPTION
## Summary

Documents the upstream ECK transport/HTTP CA-rotation issue (AKI/SKI mismatch → `PKIX path validation failed`, ES nodes fail to rejoin / Kibana fails to connect) in the **3.21-2** and **3.22-2** release notes.

- Known issue added to the latest section of each version (3.21.9 and 3.22.6).
- Includes the delete-cert-secret remediation (ECK regenerates all certs under the current CA; ES hot-reloads, no pod restart) and a link to the [Elastic support article](https://support.elastic.co/knowledge/5198af8e).
- The 3.22 entry states the fix ships in **3.22.7**. The 3.21 entry omits a fix version (no 3.21 patch planned).

Ref: EV-6724.
