### PR TITLE
docs(gateway): fix default-deny step for namespaced mode

### DIFF
--- a/calico-enterprise/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico-enterprise/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -30,8 +30,11 @@ You need to do the following:
 ## Create an ingress gateway
 
 1. If you are using a [global default deny policy](../../network-policy/beginners/kubernetes-default-deny.mdx),
-   allow traffic through the gateway by adding the `tigera-gateway` namespace to the list of excluded namespaces in the
-   `namespaceSelector` field.
+   you do not need to allow the gateway proxy's own traffic. The Tigera Operator allows it through a
+   policy in the `calico-system` tier. You do need to allow the gateway proxy to reach your backend
+   workloads. The proxy pods carry the label `gateway.envoyproxy.io/owning-gateway-name`, so you can
+   select them in an egress rule. Without that rule, the gateway is reachable but returns `503` because
+   the proxy cannot connect to the backend.
 
 1. To enable Gateway API support, create a `GatewayAPI` resource with the name `tigera-secure`:
 

--- a/calico-enterprise/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico-enterprise/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -87,42 +87,55 @@ You need to do the following:
    kubectl get pods -n <gateway-namespace>
    ```
 
-1. If your cluster enforces a [global default deny policy](../../network-policy/beginners/kubernetes-default-deny.mdx), apply a network policy in the `Gateway` namespace that lets the proxy pods reach the gateway controller, the Kubernetes API server, and DNS.
-   Without it, the proxy cannot start.
+1. If your cluster enforces a [global default deny policy](../../network-policy/beginners/kubernetes-default-deny.mdx), you do not need to allow the proxy's own traffic to the gateway controller or to DNS.
+   The Tigera Operator creates a `GlobalNetworkPolicy` named `calico-system.envoy-gateway-proxy` that lets clients reach the proxy, and lets the proxy reach DNS and the gateway controller.
+
+   You do still need two things.
+   First, the proxy pod runs a log collector that talks to the Kubernetes API server.
+   Second, the proxy needs to reach your backend workloads.
+   Until you allow the backend hop, the gateway accepts the request and then returns `503`, because the proxy cannot open a connection to the backend.
+
+   Apply a network policy in the `Gateway` namespace:
 
    ```yaml
    apiVersion: projectcalico.org/v3
    kind: NetworkPolicy
    metadata:
-     name: allow-tigera-gateway-proxy
+     name: default.allow-gateway-proxy-egress
      namespace: <gateway-namespace>
    spec:
-     selector: 'app.kubernetes.io/name == "envoy"'
-     types: [Ingress, Egress]
-     ingress:
-       - action: Allow
+     tier: default
+     order: 10
+     selector: 'k8s-app == "calico-gateway-api-proxy"'
+     types: [Egress]
      egress:
-       - action: Allow # DNS
-         protocol: UDP
-         destination:
-           namespaceSelector: 'projectcalico.org/name == "kube-system"'
-           selector: 'k8s-app == "kube-dns"'
-           ports: [53]
-       - action: Allow # configuration from the gateway controller
-         protocol: TCP
-         destination:
-           namespaceSelector: 'projectcalico.org/name == "calico-system"'
-           selector: 'app.kubernetes.io/name == "gateway-helm"'
-           ports: [18000]
        - action: Allow # Kubernetes API server
          protocol: TCP
          destination:
            services:
              name: kubernetes
              namespace: default
+       - action: Allow # your backend workloads
+         destination:
+           selector: '<your-backend-selector>'
+   ---
+   apiVersion: projectcalico.org/v3
+   kind: NetworkPolicy
+   metadata:
+     name: default.allow-backend-from-gateway-proxy
+     namespace: <gateway-namespace>
+   spec:
+     tier: default
+     order: 10
+     selector: '<your-backend-selector>'
+     types: [Ingress]
+     ingress:
+       - action: Allow
+         source:
+           selector: 'k8s-app == "calico-gateway-api-proxy"'
    ```
-   Replace `<gateway-namespace>` with the namespace where you created the `Gateway`.
-   Add egress rules for your own backends as needed.
+   Replace `<gateway-namespace>` with the namespace where you created the `Gateway`, and `<your-backend-selector>` with a selector that matches your backend pods.
+   Put these policies in a tier that comes after `calico-system`, at an `order` lower than your default-deny policy.
 
 1. Create a gateway routing resource that refers to your `Gateway` resource as `.spec.parentRefs`:
 

--- a/calico/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -30,8 +30,11 @@ You need to do the following:
 ## Create an ingress gateway
 
 1. If you are using a [global default deny policy](../../network-policy/get-started/kubernetes-default-deny.mdx),
-   allow traffic through the gateway by adding the `tigera-gateway` namespace to the list of excluded namespaces in the
-   `namespaceSelector` field.
+   you do not need to allow the gateway proxy's own traffic. The Tigera Operator allows it through a
+   policy in the `calico-system` tier. You do need to allow the gateway proxy to reach your backend
+   workloads. The proxy pods carry the label `gateway.envoyproxy.io/owning-gateway-name`, so you can
+   select them in an egress rule. Without that rule, the gateway is reachable but returns `503` because
+   the proxy cannot connect to the backend.
 
 1. To enable Gateway API support, create a `GatewayAPI` resource with the name `default`:
 

--- a/calico/networking/ingress-gateway/create-ingress-gateway.mdx
+++ b/calico/networking/ingress-gateway/create-ingress-gateway.mdx
@@ -81,36 +81,46 @@ You need to do the following:
    kubectl get pods -n <gateway-namespace>
    ```
 
-1. If your cluster enforces a [global default deny policy](../../network-policy/get-started/kubernetes-default-deny.mdx), apply a network policy in the `Gateway` namespace that lets the proxy pods reach the gateway controller and DNS.
-   Without it, the proxy cannot start.
+1. If your cluster enforces a [global default deny policy](../../network-policy/get-started/kubernetes-default-deny.mdx), you do not need to allow the proxy's own traffic.
+   The Tigera Operator creates a `GlobalNetworkPolicy` named `calico-system.envoy-gateway-proxy` that lets clients reach the proxy, and lets the proxy reach DNS and the gateway controller.
+
+   You do still need to allow the proxy to reach your backend workloads.
+   Until you do, the gateway accepts the request and then returns `503`, because the proxy cannot open a connection to the backend.
+   Apply a network policy in the `Gateway` namespace that allows both directions of that hop:
 
    ```yaml
    apiVersion: projectcalico.org/v3
    kind: NetworkPolicy
    metadata:
-     name: allow-tigera-gateway-proxy
+     name: default.allow-gateway-proxy-to-backend
      namespace: <gateway-namespace>
    spec:
-     selector: 'app.kubernetes.io/name == "envoy"'
-     types: [Ingress, Egress]
+     tier: default
+     order: 10
+     selector: 'k8s-app == "calico-gateway-api-proxy"'
+     types: [Egress]
+     egress:
+       - action: Allow
+         destination:
+           selector: '<your-backend-selector>'
+   ---
+   apiVersion: projectcalico.org/v3
+   kind: NetworkPolicy
+   metadata:
+     name: default.allow-backend-from-gateway-proxy
+     namespace: <gateway-namespace>
+   spec:
+     tier: default
+     order: 10
+     selector: '<your-backend-selector>'
+     types: [Ingress]
      ingress:
        - action: Allow
-     egress:
-       - action: Allow # DNS
-         protocol: UDP
-         destination:
-           namespaceSelector: 'projectcalico.org/name == "kube-system"'
-           selector: 'k8s-app == "kube-dns"'
-           ports: [53]
-       - action: Allow # configuration from the gateway controller
-         protocol: TCP
-         destination:
-           namespaceSelector: 'projectcalico.org/name == "calico-system"'
-           selector: 'app.kubernetes.io/name == "gateway-helm"'
-           ports: [18000]
+         source:
+           selector: 'k8s-app == "calico-gateway-api-proxy"'
    ```
-   Replace `<gateway-namespace>` with the namespace where you created the `Gateway`.
-   Add egress rules for your own backends as needed.
+   Replace `<gateway-namespace>` with the namespace where you created the `Gateway`, and `<your-backend-selector>` with a selector that matches your backend pods.
+   Put these policies in a tier that comes after `calico-system`, at an `order` lower than your default-deny policy.
 
 1. Create a gateway routing resource that refers to your `Gateway` resource as `.spec.parentRefs`:
 


### PR DESCRIPTION
Product Version(s):
Calico Enterprise 3.24 and Calico Open Source v3.33, the versions where the gateway proxy runs in the Gateway's own namespace. Only the unversioned pages are touched. Older snapshots predate namespaced mode and are left alone.

Issue:
https://github.com/tigera/operator/pull/4970

Link to docs preview:
- Calico Open Source: https://deploy-preview-2802--calico-docs-preview-next.netlify.app/calico/next/networking/ingress-gateway/create-ingress-gateway
- Calico Enterprise: https://deploy-preview-2802--calico-docs-preview-next.netlify.app/calico-enterprise/next/networking/ingress-gateway/create-ingress-gateway

Both links point at the `calico-docs-preview-next` build. The `tigera` preview still serves the old text on the `next` routes, so it is not the one to read for this PR.

SME review:
- [ ] An SME has approved this change.

DOCS review:
- [ ] A member of the docs team has approved this change.

Additional information:

This PR started out as a fix for the old step that told users to exclude the `tigera-gateway` namespace. #2873 already fixed that, so this is now a smaller follow-up on top of it.

#2873 added a reference NetworkPolicy that users apply in each Gateway namespace. It allows DNS and the hop to the gateway controller. With https://github.com/tigera/operator/pull/4970 the operator renders `calico-system.envoy-gateway-proxy`, which already allows those two things, plus inbound traffic to the proxy. So the reference policy would ask users to write rules the operator now owns.

What the operator's policy leaves alone on purpose is the backend hop. Its egress rules end in a `Pass`, which hands the decision to the user's own tier so they stay in control of which backends the proxy can reach. Under default deny that hop is denied, and the gateway returns `503` after Envoy's upstream connect timeout.

So the step now covers only the user's part:

- Proxy egress to the backend, and backend ingress from the proxy. Both are needed, because default deny applies to the backend pod too. The earlier version of this page only showed the egress half.
- On Enterprise, egress to the Kubernetes API server. The proxy pod runs a log collector that talks to it, and the operator's policy does not cover that hop.

The example selects proxies by `k8s-app == "calico-gateway-api-proxy"`, the Calico-owned label that #4970 stamps on the proxy pod template. The page used to use Envoy Gateway's own `app.kubernetes.io/name == "envoy"`.

Both policies go in the `default` tier at `order: 10`, so they sit after `calico-system` and take effect before a default-deny.

This should merge in the same release as https://github.com/tigera/operator/pull/4970. The text describes what the operator does once that lands.

Merge checklist:
- [ ] Deploy preview inspected wherever changes were made
- [ ] Build completed successfully
- [ ] Test have passed
