### PR TITLE
CI-1987: Add release note for non-cluster-host Typha crashloop fix

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -389,6 +389,7 @@ June 17, 2026
 #### Bug fixes
 
 * Fixed an RBAC error that could prevent the operator from creating secrets in the `tigera-manager` namespace on fresh installs with the `Authentication` resource configured.
+* Fixed an issue where the non-cluster host Typha deployment could crashloop on clusters where the host-network Kubernetes API server endpoint is not reachable from pod-networked pods (for example, MKE's `proxy.local`). The pod-network endpoint from the `kubernetes-service-endpoint` ConfigMap is now used when set.
 * Security updates.
 
 #### Known issues

--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -188,6 +188,10 @@ This release is for previewing and testing purposes only. It is not supported fo
 
 {/* TODO: fill in subsections for 3.23.0-2.0 — #### Upgrade notes, #### Enhancements, #### Bug fixes, #### Known issues. Omit any subsection with no items. */}
 
+#### Bug fixes
+
+* Fixed an issue where the non-cluster host Typha deployment could crashloop on clusters where the host-network Kubernetes API server endpoint is not reachable from pod-networked pods (for example, MKE's `proxy.local`). The pod-network endpoint from the `kubernetes-service-endpoint` ConfigMap is now used when set.
+
 #### Known issues
 
 * `clusterinformation` will incorrectly state `calicoVersion` as `v3.31.0`; The correct Calico open-source version this Calico Enterprise release is based on is `v3.32.0`. This is a purely a cosmetic bug with no user impact and can be ignored.


### PR DESCRIPTION
Adds a release note for the non-cluster-host Typha pod-network endpoint fix, backported to operator v1.40.12 (#4841) and v1.42.1 (#4842).

- **Calico Enterprise 3.22.6** — added bullet to existing Bug fixes
- **Calico Enterprise 3.23.0-2.0** — added new Bug fixes section

See https://tigera.atlassian.net/browse/CI-1987 and https://github.com/tigera/operator/pull/4840.

```release-note
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)