### PR TITLE
Remove dead projectcalico.org "Everything you need to know" video links

### DIFF
--- a/calico-cloud/networking/training/about-kubernetes-networking.mdx
+++ b/calico-cloud/networking/training/about-kubernetes-networking.mdx
@@ -135,6 +135,3 @@ as IPv4 or IPv6 addresses.
 ## Additional resources
 
 - [The Kubernetes Network Model](https://kubernetes.io/docs/concepts/cluster-administration/networking/#the-kubernetes-network-model)
-- [Video: Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
-- [Video: Everything you need to know about Kubernetes networking on Google Cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)

--- a/calico-cloud/tutorials/training/about-kubernetes-ingress.mdx
+++ b/calico-cloud/tutorials/training/about-kubernetes-ingress.mdx
@@ -129,8 +129,3 @@ over these diagrams if you don't want to dig deeper into how services and ingres
 **External ingress solution direct to pods**
 
 ![External ingress direct to pods](/img/calico-cloud/ingress-external-direct-to-pods.svg)
-
-## Additional resources
-
-- [Video: Everything you need to know about Kubernetes Ingress networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-ingress-networking/)
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)

--- a/calico-cloud/tutorials/training/about-kubernetes-networking.mdx
+++ b/calico-cloud/tutorials/training/about-kubernetes-networking.mdx
@@ -126,6 +126,3 @@ as IPv4 or IPv6 addresses.
 ## Additional resources
 
 - [The Kubernetes Network Model](https://kubernetes.io/docs/concepts/cluster-administration/networking/#the-kubernetes-network-model)
-- [Video: Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
-- [Video: Everything you need to know about Kubernetes networking on Google Cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)

--- a/calico-cloud/tutorials/training/about-kubernetes-services.mdx
+++ b/calico-cloud/tutorials/training/about-kubernetes-services.mdx
@@ -136,6 +136,5 @@ provides even load balancing independent of topology, with reduced CPU and laten
 
 # Additional resources
 
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)
 - [Blog: Introducing the Calico eBPF data plane](https://www.projectcalico.org/introducing-the-calico-ebpf-dataplane/)
 - [Blog: Hands on with Calico eBPF native service handling](https://www.projectcalico.org/hands-on-with-calicos-ebpf-service-handling/)

--- a/calico-cloud_versioned_docs/version-22-2/networking/training/about-kubernetes-networking.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/networking/training/about-kubernetes-networking.mdx
@@ -135,6 +135,3 @@ as IPv4 or IPv6 addresses.
 ## Additional resources
 
 - [The Kubernetes Network Model](https://kubernetes.io/docs/concepts/cluster-administration/networking/#the-kubernetes-network-model)
-- [Video: Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
-- [Video: Everything you need to know about Kubernetes networking on Google Cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)

--- a/calico-cloud_versioned_docs/version-22-2/tutorials/training/about-kubernetes-ingress.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/tutorials/training/about-kubernetes-ingress.mdx
@@ -129,8 +129,3 @@ over these diagrams if you don't want to dig deeper into how services and ingres
 **External ingress solution direct to pods**
 
 ![External ingress direct to pods](/img/calico-cloud/ingress-external-direct-to-pods.svg)
-
-## Additional resources
-
-- [Video: Everything you need to know about Kubernetes Ingress networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-ingress-networking/)
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)

--- a/calico-cloud_versioned_docs/version-22-2/tutorials/training/about-kubernetes-networking.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/tutorials/training/about-kubernetes-networking.mdx
@@ -126,6 +126,3 @@ as IPv4 or IPv6 addresses.
 ## Additional resources
 
 - [The Kubernetes Network Model](https://kubernetes.io/docs/concepts/cluster-administration/networking/#the-kubernetes-network-model)
-- [Video: Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
-- [Video: Everything you need to know about Kubernetes networking on Google Cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)

--- a/calico-cloud_versioned_docs/version-22-2/tutorials/training/about-kubernetes-services.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/tutorials/training/about-kubernetes-services.mdx
@@ -136,6 +136,5 @@ provides even load balancing independent of topology, with reduced CPU and laten
 
 # Additional resources
 
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)
 - [Blog: Introducing the Calico eBPF data plane](https://www.projectcalico.org/introducing-the-calico-ebpf-dataplane/)
 - [Blog: Hands on with Calico eBPF native service handling](https://www.projectcalico.org/hands-on-with-calicos-ebpf-service-handling/)

--- a/calico-enterprise/getting-started/install-on-clusters/aks.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/aks.mdx
@@ -81,7 +81,6 @@ Install $[prodname] on an AKS managed Kubernetes cluster.
 ## Next steps
 
 - [Configure access to the $[prodname] web console](../../operations/cnx/access-the-manager.mdx)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
 - [Get started with Kubernetes network policy](../../network-policy/get-started/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../network-policy/beginners/kubernetes-default-deny.mdx)

--- a/calico-enterprise/getting-started/install-on-clusters/aws.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/aws.mdx
@@ -151,5 +151,4 @@ After the cluster is up and ready, [Install $[prodname]](kubernetes/generic-inst
 
 ## Next steps
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Try out $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)

--- a/calico-enterprise/getting-started/install-on-clusters/eks.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/eks.mdx
@@ -54,6 +54,5 @@ Install $[prodname] on an EKS managed Kubernetes cluster.
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Get started with $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../network-policy/beginners/kubernetes-default-deny.mdx)

--- a/calico-enterprise/getting-started/install-on-clusters/gke.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/gke.mdx
@@ -65,7 +65,6 @@ The geeky details of what you get:
 ## Next steps
 
 - [Configure access to the $[prodname] web console](../../operations/cnx/access-the-manager.mdx)
-- [Video: Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)
 - [Get started with Kubernetes network policy](../../network-policy/get-started/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../network-policy/beginners/kubernetes-default-deny.mdx)

--- a/calico-enterprise/network-policy/get-started/about-kubernetes-ingress.mdx
+++ b/calico-enterprise/network-policy/get-started/about-kubernetes-ingress.mdx
@@ -129,8 +129,3 @@ over these diagrams if you don't want to dig deeper into how services and ingres
 **External ingress solution direct to pods**
 
 ![External ingress direct to pods](/img/calico-enterprise/ingress-external-direct-to-pods.svg)
-
-## Additional resources
-
-- [Video: Everything you need to know about Kubernetes Ingress networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-ingress-networking/)
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)

--- a/calico-enterprise/network-policy/get-started/about-kubernetes-services.mdx
+++ b/calico-enterprise/network-policy/get-started/about-kubernetes-services.mdx
@@ -136,6 +136,5 @@ provides even load balancing independent of topology, with reduced CPU and laten
 
 # Additional resources
 
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)
 - [Blog: Introducing the Calico eBPF data plane](https://www.projectcalico.org/introducing-the-calico-ebpf-dataplane/)
 - [Blog: Hands on with Calico eBPF native service handling](https://www.projectcalico.org/hands-on-with-calicos-ebpf-service-handling/)

--- a/calico-enterprise/networking/determine-best-networking.mdx
+++ b/calico-enterprise/networking/determine-best-networking.mdx
@@ -190,8 +190,6 @@ If you prefer to avoid dependencies on a specific cloud provider, or allocating 
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
 
-You can learn more about Kubernetes Networking on AWS, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/).
-
 ### Azure
 
 If you would like pod IP addresses to be routable outside of the cluster then you must use the Azure CNI plugin. This is supported by [AKS](https://azure.microsoft.com/en-us/products/kubernetes-service/), with Calico for network policy. Pod IP addresses are allocated from the underlying VNet.
@@ -214,8 +212,6 @@ If you are using AKS and prefer to avoid dependencies on a specific cloud provid
   prodname='$[prodname]'
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
-
-You can learn more about Kubernetes Networking on Azure, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/).
 
 ### Google Cloud
 
@@ -241,8 +237,6 @@ _Alternative:_
   prodname='$[prodname]'
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:IPIP,Routing:BGP'
 />
-
-You can learn more about Kubernetes Networking on Google cloud, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/).
 
 ### Anywhere
 

--- a/calico-enterprise/networking/training/about-kubernetes-networking.mdx
+++ b/calico-enterprise/networking/training/about-kubernetes-networking.mdx
@@ -129,6 +129,3 @@ as IPv4 or IPv6 addresses.
 ## Additional resources
 
 - [The Kubernetes Network Model](https://kubernetes.io/docs/concepts/cluster-administration/networking/#the-kubernetes-network-model)
-- [Video: Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
-- [Video: Everything you need to know about Kubernetes networking on Google Cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/aks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/aks.mdx
@@ -81,7 +81,6 @@ Install $[prodname] on an AKS managed Kubernetes cluster.
 ## Next steps
 
 - [Configure access to the $[prodname] web console](../../operations/cnx/access-the-manager.mdx)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
 - [Get started with Kubernetes network policy](../../network-policy/get-started/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../network-policy/beginners/kubernetes-default-deny.mdx)

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/aws.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/aws.mdx
@@ -151,5 +151,4 @@ After the cluster is up and ready, [Install $[prodname]](kubernetes/generic-inst
 
 ## Next steps
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Try out $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/eks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/eks.mdx
@@ -54,6 +54,5 @@ Install $[prodname] on an EKS managed Kubernetes cluster.
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Get started with $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../network-policy/beginners/kubernetes-default-deny.mdx)

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/gke.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/gke.mdx
@@ -63,7 +63,6 @@ The geeky details of what you get:
 ## Next steps
 
 - [Configure access to the $[prodname] web console](../../operations/cnx/access-the-manager.mdx)
-- [Video: Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)
 - [Get started with Kubernetes network policy](../../network-policy/get-started/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../network-policy/beginners/kubernetes-default-deny.mdx)

--- a/calico-enterprise_versioned_docs/version-3.20-2/network-policy/get-started/about-kubernetes-ingress.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/network-policy/get-started/about-kubernetes-ingress.mdx
@@ -129,8 +129,3 @@ over these diagrams if you don't want to dig deeper into how services and ingres
 **External ingress solution direct to pods**
 
 ![External ingress direct to pods](/img/calico-enterprise/ingress-external-direct-to-pods.svg)
-
-## Additional resources
-
-- [Video: Everything you need to know about Kubernetes Ingress networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-ingress-networking/)
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)

--- a/calico-enterprise_versioned_docs/version-3.20-2/network-policy/get-started/about-kubernetes-services.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/network-policy/get-started/about-kubernetes-services.mdx
@@ -136,6 +136,5 @@ provides even load balancing independent of topology, with reduced CPU and laten
 
 # Additional resources
 
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)
 - [Blog: Introducing the Calico eBPF data plane](https://www.projectcalico.org/introducing-the-calico-ebpf-dataplane/)
 - [Blog: Hands on with Calico eBPF native service handling](https://www.projectcalico.org/hands-on-with-calicos-ebpf-service-handling/)

--- a/calico-enterprise_versioned_docs/version-3.20-2/networking/determine-best-networking.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/networking/determine-best-networking.mdx
@@ -190,8 +190,6 @@ If you prefer to avoid dependencies on a specific cloud provider, or allocating 
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
 
-You can learn more about Kubernetes Networking on AWS, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/).
-
 ### Azure
 
 If you would like pod IP addresses to be routable outside of the cluster then you must use the Azure CNI plugin. This is supported by [AKS](https://azure.microsoft.com/en-us/products/kubernetes-service/), with Calico for network policy. Pod IP addresses are allocated from the underlying VNet.
@@ -214,8 +212,6 @@ If you are using AKS and prefer to avoid dependencies on a specific cloud provid
   prodname='$[prodname]'
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
-
-You can learn more about Kubernetes Networking on Azure, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/).
 
 ### Google Cloud
 
@@ -241,8 +237,6 @@ _Alternative:_
   prodname='$[prodname]'
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:IPIP,Routing:BGP'
 />
-
-You can learn more about Kubernetes Networking on Google cloud, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/).
 
 ### Anywhere
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/networking/training/about-kubernetes-networking.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/networking/training/about-kubernetes-networking.mdx
@@ -129,6 +129,3 @@ as IPv4 or IPv6 addresses.
 ## Additional resources
 
 - [The Kubernetes Network Model](https://kubernetes.io/docs/concepts/cluster-administration/networking/#the-kubernetes-network-model)
-- [Video: Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
-- [Video: Everything you need to know about Kubernetes networking on Google Cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/aks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/aks.mdx
@@ -81,7 +81,6 @@ Install $[prodname] on an AKS managed Kubernetes cluster.
 ## Next steps
 
 - [Configure access to the $[prodname] web console](../../operations/cnx/access-the-manager.mdx)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
 - [Get started with Kubernetes network policy](../../network-policy/get-started/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../network-policy/beginners/kubernetes-default-deny.mdx)

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/aws.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/aws.mdx
@@ -151,5 +151,4 @@ After the cluster is up and ready, [Install $[prodname]](kubernetes/generic-inst
 
 ## Next steps
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Try out $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/eks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/eks.mdx
@@ -54,6 +54,5 @@ Install $[prodname] on an EKS managed Kubernetes cluster.
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Get started with $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../network-policy/beginners/kubernetes-default-deny.mdx)

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/gke.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/gke.mdx
@@ -63,7 +63,6 @@ The geeky details of what you get:
 ## Next steps
 
 - [Configure access to the $[prodname] web console](../../operations/cnx/access-the-manager.mdx)
-- [Video: Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)
 - [Get started with Kubernetes network policy](../../network-policy/get-started/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../network-policy/beginners/kubernetes-default-deny.mdx)

--- a/calico-enterprise_versioned_docs/version-3.21-2/network-policy/get-started/about-kubernetes-ingress.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/network-policy/get-started/about-kubernetes-ingress.mdx
@@ -129,8 +129,3 @@ over these diagrams if you don't want to dig deeper into how services and ingres
 **External ingress solution direct to pods**
 
 ![External ingress direct to pods](/img/calico-enterprise/ingress-external-direct-to-pods.svg)
-
-## Additional resources
-
-- [Video: Everything you need to know about Kubernetes Ingress networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-ingress-networking/)
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)

--- a/calico-enterprise_versioned_docs/version-3.21-2/network-policy/get-started/about-kubernetes-services.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/network-policy/get-started/about-kubernetes-services.mdx
@@ -136,6 +136,5 @@ provides even load balancing independent of topology, with reduced CPU and laten
 
 # Additional resources
 
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)
 - [Blog: Introducing the Calico eBPF data plane](https://www.projectcalico.org/introducing-the-calico-ebpf-dataplane/)
 - [Blog: Hands on with Calico eBPF native service handling](https://www.projectcalico.org/hands-on-with-calicos-ebpf-service-handling/)

--- a/calico-enterprise_versioned_docs/version-3.21-2/networking/determine-best-networking.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/networking/determine-best-networking.mdx
@@ -190,8 +190,6 @@ If you prefer to avoid dependencies on a specific cloud provider, or allocating 
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
 
-You can learn more about Kubernetes Networking on AWS, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/).
-
 ### Azure
 
 If you would like pod IP addresses to be routable outside of the cluster then you must use the Azure CNI plugin. This is supported by [AKS](https://azure.microsoft.com/en-us/products/kubernetes-service/), with Calico for network policy. Pod IP addresses are allocated from the underlying VNet.
@@ -214,8 +212,6 @@ If you are using AKS and prefer to avoid dependencies on a specific cloud provid
   prodname='$[prodname]'
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
-
-You can learn more about Kubernetes Networking on Azure, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/).
 
 ### Google Cloud
 
@@ -241,8 +237,6 @@ _Alternative:_
   prodname='$[prodname]'
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:IPIP,Routing:BGP'
 />
-
-You can learn more about Kubernetes Networking on Google cloud, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/).
 
 ### Anywhere
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/networking/training/about-kubernetes-networking.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/networking/training/about-kubernetes-networking.mdx
@@ -129,6 +129,3 @@ as IPv4 or IPv6 addresses.
 ## Additional resources
 
 - [The Kubernetes Network Model](https://kubernetes.io/docs/concepts/cluster-administration/networking/#the-kubernetes-network-model)
-- [Video: Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
-- [Video: Everything you need to know about Kubernetes networking on Google Cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/aks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/aks.mdx
@@ -81,7 +81,6 @@ Install $[prodname] on an AKS managed Kubernetes cluster.
 ## Next steps
 
 - [Configure access to the $[prodname] web console](../../operations/cnx/access-the-manager.mdx)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
 - [Get started with Kubernetes network policy](../../network-policy/get-started/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../network-policy/beginners/kubernetes-default-deny.mdx)

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/aws.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/aws.mdx
@@ -151,5 +151,4 @@ After the cluster is up and ready, [Install $[prodname]](kubernetes/generic-inst
 
 ## Next steps
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Try out $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/eks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/eks.mdx
@@ -54,6 +54,5 @@ Install $[prodname] on an EKS managed Kubernetes cluster.
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Get started with $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../network-policy/beginners/kubernetes-default-deny.mdx)

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/gke.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/gke.mdx
@@ -63,7 +63,6 @@ The geeky details of what you get:
 ## Next steps
 
 - [Configure access to the $[prodname] web console](../../operations/cnx/access-the-manager.mdx)
-- [Video: Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)
 - [Get started with Kubernetes network policy](../../network-policy/get-started/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../network-policy/beginners/kubernetes-default-deny.mdx)

--- a/calico-enterprise_versioned_docs/version-3.22-2/network-policy/get-started/about-kubernetes-ingress.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/network-policy/get-started/about-kubernetes-ingress.mdx
@@ -129,8 +129,3 @@ over these diagrams if you don't want to dig deeper into how services and ingres
 **External ingress solution direct to pods**
 
 ![External ingress direct to pods](/img/calico-enterprise/ingress-external-direct-to-pods.svg)
-
-## Additional resources
-
-- [Video: Everything you need to know about Kubernetes Ingress networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-ingress-networking/)
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)

--- a/calico-enterprise_versioned_docs/version-3.22-2/network-policy/get-started/about-kubernetes-services.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/network-policy/get-started/about-kubernetes-services.mdx
@@ -136,6 +136,5 @@ provides even load balancing independent of topology, with reduced CPU and laten
 
 # Additional resources
 
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)
 - [Blog: Introducing the Calico eBPF data plane](https://www.projectcalico.org/introducing-the-calico-ebpf-dataplane/)
 - [Blog: Hands on with Calico eBPF native service handling](https://www.projectcalico.org/hands-on-with-calicos-ebpf-service-handling/)

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/determine-best-networking.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/determine-best-networking.mdx
@@ -190,8 +190,6 @@ If you prefer to avoid dependencies on a specific cloud provider, or allocating 
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
 
-You can learn more about Kubernetes Networking on AWS, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/).
-
 ### Azure
 
 If you would like pod IP addresses to be routable outside of the cluster then you must use the Azure CNI plugin. This is supported by [AKS](https://azure.microsoft.com/en-us/products/kubernetes-service/), with Calico for network policy. Pod IP addresses are allocated from the underlying VNet.
@@ -214,8 +212,6 @@ If you are using AKS and prefer to avoid dependencies on a specific cloud provid
   prodname='$[prodname]'
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
-
-You can learn more about Kubernetes Networking on Azure, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/).
 
 ### Google Cloud
 
@@ -241,8 +237,6 @@ _Alternative:_
   prodname='$[prodname]'
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:IPIP,Routing:BGP'
 />
-
-You can learn more about Kubernetes Networking on Google cloud, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/).
 
 ### Anywhere
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/training/about-kubernetes-networking.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/training/about-kubernetes-networking.mdx
@@ -129,6 +129,3 @@ as IPv4 or IPv6 addresses.
 ## Additional resources
 
 - [The Kubernetes Network Model](https://kubernetes.io/docs/concepts/cluster-administration/networking/#the-kubernetes-network-model)
-- [Video: Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
-- [Video: Everything you need to know about Kubernetes networking on Google Cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)

--- a/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/aks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/aks.mdx
@@ -81,7 +81,6 @@ Install $[prodname] on an AKS managed Kubernetes cluster.
 ## Next steps
 
 - [Configure access to the $[prodname] web console](../../operations/cnx/access-the-manager.mdx)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
 - [Get started with Kubernetes network policy](../../network-policy/get-started/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../network-policy/beginners/kubernetes-default-deny.mdx)

--- a/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/aws.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/aws.mdx
@@ -151,5 +151,4 @@ After the cluster is up and ready, [Install $[prodname]](kubernetes/generic-inst
 
 ## Next steps
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Try out $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)

--- a/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/eks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/eks.mdx
@@ -54,6 +54,5 @@ Install $[prodname] on an EKS managed Kubernetes cluster.
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Get started with $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../network-policy/beginners/kubernetes-default-deny.mdx)

--- a/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/gke.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/gke.mdx
@@ -65,7 +65,6 @@ The geeky details of what you get:
 ## Next steps
 
 - [Configure access to the $[prodname] web console](../../operations/cnx/access-the-manager.mdx)
-- [Video: Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)
 - [Get started with Kubernetes network policy](../../network-policy/get-started/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../network-policy/beginners/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../network-policy/beginners/kubernetes-default-deny.mdx)

--- a/calico-enterprise_versioned_docs/version-3.23-2/network-policy/get-started/about-kubernetes-ingress.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/network-policy/get-started/about-kubernetes-ingress.mdx
@@ -129,8 +129,3 @@ over these diagrams if you don't want to dig deeper into how services and ingres
 **External ingress solution direct to pods**
 
 ![External ingress direct to pods](/img/calico-enterprise/ingress-external-direct-to-pods.svg)
-
-## Additional resources
-
-- [Video: Everything you need to know about Kubernetes Ingress networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-ingress-networking/)
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)

--- a/calico-enterprise_versioned_docs/version-3.23-2/network-policy/get-started/about-kubernetes-services.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/network-policy/get-started/about-kubernetes-services.mdx
@@ -136,6 +136,5 @@ provides even load balancing independent of topology, with reduced CPU and laten
 
 # Additional resources
 
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)
 - [Blog: Introducing the Calico eBPF data plane](https://www.projectcalico.org/introducing-the-calico-ebpf-dataplane/)
 - [Blog: Hands on with Calico eBPF native service handling](https://www.projectcalico.org/hands-on-with-calicos-ebpf-service-handling/)

--- a/calico-enterprise_versioned_docs/version-3.23-2/networking/determine-best-networking.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/networking/determine-best-networking.mdx
@@ -190,8 +190,6 @@ If you prefer to avoid dependencies on a specific cloud provider, or allocating 
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
 
-You can learn more about Kubernetes Networking on AWS, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/).
-
 ### Azure
 
 If you would like pod IP addresses to be routable outside of the cluster then you must use the Azure CNI plugin. This is supported by [AKS](https://azure.microsoft.com/en-us/products/kubernetes-service/), with Calico for network policy. Pod IP addresses are allocated from the underlying VNet.
@@ -214,8 +212,6 @@ If you are using AKS and prefer to avoid dependencies on a specific cloud provid
   prodname='$[prodname]'
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
-
-You can learn more about Kubernetes Networking on Azure, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/).
 
 ### Google Cloud
 
@@ -241,8 +237,6 @@ _Alternative:_
   prodname='$[prodname]'
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:IPIP,Routing:BGP'
 />
-
-You can learn more about Kubernetes Networking on Google cloud, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/).
 
 ### Anywhere
 

--- a/calico-enterprise_versioned_docs/version-3.23-2/networking/training/about-kubernetes-networking.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/networking/training/about-kubernetes-networking.mdx
@@ -129,6 +129,3 @@ as IPv4 or IPv6 addresses.
 ## Additional resources
 
 - [The Kubernetes Network Model](https://kubernetes.io/docs/concepts/cluster-administration/networking/#the-kubernetes-network-model)
-- [Video: Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
-- [Video: Everything you need to know about Kubernetes networking on Google Cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)

--- a/calico/about/kubernetes-training/about-k8s-networking.mdx
+++ b/calico/about/kubernetes-training/about-k8s-networking.mdx
@@ -127,6 +127,3 @@ as IPv4 or IPv6 addresses.
 ## Additional resources
 
 - [The Kubernetes Network Model](https://kubernetes.io/docs/concepts/cluster-administration/networking/#the-kubernetes-network-model)
-- [Video: Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
-- [Video: Everything you need to know about Kubernetes networking on Google Cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)

--- a/calico/about/kubernetes-training/about-kubernetes-ingress.mdx
+++ b/calico/about/kubernetes-training/about-kubernetes-ingress.mdx
@@ -129,8 +129,3 @@ over these diagrams if you don't want to dig deeper into how services and ingres
 **External ingress solution direct to pods**
 
 ![External ingress direct to pods](/img/calico-enterprise/ingress-external-direct-to-pods.svg)
-
-## Additional resources
-
-- [Video: Everything you need to know about Kubernetes Ingress networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-ingress-networking/)
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)

--- a/calico/about/kubernetes-training/about-kubernetes-services.mdx
+++ b/calico/about/kubernetes-training/about-kubernetes-services.mdx
@@ -136,6 +136,5 @@ provides even load balancing independent of topology, with reduced CPU and laten
 
 # Additional resources
 
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)
 - [Blog: Introducing the Calico eBPF data plane](https://www.projectcalico.org/introducing-the-calico-ebpf-dataplane/)
 - [Blog: Hands on with Calico eBPF native service handling](https://www.projectcalico.org/hands-on-with-calicos-ebpf-service-handling/)

--- a/calico/getting-started/kubernetes/managed-public-cloud/aks.mdx
+++ b/calico/getting-started/kubernetes/managed-public-cloud/aks.mdx
@@ -286,7 +286,6 @@ The geeky details of what you get:
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
 - [Get started with Kubernetes network policy](../../../network-policy/get-started/kubernetes-policy/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../../network-policy/get-started/kubernetes-default-deny.mdx)

--- a/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -296,7 +296,6 @@ Before you get started, make sure you have downloaded and configured the [necess
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Get started with Kubernetes network policy](../../../network-policy/get-started/kubernetes-policy/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../../network-policy/get-started/kubernetes-default-deny.mdx)

--- a/calico/getting-started/kubernetes/managed-public-cloud/gke.mdx
+++ b/calico/getting-started/kubernetes/managed-public-cloud/gke.mdx
@@ -74,7 +74,6 @@ For clusters using Dataplane V1, references to "network policy" often describe i
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)
 - [Get started with Kubernetes network policy](../../../network-policy/get-started/kubernetes-policy/kubernetes-network-policy.mdx)
 - [Get started with Calico network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../../network-policy/get-started/kubernetes-default-deny.mdx)

--- a/calico/getting-started/kubernetes/self-managed-public-cloud/aws.mdx
+++ b/calico/getting-started/kubernetes/self-managed-public-cloud/aws.mdx
@@ -112,5 +112,4 @@ The geeky details of what you get:
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Try out $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)

--- a/calico/getting-started/kubernetes/self-managed-public-cloud/azure.mdx
+++ b/calico/getting-started/kubernetes/self-managed-public-cloud/azure.mdx
@@ -84,5 +84,4 @@ Terraform is a tool for automating infrastructure provisioning using declarative
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
 - [Try out $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)

--- a/calico/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
+++ b/calico/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
@@ -234,5 +234,4 @@ You may have noticed that the bulk of the above instructions are about provision
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)
 - [Try out $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)

--- a/calico/networking/determine-best-networking.mdx
+++ b/calico/networking/determine-best-networking.mdx
@@ -200,8 +200,6 @@ If you prefer to avoid dependencies on a specific cloud provider, or allocating 
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
 
-You can learn more about Kubernetes Networking on AWS, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/).
-
 ### Azure
 
 If you would like pod IP addresses to be routable outside of the cluster then you must use the Azure CNI plugin. This is supported by [AKS](https://azure.microsoft.com/en-us/products/kubernetes-service/), with Calico for network policy. Pod IP addresses are allocated from the underlying VNet.
@@ -238,8 +236,6 @@ If you aren’t using AKS, and prefer to avoid dependencies on a specific cloud 
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
 
-You can learn more about Kubernetes Networking on Azure, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/).
-
 ### Google Cloud
 
 If you would like pod IP addresses to be routable outside of the cluster then you must use the Google cloud provider integration in conjunction with host-local IPAM CNI plugin. This is supported by [GKE](https://cloud.google.com/kubernetes-engine), with Calico for network policy. Pod IP addresses are allocated from the underlying VPC, and corresponding Alias IP addresses are automatically assigned to nodes.
@@ -264,8 +260,6 @@ _Alternative:_
   prodname='$[prodname]'
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:IPIP,Routing:BGP'
 />
-
-You can learn more about Kubernetes Networking on Google cloud, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/).
 
 ### IBM Cloud
 

--- a/calico_versioned_docs/version-3.29/about/kubernetes-training/about-k8s-networking.mdx
+++ b/calico_versioned_docs/version-3.29/about/kubernetes-training/about-k8s-networking.mdx
@@ -127,6 +127,3 @@ as IPv4 or IPv6 addresses.
 ## Additional resources
 
 - [The Kubernetes Network Model](https://kubernetes.io/docs/concepts/cluster-administration/networking/#the-kubernetes-network-model)
-- [Video: Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
-- [Video: Everything you need to know about Kubernetes networking on Google Cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)

--- a/calico_versioned_docs/version-3.29/about/kubernetes-training/about-kubernetes-ingress.mdx
+++ b/calico_versioned_docs/version-3.29/about/kubernetes-training/about-kubernetes-ingress.mdx
@@ -129,8 +129,3 @@ over these diagrams if you don't want to dig deeper into how services and ingres
 **External ingress solution direct to pods**
 
 ![External ingress direct to pods](/img/calico-enterprise/ingress-external-direct-to-pods.svg)
-
-## Additional resources
-
-- [Video: Everything you need to know about Kubernetes Ingress networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-ingress-networking/)
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)

--- a/calico_versioned_docs/version-3.29/about/kubernetes-training/about-kubernetes-services.mdx
+++ b/calico_versioned_docs/version-3.29/about/kubernetes-training/about-kubernetes-services.mdx
@@ -136,6 +136,5 @@ provides even load balancing independent of topology, with reduced CPU and laten
 
 # Additional resources
 
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)
 - [Blog: Introducing the Calico eBPF data plane](https://www.projectcalico.org/introducing-the-calico-ebpf-dataplane/)
 - [Blog: Hands on with Calico eBPF native service handling](https://www.projectcalico.org/hands-on-with-calicos-ebpf-service-handling/)

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/managed-public-cloud/aks.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/managed-public-cloud/aks.mdx
@@ -286,7 +286,6 @@ The geeky details of what you get:
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
 - [Get started with Kubernetes network policy](../../../network-policy/get-started/kubernetes-policy/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../../network-policy/get-started/kubernetes-default-deny.mdx)

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -244,7 +244,6 @@ Before you get started, make sure you have downloaded and configured the [necess
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Get started with Kubernetes network policy](../../../network-policy/get-started/kubernetes-policy/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../../network-policy/get-started/kubernetes-default-deny.mdx)

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/managed-public-cloud/gke.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/managed-public-cloud/gke.mdx
@@ -72,7 +72,6 @@ For clusters using Dataplane V1, references to "network policy" often describe i
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)
 - [Get started with Kubernetes network policy](../../../network-policy/get-started/kubernetes-policy/kubernetes-network-policy.mdx)
 - [Get started with Calico network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../../network-policy/get-started/kubernetes-default-deny.mdx)

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/self-managed-public-cloud/aws.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/self-managed-public-cloud/aws.mdx
@@ -112,5 +112,4 @@ The geeky details of what you get:
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Try out $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/self-managed-public-cloud/azure.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/self-managed-public-cloud/azure.mdx
@@ -84,5 +84,4 @@ Terraform is a tool for automating infrastructure provisioning using declarative
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
 - [Try out $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
@@ -233,5 +233,4 @@ You may have noticed that the bulk of the above instructions are about provision
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)
 - [Try out $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)

--- a/calico_versioned_docs/version-3.29/networking/determine-best-networking.mdx
+++ b/calico_versioned_docs/version-3.29/networking/determine-best-networking.mdx
@@ -200,8 +200,6 @@ If you prefer to avoid dependencies on a specific cloud provider, or allocating 
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
 
-You can learn more about Kubernetes Networking on AWS, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/).
-
 ### Azure
 
 If you would like pod IP addresses to be routable outside of the cluster then you must use the Azure CNI plugin. This is supported by [AKS](https://azure.microsoft.com/en-us/products/kubernetes-service/), with Calico for network policy. Pod IP addresses are allocated from the underlying VNet.
@@ -238,8 +236,6 @@ If you aren’t using AKS, and prefer to avoid dependencies on a specific cloud 
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
 
-You can learn more about Kubernetes Networking on Azure, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/).
-
 ### Google Cloud
 
 If you would like pod IP addresses to be routable outside of the cluster then you must use the Google cloud provider integration in conjunction with host-local IPAM CNI plugin. This is supported by [GKE](https://cloud.google.com/kubernetes-engine), with Calico for network policy. Pod IP addresses are allocated from the underlying VPC, and corresponding Alias IP addresses are automatically assigned to nodes.
@@ -264,8 +260,6 @@ _Alternative:_
   prodname='$[prodname]'
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:IPIP,Routing:BGP'
 />
-
-You can learn more about Kubernetes Networking on Google cloud, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/).
 
 ### IBM Cloud
 

--- a/calico_versioned_docs/version-3.30/about/kubernetes-training/about-k8s-networking.mdx
+++ b/calico_versioned_docs/version-3.30/about/kubernetes-training/about-k8s-networking.mdx
@@ -127,6 +127,3 @@ as IPv4 or IPv6 addresses.
 ## Additional resources
 
 - [The Kubernetes Network Model](https://kubernetes.io/docs/concepts/cluster-administration/networking/#the-kubernetes-network-model)
-- [Video: Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
-- [Video: Everything you need to know about Kubernetes networking on Google Cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)

--- a/calico_versioned_docs/version-3.30/about/kubernetes-training/about-kubernetes-ingress.mdx
+++ b/calico_versioned_docs/version-3.30/about/kubernetes-training/about-kubernetes-ingress.mdx
@@ -129,8 +129,3 @@ over these diagrams if you don't want to dig deeper into how services and ingres
 **External ingress solution direct to pods**
 
 ![External ingress direct to pods](/img/calico-enterprise/ingress-external-direct-to-pods.svg)
-
-## Additional resources
-
-- [Video: Everything you need to know about Kubernetes Ingress networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-ingress-networking/)
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)

--- a/calico_versioned_docs/version-3.30/about/kubernetes-training/about-kubernetes-services.mdx
+++ b/calico_versioned_docs/version-3.30/about/kubernetes-training/about-kubernetes-services.mdx
@@ -136,6 +136,5 @@ provides even load balancing independent of topology, with reduced CPU and laten
 
 # Additional resources
 
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)
 - [Blog: Introducing the Calico eBPF data plane](https://www.projectcalico.org/introducing-the-calico-ebpf-dataplane/)
 - [Blog: Hands on with Calico eBPF native service handling](https://www.projectcalico.org/hands-on-with-calicos-ebpf-service-handling/)

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/managed-public-cloud/aks.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/managed-public-cloud/aks.mdx
@@ -286,7 +286,6 @@ The geeky details of what you get:
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
 - [Get started with Kubernetes network policy](../../../network-policy/get-started/kubernetes-policy/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../../network-policy/get-started/kubernetes-default-deny.mdx)

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -296,7 +296,6 @@ Before you get started, make sure you have downloaded and configured the [necess
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Get started with Kubernetes network policy](../../../network-policy/get-started/kubernetes-policy/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../../network-policy/get-started/kubernetes-default-deny.mdx)

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/managed-public-cloud/gke.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/managed-public-cloud/gke.mdx
@@ -72,7 +72,6 @@ For clusters using Dataplane V1, references to "network policy" often describe i
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)
 - [Get started with Kubernetes network policy](../../../network-policy/get-started/kubernetes-policy/kubernetes-network-policy.mdx)
 - [Get started with Calico network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../../network-policy/get-started/kubernetes-default-deny.mdx)

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/self-managed-public-cloud/aws.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/self-managed-public-cloud/aws.mdx
@@ -112,5 +112,4 @@ The geeky details of what you get:
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Try out $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/self-managed-public-cloud/azure.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/self-managed-public-cloud/azure.mdx
@@ -84,5 +84,4 @@ Terraform is a tool for automating infrastructure provisioning using declarative
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
 - [Try out $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
@@ -234,5 +234,4 @@ You may have noticed that the bulk of the above instructions are about provision
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)
 - [Try out $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)

--- a/calico_versioned_docs/version-3.30/networking/determine-best-networking.mdx
+++ b/calico_versioned_docs/version-3.30/networking/determine-best-networking.mdx
@@ -200,8 +200,6 @@ If you prefer to avoid dependencies on a specific cloud provider, or allocating 
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
 
-You can learn more about Kubernetes Networking on AWS, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/).
-
 ### Azure
 
 If you would like pod IP addresses to be routable outside of the cluster then you must use the Azure CNI plugin. This is supported by [AKS](https://azure.microsoft.com/en-us/products/kubernetes-service/), with Calico for network policy. Pod IP addresses are allocated from the underlying VNet.
@@ -238,8 +236,6 @@ If you aren’t using AKS, and prefer to avoid dependencies on a specific cloud 
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
 
-You can learn more about Kubernetes Networking on Azure, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/).
-
 ### Google Cloud
 
 If you would like pod IP addresses to be routable outside of the cluster then you must use the Google cloud provider integration in conjunction with host-local IPAM CNI plugin. This is supported by [GKE](https://cloud.google.com/kubernetes-engine), with Calico for network policy. Pod IP addresses are allocated from the underlying VPC, and corresponding Alias IP addresses are automatically assigned to nodes.
@@ -264,8 +260,6 @@ _Alternative:_
   prodname='$[prodname]'
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:IPIP,Routing:BGP'
 />
-
-You can learn more about Kubernetes Networking on Google cloud, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/).
 
 ### IBM Cloud
 

--- a/calico_versioned_docs/version-3.31/about/kubernetes-training/about-k8s-networking.mdx
+++ b/calico_versioned_docs/version-3.31/about/kubernetes-training/about-k8s-networking.mdx
@@ -127,6 +127,3 @@ as IPv4 or IPv6 addresses.
 ## Additional resources
 
 - [The Kubernetes Network Model](https://kubernetes.io/docs/concepts/cluster-administration/networking/#the-kubernetes-network-model)
-- [Video: Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
-- [Video: Everything you need to know about Kubernetes networking on Google Cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)

--- a/calico_versioned_docs/version-3.31/about/kubernetes-training/about-kubernetes-ingress.mdx
+++ b/calico_versioned_docs/version-3.31/about/kubernetes-training/about-kubernetes-ingress.mdx
@@ -129,8 +129,3 @@ over these diagrams if you don't want to dig deeper into how services and ingres
 **External ingress solution direct to pods**
 
 ![External ingress direct to pods](/img/calico-enterprise/ingress-external-direct-to-pods.svg)
-
-## Additional resources
-
-- [Video: Everything you need to know about Kubernetes Ingress networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-ingress-networking/)
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)

--- a/calico_versioned_docs/version-3.31/about/kubernetes-training/about-kubernetes-services.mdx
+++ b/calico_versioned_docs/version-3.31/about/kubernetes-training/about-kubernetes-services.mdx
@@ -136,6 +136,5 @@ provides even load balancing independent of topology, with reduced CPU and laten
 
 # Additional resources
 
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)
 - [Blog: Introducing the Calico eBPF data plane](https://www.projectcalico.org/introducing-the-calico-ebpf-dataplane/)
 - [Blog: Hands on with Calico eBPF native service handling](https://www.projectcalico.org/hands-on-with-calicos-ebpf-service-handling/)

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/managed-public-cloud/aks.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/managed-public-cloud/aks.mdx
@@ -286,7 +286,6 @@ The geeky details of what you get:
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
 - [Get started with Kubernetes network policy](../../../network-policy/get-started/kubernetes-policy/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../../network-policy/get-started/kubernetes-default-deny.mdx)

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -296,7 +296,6 @@ Before you get started, make sure you have downloaded and configured the [necess
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Get started with Kubernetes network policy](../../../network-policy/get-started/kubernetes-policy/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../../network-policy/get-started/kubernetes-default-deny.mdx)

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/managed-public-cloud/gke.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/managed-public-cloud/gke.mdx
@@ -72,7 +72,6 @@ For clusters using Dataplane V1, references to "network policy" often describe i
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)
 - [Get started with Kubernetes network policy](../../../network-policy/get-started/kubernetes-policy/kubernetes-network-policy.mdx)
 - [Get started with Calico network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../../network-policy/get-started/kubernetes-default-deny.mdx)

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/self-managed-public-cloud/aws.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/self-managed-public-cloud/aws.mdx
@@ -112,5 +112,4 @@ The geeky details of what you get:
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Try out $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/self-managed-public-cloud/azure.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/self-managed-public-cloud/azure.mdx
@@ -84,5 +84,4 @@ Terraform is a tool for automating infrastructure provisioning using declarative
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
 - [Try out $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
@@ -234,5 +234,4 @@ You may have noticed that the bulk of the above instructions are about provision
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)
 - [Try out $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)

--- a/calico_versioned_docs/version-3.31/networking/determine-best-networking.mdx
+++ b/calico_versioned_docs/version-3.31/networking/determine-best-networking.mdx
@@ -200,8 +200,6 @@ If you prefer to avoid dependencies on a specific cloud provider, or allocating 
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
 
-You can learn more about Kubernetes Networking on AWS, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/).
-
 ### Azure
 
 If you would like pod IP addresses to be routable outside of the cluster then you must use the Azure CNI plugin. This is supported by [AKS](https://azure.microsoft.com/en-us/products/kubernetes-service/), with Calico for network policy. Pod IP addresses are allocated from the underlying VNet.
@@ -238,8 +236,6 @@ If you aren’t using AKS, and prefer to avoid dependencies on a specific cloud 
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
 
-You can learn more about Kubernetes Networking on Azure, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/).
-
 ### Google Cloud
 
 If you would like pod IP addresses to be routable outside of the cluster then you must use the Google cloud provider integration in conjunction with host-local IPAM CNI plugin. This is supported by [GKE](https://cloud.google.com/kubernetes-engine), with Calico for network policy. Pod IP addresses are allocated from the underlying VPC, and corresponding Alias IP addresses are automatically assigned to nodes.
@@ -264,8 +260,6 @@ _Alternative:_
   prodname='$[prodname]'
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:IPIP,Routing:BGP'
 />
-
-You can learn more about Kubernetes Networking on Google cloud, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/).
 
 ### IBM Cloud
 

--- a/calico_versioned_docs/version-3.32/about/kubernetes-training/about-k8s-networking.mdx
+++ b/calico_versioned_docs/version-3.32/about/kubernetes-training/about-k8s-networking.mdx
@@ -127,6 +127,3 @@ as IPv4 or IPv6 addresses.
 ## Additional resources
 
 - [The Kubernetes Network Model](https://kubernetes.io/docs/concepts/cluster-administration/networking/#the-kubernetes-network-model)
-- [Video: Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
-- [Video: Everything you need to know about Kubernetes networking on Google Cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)

--- a/calico_versioned_docs/version-3.32/about/kubernetes-training/about-kubernetes-ingress.mdx
+++ b/calico_versioned_docs/version-3.32/about/kubernetes-training/about-kubernetes-ingress.mdx
@@ -129,8 +129,3 @@ over these diagrams if you don't want to dig deeper into how services and ingres
 **External ingress solution direct to pods**
 
 ![External ingress direct to pods](/img/calico-enterprise/ingress-external-direct-to-pods.svg)
-
-## Additional resources
-
-- [Video: Everything you need to know about Kubernetes Ingress networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-ingress-networking/)
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)

--- a/calico_versioned_docs/version-3.32/about/kubernetes-training/about-kubernetes-services.mdx
+++ b/calico_versioned_docs/version-3.32/about/kubernetes-training/about-kubernetes-services.mdx
@@ -136,6 +136,5 @@ provides even load balancing independent of topology, with reduced CPU and laten
 
 # Additional resources
 
-- [Video: Everything you need to know about Kubernetes Services networking ](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-services-networking/)
 - [Blog: Introducing the Calico eBPF data plane](https://www.projectcalico.org/introducing-the-calico-ebpf-dataplane/)
 - [Blog: Hands on with Calico eBPF native service handling](https://www.projectcalico.org/hands-on-with-calicos-ebpf-service-handling/)

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/managed-public-cloud/aks.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/managed-public-cloud/aks.mdx
@@ -286,7 +286,6 @@ The geeky details of what you get:
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
 - [Get started with Kubernetes network policy](../../../network-policy/get-started/kubernetes-policy/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../../network-policy/get-started/kubernetes-default-deny.mdx)

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/managed-public-cloud/eks.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/managed-public-cloud/eks.mdx
@@ -296,7 +296,6 @@ Before you get started, make sure you have downloaded and configured the [necess
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Get started with Kubernetes network policy](../../../network-policy/get-started/kubernetes-policy/kubernetes-network-policy.mdx)
 - [Get started with $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../../network-policy/get-started/kubernetes-default-deny.mdx)

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/managed-public-cloud/gke.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/managed-public-cloud/gke.mdx
@@ -74,7 +74,6 @@ For clusters using Dataplane V1, references to "network policy" often describe i
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)
 - [Get started with Kubernetes network policy](../../../network-policy/get-started/kubernetes-policy/kubernetes-network-policy.mdx)
 - [Get started with Calico network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)
 - [Enable default deny for Kubernetes pods](../../../network-policy/get-started/kubernetes-default-deny.mdx)

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/self-managed-public-cloud/aws.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/self-managed-public-cloud/aws.mdx
@@ -112,5 +112,4 @@ The geeky details of what you get:
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes pod networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/)
 - [Try out $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/self-managed-public-cloud/azure.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/self-managed-public-cloud/azure.mdx
@@ -84,5 +84,4 @@ Terraform is a tool for automating infrastructure provisioning using declarative
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/)
 - [Try out $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
@@ -234,5 +234,4 @@ You may have noticed that the bulk of the above instructions are about provision
 
 **Recommended**
 
-- [Video: Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/)
 - [Try out $[prodname] network policy](../../../network-policy/get-started/calico-policy/calico-network-policy.mdx)

--- a/calico_versioned_docs/version-3.32/networking/determine-best-networking.mdx
+++ b/calico_versioned_docs/version-3.32/networking/determine-best-networking.mdx
@@ -200,8 +200,6 @@ If you prefer to avoid dependencies on a specific cloud provider, or allocating 
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
 
-You can learn more about Kubernetes Networking on AWS, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on AWS](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-pod-networking-on-aws/).
-
 ### Azure
 
 If you would like pod IP addresses to be routable outside of the cluster then you must use the Azure CNI plugin. This is supported by [AKS](https://azure.microsoft.com/en-us/products/kubernetes-service/), with Calico for network policy. Pod IP addresses are allocated from the underlying VNet.
@@ -238,8 +236,6 @@ If you aren’t using AKS, and prefer to avoid dependencies on a specific cloud 
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Cross-subnet:VXLAN,Routing:Calico'
 />
 
-You can learn more about Kubernetes Networking on Azure, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Azure](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-azure/).
-
 ### Google Cloud
 
 If you would like pod IP addresses to be routable outside of the cluster then you must use the Google cloud provider integration in conjunction with host-local IPAM CNI plugin. This is supported by [GKE](https://cloud.google.com/kubernetes-engine), with Calico for network policy. Pod IP addresses are allocated from the underlying VPC, and corresponding Alias IP addresses are automatically assigned to nodes.
@@ -264,8 +260,6 @@ _Alternative:_
   prodname='$[prodname]'
   details='Policy:Calico,IPAM:Calico,CNI:Calico,Overlay:IPIP,Routing:BGP'
 />
-
-You can learn more about Kubernetes Networking on Google cloud, including how each of the above options works under the covers, in this short video: [Everything you need to know about Kubernetes networking on Google cloud](https://www.projectcalico.org/everything-you-need-to-know-about-kubernetes-networking-on-google-cloud/).
 
 ### IBM Cloud
 


### PR DESCRIPTION
## Summary

Meysam flagged in #marketing that the **Additional resources** links on the [Kubernetes networking training page](https://docs.tigera.io/calico-enterprise/latest/networking/training/about-kubernetes-networking) no longer play their videos — the linked `projectcalico.org` blog pages are dead. This removes those links from **all locations** in the docs (current + versioned) across Calico, Calico Enterprise, and Calico Cloud.

## What was removed

All links to `projectcalico.org/everything-you-need-to-know-about-kubernetes-*`, in both forms:

- `Video:` bullets in **Additional resources** / **Next steps** / **Recommended** lists
- Inline "…in this short video: […]" sentences in **determine-best-networking**

Where an *Additional resources* section contained only these video links (the `about-kubernetes-ingress` pages), the now-empty heading is removed as well.

## What was kept

- Unrelated `Blog:` links on the same pages
- `kubernetes.io` reference links

## Scope

98 files changed, deletions only (224 lines). No content additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)