### PR TITLE
DOCS-2970: Fix FelixConfiguration reference dropping iptables/dataplane fields

### DIFF
--- a/calico-enterprise/reference/resources/felixconfig.mdx
+++ b/calico-enterprise/reference/resources/felixconfig.mdx
@@ -133,49 +133,49 @@ At most one selector-scoped FelixConfiguration should match any given node. If m
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Common'
+  name='Dataplane: Common'
 />
 
 #### Data plane: iptables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: iptables'
+  name='Dataplane: iptables'
 />
 
 #### Data plane: nftables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: nftables'
+  name='Dataplane: nftables'
 />
 
 #### Data plane: eBPF
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: eBPF'
+  name='Dataplane: eBPF'
 />
 
 #### Data plane: Windows
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Windows'
+  name='Dataplane: Windows'
 />
 
 #### Data plane: OpenStack support
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: OpenStack support'
+  name='Dataplane: OpenStack support'
 />
 
 #### Data plane: XDP acceleration for iptables data plane
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: XDP acceleration for iptables data plane'
+  name='Dataplane: XDP acceleration for iptables dataplane'
 />
 
 #### Overlay: VXLAN overlay
@@ -196,7 +196,7 @@ At most one selector-scoped FelixConfiguration should match any given node. If m
 
 <FelixConfig
   configType='yaml'
-  name='Overlay: WireGuard'
+  name='Overlay: Wireguard'
 />
 
 #### Overlay: IPSec

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/resources/felixconfig.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/resources/felixconfig.mdx
@@ -85,49 +85,49 @@ spec:
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Common'
+  name='Dataplane: Common'
 />
 
 #### Data plane: iptables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: iptables'
+  name='Dataplane: iptables'
 />
 
 #### Data plane: nftables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: nftables'
+  name='Dataplane: nftables'
 />
 
 #### Data plane: eBPF
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: eBPF'
+  name='Dataplane: eBPF'
 />
 
 #### Data plane: Windows
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Windows'
+  name='Dataplane: Windows'
 />
 
 #### Data plane: OpenStack support
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: OpenStack support'
+  name='Dataplane: OpenStack support'
 />
 
 #### Data plane: XDP acceleration for iptables data plane
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: XDP acceleration for iptables data plane'
+  name='Dataplane: XDP acceleration for iptables dataplane'
 />
 
 #### Overlay: VXLAN overlay
@@ -148,7 +148,7 @@ spec:
 
 <FelixConfig
   configType='yaml'
-  name='Overlay: WireGuard'
+  name='Overlay: Wireguard'
 />
 
 #### Overlay: IPSec

--- a/calico-enterprise_versioned_docs/version-3.22-2/reference/resources/felixconfig.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/reference/resources/felixconfig.mdx
@@ -85,49 +85,49 @@ spec:
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Common'
+  name='Dataplane: Common'
 />
 
 #### Data plane: iptables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: iptables'
+  name='Dataplane: iptables'
 />
 
 #### Data plane: nftables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: nftables'
+  name='Dataplane: nftables'
 />
 
 #### Data plane: eBPF
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: eBPF'
+  name='Dataplane: eBPF'
 />
 
 #### Data plane: Windows
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Windows'
+  name='Dataplane: Windows'
 />
 
 #### Data plane: OpenStack support
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: OpenStack support'
+  name='Dataplane: OpenStack support'
 />
 
 #### Data plane: XDP acceleration for iptables data plane
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: XDP acceleration for iptables data plane'
+  name='Dataplane: XDP acceleration for iptables dataplane'
 />
 
 #### Overlay: VXLAN overlay
@@ -148,7 +148,7 @@ spec:
 
 <FelixConfig
   configType='yaml'
-  name='Overlay: WireGuard'
+  name='Overlay: Wireguard'
 />
 
 #### Overlay: IPSec

--- a/calico-enterprise_versioned_docs/version-3.23-2/reference/resources/felixconfig.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/reference/resources/felixconfig.mdx
@@ -133,49 +133,49 @@ At most one selector-scoped FelixConfiguration should match any given node. If m
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Common'
+  name='Dataplane: Common'
 />
 
 #### Data plane: iptables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: iptables'
+  name='Dataplane: iptables'
 />
 
 #### Data plane: nftables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: nftables'
+  name='Dataplane: nftables'
 />
 
 #### Data plane: eBPF
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: eBPF'
+  name='Dataplane: eBPF'
 />
 
 #### Data plane: Windows
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Windows'
+  name='Dataplane: Windows'
 />
 
 #### Data plane: OpenStack support
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: OpenStack support'
+  name='Dataplane: OpenStack support'
 />
 
 #### Data plane: XDP acceleration for iptables data plane
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: XDP acceleration for iptables data plane'
+  name='Dataplane: XDP acceleration for iptables dataplane'
 />
 
 #### Overlay: VXLAN overlay
@@ -196,7 +196,7 @@ At most one selector-scoped FelixConfiguration should match any given node. If m
 
 <FelixConfig
   configType='yaml'
-  name='Overlay: WireGuard'
+  name='Overlay: Wireguard'
 />
 
 #### Overlay: IPSec

--- a/calico/reference/resources/felixconfig.mdx
+++ b/calico/reference/resources/felixconfig.mdx
@@ -124,49 +124,49 @@ At most one selector-scoped FelixConfiguration should match any given node. If m
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Common'
+  name='Dataplane: Common'
 />
 
 #### Data plane: iptables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: iptables'
+  name='Dataplane: iptables'
 />
 
 #### Data plane: nftables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: nftables'
+  name='Dataplane: nftables'
 />
 
 #### Data plane: eBPF
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: eBPF'
+  name='Dataplane: eBPF'
 />
 
 #### Data plane: Windows
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Windows'
+  name='Dataplane: Windows'
 />
 
 #### Data plane: OpenStack support
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: OpenStack support'
+  name='Dataplane: OpenStack support'
 />
 
 #### Data plane: XDP acceleration for iptables data plane
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: XDP acceleration for iptables data plane'
+  name='Dataplane: XDP acceleration for iptables dataplane'
 />
 
 #### Overlay: VXLAN overlay
@@ -187,7 +187,7 @@ At most one selector-scoped FelixConfiguration should match any given node. If m
 
 <FelixConfig
   configType='yaml'
-  name='Overlay: WireGuard'
+  name='Overlay: Wireguard'
 />
 
 #### AWS integration

--- a/calico_versioned_docs/version-3.29/reference/resources/felixconfig.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/felixconfig.mdx
@@ -139,7 +139,7 @@ spec:
 
 <FelixConfig
   configType='yaml'
-  name='Overlay: WireGuard'
+  name='Overlay: Wireguard'
 />
 
 #### AWS integration

--- a/calico_versioned_docs/version-3.30/reference/resources/felixconfig.mdx
+++ b/calico_versioned_docs/version-3.30/reference/resources/felixconfig.mdx
@@ -76,49 +76,49 @@ spec:
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Common'
+  name='Dataplane: Common'
 />
 
 #### Data plane: iptables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: iptables'
+  name='Dataplane: iptables'
 />
 
 #### Data plane: nftables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: nftables'
+  name='Dataplane: nftables'
 />
 
 #### Data plane: eBPF
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: eBPF'
+  name='Dataplane: eBPF'
 />
 
 #### Data plane: Windows
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Windows'
+  name='Dataplane: Windows'
 />
 
 #### Data plane: OpenStack support
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: OpenStack support'
+  name='Dataplane: OpenStack support'
 />
 
 #### Data plane: XDP acceleration for iptables data plane
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: XDP acceleration for iptables data plane'
+  name='Dataplane: XDP acceleration for iptables dataplane'
 />
 
 #### Overlay: VXLAN overlay
@@ -139,7 +139,7 @@ spec:
 
 <FelixConfig
   configType='yaml'
-  name='Overlay: WireGuard'
+  name='Overlay: Wireguard'
 />
 
 #### AWS integration

--- a/calico_versioned_docs/version-3.31/reference/resources/felixconfig.mdx
+++ b/calico_versioned_docs/version-3.31/reference/resources/felixconfig.mdx
@@ -76,49 +76,49 @@ spec:
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Common'
+  name='Dataplane: Common'
 />
 
 #### Data plane: iptables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: iptables'
+  name='Dataplane: iptables'
 />
 
 #### Data plane: nftables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: nftables'
+  name='Dataplane: nftables'
 />
 
 #### Data plane: eBPF
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: eBPF'
+  name='Dataplane: eBPF'
 />
 
 #### Data plane: Windows
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Windows'
+  name='Dataplane: Windows'
 />
 
 #### Data plane: OpenStack support
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: OpenStack support'
+  name='Dataplane: OpenStack support'
 />
 
 #### Data plane: XDP acceleration for iptables data plane
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: XDP acceleration for iptables data plane'
+  name='Dataplane: XDP acceleration for iptables dataplane'
 />
 
 #### Overlay: VXLAN overlay
@@ -139,7 +139,7 @@ spec:
 
 <FelixConfig
   configType='yaml'
-  name='Overlay: WireGuard'
+  name='Overlay: Wireguard'
 />
 
 #### AWS integration

--- a/calico_versioned_docs/version-3.32/reference/resources/felixconfig.mdx
+++ b/calico_versioned_docs/version-3.32/reference/resources/felixconfig.mdx
@@ -124,49 +124,49 @@ At most one selector-scoped FelixConfiguration should match any given node. If m
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Common'
+  name='Dataplane: Common'
 />
 
 #### Data plane: iptables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: iptables'
+  name='Dataplane: iptables'
 />
 
 #### Data plane: nftables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: nftables'
+  name='Dataplane: nftables'
 />
 
 #### Data plane: eBPF
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: eBPF'
+  name='Dataplane: eBPF'
 />
 
 #### Data plane: Windows
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Windows'
+  name='Dataplane: Windows'
 />
 
 #### Data plane: OpenStack support
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: OpenStack support'
+  name='Dataplane: OpenStack support'
 />
 
 #### Data plane: XDP acceleration for iptables data plane
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: XDP acceleration for iptables data plane'
+  name='Dataplane: XDP acceleration for iptables dataplane'
 />
 
 #### Overlay: VXLAN overlay
@@ -187,7 +187,7 @@ At most one selector-scoped FelixConfiguration should match any given node. If m
 
 <FelixConfig
   configType='yaml'
-  name='Overlay: WireGuard'
+  name='Overlay: Wireguard'
 />
 
 #### AWS integration


### PR DESCRIPTION
## Problem

The **FelixConfiguration** reference page silently drops 8 field groups — including the entire **Dataplane: iptables** group and with it **`iptablesRefreshInterval`** — on both Calico Enterprise and open-source Calico. The fields still render correctly in the REST API reference.

Jira: **DOCS-2970**.

## Root cause

`felixconfig.mdx` renders field groups via the `FelixConfig` component (`_includes/components/FelixConfig/index.js`), which matches a group by **exact string**:

```js
const matchedGroup = jsonData.Groups.find((group) => group.Name === name);
if (!matchedGroup) return <p>No matching group found for '{name}'.</p>;
```

The group names come from `config-params.json`, which is **auto-synced from the Felix source repos** (source of truth, not hand-edited). The prose/casing style sweep `573e3bb3` ("Fix prose terminology and casing across all docs") rewrote the functional `name=` **lookup keys** as if they were prose:

- `Dataplane:` → `Data plane:`
- `...iptables dataplane` → `...iptables data plane`
- `Wireguard` → `WireGuard`

Those keys no longer matched any generated group name, so the groups rendered "No matching group found" and their fields disappeared.

## Fix

Correct the `name=` lookup keys in the affected `felixconfig.mdx` files (current + `versioned_docs`) to exactly match each file's **own** `config-params.json`. Only the lookup keys change — the visible `####` headings keep the restyled prose spelling.

- 8 files get all 8 keys corrected.
- `calico_versioned_docs/version-3.29` already uses `Data plane:` in its own JSON, so only the `Overlay: WireGuard` → `Overlay: Wireguard` fix applies there.
- `calico-cloud` was untouched by the sweep and is unaffected.

Verified: after the change, every `name=` value in each file resolves to a group `Name` in its sibling `config-params.json`, and the diff touches only `name=` lines.

Follow-up (not in this PR): harden the `FelixConfig` component matching so a future prose sweep cannot silently break lookups again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)