### PR TITLE
DOCS-2970: Fail the build when a FelixConfig lookup key doesn't resolve

### DIFF
--- a/calico-cloud/_includes/components/FelixConfig/index.js
+++ b/calico-cloud/_includes/components/FelixConfig/index.js
@@ -32,7 +32,15 @@ const FelixConfig = ({ configType, name }) => {
   // Debugging logs
 
   if (!matchedGroup) {
-    return <p>No matching group found for '{name}'.</p>;
+    // Fail the build loudly rather than silently dropping the group's fields.
+    // `name` must exactly match a group Name in config-params.json, which is
+    // auto-synced from the Felix source repos. A prose/casing sweep once
+    // restyled these lookup keys and silently dropped fields (DOCS-2970).
+    throw new Error(
+      `FelixConfig: no group named '${name}' in config-params.json. The 'name' `
+      + `prop must exactly match a group Name in config-params.json; do not `
+      + `restyle it as prose.`
+    );
   }
 
   let content;

--- a/calico-cloud_versioned_docs/version-22-2/_includes/components/FelixConfig/index.js
+++ b/calico-cloud_versioned_docs/version-22-2/_includes/components/FelixConfig/index.js
@@ -32,7 +32,15 @@ const FelixConfig = ({ configType, name }) => {
   // Debugging logs
 
   if (!matchedGroup) {
-    return <p>No matching group found for '{name}'.</p>;
+    // Fail the build loudly rather than silently dropping the group's fields.
+    // `name` must exactly match a group Name in config-params.json, which is
+    // auto-synced from the Felix source repos. A prose/casing sweep once
+    // restyled these lookup keys and silently dropped fields (DOCS-2970).
+    throw new Error(
+      `FelixConfig: no group named '${name}' in config-params.json. The 'name' `
+      + `prop must exactly match a group Name in config-params.json; do not `
+      + `restyle it as prose.`
+    );
   }
 
   let content;

--- a/calico-enterprise/_includes/components/FelixConfig/index.js
+++ b/calico-enterprise/_includes/components/FelixConfig/index.js
@@ -32,7 +32,15 @@ const FelixConfig = ({ configType, name }) => {
   // Debugging logs
 
   if (!matchedGroup) {
-    return <p>No matching group found for '{name}'.</p>;
+    // Fail the build loudly rather than silently dropping the group's fields.
+    // `name` must exactly match a group Name in config-params.json, which is
+    // auto-synced from the Felix source repos. A prose/casing sweep once
+    // restyled these lookup keys and silently dropped fields (DOCS-2970).
+    throw new Error(
+      `FelixConfig: no group named '${name}' in config-params.json. The 'name' `
+      + `prop must exactly match a group Name in config-params.json; do not `
+      + `restyle it as prose.`
+    );
   }
 
   let content;

--- a/calico-enterprise/reference/resources/felixconfig.mdx
+++ b/calico-enterprise/reference/resources/felixconfig.mdx
@@ -133,49 +133,49 @@ At most one selector-scoped FelixConfiguration should match any given node. If m
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Common'
+  name='Dataplane: Common'
 />
 
 #### Data plane: iptables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: iptables'
+  name='Dataplane: iptables'
 />
 
 #### Data plane: nftables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: nftables'
+  name='Dataplane: nftables'
 />
 
 #### Data plane: eBPF
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: eBPF'
+  name='Dataplane: eBPF'
 />
 
 #### Data plane: Windows
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Windows'
+  name='Dataplane: Windows'
 />
 
 #### Data plane: OpenStack support
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: OpenStack support'
+  name='Dataplane: OpenStack support'
 />
 
 #### Data plane: XDP acceleration for iptables data plane
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: XDP acceleration for iptables data plane'
+  name='Dataplane: XDP acceleration for iptables dataplane'
 />
 
 #### Overlay: VXLAN overlay
@@ -196,7 +196,7 @@ At most one selector-scoped FelixConfiguration should match any given node. If m
 
 <FelixConfig
   configType='yaml'
-  name='Overlay: WireGuard'
+  name='Overlay: Wireguard'
 />
 
 #### Overlay: IPSec

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/FelixConfig/index.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/FelixConfig/index.js
@@ -32,7 +32,15 @@ const FelixConfig = ({ configType, name }) => {
   // Debugging logs
 
   if (!matchedGroup) {
-    return <p>No matching group found for '{name}'.</p>;
+    // Fail the build loudly rather than silently dropping the group's fields.
+    // `name` must exactly match a group Name in config-params.json, which is
+    // auto-synced from the Felix source repos. A prose/casing sweep once
+    // restyled these lookup keys and silently dropped fields (DOCS-2970).
+    throw new Error(
+      `FelixConfig: no group named '${name}' in config-params.json. The 'name' `
+      + `prop must exactly match a group Name in config-params.json; do not `
+      + `restyle it as prose.`
+    );
   }
 
   let content;

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/resources/felixconfig.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/resources/felixconfig.mdx
@@ -85,49 +85,49 @@ spec:
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Common'
+  name='Dataplane: Common'
 />
 
 #### Data plane: iptables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: iptables'
+  name='Dataplane: iptables'
 />
 
 #### Data plane: nftables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: nftables'
+  name='Dataplane: nftables'
 />
 
 #### Data plane: eBPF
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: eBPF'
+  name='Dataplane: eBPF'
 />
 
 #### Data plane: Windows
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Windows'
+  name='Dataplane: Windows'
 />
 
 #### Data plane: OpenStack support
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: OpenStack support'
+  name='Dataplane: OpenStack support'
 />
 
 #### Data plane: XDP acceleration for iptables data plane
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: XDP acceleration for iptables data plane'
+  name='Dataplane: XDP acceleration for iptables dataplane'
 />
 
 #### Overlay: VXLAN overlay
@@ -148,7 +148,7 @@ spec:
 
 <FelixConfig
   configType='yaml'
-  name='Overlay: WireGuard'
+  name='Overlay: Wireguard'
 />
 
 #### Overlay: IPSec

--- a/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/FelixConfig/index.js
+++ b/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/FelixConfig/index.js
@@ -32,7 +32,15 @@ const FelixConfig = ({ configType, name }) => {
   // Debugging logs
 
   if (!matchedGroup) {
-    return <p>No matching group found for '{name}'.</p>;
+    // Fail the build loudly rather than silently dropping the group's fields.
+    // `name` must exactly match a group Name in config-params.json, which is
+    // auto-synced from the Felix source repos. A prose/casing sweep once
+    // restyled these lookup keys and silently dropped fields (DOCS-2970).
+    throw new Error(
+      `FelixConfig: no group named '${name}' in config-params.json. The 'name' `
+      + `prop must exactly match a group Name in config-params.json; do not `
+      + `restyle it as prose.`
+    );
   }
 
   let content;

--- a/calico-enterprise_versioned_docs/version-3.22-2/reference/resources/felixconfig.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/reference/resources/felixconfig.mdx
@@ -85,49 +85,49 @@ spec:
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Common'
+  name='Dataplane: Common'
 />
 
 #### Data plane: iptables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: iptables'
+  name='Dataplane: iptables'
 />
 
 #### Data plane: nftables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: nftables'
+  name='Dataplane: nftables'
 />
 
 #### Data plane: eBPF
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: eBPF'
+  name='Dataplane: eBPF'
 />
 
 #### Data plane: Windows
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Windows'
+  name='Dataplane: Windows'
 />
 
 #### Data plane: OpenStack support
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: OpenStack support'
+  name='Dataplane: OpenStack support'
 />
 
 #### Data plane: XDP acceleration for iptables data plane
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: XDP acceleration for iptables data plane'
+  name='Dataplane: XDP acceleration for iptables dataplane'
 />
 
 #### Overlay: VXLAN overlay
@@ -148,7 +148,7 @@ spec:
 
 <FelixConfig
   configType='yaml'
-  name='Overlay: WireGuard'
+  name='Overlay: Wireguard'
 />
 
 #### Overlay: IPSec

--- a/calico-enterprise_versioned_docs/version-3.23-2/_includes/components/FelixConfig/index.js
+++ b/calico-enterprise_versioned_docs/version-3.23-2/_includes/components/FelixConfig/index.js
@@ -32,7 +32,15 @@ const FelixConfig = ({ configType, name }) => {
   // Debugging logs
 
   if (!matchedGroup) {
-    return <p>No matching group found for '{name}'.</p>;
+    // Fail the build loudly rather than silently dropping the group's fields.
+    // `name` must exactly match a group Name in config-params.json, which is
+    // auto-synced from the Felix source repos. A prose/casing sweep once
+    // restyled these lookup keys and silently dropped fields (DOCS-2970).
+    throw new Error(
+      `FelixConfig: no group named '${name}' in config-params.json. The 'name' `
+      + `prop must exactly match a group Name in config-params.json; do not `
+      + `restyle it as prose.`
+    );
   }
 
   let content;

--- a/calico-enterprise_versioned_docs/version-3.23-2/reference/resources/felixconfig.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/reference/resources/felixconfig.mdx
@@ -133,49 +133,49 @@ At most one selector-scoped FelixConfiguration should match any given node. If m
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Common'
+  name='Dataplane: Common'
 />
 
 #### Data plane: iptables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: iptables'
+  name='Dataplane: iptables'
 />
 
 #### Data plane: nftables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: nftables'
+  name='Dataplane: nftables'
 />
 
 #### Data plane: eBPF
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: eBPF'
+  name='Dataplane: eBPF'
 />
 
 #### Data plane: Windows
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Windows'
+  name='Dataplane: Windows'
 />
 
 #### Data plane: OpenStack support
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: OpenStack support'
+  name='Dataplane: OpenStack support'
 />
 
 #### Data plane: XDP acceleration for iptables data plane
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: XDP acceleration for iptables data plane'
+  name='Dataplane: XDP acceleration for iptables dataplane'
 />
 
 #### Overlay: VXLAN overlay
@@ -196,7 +196,7 @@ At most one selector-scoped FelixConfiguration should match any given node. If m
 
 <FelixConfig
   configType='yaml'
-  name='Overlay: WireGuard'
+  name='Overlay: Wireguard'
 />
 
 #### Overlay: IPSec

--- a/calico/_includes/components/FelixConfig/index.js
+++ b/calico/_includes/components/FelixConfig/index.js
@@ -32,7 +32,15 @@ const FelixConfig = ({ configType, name }) => {
   // Debugging logs
 
   if (!matchedGroup) {
-    return <p>No matching group found for '{name}'.</p>;
+    // Fail the build loudly rather than silently dropping the group's fields.
+    // `name` must exactly match a group Name in config-params.json, which is
+    // auto-synced from the Felix source repos. A prose/casing sweep once
+    // restyled these lookup keys and silently dropped fields (DOCS-2970).
+    throw new Error(
+      `FelixConfig: no group named '${name}' in config-params.json. The 'name' `
+      + `prop must exactly match a group Name in config-params.json; do not `
+      + `restyle it as prose.`
+    );
   }
 
   let content;

--- a/calico/reference/resources/felixconfig.mdx
+++ b/calico/reference/resources/felixconfig.mdx
@@ -124,49 +124,49 @@ At most one selector-scoped FelixConfiguration should match any given node. If m
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Common'
+  name='Dataplane: Common'
 />
 
 #### Data plane: iptables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: iptables'
+  name='Dataplane: iptables'
 />
 
 #### Data plane: nftables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: nftables'
+  name='Dataplane: nftables'
 />
 
 #### Data plane: eBPF
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: eBPF'
+  name='Dataplane: eBPF'
 />
 
 #### Data plane: Windows
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Windows'
+  name='Dataplane: Windows'
 />
 
 #### Data plane: OpenStack support
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: OpenStack support'
+  name='Dataplane: OpenStack support'
 />
 
 #### Data plane: XDP acceleration for iptables data plane
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: XDP acceleration for iptables data plane'
+  name='Dataplane: XDP acceleration for iptables dataplane'
 />
 
 #### Overlay: VXLAN overlay
@@ -187,7 +187,7 @@ At most one selector-scoped FelixConfiguration should match any given node. If m
 
 <FelixConfig
   configType='yaml'
-  name='Overlay: WireGuard'
+  name='Overlay: Wireguard'
 />
 
 #### AWS integration

--- a/calico_versioned_docs/version-3.29/_includes/components/FelixConfig/index.js
+++ b/calico_versioned_docs/version-3.29/_includes/components/FelixConfig/index.js
@@ -32,7 +32,15 @@ const FelixConfig = ({ configType, name }) => {
   // Debugging logs
 
   if (!matchedGroup) {
-    return <p>No matching group found for '{name}'.</p>;
+    // Fail the build loudly rather than silently dropping the group's fields.
+    // `name` must exactly match a group Name in config-params.json, which is
+    // auto-synced from the Felix source repos. A prose/casing sweep once
+    // restyled these lookup keys and silently dropped fields (DOCS-2970).
+    throw new Error(
+      `FelixConfig: no group named '${name}' in config-params.json. The 'name' `
+      + `prop must exactly match a group Name in config-params.json; do not `
+      + `restyle it as prose.`
+    );
   }
 
   let content;

--- a/calico_versioned_docs/version-3.29/reference/felix/configuration.mdx
+++ b/calico_versioned_docs/version-3.29/reference/felix/configuration.mdx
@@ -58,31 +58,31 @@ The full list of parameters which can be set is as follows.
 
 ### Data plane: Common
 
-<FelixConfig configType='configenv' name="Dataplane: Common" />
+<FelixConfig configType='configenv' name="Data plane: Common" />
 
 ### Data plane: iptables
 
-<FelixConfig configType='configenv' name="Dataplane: iptables" />
+<FelixConfig configType='configenv' name="Data plane: iptables" />
 
 ### Data plane: nftables
 
-<FelixConfig configType='configenv' name="Dataplane: nftables" />
+<FelixConfig configType='configenv' name="Data plane: nftables" />
 
 ### Data plane: eBPF
 
-<FelixConfig configType='configenv' name="Dataplane: eBPF" />
+<FelixConfig configType='configenv' name="Data plane: eBPF" />
 
 ### Data plane: Windows
 
-<FelixConfig configType='configenv' name="Dataplane: Windows" />
+<FelixConfig configType='configenv' name="Data plane: Windows" />
 
 ### Data plane: OpenStack support
 
-<FelixConfig configType='configenv' name="Dataplane: OpenStack support" />
+<FelixConfig configType='configenv' name="Data plane: OpenStack support" />
 
 ### Data plane: XDP acceleration for iptables data plane
 
-<FelixConfig configType='configenv' name="Dataplane: XDP acceleration for iptables dataplane" />
+<FelixConfig configType='configenv' name="Data plane: XDP acceleration for iptables data plane" />
 
 ### Overlay: VXLAN overlay
 

--- a/calico_versioned_docs/version-3.29/reference/resources/felixconfig.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/felixconfig.mdx
@@ -139,7 +139,7 @@ spec:
 
 <FelixConfig
   configType='yaml'
-  name='Overlay: WireGuard'
+  name='Overlay: Wireguard'
 />
 
 #### AWS integration

--- a/calico_versioned_docs/version-3.30/_includes/components/FelixConfig/index.js
+++ b/calico_versioned_docs/version-3.30/_includes/components/FelixConfig/index.js
@@ -32,7 +32,15 @@ const FelixConfig = ({ configType, name }) => {
   // Debugging logs
 
   if (!matchedGroup) {
-    return <p>No matching group found for '{name}'.</p>;
+    // Fail the build loudly rather than silently dropping the group's fields.
+    // `name` must exactly match a group Name in config-params.json, which is
+    // auto-synced from the Felix source repos. A prose/casing sweep once
+    // restyled these lookup keys and silently dropped fields (DOCS-2970).
+    throw new Error(
+      `FelixConfig: no group named '${name}' in config-params.json. The 'name' `
+      + `prop must exactly match a group Name in config-params.json; do not `
+      + `restyle it as prose.`
+    );
   }
 
   let content;

--- a/calico_versioned_docs/version-3.30/reference/resources/felixconfig.mdx
+++ b/calico_versioned_docs/version-3.30/reference/resources/felixconfig.mdx
@@ -76,49 +76,49 @@ spec:
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Common'
+  name='Dataplane: Common'
 />
 
 #### Data plane: iptables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: iptables'
+  name='Dataplane: iptables'
 />
 
 #### Data plane: nftables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: nftables'
+  name='Dataplane: nftables'
 />
 
 #### Data plane: eBPF
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: eBPF'
+  name='Dataplane: eBPF'
 />
 
 #### Data plane: Windows
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Windows'
+  name='Dataplane: Windows'
 />
 
 #### Data plane: OpenStack support
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: OpenStack support'
+  name='Dataplane: OpenStack support'
 />
 
 #### Data plane: XDP acceleration for iptables data plane
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: XDP acceleration for iptables data plane'
+  name='Dataplane: XDP acceleration for iptables dataplane'
 />
 
 #### Overlay: VXLAN overlay
@@ -139,7 +139,7 @@ spec:
 
 <FelixConfig
   configType='yaml'
-  name='Overlay: WireGuard'
+  name='Overlay: Wireguard'
 />
 
 #### AWS integration

--- a/calico_versioned_docs/version-3.31/_includes/components/FelixConfig/index.js
+++ b/calico_versioned_docs/version-3.31/_includes/components/FelixConfig/index.js
@@ -32,7 +32,15 @@ const FelixConfig = ({ configType, name }) => {
   // Debugging logs
 
   if (!matchedGroup) {
-    return <p>No matching group found for '{name}'.</p>;
+    // Fail the build loudly rather than silently dropping the group's fields.
+    // `name` must exactly match a group Name in config-params.json, which is
+    // auto-synced from the Felix source repos. A prose/casing sweep once
+    // restyled these lookup keys and silently dropped fields (DOCS-2970).
+    throw new Error(
+      `FelixConfig: no group named '${name}' in config-params.json. The 'name' `
+      + `prop must exactly match a group Name in config-params.json; do not `
+      + `restyle it as prose.`
+    );
   }
 
   let content;

--- a/calico_versioned_docs/version-3.31/reference/resources/felixconfig.mdx
+++ b/calico_versioned_docs/version-3.31/reference/resources/felixconfig.mdx
@@ -76,49 +76,49 @@ spec:
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Common'
+  name='Dataplane: Common'
 />
 
 #### Data plane: iptables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: iptables'
+  name='Dataplane: iptables'
 />
 
 #### Data plane: nftables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: nftables'
+  name='Dataplane: nftables'
 />
 
 #### Data plane: eBPF
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: eBPF'
+  name='Dataplane: eBPF'
 />
 
 #### Data plane: Windows
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Windows'
+  name='Dataplane: Windows'
 />
 
 #### Data plane: OpenStack support
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: OpenStack support'
+  name='Dataplane: OpenStack support'
 />
 
 #### Data plane: XDP acceleration for iptables data plane
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: XDP acceleration for iptables data plane'
+  name='Dataplane: XDP acceleration for iptables dataplane'
 />
 
 #### Overlay: VXLAN overlay
@@ -139,7 +139,7 @@ spec:
 
 <FelixConfig
   configType='yaml'
-  name='Overlay: WireGuard'
+  name='Overlay: Wireguard'
 />
 
 #### AWS integration

--- a/calico_versioned_docs/version-3.32/_includes/components/FelixConfig/index.js
+++ b/calico_versioned_docs/version-3.32/_includes/components/FelixConfig/index.js
@@ -32,7 +32,15 @@ const FelixConfig = ({ configType, name }) => {
   // Debugging logs
 
   if (!matchedGroup) {
-    return <p>No matching group found for '{name}'.</p>;
+    // Fail the build loudly rather than silently dropping the group's fields.
+    // `name` must exactly match a group Name in config-params.json, which is
+    // auto-synced from the Felix source repos. A prose/casing sweep once
+    // restyled these lookup keys and silently dropped fields (DOCS-2970).
+    throw new Error(
+      `FelixConfig: no group named '${name}' in config-params.json. The 'name' `
+      + `prop must exactly match a group Name in config-params.json; do not `
+      + `restyle it as prose.`
+    );
   }
 
   let content;

--- a/calico_versioned_docs/version-3.32/reference/resources/felixconfig.mdx
+++ b/calico_versioned_docs/version-3.32/reference/resources/felixconfig.mdx
@@ -124,49 +124,49 @@ At most one selector-scoped FelixConfiguration should match any given node. If m
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Common'
+  name='Dataplane: Common'
 />
 
 #### Data plane: iptables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: iptables'
+  name='Dataplane: iptables'
 />
 
 #### Data plane: nftables
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: nftables'
+  name='Dataplane: nftables'
 />
 
 #### Data plane: eBPF
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: eBPF'
+  name='Dataplane: eBPF'
 />
 
 #### Data plane: Windows
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: Windows'
+  name='Dataplane: Windows'
 />
 
 #### Data plane: OpenStack support
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: OpenStack support'
+  name='Dataplane: OpenStack support'
 />
 
 #### Data plane: XDP acceleration for iptables data plane
 
 <FelixConfig
   configType='yaml'
-  name='Data plane: XDP acceleration for iptables data plane'
+  name='Dataplane: XDP acceleration for iptables dataplane'
 />
 
 #### Overlay: VXLAN overlay
@@ -187,7 +187,7 @@ At most one selector-scoped FelixConfiguration should match any given node. If m
 
 <FelixConfig
   configType='yaml'
-  name='Overlay: WireGuard'
+  name='Overlay: Wireguard'
 />
 
 #### AWS integration


### PR DESCRIPTION
## Why

Follow-up hardening for the FelixConfiguration content fix (#2819, DOCS-2970).

The `FelixConfig` component degraded **silently**: when a group-name lookup missed, it rendered a small "No matching group found" paragraph that was easy to overlook. That's exactly how a prose/casing style sweep dropped `iptablesRefreshInterval` and 7 other groups from the reference page without anyone noticing until the Visa RCA (CI-2011).

## Change

Turn the silent miss into a thrown error, so a broken lookup **fails the Docusaurus build** instead of shipping a page with missing fields:

```js
if (!matchedGroup) {
  throw new Error(
    `FelixConfig: no group named '${name}' in config-params.json. ...`
  );
}
```

This guards against **every** cause — Vale-driven sweeps, manual edits, refactors, or a `config-params.json` regen that renames a group — not just the one that triggered DOCS-2970. Applied to all component copies (current + `versioned_docs` across `calico`, `calico-enterprise`, `calico-cloud`), since style sweeps edit versioned pages too.

Pre-flight verified: all 22 `<FelixConfig>` pages in the repo currently resolve against their sibling `config-params.json`, so this does not break the build once #2819 lands.

## ⚠️ Merge order

**Stacks on #2819 — merge that first.** This branch is based on #2819, so until it merges this PR's diff also shows the content fix; afterward it reduces to just the `index.js` guard. Merging this *before* #2819 would fail the build (the still-broken lookups on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)