### PR TITLE
Reclaim broken backlinks (part 2): 32 more 301 redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -135,7 +135,7 @@
 # DR 83
 /calico/latest/security/kubernetes-nodes /calico/latest/network-policy/hosts/kubernetes-nodes 301
 # DR 79
-/calico/latest/en/latest/understanding.html /calico/latest/about/ 301
+/calico/latest/en/latest/understanding.html /calico/latest/about 301
 # DR 73
 /calico/latest/security/ /calico/latest/network-policy/ 301
 # DR 72
@@ -143,7 +143,7 @@
 /calico/latest/latest/getting-started/kubernetes/requirements /calico/latest/getting-started/kubernetes/requirements 301
 /calico/latest/latest/getting-started/kubernetes/installation/hosted/kubeadm/ /calico/latest/getting-started/kubernetes/self-managed-onprem/onpremises 301
 /calico/latest/latest/getting-started/kubernetes/installation/hosted/ /calico/latest/getting-started/ 301
-/calico/latest/master/introduction/ /calico/latest/about/ 301
+/calico/latest/master/introduction/ /calico/latest/about 301
 /calico/latest/getting-started/clis/calicoctl/configure/overview /calico/latest/operations/calicoctl/configure/overview 301
 /calico/latest/latest/getting-started/kubernetes/installation/ /calico/latest/getting-started/ 301
 /calico/latest/releases /calico/latest/release-notes/ 301
@@ -154,7 +154,7 @@
 /calico/latest/latest/getting-started/bare-metal/bare-metal /calico/latest/getting-started/bare-metal/ 301
 /calico/latest/security/service-policy /calico/latest/network-policy/policy-rules/service-policy 301
 /calico/latest/security/app-layer-policy /calico/latest/network-policy/istio/app-layer-policy 301
-/calico/latest/master /calico/latest/about/ 301
+/calico/latest/master /calico/latest/about 301
 /calico/latest/maintenance/troubleshoot/troubleshoot-ebpf /calico/latest/operations/ebpf/troubleshoot-ebpf 301
 /calico/latest/master/getting-started/bare-metal/bare-metal /calico/latest/getting-started/bare-metal/ 301
 # DR 30

--- a/static/_redirects
+++ b/static/_redirects
@@ -121,6 +121,50 @@
 # DR 90
 /calico/latest/en/latest/index.html /calico/latest/about 301
 /calico/latest/en/latest/involved.html /calico/latest/reference/involved 301
+# additional broken paths from full subdomain backlink export, ordered by DR
+# DR 88
+/calico/latest/master/networking/bgp /calico/latest/networking/configuring/bgp 301
+/calico/latest/networking/add-floating-ip /calico/latest/networking/ipam/add-floating-ip 301
+/calico/latest/networking/node /calico/latest/reference/configure-calico-node 301
+# DR 87
+/calico/latest/latest/reference/resources/networkpolicy /calico/latest/reference/resources/networkpolicy 301
+# DR 84
+/calico/latest/networking/ipv6 /calico/latest/networking/ipam/ipv6 301
+/calico/latest/networking/kubernetes-network-policy /calico/latest/network-policy/get-started/kubernetes-policy/kubernetes-network-policy 301
+/calico/latest/getting-started/kubernetes/windows-calico/quickstart /calico/latest/getting-started/kubernetes/windows-calico/ 301
+# DR 83
+/calico/latest/security/kubernetes-nodes /calico/latest/network-policy/hosts/kubernetes-nodes 301
+# DR 79
+/calico/latest/en/latest/understanding.html /calico/latest/about/ 301
+# DR 73
+/calico/latest/security/ /calico/latest/network-policy/ 301
+# DR 72
+/calico/latest/master/reference/cni-plugin/configuration /calico/latest/reference/configure-cni-plugins 301
+/calico/latest/latest/getting-started/kubernetes/requirements /calico/latest/getting-started/kubernetes/requirements 301
+/calico/latest/latest/getting-started/kubernetes/installation/hosted/kubeadm/ /calico/latest/getting-started/kubernetes/self-managed-onprem/onpremises 301
+/calico/latest/latest/getting-started/kubernetes/installation/hosted/ /calico/latest/getting-started/ 301
+/calico/latest/master/introduction/ /calico/latest/about/ 301
+/calico/latest/getting-started/clis/calicoctl/configure/overview /calico/latest/operations/calicoctl/configure/overview 301
+/calico/latest/latest/getting-started/kubernetes/installation/ /calico/latest/getting-started/ 301
+/calico/latest/releases /calico/latest/release-notes/ 301
+/calico/latest/getting-started/clis/calicoctl/configure/kdd /calico/latest/operations/calicoctl/configure/kdd 301
+/calico/latest/master/security/app-layer-policy /calico/latest/network-policy/istio/app-layer-policy 301
+/calico/latest/en/1.4.0/datapath.html /calico/latest/reference/architecture/data-path 301
+/calico/latest/networking/enabling-ipvs /calico/latest/networking/configuring/use-ipvs 301
+/calico/latest/latest/getting-started/bare-metal/bare-metal /calico/latest/getting-started/bare-metal/ 301
+/calico/latest/security/service-policy /calico/latest/network-policy/policy-rules/service-policy 301
+/calico/latest/security/app-layer-policy /calico/latest/network-policy/istio/app-layer-policy 301
+/calico/latest/master /calico/latest/about/ 301
+/calico/latest/maintenance/troubleshoot/troubleshoot-ebpf /calico/latest/operations/ebpf/troubleshoot-ebpf 301
+/calico/latest/master/getting-started/bare-metal/bare-metal /calico/latest/getting-started/bare-metal/ 301
+# DR 30
+/calico-enterprise/latest/getting-started/install-on-clusters/windows-calico/quickstart /calico-enterprise/latest/getting-started/install-on-clusters/windows-calico/ 301
+# DR 23
+/calico/latest/operations/typha /calico/latest/reference/typha/ 301
+# DR 11
+/calico/latest/master/getting-started/docker/installation/manual /calico/latest/getting-started/ 301
+# DR 3
+/calico/latest/networking/assign-ip-addresses-topology /calico/latest/networking/ipam/assign-ip-addresses-topology 301
 
 # Removing placeholder index pages
 


### PR DESCRIPTION
## What

Follow-up to the first broken-backlink PR (which merged as 24 redirects). Adds **32 more** `301` redirects to `static/_redirects` for `docs.tigera.io/calico*` (and one `docs.tigera.io/calico-enterprise*`) URLs surfaced by the **full tigera.io subdomain** backlink export that the first pass didn't cover. Each broken URL maps **1:1** to the most relevant live page, ordered by referring-domain rating.

## Why

SEO audit request from Laura Ferguson (Corporate Marketing, 2026-07): "Reclaim high-authority broken backlinks with 301 redirects." The full subdomain export contains 653 `docs.tigera.io` backlink rows → 56 unique broken paths; 24 landed in the first PR, these are the remaining 32. (`www.tigera.io` rows are out of scope — already addressed per Laura.)

## Verification

- All unique **destination** URLs return `200` on the live site.
- Sampled **source** paths confirmed `404` today.
- No duplicate `from` paths, no shadowing wildcard; all rules well-formed (`from to 301`).
- Rebased on current `upstream/main` (post first-PR merge); diff is exactly these 32 rules.

## Judgment calls to review

Where a feature/page was removed and has **no direct successor**, the redirect points to the nearest relevant page or section landing (never the homepage):

- `security/` (bare) → `/network-policy/`
- `.../installation/hosted*`, `.../installation/`, `master/getting-started/docker/installation/manual` → `/getting-started/` (kubeadm variant → `self-managed-onprem/onpremises`)
- `en/latest/*.html`, `en/1.4.0/datapath.html`, `master`, `master/introduction/` → `/about/` or `/reference/architecture/data-path`
- both `app-layer-policy` variants → `/network-policy/istio/app-layer-policy`

Reviewers/product may want more precise destinations for these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)