### PR TITLE
DOCS-2975: Update Calico Enterprise 3.20 archive link

### DIFF
--- a/src/pages/archive.md
+++ b/src/pages/archive.md
@@ -33,7 +33,7 @@ description: Links to all versions of product documentation for Calico, Calico E
 
 * [Calico Enterprise 3.22](https://docs.tigera.io/calico-enterprise/latest/about)
 * [Calico Enterprise 3.21](https://docs.tigera.io/calico-enterprise/3.21/about)
-* [Calico Enterprise 3.20](https://docs.tigera.io/calico-enterprise/3.20/about)
+* [Calico Enterprise 3.20](https://archive-ce-3-20.netlify.app/calico-enterprise/3.20/about)
 * [Calico Enterprise 3.19](https://archive-ce-3-19.netlify.app/calico-enterprise/3.19/about)
 * [Calico Enterprise 3.18](https://archive-ce-3-18.netlify.app/calico-enterprise/3.18/about)
 * [Calico Enterprise 3.17](https://archive-ce-3-17.netlify.app/calico-enterprise/3.17/about)


### PR DESCRIPTION
Points the Calico Enterprise 3.20 entry on the [documentation archive page](https://docs.tigera.io/archive) to the new archive Netlify site (`archive-ce-3-20.netlify.app`), now that CE 3.20 has been archived.

One-line change in `src/pages/archive.md`; safe for quick merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)