### PR TITLE
DOCS-2973: Harden tag/lynx auth cookie: signed, expiring session token

### DIFF
--- a/netlify/edge-functions/lynx-auth.js
+++ b/netlify/edge-functions/lynx-auth.js
@@ -1,24 +1,85 @@
 const PASSWORD = Netlify.env.get('LYNX_PASSWORD');
+const SIGNING_KEY = Netlify.env.get('PROXY_SECRET');
+
+const COOKIE_NAME = 'lynx_auth';
+const COOKIE_PATH = '/lynx';
+const SESSION_TTL = 86400; // seconds
+
+const encoder = new TextEncoder();
+
+// HMAC-SHA256 the message with SIGNING_KEY, returned as hex.
+async function sign(message) {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(SIGNING_KEY),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const mac = await crypto.subtle.sign('HMAC', key, encoder.encode(message));
+  return [...new Uint8Array(mac)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// Issue a session token of the form `<expiry>.<hmac(expiry)>`.
+async function issueToken() {
+  const expiry = Math.floor(Date.now() / 1000) + SESSION_TTL;
+  return `${expiry}.${await sign(String(expiry))}`;
+}
+
+// Constant-time comparison to avoid leaking the signature via timing.
+function timingSafeEqual(a, b) {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+// Parse a Cookie header into exact name/value pairs.
+function parseCookies(header) {
+  const jar = {};
+  for (const pair of header.split(';')) {
+    const eq = pair.indexOf('=');
+    if (eq === -1) continue;
+    const name = pair.slice(0, eq).trim();
+    if (name) jar[name] = pair.slice(eq + 1).trim();
+  }
+  return jar;
+}
+
+// Validate a session token: signature must verify and it must not be expired.
+async function isAuthenticated(token) {
+  if (!token) return false;
+  const dot = token.indexOf('.');
+  if (dot === -1) return false;
+  const expiry = token.slice(0, dot);
+  const mac = token.slice(dot + 1);
+  if (!/^\d+$/.test(expiry) || Number(expiry) < Math.floor(Date.now() / 1000)) return false;
+  return timingSafeEqual(mac, await sign(expiry));
+}
 
 export default async (request, context) => {
-  if (!PASSWORD) {
-    return new Response('Server configuration error: LYNX_PASSWORD is not set.', {
+  if (!PASSWORD || !SIGNING_KEY) {
+    return new Response('Server configuration error: LYNX_PASSWORD or PROXY_SECRET is not set.', {
       status: 500,
       headers: { 'Content-Type': 'text/plain' },
     });
   }
 
-  const cookie = request.headers.get('cookie') || '';
+  const cookies = parseCookies(request.headers.get('cookie') || '');
 
   // Already authenticated — proxy to the private site with shared secret
-  if (cookie.includes('lynx_auth=authorized')) {
+  if (await isAuthenticated(cookies[COOKIE_NAME])) {
     const url = new URL(request.url);
     const path = url.pathname.replace(/^\/lynx/, '') || '/';
     const target = `https://lynx-docs-tigera.netlify.app/lynx${path}${url.search}`;
     const proxyHeaders = new Headers(request.headers);
-    proxyHeaders.set('x-proxy-secret', Netlify.env.get('PROXY_SECRET'));
+    proxyHeaders.delete('cookie'); // don't leak the auth cookie to the upstream site
+    proxyHeaders.set('x-proxy-secret', SIGNING_KEY);
+    const hasBody = request.method !== 'GET' && request.method !== 'HEAD';
     return fetch(target, {
+      method: request.method,
       headers: proxyHeaders,
+      ...(hasBody ? { body: request.body, duplex: 'half' } : {}),
     });
   }
 
@@ -31,7 +92,7 @@ export default async (request, context) => {
         status: 302,
         headers: {
           'Location': url.pathname + url.search,
-          'Set-Cookie': 'lynx_auth=authorized; Path=/lynx; HttpOnly; Secure; SameSite=Lax; Max-Age=86400',
+          'Set-Cookie': `${COOKIE_NAME}=${await issueToken()}; Path=${COOKIE_PATH}; HttpOnly; Secure; SameSite=Lax; Max-Age=${SESSION_TTL}`,
         },
       });
     }

--- a/netlify/edge-functions/tag-auth.js
+++ b/netlify/edge-functions/tag-auth.js
@@ -1,24 +1,85 @@
 const PASSWORD = Netlify.env.get('TAG_PASSWORD');
+const SIGNING_KEY = Netlify.env.get('PROXY_SECRET');
+
+const COOKIE_NAME = 'tag_auth';
+const COOKIE_PATH = '/tag';
+const SESSION_TTL = 86400; // seconds
+
+const encoder = new TextEncoder();
+
+// HMAC-SHA256 the message with SIGNING_KEY, returned as hex.
+async function sign(message) {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(SIGNING_KEY),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const mac = await crypto.subtle.sign('HMAC', key, encoder.encode(message));
+  return [...new Uint8Array(mac)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// Issue a session token of the form `<expiry>.<hmac(expiry)>`.
+async function issueToken() {
+  const expiry = Math.floor(Date.now() / 1000) + SESSION_TTL;
+  return `${expiry}.${await sign(String(expiry))}`;
+}
+
+// Constant-time comparison to avoid leaking the signature via timing.
+function timingSafeEqual(a, b) {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+// Parse a Cookie header into exact name/value pairs.
+function parseCookies(header) {
+  const jar = {};
+  for (const pair of header.split(';')) {
+    const eq = pair.indexOf('=');
+    if (eq === -1) continue;
+    const name = pair.slice(0, eq).trim();
+    if (name) jar[name] = pair.slice(eq + 1).trim();
+  }
+  return jar;
+}
+
+// Validate a session token: signature must verify and it must not be expired.
+async function isAuthenticated(token) {
+  if (!token) return false;
+  const dot = token.indexOf('.');
+  if (dot === -1) return false;
+  const expiry = token.slice(0, dot);
+  const mac = token.slice(dot + 1);
+  if (!/^\d+$/.test(expiry) || Number(expiry) < Math.floor(Date.now() / 1000)) return false;
+  return timingSafeEqual(mac, await sign(expiry));
+}
 
 export default async (request, context) => {
-  if (!PASSWORD) {
-    return new Response('Server configuration error: TAG_PASSWORD is not set.', {
+  if (!PASSWORD || !SIGNING_KEY) {
+    return new Response('Server configuration error: TAG_PASSWORD or PROXY_SECRET is not set.', {
       status: 500,
       headers: { 'Content-Type': 'text/plain' },
     });
   }
 
-  const cookie = request.headers.get('cookie') || '';
+  const cookies = parseCookies(request.headers.get('cookie') || '');
 
   // Already authenticated — proxy to the private site with shared secret
-  if (cookie.includes('tag_auth=authorized')) {
+  if (await isAuthenticated(cookies[COOKIE_NAME])) {
     const url = new URL(request.url);
     const path = url.pathname.replace(/^\/tag/, '') || '/';
     const target = `https://tag-docs-tigera.netlify.app/tag${path}${url.search}`;
     const proxyHeaders = new Headers(request.headers);
-    proxyHeaders.set('x-proxy-secret', Netlify.env.get('PROXY_SECRET'));
+    proxyHeaders.delete('cookie'); // don't leak the auth cookie to the upstream site
+    proxyHeaders.set('x-proxy-secret', SIGNING_KEY);
+    const hasBody = request.method !== 'GET' && request.method !== 'HEAD';
     return fetch(target, {
+      method: request.method,
       headers: proxyHeaders,
+      ...(hasBody ? { body: request.body, duplex: 'half' } : {}),
     });
   }
 
@@ -31,7 +92,7 @@ export default async (request, context) => {
         status: 302,
         headers: {
           'Location': url.pathname + url.search,
-          'Set-Cookie': 'tag_auth=authorized; Path=/tag; HttpOnly; Secure; SameSite=Lax; Max-Age=86400',
+          'Set-Cookie': `${COOKIE_NAME}=${await issueToken()}; Path=${COOKIE_PATH}; HttpOnly; Secure; SameSite=Lax; Max-Age=${SESSION_TTL}`,
         },
       });
     }


### PR DESCRIPTION
## What

Hardens the session cookie in **both** `tag-auth` and `lynx-auth` edge functions. Follow-up to #2825; addresses the automated security review and Copilot's review comments on that PR (the fix landed after #2825 was already merged, so it ships here).

## Problem

Both functions marked an authenticated session with a static cookie `*_auth=authorized` and checked it with `cookie.includes('..._auth=authorized')`. That's:
- **Forgeable** — the value is a known constant, so anyone can set the cookie and bypass the password gate.
- **Bypassable via substring** — `includes()` matches `xlynx_auth=authorized` too (Copilot finding).

## Fix (identical in both files)

- Cookie is now a signed, expiring token `<expiry>.<hmac>`, where `hmac = HMAC-SHA256(expiry)` keyed by the server-side `PROXY_SECRET`. Forged/replayed values fail verification; expiry is enforced server-side.
- Cookie header parsed into exact `name=value` pairs (no more substring match).
- Constant-time signature comparison.
- Fail-closed (500) if `PROXY_SECRET` is unset.
- Also addresses Copilot's proxy comment: strip the auth cookie before proxying upstream, and forward the original request method/body instead of always issuing a GET.

## Ops note

Sessions are keyed to `PROXY_SECRET` (already set on the `docs.tigera.io` site). Rotating it invalidates existing `/tag` + `/lynx` sessions — users simply re-login.

## Verification
- `node --check` passes on both files; they remain byte-identical after tag↔lynx normalization.
- On deploy preview: correct password sets a `*_auth=<expiry>.<hmac>` cookie and proxies content; a hand-set `*_auth=authorized` (or `x<name>_auth=...`) no longer authenticates; expired token re-prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)