### PR TITLE
Correct 3.23.1 component/operator versions in releases.json

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.23-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.23-2/releases.json
@@ -2,7 +2,7 @@
   {
     "title": "v3.23.1",
     "tigera-operator": {
-      "version": "v1.42.3",
+      "version": "v1.42.4",
       "image": "tigera/operator",
       "registry": "quay.io"
     },
@@ -86,13 +86,13 @@
         "image": "tigera/dikastes"
       },
       "eck-elasticsearch": {
-        "version": "8.19.15"
+        "version": "8.19.16"
       },
       "eck-elasticsearch-operator": {
         "version": "2.16.0"
       },
       "eck-kibana": {
-        "version": "8.19.15"
+        "version": "8.19.16"
       },
       "egress-gateway": {
         "version": "v3.23.1",
@@ -103,15 +103,15 @@
         "image": "tigera/intrusion-detection-job-installer"
       },
       "elasticsearch": {
-        "version": "v3.23.0-2.0",
+        "version": "v3.23.1",
         "image": "tigera/elasticsearch"
       },
       "elasticsearch-metrics": {
-        "version": "v3.23.0-2.0",
+        "version": "v3.23.1",
         "image": "tigera/elasticsearch-metrics"
       },
       "elasticsearch-operator": {
-        "version": "v3.23.0-2.0",
+        "version": "v3.23.1",
         "image": "tigera/eck-operator"
       },
       "envoy": {
@@ -119,7 +119,7 @@
         "image": "tigera/envoy"
       },
       "es-gateway": {
-        "version": "v3.23.0-2.0",
+        "version": "v3.23.1",
         "image": "tigera/es-gateway"
       },
       "firewall-integration": {
@@ -187,7 +187,7 @@
         "image": "tigera/key-cert-provisioner"
       },
       "kibana": {
-        "version": "v3.23.0-2.0",
+        "version": "v3.23.1",
         "image": "tigera/kibana"
       },
       "kube-controllers": {
@@ -298,7 +298,7 @@
   {
     "title": "v3.23.0-2.0",
     "tigera-operator": {
-      "version": "v1.42.2",
+      "version": "v1.42.1",
       "image": "tigera/operator",
       "registry": "quay.io"
     },


### PR DESCRIPTION
## What

The `version-3.23-2/releases.json` **v3.23.1** entry was a partial copy of the `3.23.0-2.0` entry that never got fully bumped, so several versions are wrong. This reconciles it with the source of truth — calico-private `calico/_data/versions.yml` at the `v3.23.1` and `v3.23.0-2.0` release tags (cross-checked against the `release-calient-v3.23` branch head).

### v3.23.1 entry

| Field | was | corrected to |
|---|---|---|
| tigera-operator | `v1.42.3` | **`v1.42.4`** |
| elasticsearch | `v3.23.0-2.0` | **`v3.23.1`** |
| elasticsearch-metrics | `v3.23.0-2.0` | **`v3.23.1`** |
| elasticsearch-operator | `v3.23.0-2.0` | **`v3.23.1`** |
| es-gateway | `v3.23.0-2.0` | **`v3.23.1`** |
| kibana | `v3.23.0-2.0` | **`v3.23.1`** |
| eck-elasticsearch | `8.19.15` | **`8.19.16`** |
| eck-kibana | `8.19.15` | **`8.19.16`** |

### v3.23.0-2.0 entry

| Field | was | corrected to |
|---|---|---|
| tigera-operator | `v1.42.2` | **`v1.42.1`** |

The `v3.23.0-1.0` entry (operator `v1.41.1`) already matched and is unchanged. No other `releases.json` file carries a v3.23.1 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)