### PR TITLE
Skip pre-publish downloads.tigera.io URLs in link check

### DIFF
--- a/src/utils/linkChecker.js
+++ b/src/utils/linkChecker.js
@@ -24,6 +24,8 @@ const defaultSkipList = [
   /^https?:\/\/www\.calicocloud\.io/,
   /^https?:\/\/hypershift-docs\.netlify\.app/,
   /^https?:\/\/(www\.)?ubuntu\.com\/.*/,
+  // debs directory listing 403s (index forbidden) even when the packages exist.
+  /^https?:\/\/downloads\.tigera\.io\/ee\/debs\/v3\.23\/?$/,
   /^https?:\/\/docs\.tigera\.io\/calico\/latest\/networking\/kubevirt\/?$/,
   /^https?:\/\/docs\.openshift\.com\/.*/,
   /^https?:\/\/docs\.redhat\.com\/.*/,

--- a/src/utils/linkChecker.js
+++ b/src/utils/linkChecker.js
@@ -26,6 +26,8 @@ const defaultSkipList = [
   /^https?:\/\/(www\.)?ubuntu\.com\/.*/,
   // debs directory listing 403s (index forbidden) even when the packages exist.
   /^https?:\/\/downloads\.tigera\.io\/ee\/debs\/v3\.23\/?$/,
+  // VERY TEMPORARY: remove once the 3.23.1 artifact is published to the download server.
+  /^https?:\/\/downloads\.tigera\.io\/ee\/v3\.23\.1\/manifests\/prometheus\/operator-metrics-service-monitor\.yaml$/,
   /^https?:\/\/docs\.tigera\.io\/calico\/latest\/networking\/kubevirt\/?$/,
   /^https?:\/\/docs\.openshift\.com\/.*/,
   /^https?:\/\/docs\.redhat\.com\/.*/,


### PR DESCRIPTION
## What

Adds two `downloads.tigera.io` entries to the link-checker skip list (`src/utils/linkChecker.js`):

1. **`ee/debs/v3.23/`** — a **directory listing** the download server returns 403 for (index forbidden) even when the `.deb` packages inside are published. Permanent false positive; it's the value produced by `debPkgUrl` on the bare-metal/about page.
2. **`ee/v3.23.1/manifests/prometheus/operator-metrics-service-monitor.yaml`** — **VERY TEMPORARY**, flagged inline. This artifact simply isn't on the download server yet; the skip must be **removed once 3.23.1 is published**.

Other specific package/artifact URLs are **left checked** — a genuinely missing package should still break the build.

> Note: touches the same `defaultSkipList` as #2828 (dead-link fixes); a small merge conflict is possible depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)