### PR TITLE
Fix broken links in next docs build

### DIFF
--- a/calico-cloud/networking/index.mdx
+++ b/calico-cloud/networking/index.mdx
@@ -28,8 +28,6 @@ The $[prodname] network plugins provide a range of networking options to fit you
   <DocCardLink docId='networking/configuring/workloads-outside-cluster' />
   <DocCardLink docId='networking/configuring/pod-mac-address' />
   <DocCardLink docId='networking/configuring/node-local-dns-cache' />
-  <DocCardLink docId='networking/configuring/add-maglev-load-balancing' />
-  <DocCardLink docId='networking/configuring/mark-lb-node-for-maintenance' />
 </DocCardLinkLayout>
 
 ## IP address management

--- a/calico-enterprise/operations/comms/index.mdx
+++ b/calico-enterprise/operations/comms/index.mdx
@@ -1,5 +1,6 @@
 ---
 description: Provide custom TLS certificates for Calico components.
+slug: /operations/comms/index
 ---
 
 # Provide TLS certificates for Calico components

--- a/calico/networking/configuring/add-maglev-load-balancing.mdx
+++ b/calico/networking/configuring/add-maglev-load-balancing.mdx
@@ -26,7 +26,7 @@ Note Maglev load balancing cannot be used with the following:
 
 ## Prerequisites
 
-* Your cluster uses the eBPF data plane with [direct server return mode](../../../operations/ebpf/enabling-ebpf#try-out-direct-server-return-mode).
+* Your cluster uses the eBPF data plane with [direct server return mode](../../operations/ebpf/enabling-ebpf.mdx#enable-direct-server-return-mode).
 * All your nodes are running on Linux.
 * You have a service with a VIP/External-IP, possibly allocated by $[prodname] [LB IPAM](../ipam/service-loadbalancer.mdx), which you are advertising outside of your cluster.
 


### PR DESCRIPTION
yarn build-next fails on main due to three pre-existing broken links in the next trees. This fixes all three:

- calico: the maglev page's eBPF direct-server-return prerequisite link used one too many ../ and a stale anchor. Corrected the path and anchor.
- calico-cloud: removed the next-only maglev and mark-lb-node cards from the networking index. DocCardLink resolves calico-cloud to the released (version-less) path, where these next-only pages don't exist. They remain reachable via the sidebar.
- calico-enterprise: added a slug to comms/index so the operations index DocCardLink resolves to a real route (index docs otherwise route to the directory, dropping the /index the card links to).