### PR TITLE
docs-2977: add weekly link-check workflow

### DIFF
--- a/.github/workflows/link-check-weekly.yml
+++ b/.github/workflows/link-check-weekly.yml
@@ -1,0 +1,81 @@
+name: Weekly link check
+
+on:
+  # Weekly schedule: Monday at 07:00 UTC (after the llms.txt job at 06:00).
+  schedule:
+    - cron: '0 7 * * 1'
+
+  # Manual trigger via GitHub UI
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  link-check:
+    name: Build, serve, and crawl the docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'yarn'
+
+      - name: Build the site
+        run: make build
+        env:
+          NODE_OPTIONS: '--max-old-space-size=6000'
+          DOCUSAURUS_IGNORE_SSG_WARNINGS: 'true'
+
+      - name: Install Playwright Chrome
+        run: yarn playwright install --with-deps chrome
+
+      - name: Serve the site and run the link check
+        run: make test 2>&1 | tee link-check.log
+        env:
+          CI: 'true'
+
+      - name: Upload the link-check log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: link-check-log
+          path: link-check.log
+          if-no-files-found: ignore
+
+      - name: Open or update an issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TITLE="Weekly link check failed"
+          BODY_FILE=issue-body.md
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          {
+            echo "The weekly link check found broken links or errors."
+            echo ""
+            echo "Run: ${RUN_URL}"
+            echo ""
+            echo "Last lines of the report (full log is in the run artifact \"link-check-log\"):"
+            echo ""
+            echo '```'
+            tail -n 200 link-check.log 2>/dev/null || echo "(no log captured)"
+            echo '```'
+          } > "$BODY_FILE"
+          NUM=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --search "\"$TITLE\" in:title" --json number --jq '.[0].number')
+          if [ -n "$NUM" ]; then
+            gh issue comment "$NUM" --repo "$GITHUB_REPOSITORY" --body-file "$BODY_FILE"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" --body-file "$BODY_FILE"
+          fi

--- a/.github/workflows/link-check-weekly.yml
+++ b/.github/workflows/link-check-weekly.yml
@@ -73,7 +73,7 @@ jobs:
             echo '```'
           } > "$BODY_FILE"
           NUM=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
-            --search "\"$TITLE\" in:title" --json number --jq '.[0].number')
+            --search "\"$TITLE\" in:title" --json number --jq '.[0].number // empty')
           if [ -n "$NUM" ]; then
             gh issue comment "$NUM" --repo "$GITHUB_REPOSITORY" --body-file "$BODY_FILE"
           else


### PR DESCRIPTION
Part of DOCS-2977.

## What this does

Add a GitHub Actions workflow, `.github/workflows/link-check-weekly.yml`, that runs the full link checker on a schedule.

- Runs every Monday at 07:00 UTC, and on manual trigger (`workflow_dispatch`).
- Builds the site, serves it, installs Chrome, and runs the crawler (`make build` then `make test`).
- On failure, opens or updates a GitHub issue titled "Weekly link check failed" with the last 200 lines of the report.
- Uploads the full log as a run artifact.

## Why

The crawler only ran by hand before. Nothing ran it on a schedule. Now broken links show up as a tracked issue once a week.

## Notes

- This workflow does not gate pull requests. A full external crawl is slow and can be flaky, so it should not block merges.
- It reuses the existing `make build` and `make test` targets. It does not change the crawler or the build.
- It does not build the `next` docs (`BUILD_NEXT` is unset), so it checks released versions only.

## How to validate

- Run the workflow by hand from the Actions tab (`workflow_dispatch`) on this branch.
- Confirm it builds, serves, and crawls, and that the log shows the `LINK-CHECK REPORT`.
- To test the failure path, add a known-dead URL to a page, run it, and confirm the run fails and opens an issue. Remove the URL after.
