### PR TITLE
EV-6784: fix $[prodname] leaking into v3.23 TLS sidebar label

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.23-2/operations/comms/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/operations/comms/index.mdx
@@ -2,7 +2,7 @@
 description: Provide custom TLS certificates for Calico Enterprise components.
 ---
 
-# Provide TLS certificates for $[prodname] components
+# Provide TLS certificates for Calico components
 
 $[prodname] uses TLS certificates for mutual authentication between components. The operator automatically generates and manages these certificates using a self-signed CA (`tigera-operator-signer`).
 


### PR DESCRIPTION
## Summary

The Operations sidebar entry for Enterprise **v3.23** shows the literal `$[prodname]` — "Provide TLS certificates for $[prodname] components".

Docusaurus derives the sidebar label from the raw H1 *before* the `variablesPlugin` remark transform runs, so the variable is substituted in the page body but leaks verbatim into the sidebar. Only the `version-3.23-2` snapshot is affected; current sources already use the literal "Calico components" in the H1, and the charmed-k8s page is protected by its `title` frontmatter.

Fix: change the v3.23 H1 to "Provide TLS certificates for Calico components", matching the corrected current source.

Jira: https://tigera.atlassian.net/browse/EV-6784

```release-note
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)