### PR TITLE
docs-2981: fix the Envoy Gateway version in ingress gateway docs

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.22-2/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.22-2/variables.js
@@ -19,7 +19,7 @@ const variables = {
   noderunning: 'calico-node',
   rootDirWindows: 'C:\\TigeraCalico',
   registry: 'quay.io/',
-  envoyVersion: '1.5.0',
+  envoyVersion: '1.7.2',
   chart_version_name: 'v3.22.6-0',
   tigeraOperator: releases[0]['tigera-operator'],
   dikastesVersion: releases[0].components.dikastes.version,

--- a/calico-enterprise_versioned_docs/version-3.23-2/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.23-2/variables.js
@@ -21,7 +21,7 @@ const variables = {
   noderunning: 'calico-node',
   rootDirWindows: 'C:\\TigeraCalico',
   registry: 'quay.io/',
-  envoyVersion: '1.5.0',
+  envoyVersion: '1.8.0',
   chart_version_name: 'v3.23.1-0',
   tigeraOperator: releases[0]['tigera-operator'],
   dikastesVersion: releases[0].components.dikastes.version,

--- a/calico_versioned_docs/version-3.30/variables.js
+++ b/calico_versioned_docs/version-3.30/variables.js
@@ -21,7 +21,7 @@ const variables = {
   releases,
   registry: '',
   vppbranch: 'v3.30.0',
-  envoyVersion: '1.3.2',
+  envoyVersion: '1.5.7',
   tigeraOperator: releases[0]['tigera-operator'],
   tigeraOperatorVersionShort: releases[0]['tigera-operator'].version.split('.').slice(0, 2).join('.'),
   imageNames: {

--- a/calico_versioned_docs/version-3.31/variables.js
+++ b/calico_versioned_docs/version-3.31/variables.js
@@ -20,7 +20,7 @@ const variables = {
   releases,
   registry: '',
   vppbranch: 'v3.31.0',
-  envoyVersion: '1.5.6',
+  envoyVersion: '1.8.0',
   tigeraOperator: releases[0]['tigera-operator'],
   tigeraOperatorVersionShort: releases[0]['tigera-operator'].version.split('.').slice(0, 2).join('.'),
   imageNames: {


### PR DESCRIPTION
## What this does

This PR fixes the upstream Envoy Gateway version shown in the ingress gateway docs. The version comes from a page variable named `envoyVersion`. It was wrong in four doc versions.

## Changes

| Doc version | Before | After |
|---|---|---|
| Calico 3.30 | 1.3.2 | 1.5.7 |
| Calico 3.31 | 1.5.6 | 1.8.0 |
| Calico Enterprise 3.22 | 1.5.0 | 1.7.2 |
| Calico Enterprise 3.23 | 1.5.0 | 1.8.0 |

## Why

The "Customize your ingress gateway" page uses `envoyVersion` to tell users which Envoy Gateway version their config must match. A wrong value points users at the wrong API fields and the wrong upstream docs.

## Source of truth

Each value comes from the release notes for that version:

- Calico 3.30.6: "Upgrade Envoy Gateway 1.3.2 -> 1.5.7"
- Calico 3.31.6: "Upgrade bundled Envoy Gateway to v1.8.0 (adds ListenerSet support)"
- Calico Enterprise 3.22.5: "Updated the Envoy Gateway CRDs in the operator project to v1.7.2"

Calico Enterprise 3.23 has no release note for this. Its value comes from the operator release (v1.42.1) and matches Calico 3.32.

## Not in this PR

- Values for master, Calico Cloud, and Enterprise 3.21. These have no release note yet.
- Adding `envoyVersion` to the rebuild template so it cannot be dropped on the next version cut.
- Pinning the upstream Envoy Gateway doc links to a version URL.

Ticket: DOCS-2981

🤖 Generated with [Claude Code](https://claude.com/claude-code)