### PR TITLE
Add archive redirects for Calico Enterprise 3.20 and 3.19

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -43,7 +43,6 @@
 /calicc-enterprise/3.23/ /calico-enterprise/latest/about 301
 /calico-enterprise/3.22/ /calico-enterprise/3.22/about 301
 /calico-enterprise/3.21/ /calico-enterprise/3.21/about 301
-/calico-enterprise/3.20/ /calico-enterprise/3.20/about 301
 /calico-enterprise/3.18/ /calico-enterprise/3.18/about 301
 /calico-enterprise/3.17/ /calico-enterprise/3.17/about 301
 /calico-enterprise/3.16/ /calico-enterprise/3.16/about-calico-enterprise 301
@@ -56,6 +55,8 @@
 /calico/3.26/* https://archive-os-3-26.netlify.app/calico/3.26/:splat 301
 /calico/3.25/* https://archive-os-3-25.netlify.app/calico/3.25/:splat 301
 /calico/3.24/* https://archive-os-3-24.netlify.app/calico/3.24/:splat 301
+/calico-enterprise/3.20/* https://archive-ce-3-20.netlify.app/calico-enterprise/3.20/:splat 301
+/calico-enterprise/3.19/* https://archive-ce-3-19.netlify.app/calico-enterprise/3.19/:splat 301
 /calico-enterprise/3.18/* https://archive-ce-3-18.netlify.app/calico-enterprise/3.18/:splat 301
 /calico-enterprise/3.17/* https://archive-ce-3-17.netlify.app/calico-enterprise/3.17/:splat 301
 /calico-enterprise/3.16/* https://archive-ce-3-16.netlify.app/calico-enterprise/3.16/:splat 301


### PR DESCRIPTION
## Problem

`https://docs.tigera.io/calico-enterprise/3.20/about` returns a **404**.

When CE 3.20 was archived, it was dropped from `onlyIncludeVersions` in `docusaurus.config.js` and its archive link in `src/pages/archive.md` was repointed to `https://archive-ce-3-20.netlify.app`. However, the `_redirects` splat rule that forwards `/calico-enterprise/3.20/*` to the Netlify archive site was never added — so every 3.20 URL 404s on the main site.

CE 3.19 has the **same gap** (`/calico-enterprise/3.19/about` also 404s), so this PR fixes both.

## Fix

- Add Netlify archive splat rules for `/calico-enterprise/3.20/*` and `/calico-enterprise/3.19/*`, matching the existing pattern for 3.14–3.18.
- Drop the now-stale bare `/calico-enterprise/3.20/` redirect, which pointed to `/calico-enterprise/3.20/about` — a path that is no longer built (consistent with how 3.19's bare rule was already removed).

## Verification

- `https://archive-ce-3-20.netlify.app/calico-enterprise/3.20/about` → valid page ✅
- `https://archive-ce-3-19.netlify.app/calico-enterprise/3.19/about` → valid page ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)