### PR TITLE
Add KubeVirt VM live migration to CE 3.23 release notes

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -67,6 +67,14 @@ This is the first phase of phasing out the aggregated API server: in a future re
 
 For more information, see [Enable native v3 CRDs](../operations/native-v3-crds.mdx) and [Migrate from API server to native CRDs](../operations/crd-migration.mdx).
 
+### Live migration for KubeVirt VMs
+
+$[prodname] now provides first-class networking for KubeVirt virtual machines, including persistent IP addresses and BGP-aware live migration.
+A VM keeps the same IP address across reboots, pod evictions, and live migrations, and $[prodname] uses route priority to steer traffic to the new host as a running VM migrates between nodes without breaking established connections.
+In single-rack iBGP deployments this works automatically; in multi-rack or eBGP topologies, you configure `BGPFilter` resources to propagate route priority across AS boundaries.
+
+For more information, see [Calico Enterprise networking for KubeVirt](../networking/kubevirt/kubevirt-networking.mdx) and [BGP routing for KubeVirt live migration](../networking/kubevirt/live-migration-bgp.mdx).
+
 {/* End 3.23.0-2.0 features */}
 
 {/* Start 3.23.0-1.0 features */}


### PR DESCRIPTION
## What

Adds a **Live migration for KubeVirt VMs** entry to the Calico Enterprise 3.23 release notes (`calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx`).

## Why

A customer noticed that `docs.tigera.io/calico-enterprise/latest/release-notes` says nothing about VM live migration, even though the feature shipped in Enterprise 3.23 (based on Calico Open Source 3.32, where it's a headline feature) and is already documented under `networking/kubevirt`.

The feature and its docs pages exist and are live:
- [Calico Enterprise networking for KubeVirt](https://docs.tigera.io/calico-enterprise/latest/networking/kubevirt/kubevirt-networking)
- [BGP routing for KubeVirt live migration](https://docs.tigera.io/calico-enterprise/latest/networking/kubevirt/live-migration-bgp)

It was simply omitted from the "New features and enhancements" list. This PR closes that gap.

## Notes

- Entry placed in the `3.23.0-2.0` feature block — the sub-release based on OSS 3.32.0.
- Both internal links verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)