### PR TITLE
Mark KubeVirt live migration as tech preview in CE 3.23 release notes

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -67,11 +67,13 @@ This is the first phase of phasing out the aggregated API server: in a future re
 
 For more information, see [Enable native v3 CRDs](../operations/native-v3-crds.mdx) and [Migrate from API server to native CRDs](../operations/crd-migration.mdx).
 
-### Live migration for KubeVirt VMs
+### Live migration for KubeVirt VMs (tech preview)
 
 $[prodname] now provides first-class networking for KubeVirt virtual machines, including persistent IP addresses and BGP-aware live migration.
 A VM keeps the same IP address across reboots, pod evictions, and live migrations, and $[prodname] uses route priority to steer traffic to the new host as a running VM migrates between nodes without breaking established connections.
 In single-rack iBGP deployments this works automatically; in multi-rack or eBGP topologies, you configure `BGPFilter` resources to propagate route priority across AS boundaries.
+
+Live migration support is a tech preview feature and may change significantly before it becomes GA. It currently requires BGP networking without overlay.
 
 For more information, see [Calico Enterprise networking for KubeVirt](../networking/kubevirt/kubevirt-networking.mdx) and [BGP routing for KubeVirt live migration](../networking/kubevirt/live-migration-bgp.mdx).
 


### PR DESCRIPTION
## What

Follow-up to #2855. Marks the KubeVirt live migration release-notes entry as tech preview.

## Why

#2855 merged before the tech-preview correction could be applied, so the entry currently in `main` reads as GA. The KubeVirt networking page marks live migration as a tech preview feature:

> `networking/kubevirt/kubevirt-networking.mdx` — "Live migration support is a tech preview feature. Tech preview features may be subject to significant changes before they become GA."

(Note: persistent IPs are GA; only live migration is tech preview.)

## Changes

- Add the `(tech preview)` heading suffix, consistent with other tech-preview items in this section (Multi-VRF, Native v3 CRDs).
- Add a line noting live migration is tech preview and currently requires BGP networking without overlay.

Picks up the Copilot review comment from #2855.

🤖 Generated with [Claude Code](https://claude.com/claude-code)