### PR TITLE
[CORE-11848] Update QoS controls docs

### DIFF
--- a/calico-cloud/networking/configuring/qos-controls.mdx
+++ b/calico-cloud/networking/configuring/qos-controls.mdx
@@ -14,10 +14,6 @@ Additionally, it allows configuring Differentiated Services (DiffServ) on egress
 With QoS controls, $[prodname] enforces network resource limits (bandwidth, packet rate, connections) for Kubernetes pods and OpenStack VMs, ensuring fair resource allocation and preventing performance degradation for other workloads.
 $[prodname] can also apply DiffServ on egress traffic to allow upstream devices to prioritise forwarding accordingly.
 
-## Limitations
-
-* Configuring limits for established connections is not supported on installations that use the eBPF data plane.
-
 ## Concepts
 
 ### Quality of Service Controls
@@ -130,3 +126,19 @@ spec:
 |---------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `qos.projectcalico.org/dscp` | Specifies the DSCP value of egress traffic toward an endpoint outside cluster or another host in cluster.<br/>Min value: `0`<br/>Max value: `63`<br/>String values: DF, EF, AF11, AF12, AF13, AF21, AF22, AF23, AF31, AF32, AF33, AF41, AF42, AF43, CS0, CS1, CS2, CS3, CS4, CS5, CS6                                                                                                                                     |
 
+## Troubleshooting
+
+### Bandwidth is not enforced on eBPF
+
+If you use the eBPF data plane and bandwidth limits aren't being enforced, check the calico-node logs to see if `tcx` is supported by the operating system.
+`tcx` is present in the Linux kernel version 6.6 and later, and it is required for bandwidth limits to work with the eBPF data plane.
+
+The following example shows logs that indicate an unsupported kernel version:
+
+```
+$ kubectl logs -n calico-system ds/calico-node | grep tcx
+Found 4 pods, using pod/calico-node-j9z5d
+Defaulted container "calico-node" out of: calico-node, flexvol-driver (init), ebpf-bootstrap (init), install-cni (init)
+bird: libbpf: prog 'cali_tcx_test': failed to attach to tcx: Invalid argument
+2025-10-15 16:31:48.522 [INFO][81] felix/bpf_ep_mgr.go 595: tcx is not supported. Falling back to tc
+```

--- a/calico-enterprise/networking/configuring/qos-controls.mdx
+++ b/calico-enterprise/networking/configuring/qos-controls.mdx
@@ -18,10 +18,6 @@ $[prodname] can also apply DiffServ on egress traffic to allow upstream devices 
 
 * If you use the eBPF data plane, your Linux nodes must be running kernel version 6.6 or higher in order to configure bandwidth QoS controls.
 
-## Limitations
-
-* Configuring limits for established connections is not supported on installations that use the eBPF data plane.
-
 ## Concepts
 
 ### Quality of Service Controls

--- a/calico/networking/configuring/qos-controls.mdx
+++ b/calico/networking/configuring/qos-controls.mdx
@@ -26,10 +26,6 @@ $[prodname] can also apply DiffServ on egress traffic to allow upstream devices 
 
 * If you use the eBPF data plane, your Linux nodes must be running kernel version 6.6 or higher in order to configure bandwidth QoS controls.
 
-## Limitations
-
-* Configuring limits for established connections is not supported on installations that use the eBPF data plane.
-
 ## Concepts
 
 ### Quality of Service Controls


### PR DESCRIPTION
Update the QoS controls docs to remove connection limit + eBPF limitation. Also, add troubleshooting to CC doc to sync all products.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Issue: CORE-11848
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->