### PR TITLE
SEO: Give release notes pages product-specific titles

### DIFF
--- a/calico-cloud/release-notes/index.mdx
+++ b/calico-cloud/release-notes/index.mdx
@@ -1,6 +1,7 @@
 ---
 description: Find what changed in each release of Calico Cloud, including new features, web console updates, enhancements, and fixes across dated releases.
-title: Release notes
+title: Calico Cloud release notes
+sidebar_label: Release notes
 ---
 
 # Calico Cloud release notes

--- a/calico-cloud_versioned_docs/version-22-2/release-notes/index.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/release-notes/index.mdx
@@ -1,6 +1,7 @@
 ---
 description: Find what changed in each release of Calico Cloud, including new features, web console updates, enhancements, and fixes across dated releases.
-title: Release notes
+title: Calico Cloud release notes
+sidebar_label: Release notes
 ---
 
 import IconUser from '/img/icons/user-icon.svg';

--- a/calico-enterprise/release-notes/_template.mdx
+++ b/calico-enterprise/release-notes/_template.mdx
@@ -1,6 +1,7 @@
 ---
 description: Release notes for the current Calico Enterprise release — new features, enhancements, technology previews, deprecations, upgrade notes, and bug fixes.
-title: Release notes
+title: Calico Enterprise release notes
+sidebar_label: Release notes
 ---
 
 {/*

--- a/calico-enterprise/release-notes/index.mdx
+++ b/calico-enterprise/release-notes/index.mdx
@@ -1,6 +1,7 @@
 ---
 description: Release notes for the current Calico Enterprise release — new features, enhancements, technology previews, deprecations, and bug fixes.
-title: Release notes
+title: Calico Enterprise release notes
+sidebar_label: Release notes
 ---
 
 # Calico Enterprise X.Y release notes

--- a/calico-enterprise_versioned_docs/version-3.20-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/release-notes/index.mdx
@@ -1,6 +1,7 @@
 ---
 description: What's new, and why features provide value for upgrading.
-title: Release notes
+title: Calico Enterprise release notes
+sidebar_label: Release notes
 ---
 
 import CodeBlock from '@theme/CodeBlock';

--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -1,6 +1,7 @@
 ---
 description: What's new, and why features provide value for upgrading.
-title: Release notes
+title: Calico Enterprise release notes
+sidebar_label: Release notes
 ---
 
 # Calico Enterprise 3.21 release notes

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -1,6 +1,7 @@
 ---
 description: Release notes for the current Calico Enterprise release — new features, enhancements, technology previews, deprecations, and bug fixes.
-title: Release notes
+title: Calico Enterprise release notes
+sidebar_label: Release notes
 ---
 
 # Calico Enterprise 3.22 release notes

--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -1,6 +1,7 @@
 ---
 description: Release notes for the current Calico Enterprise release — new features, enhancements, technology previews, deprecations, upgrade notes, and bug fixes.
-title: Release notes
+title: Calico Enterprise release notes
+sidebar_label: Release notes
 ---
 
 # Calico Enterprise 3.23 release notes

--- a/calico/release-notes/index.mdx
+++ b/calico/release-notes/index.mdx
@@ -1,6 +1,7 @@
 ---
 description: Release notes for the current Calico Open Source release — new features, enhancements, technology previews, deprecations, bug fixes, and known issues.
-title: Release notes
+title: Calico Open Source release notes
+sidebar_label: Release notes
 ---
 
 # Calico Open Source 3.30 release notes

--- a/calico_versioned_docs/version-3.29/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.29/release-notes/index.mdx
@@ -1,6 +1,7 @@
 ---
 description: Release notes for Calico Open Source
-title: Release notes
+title: Calico Open Source release notes
+sidebar_label: Release notes
 ---
 
 # Calico Open Source 3.29 release notes

--- a/calico_versioned_docs/version-3.30/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.30/release-notes/index.mdx
@@ -1,6 +1,7 @@
 ---
 description: Release notes for Calico Open Source
-title: Release notes
+title: Calico Open Source release notes
+sidebar_label: Release notes
 ---
 
 # Calico Open Source 3.30 release notes

--- a/calico_versioned_docs/version-3.31/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.31/release-notes/index.mdx
@@ -1,6 +1,7 @@
 ---
 description: Release notes for Calico Open Source
-title: Release notes
+title: Calico Open Source release notes
+sidebar_label: Release notes
 ---
 
 # Calico Open Source 3.31 release notes

--- a/calico_versioned_docs/version-3.32/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.32/release-notes/index.mdx
@@ -1,6 +1,7 @@
 ---
 description: Release notes for the current Calico Open Source release — new features, enhancements, technology previews, deprecations, bug fixes, and known issues.
-title: Release notes
+title: Calico Open Source release notes
+sidebar_label: Release notes
 ---
 
 # Calico Open Source 3.32 release notes


### PR DESCRIPTION
## Problem

Every product's release notes page uses the generic frontmatter `title: Release notes`, which renders as:

```
<title>Release notes | Calico Documentation</title>
```

The product name is missing from the `<title>` tag — the element search engines weight most heavily — so the page has a weak exact-match signal for high-intent queries like **"Calico release notes"**. (In the field, the release notes page is being out-ranked by less relevant pages such as *Component versions*.)

## Change

Set product-specific `title` frontmatter across the current + all versioned docs for each product:

| Product | New `title` |
|---|---|
| Calico Open Source | `Calico Open Source release notes` |
| Calico Enterprise | `Calico Enterprise release notes` |
| Calico Cloud | `Calico Cloud release notes` |

The title is intentionally **version-less** (not "3.32"), so the `<title>` stays stable across releases instead of churning every cut.

Also added `sidebar_label: Release notes` to each page so the sidebar/navigation label is unchanged (the Calico OSS sidebar derives its label from `title`). The Calico Enterprise release-notes `_template.mdx` is updated too, so future cut pages inherit the correct title.

## Notes

- No content, routing, or redirect changes — frontmatter only.
- Body `# H1` headings (e.g. "Calico Open Source 3.32 release notes") are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)