### PR TITLE
SEO: Emit <lastmod> in sitemap

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -87,6 +87,7 @@ export default async function createAsyncConfig() {
             sidebarPath: false,
           },
           sitemap: {
+            lastmod: 'date',
             ignorePatterns: ['/calico/[0-9]*.[0-9]*/**', '/calico-enterprise/[0-9]*.[0-9]*/**'],
           },
           googleTagManager: {


### PR DESCRIPTION
## Problem

The generated `sitemap.xml` contains no `<lastmod>` timestamps — every entry is just:

```xml
<url><loc>.../calico/latest/release-notes/</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
```

Without `<lastmod>`, search engines have no signal that a page changed, so they recrawl lazily. This hits pages whose **body is fully replaced each release under a stable URL** hardest — above all `/calico/latest/release-notes/`, whose content swaps every minor release. In the field, Google's indexed copy of that page was stale by several releases (showing 3.28-era content while live was 3.32).

## Change

Enable the sitemap plugin's `lastmod: 'date'` option:

```js
sitemap: {
  lastmod: 'date',
  ignorePatterns: ['/calico/[0-9]*.[0-9]*/**', '/calico-enterprise/[0-9]*.[0-9]*/**'],
},
```

Each URL now gets a `<lastmod>` date (derived from git history / file mtime). `'date'` emits `YYYY-MM-DD` (day granularity, appropriate for docs).

## Notes

- Supported since Docusaurus 3.4; this project is on `^3.10.1`.
- Config-only; no content or routing changes.
- Pairs with #2858 (product-specific release-notes titles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)