### PR TITLE
docs(ingress-gateway): fix Gateway API supported versions for v1.5.1 and add v3.32 upgrade note

### DIFF
--- a/calico-enterprise/networking/ingress-gateway/about-calico-ingress-gateway.mdx
+++ b/calico-enterprise/networking/ingress-gateway/about-calico-ingress-gateway.mdx
@@ -70,18 +70,18 @@ Calico Ingress Gateway does not place more than one gateway behind a single load
 
 Calico Ingress Gateway supports the following Gateway API resources.
 
-| Resource         | Versions          |
-| ---------------- | ----------------- |
-| BackendLBPolicy  | v1alpha2          |
-| BackendTLSPolicy | v1alpha3          |
-| GatewayClass     | v1, v1beta1       |
-| Gateway          | v1, v1beta1       |
-| GRPCRoute        | v1, v1alpha2      |
-| HTTPRoute        | v1, v1beta1       |
-| ReferenceGrant   | v1beta1, v1alpha2 |
-| TCPRoute         | v1alpha2          |
-| TLSRoute         | v1alpha2          |
-| UDPRoute         | v1alpha2          |
+| Resource         | Versions               |
+| ---------------- | ---------------------- |
+| BackendTLSPolicy | v1, v1alpha3           |
+| GatewayClass     | v1, v1beta1            |
+| Gateway          | v1, v1beta1            |
+| GRPCRoute        | v1                     |
+| HTTPRoute        | v1, v1beta1            |
+| ListenerSet      | v1                     |
+| ReferenceGrant   | v1, v1beta1            |
+| TCPRoute         | v1alpha2               |
+| TLSRoute         | v1, v1alpha2, v1alpha3 |
+| UDPRoute         | v1alpha2               |
 
 :::note
 
@@ -89,7 +89,7 @@ OpenShift 4.19 introduced [restrictions](https://docs.redhat.com/en/documentatio
 
 - The available Gateway API resources in OpenShift 4.19 are: `GatewayClass`, `Gateway`, `GRPCRoute`, `HTTPRoute` and `ReferenceGrant`.
 
-- Other Gateway API resources, namely `BackendLBPolicy`, `BackendTLSPolicy`, `TCPRoute`, `TLSRoute` and `UDPRoute`, are not available in OpenShift 4.19.
+- Other Gateway API resources, namely `BackendTLSPolicy`, `ListenerSet`, `TCPRoute`, `TLSRoute` and `UDPRoute`, are not available in OpenShift 4.19.
 
 :::
 

--- a/calico-enterprise_versioned_docs/version-3.23-2/networking/ingress-gateway/about-calico-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/networking/ingress-gateway/about-calico-ingress-gateway.mdx
@@ -51,18 +51,18 @@ This feature allows operators to secure their ingress points against the OWASP T
 
 Calico Ingress Gateway supports the following Gateway API resources.
 
-| Resource         | Versions          |
-| ---------------- | ----------------- |
-| BackendLBPolicy  | v1alpha2          |
-| BackendTLSPolicy | v1alpha3          |
-| GatewayClass     | v1, v1beta1       |
-| Gateway          | v1, v1beta1       |
-| GRPCRoute        | v1, v1alpha2      |
-| HTTPRoute        | v1, v1beta1       |
-| ReferenceGrant   | v1beta1, v1alpha2 |
-| TCPRoute         | v1alpha2          |
-| TLSRoute         | v1alpha2          |
-| UDPRoute         | v1alpha2          |
+| Resource         | Versions               |
+| ---------------- | ---------------------- |
+| BackendTLSPolicy | v1, v1alpha3           |
+| GatewayClass     | v1, v1beta1            |
+| Gateway          | v1, v1beta1            |
+| GRPCRoute        | v1                     |
+| HTTPRoute        | v1, v1beta1            |
+| ListenerSet      | v1                     |
+| ReferenceGrant   | v1, v1beta1            |
+| TCPRoute         | v1alpha2               |
+| TLSRoute         | v1, v1alpha2, v1alpha3 |
+| UDPRoute         | v1alpha2               |
 
 :::note
 
@@ -70,7 +70,7 @@ OpenShift 4.19 introduced [restrictions](https://docs.redhat.com/en/documentatio
 
 - The available Gateway API resources in OpenShift 4.19 are: `GatewayClass`, `Gateway`, `GRPCRoute`, `HTTPRoute` and `ReferenceGrant`.
 
-- Other Gateway API resources, namely `BackendLBPolicy`, `BackendTLSPolicy`, `TCPRoute`, `TLSRoute` and `UDPRoute`, are not available in OpenShift 4.19.
+- Other Gateway API resources, namely `BackendTLSPolicy`, `ListenerSet`, `TCPRoute`, `TLSRoute` and `UDPRoute`, are not available in OpenShift 4.19.
 
 :::
 

--- a/calico/networking/ingress-gateway/about-calico-ingress-gateway.mdx
+++ b/calico/networking/ingress-gateway/about-calico-ingress-gateway.mdx
@@ -68,18 +68,18 @@ Calico Ingress Gateway does not place more than one gateway behind a single load
 
 Calico Ingress Gateway supports the following Gateway API resources.
 
-| Resource         | Versions          |
-| ---------------- | ----------------- |
-| BackendLBPolicy  | v1alpha2          |
-| BackendTLSPolicy | v1alpha3          |
-| GatewayClass     | v1, v1beta1       |
-| Gateway          | v1, v1beta1       |
-| GRPCRoute        | v1, v1alpha2      |
-| HTTPRoute        | v1, v1beta1       |
-| ReferenceGrant   | v1beta1, v1alpha2 |
-| TCPRoute         | v1alpha2          |
-| TLSRoute         | v1alpha2          |
-| UDPRoute         | v1alpha2          |
+| Resource         | Versions               |
+| ---------------- | ---------------------- |
+| BackendTLSPolicy | v1, v1alpha3           |
+| GatewayClass     | v1, v1beta1            |
+| Gateway          | v1, v1beta1            |
+| GRPCRoute        | v1                     |
+| HTTPRoute        | v1, v1beta1            |
+| ListenerSet      | v1                     |
+| ReferenceGrant   | v1, v1beta1            |
+| TCPRoute         | v1alpha2               |
+| TLSRoute         | v1, v1alpha2, v1alpha3 |
+| UDPRoute         | v1alpha2               |
 
 :::note
 
@@ -87,7 +87,7 @@ OpenShift 4.19 introduced [restrictions](https://docs.redhat.com/en/documentatio
 
 - The available Gateway API resources in OpenShift 4.19 are: `GatewayClass`, `Gateway`, `GRPCRoute`, `HTTPRoute` and `ReferenceGrant`.
 
-- Other Gateway API resources, namely `BackendLBPolicy`, `BackendTLSPolicy`, `TCPRoute`, `TLSRoute` and `UDPRoute`, are not available in OpenShift 4.19.
+- Other Gateway API resources, namely `BackendTLSPolicy`, `ListenerSet`, `TCPRoute`, `TLSRoute` and `UDPRoute`, are not available in OpenShift 4.19.
 
 :::
 

--- a/calico_versioned_docs/version-3.31/networking/ingress-gateway/about-calico-ingress-gateway.mdx
+++ b/calico_versioned_docs/version-3.31/networking/ingress-gateway/about-calico-ingress-gateway.mdx
@@ -51,18 +51,18 @@ This feature allows operators to secure their ingress points against the OWASP T
 
 Calico Ingress Gateway supports the following Gateway API resources.
 
-| Resource         | Versions          |
-| ---------------- | ----------------- |
-| BackendLBPolicy  | v1alpha2          |
-| BackendTLSPolicy | v1alpha3          |
-| GatewayClass     | v1, v1beta1       |
-| Gateway          | v1, v1beta1       |
-| GRPCRoute        | v1, v1alpha2      |
-| HTTPRoute        | v1, v1beta1       |
-| ReferenceGrant   | v1beta1, v1alpha2 |
-| TCPRoute         | v1alpha2          |
-| TLSRoute         | v1alpha2          |
-| UDPRoute         | v1alpha2          |
+| Resource         | Versions               |
+| ---------------- | ---------------------- |
+| BackendTLSPolicy | v1, v1alpha3           |
+| GatewayClass     | v1, v1beta1            |
+| Gateway          | v1, v1beta1            |
+| GRPCRoute        | v1                     |
+| HTTPRoute        | v1, v1beta1            |
+| ListenerSet      | v1                     |
+| ReferenceGrant   | v1, v1beta1            |
+| TCPRoute         | v1alpha2               |
+| TLSRoute         | v1, v1alpha2, v1alpha3 |
+| UDPRoute         | v1alpha2               |
 
 :::note
 
@@ -70,7 +70,7 @@ OpenShift 4.19 introduced [restrictions](https://docs.redhat.com/en/documentatio
 
 - The available Gateway API resources in OpenShift 4.19 are: `GatewayClass`, `Gateway`, `GRPCRoute`, `HTTPRoute` and `ReferenceGrant`.
 
-- Other Gateway API resources, namely `BackendLBPolicy`, `BackendTLSPolicy`, `TCPRoute`, `TLSRoute` and `UDPRoute`, are not available in OpenShift 4.19.
+- Other Gateway API resources, namely `BackendTLSPolicy`, `ListenerSet`, `TCPRoute`, `TLSRoute` and `UDPRoute`, are not available in OpenShift 4.19.
 
 :::
 

--- a/calico_versioned_docs/version-3.31/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.31/release-notes/index.mdx
@@ -375,3 +375,9 @@ June 18, 2026
 #### Updating
 
 To update a previous version of Calico, see [our upgrade guides](../operations/upgrading/index.mdx).
+
+If you use Calico Ingress Gateway, this release bumps the bundled Envoy Gateway to v1.8.0, which requires the Gateway API v1.5.1 CRDs. Envoy Gateway v1.8 watches `TLSRoute`, `ListenerSet`, and `BackendTLSPolicy` at `gateway.networking.k8s.io/v1`. If those CRDs are still served only at an older version, for example `v1alpha2`, the `envoy-gateway` pod fails to start with `no matches for kind "TLSRoute" in version "gateway.networking.k8s.io/v1"`.
+
+If the Tigera Operator manages your Gateway API CRDs (the default), set `crdManagement: Reconcile` on the `GatewayAPI` resource so the operator upgrades the CRDs during the upgrade. If a `safe-upgrades.gateway.networking.k8s.io` ValidatingAdmissionPolicy blocks the upgrade with `Installing experimental CRDs on top of standard channel CRDs is prohibited`, delete that policy and its binding, then let the operator reconcile. The operator recreates the policy afterward.
+
+If you manage the Gateway API CRDs yourself, install the Gateway API v1.5.1 CRDs before upgrading.

--- a/calico_versioned_docs/version-3.32/networking/ingress-gateway/about-calico-ingress-gateway.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ingress-gateway/about-calico-ingress-gateway.mdx
@@ -51,18 +51,18 @@ This feature allows operators to secure their ingress points against the OWASP T
 
 Calico Ingress Gateway supports the following Gateway API resources.
 
-| Resource         | Versions          |
-| ---------------- | ----------------- |
-| BackendLBPolicy  | v1alpha2          |
-| BackendTLSPolicy | v1alpha3          |
-| GatewayClass     | v1, v1beta1       |
-| Gateway          | v1, v1beta1       |
-| GRPCRoute        | v1, v1alpha2      |
-| HTTPRoute        | v1, v1beta1       |
-| ReferenceGrant   | v1beta1, v1alpha2 |
-| TCPRoute         | v1alpha2          |
-| TLSRoute         | v1alpha2          |
-| UDPRoute         | v1alpha2          |
+| Resource         | Versions               |
+| ---------------- | ---------------------- |
+| BackendTLSPolicy | v1, v1alpha3           |
+| GatewayClass     | v1, v1beta1            |
+| Gateway          | v1, v1beta1            |
+| GRPCRoute        | v1                     |
+| HTTPRoute        | v1, v1beta1            |
+| ListenerSet      | v1                     |
+| ReferenceGrant   | v1, v1beta1            |
+| TCPRoute         | v1alpha2               |
+| TLSRoute         | v1, v1alpha2, v1alpha3 |
+| UDPRoute         | v1alpha2               |
 
 :::note
 
@@ -70,7 +70,7 @@ OpenShift 4.19 introduced [restrictions](https://docs.redhat.com/en/documentatio
 
 - The available Gateway API resources in OpenShift 4.19 are: `GatewayClass`, `Gateway`, `GRPCRoute`, `HTTPRoute` and `ReferenceGrant`.
 
-- Other Gateway API resources, namely `BackendLBPolicy`, `BackendTLSPolicy`, `TCPRoute`, `TLSRoute` and `UDPRoute`, are not available in OpenShift 4.19.
+- Other Gateway API resources, namely `BackendTLSPolicy`, `ListenerSet`, `TCPRoute`, `TLSRoute` and `UDPRoute`, are not available in OpenShift 4.19.
 
 :::
 

--- a/calico_versioned_docs/version-3.32/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.32/release-notes/index.mdx
@@ -281,6 +281,12 @@ To update a previous version of Calico, see [our upgrade guides](../operations/u
 
 To update a previous version of Calico, see [our upgrade guides](../operations/upgrading/index.mdx).
 
+If you use Calico Ingress Gateway, this release bumps the bundled Envoy Gateway to v1.8.0, which requires the Gateway API v1.5.1 CRDs. Envoy Gateway v1.8 watches `TLSRoute`, `ListenerSet`, and `BackendTLSPolicy` at `gateway.networking.k8s.io/v1`. If those CRDs are still served only at an older version, for example `v1alpha2`, the `envoy-gateway` pod fails to start with `no matches for kind "TLSRoute" in version "gateway.networking.k8s.io/v1"`.
+
+If the Tigera Operator manages your Gateway API CRDs (the default), set `crdManagement: Reconcile` on the `GatewayAPI` resource so the operator upgrades the CRDs during the upgrade. If a `safe-upgrades.gateway.networking.k8s.io` ValidatingAdmissionPolicy blocks the upgrade with `Installing experimental CRDs on top of standard channel CRDs is prohibited`, delete that policy and its binding, then let the operator reconcile. The operator recreates the policy afterward.
+
+If you manage the Gateway API CRDs yourself, install the Gateway API v1.5.1 CRDs before upgrading.
+
 {/*
 ### Calico Open Source 3.32.2 bug fix release
 


### PR DESCRIPTION
Product Version(s):
Calico 3.32 (and next), Calico Enterprise 3.23.
Calico Cloud is likely affected too, but I still need to confirm its bundled Envoy Gateway version, so it is not included here yet.

Issue:
https://tigera.atlassian.net/browse/EV-6840

Link to docs preview:
_Pending the Netlify preview build._

SME review:
- [ ] An SME has approved this change.

DOCS review:
- [ ] A member of the docs team has approved this change.

Additional information:

Calico 3.32 and Calico Enterprise 3.23 bundle Envoy Gateway v1.8, which ships Gateway API v1.5.1. In v1.5, `TLSRoute`, `ListenerSet`, and `BackendTLSPolicy` are served at `v1`, and Envoy Gateway v1.8 watches them there. The supported-resources table still listed the older pre-v1.5 versions (for example `TLSRoute` at `v1alpha2`), which reads as if the newer versions are unsupported.

This PR does two things:

- Rebuilds the supported Gateway API resources table from the v1.5.1 experimental channel that the operator bundles. Changed rows: `TLSRoute`, `BackendTLSPolicy`, `GRPCRoute`, `ReferenceGrant`, plus a new `ListenerSet` row. `BackendLBPolicy` is left as is, since it is not in the v1.5.1 `gateway.networking.k8s.io` set and needs a separate check.
- Adds an upgrade note to the 3.32.1 release notes. If the Gateway API CRDs are still on an older version at upgrade time, the `envoy-gateway` pod fails to start. The note explains how to get the CRDs to v1.5.1: operator `crdManagement: Reconcile`, clearing the `safe-upgrades` admission policy if it blocks the change, or installing the CRDs yourself.

Only versions that bundle Gateway API v1.5.1 are touched. Calico 3.31 and Calico Enterprise 3.22 ship an older Gateway API, so their tables are correct and left alone.

The crash itself is fixed in code by https://github.com/projectcalico/calico/pull/13242 (Envoy Gateway skips absent optional CRDs). These docs cover the released versions where that fix has not landed yet.

Merge checklist:
- [ ] Deploy preview inspected wherever changes were made
- [ ] Build completed successfully
- [ ] Test have passed
