### PR TITLE
docs: fix dead external links (GKE docs migration + Rancher)

### DIFF
--- a/calico-cloud/get-started/operator-checklist.mdx
+++ b/calico-cloud/get-started/operator-checklist.mdx
@@ -614,7 +614,7 @@ Some clusters have limited pod-networked pod capacity.
 
 - For the AWS CNI plugin, the [number of pods that can be networked is based on the size of the instance](https://docs.aws.amazon.com/eks/latest/userguide/pod-networking.html).
 - For AKS with the Azure CNI, the [number of pods that can be networked is set at cluster deployment time or when new node pools are created (default of 30)](https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni#maximum-pods-per-node).
-- For GKE, there is a [hard limit of 110 pods per node](https://cloud.google.com/kubernetes-engine/docs/concepts/planning-scalability).
+- For GKE, there is a [hard limit of 110 pods per node](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/planning-scalability).
 - For Calico CNI, the pod limit is based on the available IPs in the IPPool, and there is no specific per node limit.
 
 Verify you have the following pod-networked pod capacity.

--- a/calico-cloud/get-started/operator-checklist.mdx
+++ b/calico-cloud/get-started/operator-checklist.mdx
@@ -614,7 +614,7 @@ Some clusters have limited pod-networked pod capacity.
 
 - For the AWS CNI plugin, the [number of pods that can be networked is based on the size of the instance](https://docs.aws.amazon.com/eks/latest/userguide/pod-networking.html).
 - For AKS with the Azure CNI, the [number of pods that can be networked is set at cluster deployment time or when new node pools are created (default of 30)](https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni#maximum-pods-per-node).
-- For GKE, there is a [hard limit of 110 pods per node](https://cloud.google.com/kubernetes-engine/docs/best-practices/scalability#dimension_limits).
+- For GKE, there is a [hard limit of 110 pods per node](https://cloud.google.com/kubernetes-engine/docs/concepts/planning-scalability).
 - For Calico CNI, the pod limit is based on the available IPs in the IPPool, and there is no specific per node limit.
 
 Verify you have the following pod-networked pod capacity.

--- a/calico-cloud_versioned_docs/version-22-2/get-started/operator-checklist.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/get-started/operator-checklist.mdx
@@ -650,7 +650,7 @@ Some clusters have limited pod-networked pod capacity.
 
 - For the AWS CNI plugin, the [number of pods that can be networked is based on the size of the instance](https://docs.aws.amazon.com/eks/latest/userguide/pod-networking.html).
 - For AKS with the Azure CNI, the [number of pods that can be networked is set at cluster deployment time or when new node pools are created (default of 30)](https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni#maximum-pods-per-node).
-- For GKE, there is a [hard limit of 110 pods per node](https://cloud.google.com/kubernetes-engine/docs/best-practices/scalability#dimension_limits).
+- For GKE, there is a [hard limit of 110 pods per node](https://cloud.google.com/kubernetes-engine/docs/concepts/planning-scalability).
 - For Calico CNI, the pod limit is based on the available IPs in the IPPool, and there is no specific per node limit.
 
 Verify you have the following pod-networked pod capacity.

--- a/calico-cloud_versioned_docs/version-22-2/get-started/operator-checklist.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/get-started/operator-checklist.mdx
@@ -650,7 +650,7 @@ Some clusters have limited pod-networked pod capacity.
 
 - For the AWS CNI plugin, the [number of pods that can be networked is based on the size of the instance](https://docs.aws.amazon.com/eks/latest/userguide/pod-networking.html).
 - For AKS with the Azure CNI, the [number of pods that can be networked is set at cluster deployment time or when new node pools are created (default of 30)](https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni#maximum-pods-per-node).
-- For GKE, there is a [hard limit of 110 pods per node](https://cloud.google.com/kubernetes-engine/docs/concepts/planning-scalability).
+- For GKE, there is a [hard limit of 110 pods per node](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/planning-scalability).
 - For Calico CNI, the pod limit is based on the available IPs in the IPPool, and there is no specific per node limit.
 
 Verify you have the following pod-networked pod capacity.

--- a/calico-enterprise/getting-started/install-on-clusters/gke.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/gke.mdx
@@ -41,7 +41,7 @@ The geeky details of what you get:
 
 - User account has IAM permissions
 
-  Verify your user account has IAM permissions to create Kubernetes ClusterRoles, ClusterRoleBindings, Deployments, Service Accounts, and Custom Resource Definitions. The easiest way to grant permissions is to assign the "Kubernetes Service Cluster Admin Role” to your user account. For help, see [GKE access control](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
+  Verify your user account has IAM permissions to create Kubernetes ClusterRoles, ClusterRoleBindings, Deployments, Service Accounts, and Custom Resource Definitions. The easiest way to grant permissions is to assign the "Kubernetes Service Cluster Admin Role” to your user account. For help, see [GKE access control](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
 
   :::note
 

--- a/calico-enterprise/getting-started/install-on-clusters/rancher-ui.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/rancher-ui.mdx
@@ -44,7 +44,7 @@ The geeky details of what you get:
 
 ### Prepare a Calico Open Source cluster
 
-1. [Provision an RKE2 cluster using Calico as the CNI and default config options](https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher).
+1. [Provision an RKE2 cluster using Calico as the CNI and default config options](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher).
 2. Validate that the RKE2 cluster is set up and running.
 3. In Rancher UI, open a `kubectl` shell for the cluster, and perform the next steps.
 4. Annotate the Calico Helm chart with `helmcharts.helm.cattle.io/unmanaged=true`. (This avoids Rancher resetting the CNI to Calico when the RKE2 cluster is shut down or upgraded.)

--- a/calico-enterprise/reference/support-policy.mdx
+++ b/calico-enterprise/reference/support-policy.mdx
@@ -24,7 +24,7 @@ $[prodname] supports the latest version of EKS at time of $[prodname] release, a
 
 ## Google Kubernetes Engine (GKE)
 
-$[prodname] supports the latest version of [GKE regular channel](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels) at time of $[prodname] release, as stated in the system requirements.
+$[prodname] supports the latest version of [GKE regular channel](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/release-channels) at time of $[prodname] release, as stated in the system requirements.
 
 ## Mirantis Kubernetes Engine (MKE)
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/gke.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/gke.mdx
@@ -39,7 +39,7 @@ The geeky details of what you get:
 
 - User account has IAM permissions
 
-  Verify your user account has IAM permissions to create Kubernetes ClusterRoles, ClusterRoleBindings, Deployments, Service Accounts, and Custom Resource Definitions. The easiest way to grant permissions is to assign the "Kubernetes Service Cluster Admin Role” to your user account. For help, see [GKE access control](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
+  Verify your user account has IAM permissions to create Kubernetes ClusterRoles, ClusterRoleBindings, Deployments, Service Accounts, and Custom Resource Definitions. The easiest way to grant permissions is to assign the "Kubernetes Service Cluster Admin Role” to your user account. For help, see [GKE access control](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
 
   :::note
 

--- a/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/rancher-ui.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/getting-started/install-on-clusters/rancher-ui.mdx
@@ -44,7 +44,7 @@ The geeky details of what you get:
 
 ### Prepare a Calico Open Source cluster
 
-1. [Provision an RKE2 cluster using Calico as the CNI and default config options](https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher).
+1. [Provision an RKE2 cluster using Calico as the CNI and default config options](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher).
 2. Validate that the RKE2 cluster is set up and running.
 3. In Rancher UI, open a `kubectl` shell for the cluster, and perform the next steps.
 4. Annotate the Calico Helm chart with `helmcharts.helm.cattle.io/unmanaged=true`. (This avoids Rancher resetting the CNI to Calico when the RKE2 cluster is shut down or upgraded.)

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/support-policy.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/support-policy.mdx
@@ -24,7 +24,7 @@ $[prodname] supports the latest version of EKS at time of $[prodname] release, a
 
 ## Google Kubernetes Engine (GKE)
 
-$[prodname] supports the latest version of [GKE regular channel](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels) at time of $[prodname] release, as stated in the system requirements.
+$[prodname] supports the latest version of [GKE regular channel](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/release-channels) at time of $[prodname] release, as stated in the system requirements.
 
 ## Mirantis Kubernetes Engine (MKE)
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/gke.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/gke.mdx
@@ -39,7 +39,7 @@ The geeky details of what you get:
 
 - User account has IAM permissions
 
-  Verify your user account has IAM permissions to create Kubernetes ClusterRoles, ClusterRoleBindings, Deployments, Service Accounts, and Custom Resource Definitions. The easiest way to grant permissions is to assign the "Kubernetes Service Cluster Admin Role” to your user account. For help, see [GKE access control](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
+  Verify your user account has IAM permissions to create Kubernetes ClusterRoles, ClusterRoleBindings, Deployments, Service Accounts, and Custom Resource Definitions. The easiest way to grant permissions is to assign the "Kubernetes Service Cluster Admin Role” to your user account. For help, see [GKE access control](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
 
   :::note
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/rancher-ui.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/rancher-ui.mdx
@@ -44,7 +44,7 @@ The geeky details of what you get:
 
 ### Prepare a Calico Open Source cluster
 
-1. [Provision an RKE2 cluster using Calico as the CNI and default config options](https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher).
+1. [Provision an RKE2 cluster using Calico as the CNI and default config options](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher).
 2. Validate that the RKE2 cluster is set up and running.
 3. In Rancher UI, open a `kubectl` shell for the cluster, and perform the next steps.
 4. Annotate the Calico Helm chart with `helmcharts.helm.cattle.io/unmanaged=true`. (This avoids Rancher resetting the CNI to Calico when the RKE2 cluster is shut down or upgraded.)

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/support-policy.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/support-policy.mdx
@@ -24,7 +24,7 @@ $[prodname] supports the latest version of EKS at time of $[prodname] release, a
 
 ## Google Kubernetes Engine (GKE)
 
-$[prodname] supports the latest version of [GKE regular channel](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels) at time of $[prodname] release, as stated in the system requirements.
+$[prodname] supports the latest version of [GKE regular channel](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/release-channels) at time of $[prodname] release, as stated in the system requirements.
 
 ## Mirantis Kubernetes Engine (MKE)
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/gke.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/gke.mdx
@@ -39,7 +39,7 @@ The geeky details of what you get:
 
 - User account has IAM permissions
 
-  Verify your user account has IAM permissions to create Kubernetes ClusterRoles, ClusterRoleBindings, Deployments, Service Accounts, and Custom Resource Definitions. The easiest way to grant permissions is to assign the "Kubernetes Service Cluster Admin Role” to your user account. For help, see [GKE access control](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
+  Verify your user account has IAM permissions to create Kubernetes ClusterRoles, ClusterRoleBindings, Deployments, Service Accounts, and Custom Resource Definitions. The easiest way to grant permissions is to assign the "Kubernetes Service Cluster Admin Role” to your user account. For help, see [GKE access control](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
 
   :::note
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/rancher-ui.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/rancher-ui.mdx
@@ -44,7 +44,7 @@ The geeky details of what you get:
 
 ### Prepare a Calico Open Source cluster
 
-1. [Provision an RKE2 cluster using Calico as the CNI and default config options](https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher).
+1. [Provision an RKE2 cluster using Calico as the CNI and default config options](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher).
 2. Validate that the RKE2 cluster is set up and running.
 3. In Rancher UI, open a `kubectl` shell for the cluster, and perform the next steps.
 4. Annotate the Calico Helm chart with `helmcharts.helm.cattle.io/unmanaged=true`. (This avoids Rancher resetting the CNI to Calico when the RKE2 cluster is shut down or upgraded.)

--- a/calico-enterprise_versioned_docs/version-3.22-2/reference/support-policy.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/reference/support-policy.mdx
@@ -24,7 +24,7 @@ $[prodname] supports the latest version of EKS at time of $[prodname] release, a
 
 ## Google Kubernetes Engine (GKE)
 
-$[prodname] supports the latest version of [GKE regular channel](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels) at time of $[prodname] release, as stated in the system requirements.
+$[prodname] supports the latest version of [GKE regular channel](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/release-channels) at time of $[prodname] release, as stated in the system requirements.
 
 ## Mirantis Kubernetes Engine (MKE)
 

--- a/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/gke.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/gke.mdx
@@ -41,7 +41,7 @@ The geeky details of what you get:
 
 - User account has IAM permissions
 
-  Verify your user account has IAM permissions to create Kubernetes ClusterRoles, ClusterRoleBindings, Deployments, Service Accounts, and Custom Resource Definitions. The easiest way to grant permissions is to assign the "Kubernetes Service Cluster Admin Role” to your user account. For help, see [GKE access control](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
+  Verify your user account has IAM permissions to create Kubernetes ClusterRoles, ClusterRoleBindings, Deployments, Service Accounts, and Custom Resource Definitions. The easiest way to grant permissions is to assign the "Kubernetes Service Cluster Admin Role” to your user account. For help, see [GKE access control](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
 
   :::note
 

--- a/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/rancher-ui.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/rancher-ui.mdx
@@ -44,7 +44,7 @@ The geeky details of what you get:
 
 ### Prepare a Calico Open Source cluster
 
-1. [Provision an RKE2 cluster using Calico as the CNI and default config options](https://ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher).
+1. [Provision an RKE2 cluster using Calico as the CNI and default config options](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/launch-kubernetes-with-rancher).
 2. Validate that the RKE2 cluster is set up and running.
 3. In Rancher UI, open a `kubectl` shell for the cluster, and perform the next steps.
 4. Annotate the Calico Helm chart with `helmcharts.helm.cattle.io/unmanaged=true`. (This avoids Rancher resetting the CNI to Calico when the RKE2 cluster is shut down or upgraded.)

--- a/calico-enterprise_versioned_docs/version-3.23-2/reference/support-policy.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/reference/support-policy.mdx
@@ -24,7 +24,7 @@ $[prodname] supports the latest version of EKS at time of $[prodname] release, a
 
 ## Google Kubernetes Engine (GKE)
 
-$[prodname] supports the latest version of [GKE regular channel](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels) at time of $[prodname] release, as stated in the system requirements.
+$[prodname] supports the latest version of [GKE regular channel](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/release-channels) at time of $[prodname] release, as stated in the system requirements.
 
 ## Mirantis Kubernetes Engine (MKE)
 

--- a/calico/getting-started/kubernetes/managed-public-cloud/gke.mdx
+++ b/calico/getting-started/kubernetes/managed-public-cloud/gke.mdx
@@ -55,7 +55,7 @@ The geeky details of what you get:
 
 ## Additional resources
 
-For complete GKE requirements, limitations, and other installation methods, see [Enable network policy enforcement](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy#enabling_network_policy_enforcement).
+For complete GKE requirements, limitations, and other installation methods, see [Enable network policy enforcement](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/network-policy#enabling_network_policy_enforcement).
 
 :::note
 

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/managed-public-cloud/gke.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/managed-public-cloud/gke.mdx
@@ -55,7 +55,7 @@ The geeky details of what you get:
 
 ## Additional resources
 
-For complete GKE requirements, limitations, and other installation methods, see [Enable network policy enforcement](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy#enabling_network_policy_enforcement).
+For complete GKE requirements, limitations, and other installation methods, see [Enable network policy enforcement](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/network-policy#enabling_network_policy_enforcement).
 
 :::note
 

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/managed-public-cloud/gke.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/managed-public-cloud/gke.mdx
@@ -55,7 +55,7 @@ The geeky details of what you get:
 
 ## Additional resources
 
-For complete GKE requirements, limitations, and other installation methods, see [Enable network policy enforcement](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy#enabling_network_policy_enforcement).
+For complete GKE requirements, limitations, and other installation methods, see [Enable network policy enforcement](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/network-policy#enabling_network_policy_enforcement).
 
 :::note
 

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/managed-public-cloud/gke.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/managed-public-cloud/gke.mdx
@@ -55,7 +55,7 @@ The geeky details of what you get:
 
 ## Additional resources
 
-For complete GKE requirements, limitations, and other installation methods, see [Enable network policy enforcement](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy#enabling_network_policy_enforcement).
+For complete GKE requirements, limitations, and other installation methods, see [Enable network policy enforcement](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/network-policy#enabling_network_policy_enforcement).
 
 :::note
 

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/managed-public-cloud/gke.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/managed-public-cloud/gke.mdx
@@ -55,7 +55,7 @@ The geeky details of what you get:
 
 ## Additional resources
 
-For complete GKE requirements, limitations, and other installation methods, see [Enable network policy enforcement](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy#enabling_network_policy_enforcement).
+For complete GKE requirements, limitations, and other installation methods, see [Enable network policy enforcement](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/network-policy#enabling_network_policy_enforcement).
 
 :::note
 


### PR DESCRIPTION
## Summary

Link-check is failing on current PRs due to dead external links. This fixes them across the current docs and all versioned copies.

### 1. GKE docs migrated to `docs.cloud.google.com`

Google moved the GKE documentation. `cloud.google.com/kubernetes-engine/docs/*` now issues a **cross-host 301** to `docs.cloud.google.com` that the link-checker won't follow, so it reports the links as dead (404). `docs.cloud.google.com` serves the same pages with a **direct 200 for every user-agent**.

Rewrote every `cloud.google.com/kubernetes-engine/docs/` link → `docs.cloud.google.com/kubernetes-engine/docs/`. This covers the four URLs the crawler flagged plus their versioned copies:

| URL path | Origin page |
|---|---|
| `concepts/planning-scalability` | `calico-cloud/get-started/operator-checklist` |
| `concepts/release-channels` | `calico-enterprise/.../reference/support-policy` |
| `how-to/network-policy#enabling_network_policy_enforcement` | `calico/.../managed-public-cloud/gke` |
| `how-to/role-based-access-control` | `calico-enterprise/.../install-on-clusters/gke` |

(The GKE `planning-scalability` page also replaces the old `best-practices/scalability#dimension_limits` page, which 404s outright — it still documents the 110 pods-per-node limit the text references.)

### 2. Rancher docs restructured

`ranchermanager.docs.rancher.com/pages-for-subheaders/launch-kubernetes-with-rancher` (404) → `.../how-to-guides/new-user-guides/launch-kubernetes-with-rancher`.

---

All replacement URLs verified to return 200 (including with an empty/crawler user-agent) and to still cover the referenced content. Fixed in current + all versioned docs so the same check won't fail on other versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
