### PR TITLE
docs: fix two more dead links breaking the crawler build

### DIFF
--- a/calico/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
+++ b/calico/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
@@ -19,7 +19,7 @@ Managing your own Kubernetes cluster (as opposed to using a managed-Kubernetes s
 
 ## Before you begin...
 
-[Install and configure the Google Cloud CLI tools](https://cloud.google.com/sdk/docs/quickstarts)
+[Install and configure the Google Cloud CLI tools](https://docs.cloud.google.com/sdk/docs/install)
 
 ## How to
 

--- a/calico/operations/ebpf/enabling-ebpf.mdx
+++ b/calico/operations/ebpf/enabling-ebpf.mdx
@@ -429,7 +429,7 @@ This feature is tech preview. Tech preview features may be subject to significan
 :::
 
 By default, the Calico CNI plugin creates a veth pair for each pod's network interface.
-On Linux 6.7 and later, you can opt the CNI plugin into creating a [netkit](https://docs.kernel.org/networking/netkit.html) L2 pair instead.
+On Linux 6.7 and later, you can opt the CNI plugin into creating a [netkit](https://lwn.net/Articles/949960/) L2 pair instead.
 With netkit, the eBPF data plane attaches its policy and forwarding programs via `BPF_NETKIT_PRIMARY` inside `ndo_start_xmit()`, which improves throughput and tail latency under contention compared to attaching via TC/TCX on a veth.
 
 Netkit is recommended for the eBPF data plane.

--- a/calico_versioned_docs/version-3.29/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
+++ b/calico_versioned_docs/version-3.29/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
@@ -19,7 +19,7 @@ Managing your own Kubernetes cluster (as opposed to using a managed-Kubernetes s
 
 ## Before you begin...
 
-[Install and configure the Google Cloud CLI tools](https://cloud.google.com/sdk/docs/quickstarts)
+[Install and configure the Google Cloud CLI tools](https://docs.cloud.google.com/sdk/docs/install)
 
 ## How to
 

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
@@ -19,7 +19,7 @@ Managing your own Kubernetes cluster (as opposed to using a managed-Kubernetes s
 
 ## Before you begin...
 
-[Install and configure the Google Cloud CLI tools](https://cloud.google.com/sdk/docs/quickstarts)
+[Install and configure the Google Cloud CLI tools](https://docs.cloud.google.com/sdk/docs/install)
 
 ## How to
 

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
@@ -19,7 +19,7 @@ Managing your own Kubernetes cluster (as opposed to using a managed-Kubernetes s
 
 ## Before you begin...
 
-[Install and configure the Google Cloud CLI tools](https://cloud.google.com/sdk/docs/quickstarts)
+[Install and configure the Google Cloud CLI tools](https://docs.cloud.google.com/sdk/docs/install)
 
 ## How to
 

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/self-managed-public-cloud/gce.mdx
@@ -19,7 +19,7 @@ Managing your own Kubernetes cluster (as opposed to using a managed-Kubernetes s
 
 ## Before you begin...
 
-[Install and configure the Google Cloud CLI tools](https://cloud.google.com/sdk/docs/quickstarts)
+[Install and configure the Google Cloud CLI tools](https://docs.cloud.google.com/sdk/docs/install)
 
 ## How to
 


### PR DESCRIPTION
## Summary

The production `main` build is failing because the Netlify crawler test fails the entire deploy if **any** external link on the site is dead. My earlier PR (#2866) fixed the GKE/Rancher links, but the build still errored — so I ran the repo's own `src/utils/urlCheck.js` module across all ~1,360 external links in the docs to find what else is dead.

After filtering out skip-listed hosts and template-variable artifacts, these are the only two remaining genuinely-dead, non-skip-listed links:

| Link | Problem | Fix |
|---|---|---|
| `docs.kernel.org/networking/netkit.html` | Real **404** (HEAD + GET) — kernel dropped the standalone page | `lwn.net/Articles/949960/` — LWN's authoritative "The BPF-programmable network device" writeup |
| `cloud.google.com/sdk/docs/quickstarts` | **404 to HEAD** — same Google docs migration as the GKE links; the checker marks HEAD-404 dead without trying GET | `docs.cloud.google.com/sdk/docs/install` (direct HEAD 200) |

Both replacements were verified to return `200` to a HEAD request following redirects — the exact method the crawler (`urlCheck.js`) uses. The gcloud link is fixed in the current docs and its versioned copies.

## Why the build kept failing

The crawler (`__tests__/crawler.test.js`) does a HEAD request per external link and treats **any non-200 (including a 404 returned only to HEAD) as dead**, failing `make netlify`. Google's migrated pages return 404 to HEAD on `cloud.google.com`, which is why both the GKE links (fixed in #2866) and this SDK link had to move to `docs.cloud.google.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
