### PR TITLE
docs-2985: update multi-network/VRF auto-label docs

### DIFF
--- a/calico-enterprise/network-policy/beginners/calico-labels.mdx
+++ b/calico-enterprise/network-policy/beginners/calico-labels.mdx
@@ -103,8 +103,9 @@ spec:
 
 If you enable [multiple networks](../../networking/configuring/multiple-networks), the following automatic labels are available:
 
-- `projectcalico.org/network` - Name of the network specified in the NetworkAttachmentDefinition
-- `projectcalico.org/network-namespace` - Namespace of the network
+- `projectcalico.org/network` - Name of the Calico `Network` the WorkloadEndpoint is attached to (for example, a VRF network)
+- `projectcalico.org/network-attachment` - Name of the NetworkAttachmentDefinition the WorkloadEndpoint belongs to
+- `projectcalico.org/network-attachment-namespace` - Namespace of the NetworkAttachmentDefinition
 - `projectcalico.org/network-interface` - Network interface for the WorkloadEndpoint
 
 ## Labels for matching host endpoints

--- a/calico-enterprise/network-policy/beginners/calico-labels.mdx
+++ b/calico-enterprise/network-policy/beginners/calico-labels.mdx
@@ -103,7 +103,7 @@ spec:
 
 If you enable [multiple networks](../../networking/configuring/multiple-networks), the following automatic labels are available:
 
-- `projectcalico.org/network` - Name of the Calico `Network` the WorkloadEndpoint is attached to (for example, a VRF network)
+- `projectcalico.org/network` - Name of the Calico `Network` the WorkloadEndpoint is attached to, if any (for example, a VRF network)
 - `projectcalico.org/network-attachment` - Name of the NetworkAttachmentDefinition the WorkloadEndpoint belongs to
 - `projectcalico.org/network-attachment-namespace` - Namespace of the NetworkAttachmentDefinition
 - `projectcalico.org/network-interface` - Network interface for the WorkloadEndpoint

--- a/calico-enterprise/networking/configuring/multiple-networks.mdx
+++ b/calico-enterprise/networking/configuring/multiple-networks.mdx
@@ -25,7 +25,8 @@ You install Multus on a cluster, then simply enable Multus in the $[prodname] In
 When you set the `MultiInterfaceMode` field to `Multus` in the Installation resource, the following network and network interface labels are automatically added to new workload endpoints.
 
 - `projectcalico.org/network`
-- `projectcalico.org/network-namespace`
+- `projectcalico.org/network-attachment`
+- `projectcalico.org/network-attachment-namespace`
 - `projectcalico.org/network-interface`
 
 You can then create $[prodname] policies using these label selectors to target specific networks or network interfaces.
@@ -152,7 +153,8 @@ Although not required, you may want to assign IPs from specific pools to specifi
 When MultiInterfaceMode is set to Multus, WorkloadEndpoints are created with these labels:
 
 - `projectcalico.org/network`
-- `projectcalico.org/network-namespace`
+- `projectcalico.org/network-attachment`
+- `projectcalico.org/network-attachment-namespace`
 - `projectcalico.org/network-interface`
 
 You can use these labels to enforce policies on specific interfaces and networks using policy label selectors.
@@ -226,9 +228,9 @@ metadata:
   creationTimestamp: '2020-05-04T22:23:05T'
   labels:
     projectcalico.org/namespace: default
-    projectcalico.org/network: calico
+    projectcalico.org/network-attachment: calico
+    projectcalico.org/network-attachment-namespace: default
     projectcalico.org/network-interface: net1
-    projectcalico.org/network-namespace: default
     projectcalico.org/orchestrator: k8s
     projectcalico.org/serviceaccount: default
   name: test--bz--72vg--kadm--infra--0-k8s-multus--test--pod--1-net1

--- a/calico-enterprise/networking/configuring/multiple-networks.mdx
+++ b/calico-enterprise/networking/configuring/multiple-networks.mdx
@@ -24,7 +24,7 @@ You install Multus on a cluster, then simply enable Multus in the $[prodname] In
 
 When you set the `MultiInterfaceMode` field to `Multus` in the Installation resource, the following network and network interface labels are automatically added to new workload endpoints.
 
-- `projectcalico.org/network`
+- `projectcalico.org/network` (if the endpoint is attached to a Calico Network)
 - `projectcalico.org/network-attachment`
 - `projectcalico.org/network-attachment-namespace`
 - `projectcalico.org/network-interface`
@@ -152,7 +152,7 @@ Although not required, you may want to assign IPs from specific pools to specifi
 
 When MultiInterfaceMode is set to Multus, WorkloadEndpoints are created with these labels:
 
-- `projectcalico.org/network`
+- `projectcalico.org/network` (if the endpoint is attached to a Calico Network)
 - `projectcalico.org/network-attachment`
 - `projectcalico.org/network-attachment-namespace`
 - `projectcalico.org/network-interface`

--- a/calico-enterprise/reference/resources/workloadendpoint.mdx
+++ b/calico-enterprise/reference/resources/workloadendpoint.mdx
@@ -33,8 +33,9 @@ use `calicoctl` to view this resource type.
 
 If multiple networks are enabled, workload endpoints will have additional labels which can be used in network policy selectors:
 
-- `projectcalico.org/network`: The name of the network specified in the NetworkAttachmentDefinition.
-- `projectcalico.org/network-namespace`: This namespace the network is in.
+- `projectcalico.org/network`: The name of the Calico `Network` the workload endpoint is attached to (for example, a VRF network).
+- `projectcalico.org/network-attachment`: The name of the NetworkAttachmentDefinition the workload endpoint belongs to.
+- `projectcalico.org/network-attachment-namespace`: The namespace of the NetworkAttachmentDefinition.
 - `projectcalico.org/network-interface`: The network interface for the workload endpoint.
 
 For more information, see the [multiple-networks how-to guide](../../networking/configuring/multiple-networks.mdx).

--- a/calico-enterprise/reference/resources/workloadendpoint.mdx
+++ b/calico-enterprise/reference/resources/workloadendpoint.mdx
@@ -33,7 +33,7 @@ use `calicoctl` to view this resource type.
 
 If multiple networks are enabled, workload endpoints will have additional labels which can be used in network policy selectors:
 
-- `projectcalico.org/network`: The name of the Calico `Network` the workload endpoint is attached to (for example, a VRF network).
+- `projectcalico.org/network`: The name of the Calico `Network` the workload endpoint is attached to, if any (for example, a VRF network).
 - `projectcalico.org/network-attachment`: The name of the NetworkAttachmentDefinition the workload endpoint belongs to.
 - `projectcalico.org/network-attachment-namespace`: The namespace of the NetworkAttachmentDefinition.
 - `projectcalico.org/network-interface`: The network interface for the workload endpoint.

--- a/calico-enterprise_versioned_docs/version-3.23-2/network-policy/beginners/calico-labels.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/network-policy/beginners/calico-labels.mdx
@@ -103,8 +103,9 @@ spec:
 
 If you enable [multiple networks](../../networking/configuring/multiple-networks), the following automatic labels are available:
 
-- `projectcalico.org/network` - Name of the network specified in the NetworkAttachmentDefinition
-- `projectcalico.org/network-namespace` - Namespace of the network
+- `projectcalico.org/network` - Name of the Calico `Network` the WorkloadEndpoint is attached to (for example, a VRF network)
+- `projectcalico.org/network-attachment` - Name of the NetworkAttachmentDefinition the WorkloadEndpoint belongs to
+- `projectcalico.org/network-attachment-namespace` - Namespace of the NetworkAttachmentDefinition
 - `projectcalico.org/network-interface` - Network interface for the WorkloadEndpoint
 
 ## Labels for matching host endpoints

--- a/calico-enterprise_versioned_docs/version-3.23-2/network-policy/beginners/calico-labels.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/network-policy/beginners/calico-labels.mdx
@@ -103,7 +103,7 @@ spec:
 
 If you enable [multiple networks](../../networking/configuring/multiple-networks), the following automatic labels are available:
 
-- `projectcalico.org/network` - Name of the Calico `Network` the WorkloadEndpoint is attached to (for example, a VRF network)
+- `projectcalico.org/network` - Name of the Calico `Network` the WorkloadEndpoint is attached to, if any (for example, a VRF network)
 - `projectcalico.org/network-attachment` - Name of the NetworkAttachmentDefinition the WorkloadEndpoint belongs to
 - `projectcalico.org/network-attachment-namespace` - Namespace of the NetworkAttachmentDefinition
 - `projectcalico.org/network-interface` - Network interface for the WorkloadEndpoint

--- a/calico-enterprise_versioned_docs/version-3.23-2/networking/configuring/multiple-networks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/networking/configuring/multiple-networks.mdx
@@ -25,7 +25,8 @@ You install Multus on a cluster, then simply enable Multus in the $[prodname] In
 When you set the `MultiInterfaceMode` field to `Multus` in the Installation resource, the following network and network interface labels are automatically added to new workload endpoints.
 
 - `projectcalico.org/network`
-- `projectcalico.org/network-namespace`
+- `projectcalico.org/network-attachment`
+- `projectcalico.org/network-attachment-namespace`
 - `projectcalico.org/network-interface`
 
 You can then create $[prodname] policies using these label selectors to target specific networks or network interfaces.
@@ -152,7 +153,8 @@ Although not required, you may want to assign IPs from specific pools to specifi
 When MultiInterfaceMode is set to Multus, WorkloadEndpoints are created with these labels:
 
 - `projectcalico.org/network`
-- `projectcalico.org/network-namespace`
+- `projectcalico.org/network-attachment`
+- `projectcalico.org/network-attachment-namespace`
 - `projectcalico.org/network-interface`
 
 You can use these labels to enforce policies on specific interfaces and networks using policy label selectors.
@@ -226,9 +228,9 @@ metadata:
   creationTimestamp: '2020-05-04T22:23:05T'
   labels:
     projectcalico.org/namespace: default
-    projectcalico.org/network: calico
+    projectcalico.org/network-attachment: calico
+    projectcalico.org/network-attachment-namespace: default
     projectcalico.org/network-interface: net1
-    projectcalico.org/network-namespace: default
     projectcalico.org/orchestrator: k8s
     projectcalico.org/serviceaccount: default
   name: test--bz--72vg--kadm--infra--0-k8s-multus--test--pod--1-net1

--- a/calico-enterprise_versioned_docs/version-3.23-2/networking/configuring/multiple-networks.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/networking/configuring/multiple-networks.mdx
@@ -24,7 +24,7 @@ You install Multus on a cluster, then simply enable Multus in the $[prodname] In
 
 When you set the `MultiInterfaceMode` field to `Multus` in the Installation resource, the following network and network interface labels are automatically added to new workload endpoints.
 
-- `projectcalico.org/network`
+- `projectcalico.org/network` (if the endpoint is attached to a Calico Network)
 - `projectcalico.org/network-attachment`
 - `projectcalico.org/network-attachment-namespace`
 - `projectcalico.org/network-interface`
@@ -152,7 +152,7 @@ Although not required, you may want to assign IPs from specific pools to specifi
 
 When MultiInterfaceMode is set to Multus, WorkloadEndpoints are created with these labels:
 
-- `projectcalico.org/network`
+- `projectcalico.org/network` (if the endpoint is attached to a Calico Network)
 - `projectcalico.org/network-attachment`
 - `projectcalico.org/network-attachment-namespace`
 - `projectcalico.org/network-interface`

--- a/calico-enterprise_versioned_docs/version-3.23-2/reference/resources/workloadendpoint.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/reference/resources/workloadendpoint.mdx
@@ -33,8 +33,9 @@ use `calicoctl` to view this resource type.
 
 If multiple networks are enabled, workload endpoints will have additional labels which can be used in network policy selectors:
 
-- `projectcalico.org/network`: The name of the network specified in the NetworkAttachmentDefinition.
-- `projectcalico.org/network-namespace`: This namespace the network is in.
+- `projectcalico.org/network`: The name of the Calico `Network` the workload endpoint is attached to (for example, a VRF network).
+- `projectcalico.org/network-attachment`: The name of the NetworkAttachmentDefinition the workload endpoint belongs to.
+- `projectcalico.org/network-attachment-namespace`: The namespace of the NetworkAttachmentDefinition.
 - `projectcalico.org/network-interface`: The network interface for the workload endpoint.
 
 For more information, see the [multiple-networks how-to guide](../../networking/configuring/multiple-networks.mdx).

--- a/calico-enterprise_versioned_docs/version-3.23-2/reference/resources/workloadendpoint.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/reference/resources/workloadendpoint.mdx
@@ -33,7 +33,7 @@ use `calicoctl` to view this resource type.
 
 If multiple networks are enabled, workload endpoints will have additional labels which can be used in network policy selectors:
 
-- `projectcalico.org/network`: The name of the Calico `Network` the workload endpoint is attached to (for example, a VRF network).
+- `projectcalico.org/network`: The name of the Calico `Network` the workload endpoint is attached to, if any (for example, a VRF network).
 - `projectcalico.org/network-attachment`: The name of the NetworkAttachmentDefinition the workload endpoint belongs to.
 - `projectcalico.org/network-attachment-namespace`: The namespace of the NetworkAttachmentDefinition.
 - `projectcalico.org/network-interface`: The network interface for the workload endpoint.


### PR DESCRIPTION
## Ticket
[DOCS-2985](https://tigera.atlassian.net/browse/DOCS-2985)

## What
Multi-VRF (tech preview, shipped in Calico Enterprise **3.23.0-2.0**) changed the auto-generated network labels on WorkloadEndpoints. The docs still listed the old labels. This updates the three label reference sections and the sample WorkloadEndpoint YAML, in both the current docs and the `version-3.23-2` twin.

Reported by @shaun in Slack; VRF work by @matt (CC @Pooriya).

| Label | Change |
| --- | --- |
| `projectcalico.org/network` | Meaning changed → now the Calico `Network` (for example, a VRF network), not the NetworkAttachmentDefinition |
| `projectcalico.org/network-attachment` | **New** → the NetworkAttachmentDefinition name (old meaning of `.../network`) |
| `projectcalico.org/network-attachment-namespace` | **Renamed** from `projectcalico.org/network-namespace` |
| `projectcalico.org/network-interface` | Unchanged |

Pages (Enterprise only — no OSS/Cloud equivalents):
- `network-policy/beginners/calico-labels.mdx`
- `networking/configuring/multiple-networks.mdx` (two label lists + sample WEP YAML)
- `reference/resources/workloadendpoint.mdx`

## Verified against code
`tigera/calico-private` @ tag `v3.23.0-2.0`: `api/pkg/apis/projectcalico/v3/constants.go` (L51-61), plus `libcalico-go/lib/backend/k8s/conversion/workload_endpoint_multus.go` (L331-359) and `workload_endpoint_default.go` (L200-204).

## Draft — open questions for @matt
1. **Description of `projectcalico.org/network` for VRF pods** — I've written it as "the Calico `Network` the endpoint is attached to." Does this hold for both attachment paths, including Option 1 (primary interface on a VRF via `cni.projectcalico.org/networks`)?
2. **Sample WEP YAML** — for the plain-Multus example I dropped `projectcalico.org/network` (no Calico `Network` CRD is recorded there, so the code doesn't set it) and moved the value to `network-attachment`. Is that the correct representation for a plain Multus calico network?
3. **Version scope** — edited the current tree + `version-3.23-2`. Please confirm `docs.tigera.io/.../latest/` resolves to one of these (older versions keep the old labels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-2985]: https://tigera.atlassian.net/browse/DOCS-2985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ