### PR TITLE
Fix Enterprise CRD manifest references for native v3 CRD mode

### DIFF
--- a/calico-enterprise/_includes/components/InstallAKS.js
+++ b/calico-enterprise/_includes/components/InstallAKS.js
@@ -20,7 +20,7 @@ export default function InstallAKS(props) {
       <ol>
         <li>
           <p>Install the Tigera Operator and custom resource definitions.</p>
-          <CodeBlock>kubectl create -f {filesUrl}/manifests/operator-crds.yaml</CodeBlock>
+          <CodeBlock>kubectl create -f {filesUrl}/manifests/v1_crd_projectcalico_org.yaml</CodeBlock>
           <CodeBlock>kubectl create -f {filesUrl}/manifests/tigera-operator.yaml</CodeBlock>
         </li>
         <li>
@@ -131,7 +131,7 @@ spec:
         </li>
         <li>
           <p>Install the Tigera Operator and custom resource definitions.</p>
-          <CodeBlock>kubectl create -f {filesUrl}/manifests/operator-crds.yaml</CodeBlock>
+          <CodeBlock>kubectl create -f {filesUrl}/manifests/v1_crd_projectcalico_org.yaml</CodeBlock>
           <CodeBlock>kubectl create -f {filesUrl}/manifests/tigera-operator.yaml</CodeBlock>
         </li>
         <li>

--- a/calico-enterprise/_includes/components/InstallEKS.js
+++ b/calico-enterprise/_includes/components/InstallEKS.js
@@ -22,7 +22,7 @@ export default function InstallEKS(props) {
       <ol>
         <li>
           <p>Install the Tigera Operator and custom resource definitions.</p>
-          <CodeBlock>kubectl create -f {filesUrl}/manifests/operator-crds.yaml</CodeBlock>
+          <CodeBlock>kubectl create -f {filesUrl}/manifests/v1_crd_projectcalico_org.yaml</CodeBlock>
           <CodeBlock>kubectl create -f {filesUrl}/manifests/tigera-operator.yaml</CodeBlock>
         </li>
         <li>
@@ -182,7 +182,7 @@ spec:
         </li>
         <li>
           <p>Install the Tigera Operator and custom resource definitions.</p>
-          <CodeBlock>kubectl create -f {filesUrl}/manifests/operator-crds.yaml</CodeBlock>
+          <CodeBlock>kubectl create -f {filesUrl}/manifests/v1_crd_projectcalico_org.yaml</CodeBlock>
           <CodeBlock>kubectl create -f {filesUrl}/manifests/tigera-operator.yaml</CodeBlock>
         </li>
         <li>

--- a/calico-enterprise/_includes/components/InstallGKE.js
+++ b/calico-enterprise/_includes/components/InstallGKE.js
@@ -21,7 +21,7 @@ export default function InstallGKE(props) {
       <ol>
         <li>
           <p>Install the Tigera Operator and custom resource definitions.</p>
-          <CodeBlock>kubectl create -f {filesUrl}/manifests/operator-crds.yaml</CodeBlock>
+          <CodeBlock>kubectl create -f {filesUrl}/manifests/v1_crd_projectcalico_org.yaml</CodeBlock>
           <CodeBlock>kubectl create -f {filesUrl}/manifests/tigera-operator.yaml</CodeBlock>
         </li>
         <li>

--- a/calico-enterprise/_includes/components/InstallGeneric.js
+++ b/calico-enterprise/_includes/components/InstallGeneric.js
@@ -26,7 +26,7 @@ export default function InstallGeneric(props) {
       <ol>
         <li>
           <p>Install the Tigera Operator and custom resource definitions.</p>
-          <CodeBlock>kubectl create -f {filesUrl}/manifests/operator-crds.yaml</CodeBlock>
+          <CodeBlock>kubectl create -f {filesUrl}/manifests/v1_crd_projectcalico_org.yaml</CodeBlock>
           <CodeBlock>kubectl create -f {filesUrl}/manifests/tigera-operator.yaml</CodeBlock>
         </li>
         <li>

--- a/calico-enterprise/_includes/components/InstallOpenShift.js
+++ b/calico-enterprise/_includes/components/InstallOpenShift.js
@@ -274,7 +274,7 @@ spec:
       </p>
 
       <p>(Optional) Apply the full CRDs including descriptions.</p>
-      <CodeBlock language='bash'>oc apply --server-side --force-conflicts -f {filesUrl}/manifests/operator-crds.yaml</CodeBlock>
+      <CodeBlock language='bash'>oc apply --server-side --force-conflicts -f {filesUrl}/manifests/v1_crd_projectcalico_org.yaml</CodeBlock>
 
       <When condition={props.clusterType === 'management'}>
         <>

--- a/calico-enterprise/_includes/components/InstallOpenShiftHCPResources.js
+++ b/calico-enterprise/_includes/components/InstallOpenShiftHCPResources.js
@@ -20,7 +20,7 @@ export default function InstallOpenShiftHCPResources() {
       </p>
 
       <p>(Optional) Apply the full CRDs including descriptions.</p>
-      <CodeBlock language='bash'>oc apply --server-side --force-conflicts -f {filesUrl}/manifests/operator-crds.yaml</CodeBlock>
+      <CodeBlock language='bash'>oc apply --server-side --force-conflicts -f {filesUrl}/manifests/v1_crd_projectcalico_org.yaml</CodeBlock>
     </>
   );
 }

--- a/calico-enterprise/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee/helm.mdx
@@ -59,7 +59,7 @@ The following steps assume the Calico deployment is installed on `tigera-operato
    <TabItem label="Aggregation API server" value="apiserver">
 
    ```bash
-   kubectl apply --server-side --force-conflicts -f $[filesUrl]/manifests/operator-crds.yaml
+   kubectl apply --server-side --force-conflicts -f $[filesUrl]/manifests/v1_crd_projectcalico_org.yaml
    kubectl create -f $[filesUrl]/manifests/prometheus-operator-crds.yaml
    kubectl create -f $[filesUrl]/manifests/eck-operator-crds.yaml
    ```

--- a/calico-enterprise/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
@@ -85,7 +85,7 @@ These steps differ based on your cluster type. If you are unsure of your cluster
    <TabItem label="Aggregation API server" value="apiserver">
 
    ```bash
-   kubectl apply --server-side --force-conflicts -f $[filesUrl]/manifests/operator-crds.yaml
+   kubectl apply --server-side --force-conflicts -f $[filesUrl]/manifests/v1_crd_projectcalico_org.yaml
    kubectl apply --server-side --force-conflicts -f $[filesUrl]/manifests/prometheus-operator-crds.yaml
    kubectl apply --server-side --force-conflicts -f $[filesUrl]/manifests/eck-operator-crds.yaml
    ```

--- a/calico-enterprise/operations/crd-migration.mdx
+++ b/calico-enterprise/operations/crd-migration.mdx
@@ -45,7 +45,7 @@ The locked window is typically short (seconds to a few minutes depending on clus
 
 ## Before you begin
 
-- $[prodname] v3.32+ (or the release that includes the migration controller)
+- $[prodname] v3.23+ (or the release that includes the migration controller)
 - Cluster is currently running in API server mode (the aggregated API server is deployed)
 - **If using GitOps (ArgoCD, Flux):** pause sync before starting the migration. These tools may interfere with the API group switchover. You'll update your manifests to use `projectcalico.org/v3` after migration completes.
 
@@ -58,13 +58,13 @@ The locked window is typically short (seconds to a few minutes depending on clus
    Apply the v3 CRD manifests from the $[prodname] release. While the aggregated API service is active, Kubernetes ignores these CRDs, so this is safe to do ahead of time.
 
    ```bash
-   kubectl apply -f $[manifestsUrl]/manifests/v3_projectcalico_org.yaml
+   kubectl apply -f $[filesUrl]/manifests/v3_projectcalico_org.yaml
    ```
 
 2. **Install the DatastoreMigration CRD.**
 
    ```bash
-   kubectl apply -f $[manifestsUrl]/manifests/migration.projectcalico.org_datastoremigrations.yaml
+   kubectl apply -f $[filesUrl]/manifests/migration.projectcalico.org_datastoremigrations.yaml
    ```
 
 3. **Create the DatastoreMigration CR.**

--- a/calico-enterprise/operations/native-v3-crds.mdx
+++ b/calico-enterprise/operations/native-v3-crds.mdx
@@ -135,7 +135,7 @@ helm template calico-crds crd.projectcalico.org.v1-$[chart_version_name].tgz | k
 Apply the v1 CRDs before the Tigera Operator:
 
 ```bash
-kubectl create -f $[filesUrl]/manifests/operator-crds.yaml
+kubectl create -f $[filesUrl]/manifests/v1_crd_projectcalico_org.yaml
 ```
 
 </TabItem>


### PR DESCRIPTION
Product Version(s): Calico Enterprise master

#2805 landed most of what this PR was doing. What's left are the manifest names and hosts it didn't touch.

`operator-crds.yaml` is a legacy alias for `v1_crd_projectcalico_org.yaml`. The two are byte-identical in calico-private, and the open source docs already use the v1 name. Renamed in the three remaining spots: the aggregation API server tab of both Helm upgrade pages, and the API server mode section of the native v3 CRDs page. Left the archive page and the ingress gateway canary tutorial alone, since those point at older artifacts that really are named `operator-crds.yaml`.

The managed cloud install includes (AKS, EKS, GKE, Generic, OpenShift) get the same rename. They still install the v1 bundle, which is now inconsistent with v3 being the default for new installs, but that's a behavior change rather than a naming fix so I've left it out of this PR.

The Enterprise CRD migration guide was copied from open source and pointed at `$[manifestsUrl]` (docs.tigera.io) rather than `$[filesUrl]` (downloads.tigera.io/ee), and claimed v3.32 as the version floor.

Not fixed here, filed separately as https://tigera.atlassian.net/browse/CORE-13214: `migration.projectcalico.org_datastoremigrations.yaml` is not published in any release artifact, so step 2 of the migration guide is a 404 in both products. That needs a build change, not a docs change.

Link to docs preview:
<!--- fill in once the preview builds --->

SME review:
- [ ] An SME has approved this change.

DOCS review:
- [ ] A member of the docs team has approved this change.
