### PR TITLE
DOCS-2990: Reframe native v3 CRDs as successor to the aggregated API server

### DIFF
--- a/calico-enterprise/operations/native-v3-crds.mdx
+++ b/calico-enterprise/operations/native-v3-crds.mdx
@@ -8,6 +8,8 @@ description: New installs of Calico Enterprise use native projectcalico.org/v3 C
 
 New installs of $[prodname] use native `projectcalico.org/v3` CRDs by default: Calico resources are backed directly by CRDs, eliminating the need for the Calico aggregation API server. This page explains how the mode works and how to install with the aggregation API server instead.
 
+Native `projectcalico.org/v3` CRDs are the successor to the Calico aggregation API server. The aggregation API server remains supported for now but will be removed in a future release.
+
 ## Value
 
 By default, $[prodname] uses an aggregation API server to serve `projectcalico.org/v3` APIs, storing resources internally as `crd.projectcalico.org/v1` CRDs. When using native `projectcalico.org/v3` CRDs, Calico resources are CRDs themselves, which provides several benefits:

--- a/calico-enterprise/release-notes/index.mdx
+++ b/calico-enterprise/release-notes/index.mdx
@@ -19,9 +19,11 @@ This version of Calico Enterprise is based on [Calico Open Source $[openSourceVe
 
 ## New features and enhancements
 
-- New installs default to v3 CRD mode: `projectcalico.org/v3` resources are served directly by CRDs, with no aggregation API server. Existing and upgraded clusters are unaffected. To install with the aggregation API server instead, apply the v1 CRDs before installing the operator. v3 CRD mode requires Kubernetes 1.32 or later. Native v3 CRDs are the successor to the aggregation API server. The aggregation API server will continue to be supported until native v3 CRDs are fully supported on all platforms, and will be removed in a future release. See [Native v3 CRDs](../operations/native-v3-crds.mdx).
+- New installs default to v3 CRD mode: `projectcalico.org/v3` resources are served directly by CRDs, with no aggregation API server. Existing and upgraded clusters are unaffected. To install with the aggregation API server instead, apply the v1 CRDs before installing the operator. v3 CRD mode requires Kubernetes 1.32 or later. Native v3 CRDs are the successor to the aggregation API server. See [Native v3 CRDs](../operations/native-v3-crds.mdx).
 
 ### Deprecated and removed features
+
+- $[prodname] is moving the `projectcalico.org/v3` API from the aggregated API server to native Kubernetes CRDs. Both mechanisms will be supported until native v3 CRDs are compatible with all supported platforms, after which the aggregated API server will be removed.
 
 ## Technology Preview features
 

--- a/calico-enterprise/release-notes/index.mdx
+++ b/calico-enterprise/release-notes/index.mdx
@@ -19,7 +19,7 @@ This version of Calico Enterprise is based on [Calico Open Source $[openSourceVe
 
 ## New features and enhancements
 
-- New installs default to v3 CRD mode: `projectcalico.org/v3` resources are served directly by CRDs, with no aggregation API server. Existing and upgraded clusters are unaffected. To install with the aggregation API server instead, apply the v1 CRDs before installing the operator. v3 CRD mode requires Kubernetes 1.32 or later. Native v3 CRDs are the successor to the aggregation API server, which will be removed in a future release. See [Native v3 CRDs](../operations/native-v3-crds.mdx).
+- New installs default to v3 CRD mode: `projectcalico.org/v3` resources are served directly by CRDs, with no aggregation API server. Existing and upgraded clusters are unaffected. To install with the aggregation API server instead, apply the v1 CRDs before installing the operator. v3 CRD mode requires Kubernetes 1.32 or later. Native v3 CRDs are the successor to the aggregation API server. The aggregation API server will continue to be supported until native v3 CRDs are fully supported on all platforms, and will be removed in a future release. See [Native v3 CRDs](../operations/native-v3-crds.mdx).
 
 ### Deprecated and removed features
 

--- a/calico-enterprise/release-notes/index.mdx
+++ b/calico-enterprise/release-notes/index.mdx
@@ -19,11 +19,9 @@ This version of Calico Enterprise is based on [Calico Open Source $[openSourceVe
 
 ## New features and enhancements
 
-- New installs default to v3 CRD mode: `projectcalico.org/v3` resources are served directly by CRDs, with no aggregation API server. Existing and upgraded clusters are unaffected. To install with the aggregation API server instead, apply the v1 CRDs before installing the operator. v3 CRD mode requires Kubernetes 1.32 or later. See [Native v3 CRDs](../operations/native-v3-crds.mdx).
+- New installs default to v3 CRD mode: `projectcalico.org/v3` resources are served directly by CRDs, with no aggregation API server. Existing and upgraded clusters are unaffected. To install with the aggregation API server instead, apply the v1 CRDs before installing the operator. v3 CRD mode requires Kubernetes 1.32 or later. Native v3 CRDs are the successor to the aggregation API server, which will be removed in a future release. See [Native v3 CRDs](../operations/native-v3-crds.mdx).
 
 ### Deprecated and removed features
-
-- The aggregation API server is deprecated. It remains supported for now but will be removed in a future release. New installs default to native v3 CRD mode. Clusters that use the aggregation API server can [migrate to native v3 CRDs](../operations/crd-migration.mdx).
 
 ## Technology Preview features
 

--- a/calico-enterprise_versioned_docs/version-3.23-2/operations/native-v3-crds.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/operations/native-v3-crds.mdx
@@ -14,6 +14,8 @@ This feature is tech preview. Tech preview features may be subject to significan
 
 Enable native `projectcalico.org/v3` CRDs so that Calico resources are backed directly by CRDs, eliminating the need for the Calico aggregation API server.
 
+Native `projectcalico.org/v3` CRDs are the successor to the Calico aggregation API server. The aggregation API server remains supported for now but will be removed in a future release.
+
 ## Value
 
 By default, $[prodname] uses an aggregation API server to serve `projectcalico.org/v3` APIs, storing resources internally as `crd.projectcalico.org/v1` CRDs. When using native `projectcalico.org/v3` CRDs, Calico resources are CRDs themselves, which provides several benefits:

--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -64,7 +64,7 @@ For existing clusters, a new `DatastoreMigration` controller copies resources fr
 
 Native v3 CRDs require Kubernetes 1.34 or later with the `MutatingAdmissionPolicy` feature gate enabled. The gate is GA and on by default in Kubernetes 1.36; on 1.34 and 1.35 it must be enabled explicitly on the API server.
 
-Native v3 CRDs are the successor to the aggregated API server, and will become the default install mode in a future release. The aggregation API server will continue to be supported until native v3 CRDs are fully supported on all platforms, and will be removed in a future release.
+Native v3 CRDs are the successor to the aggregated API server, and will become the default install mode in a future release.
 
 For more information, see [Enable native v3 CRDs](../operations/native-v3-crds.mdx) and [Migrate from API server to native CRDs](../operations/crd-migration.mdx).
 
@@ -135,6 +135,7 @@ For more information, see [vSphere Kubernetes Service (VKS)](../getting-started/
 
 ## Deprecated and removed features
 
+* $[prodname] is moving the `projectcalico.org/v3` API from the aggregated API server to native Kubernetes CRDs. Both mechanisms will be supported until native v3 CRDs are compatible with all supported platforms, after which the aggregated API server will be removed.
 * Support for RHEL 8 and Windows 1809 has been removed in this release.
 * Support for the x86-64 v2 chip architecture is deprecated and scheduled for removal in an upcoming release.
 * Application-layer policy and L7 observability features based on Envoy as a daemonset are deprecated and scheduled for removal in an upcoming release. These are being replaced with similar functionality using Istio Ambient Mode.

--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -64,7 +64,7 @@ For existing clusters, a new `DatastoreMigration` controller copies resources fr
 
 Native v3 CRDs require Kubernetes 1.34 or later with the `MutatingAdmissionPolicy` feature gate enabled. The gate is GA and on by default in Kubernetes 1.36; on 1.34 and 1.35 it must be enabled explicitly on the API server.
 
-Native v3 CRDs are the successor to the aggregated API server. In a future release they will become the default install mode, and the aggregated API server will be removed in a later release.
+Native v3 CRDs are the successor to the aggregated API server, and will become the default install mode in a future release. The aggregation API server will continue to be supported until native v3 CRDs are fully supported on all platforms, and will be removed in a future release.
 
 For more information, see [Enable native v3 CRDs](../operations/native-v3-crds.mdx) and [Migrate from API server to native CRDs](../operations/crd-migration.mdx).
 

--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -64,7 +64,7 @@ For existing clusters, a new `DatastoreMigration` controller copies resources fr
 
 Native v3 CRDs require Kubernetes 1.34 or later with the `MutatingAdmissionPolicy` feature gate enabled. The gate is GA and on by default in Kubernetes 1.36; on 1.34 and 1.35 it must be enabled explicitly on the API server.
 
-This is the first phase of phasing out the aggregated API server: in a future release, native v3 CRDs will become the default install mode, and in a later release the aggregated API server will be removed entirely.
+Native v3 CRDs are the successor to the aggregated API server. In a future release they will become the default install mode, and the aggregated API server will be removed in a later release.
 
 For more information, see [Enable native v3 CRDs](../operations/native-v3-crds.mdx) and [Migrate from API server to native CRDs](../operations/crd-migration.mdx).
 

--- a/calico/operations/install-apiserver.mdx
+++ b/calico/operations/install-apiserver.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 Install the Calico API server on an existing cluster to enable management of Calico APIs using kubectl.
 
-:::tip[Native v3 CRDs are the successor]
+:::tip[A simpler alternative: native v3 CRDs]
 
 New installs of $[prodname] default to [native v3 CRDs](native-v3-crds.mdx), which serve `projectcalico.org/v3` resources directly with no aggregation API server. This page covers installing or enabling the aggregation API server instead.
 

--- a/calico/operations/install-apiserver.mdx
+++ b/calico/operations/install-apiserver.mdx
@@ -29,12 +29,6 @@ New installs default to native v3 CRDs, not the aggregation API server. Use this
 
 ## Install in API server mode (v1 CRDs)
 
-:::note
-
-The aggregation API server is deprecated. It remains supported for now but will be removed in a future release. Use native v3 CRD mode for new installs. If you install in API server mode, plan to [migrate to native v3 CRDs](crd-migration.mdx) before the API server is removed.
-
-:::
-
 New installs default to v3 CRD mode. To install in the aggregation API-server mode instead, install the v1 CRDs before the operator decides the mode - the operator runs in API-server mode whenever the `crd.projectcalico.org/v1` CRDs are present.
 
 <Tabs>

--- a/calico/operations/install-apiserver.mdx
+++ b/calico/operations/install-apiserver.mdx
@@ -11,9 +11,11 @@ import TabItem from '@theme/TabItem';
 
 Install the Calico API server on an existing cluster to enable management of Calico APIs using kubectl.
 
-:::tip
+:::tip[Native v3 CRDs are the successor]
 
 New installs of $[prodname] default to [native v3 CRDs](native-v3-crds.mdx), which serve `projectcalico.org/v3` resources directly with no aggregation API server. This page covers installing or enabling the aggregation API server instead.
+
+Native v3 CRDs are the successor to the aggregation API server. The aggregation API server will continue to be supported until native v3 CRDs are fully supported on all platforms, and will be removed in a future release.
 
 :::
 

--- a/calico/operations/native-v3-crds.mdx
+++ b/calico/operations/native-v3-crds.mdx
@@ -8,6 +8,8 @@ description: New installs of Calico Open Source use native projectcalico.org/v3 
 
 New installs of $[prodname] use native `projectcalico.org/v3` CRDs by default: Calico resources are backed directly by CRDs, with no aggregation API server. This page explains how the mode works and how to install with the aggregation API server instead.
 
+Native `projectcalico.org/v3` CRDs are the successor to the Calico aggregation API server. The aggregation API server remains supported for now but will be removed in a future release.
+
 ## Value
 
 By default, $[prodname] uses an aggregation API server to serve `projectcalico.org/v3` APIs, storing resources internally as `crd.projectcalico.org/v1` CRDs. When using native `projectcalico.org/v3` CRDs, Calico resources are CRDs themselves, which provides several benefits:

--- a/calico/release-notes/index.mdx
+++ b/calico/release-notes/index.mdx
@@ -10,7 +10,7 @@ Learn about the new features, bug fixes, and other updates in this release of $[
 
 ## New features and enhancements
 
-- New installs default to v3 CRD mode: `projectcalico.org/v3` resources are served directly by CRDs, with no aggregation API server. Existing and upgraded clusters are unaffected. To install with the aggregation API server instead, apply the v1 CRDs before installing the operator. v3 CRD mode requires Kubernetes 1.32 or later. Native v3 CRDs are the successor to the aggregation API server, which will be removed in a future release. See [Native v3 CRDs](../operations/native-v3-crds.mdx).
+- New installs default to v3 CRD mode: `projectcalico.org/v3` resources are served directly by CRDs, with no aggregation API server. Existing and upgraded clusters are unaffected. To install with the aggregation API server instead, apply the v1 CRDs before installing the operator. v3 CRD mode requires Kubernetes 1.32 or later. Native v3 CRDs are the successor to the aggregation API server. The aggregation API server will continue to be supported until native v3 CRDs are fully supported on all platforms, and will be removed in a future release. See [Native v3 CRDs](../operations/native-v3-crds.mdx).
 
 ## Technology preview features
 

--- a/calico/release-notes/index.mdx
+++ b/calico/release-notes/index.mdx
@@ -10,11 +10,13 @@ Learn about the new features, bug fixes, and other updates in this release of $[
 
 ## New features and enhancements
 
-- New installs default to v3 CRD mode: `projectcalico.org/v3` resources are served directly by CRDs, with no aggregation API server. Existing and upgraded clusters are unaffected. To install with the aggregation API server instead, apply the v1 CRDs before installing the operator. v3 CRD mode requires Kubernetes 1.32 or later. Native v3 CRDs are the successor to the aggregation API server. The aggregation API server will continue to be supported until native v3 CRDs are fully supported on all platforms, and will be removed in a future release. See [Native v3 CRDs](../operations/native-v3-crds.mdx).
+- New installs default to v3 CRD mode: `projectcalico.org/v3` resources are served directly by CRDs, with no aggregation API server. Existing and upgraded clusters are unaffected. To install with the aggregation API server instead, apply the v1 CRDs before installing the operator. v3 CRD mode requires Kubernetes 1.32 or later. Native v3 CRDs are the successor to the aggregation API server. See [Native v3 CRDs](../operations/native-v3-crds.mdx).
 
 ## Technology preview features
 
 ## Deprecated and removed features
+
+- $[prodname] is moving the `projectcalico.org/v3` API from the aggregated API server to native Kubernetes CRDs. Both mechanisms will be supported until native v3 CRDs are compatible with all supported platforms, after which the aggregated API server will be removed.
 
 ## Bug fixes
 

--- a/calico/release-notes/index.mdx
+++ b/calico/release-notes/index.mdx
@@ -10,13 +10,11 @@ Learn about the new features, bug fixes, and other updates in this release of $[
 
 ## New features and enhancements
 
-- New installs default to v3 CRD mode: `projectcalico.org/v3` resources are served directly by CRDs, with no aggregation API server. Existing and upgraded clusters are unaffected. To install with the aggregation API server instead, apply the v1 CRDs before installing the operator. v3 CRD mode requires Kubernetes 1.32 or later. See [Native v3 CRDs](../operations/native-v3-crds.mdx).
+- New installs default to v3 CRD mode: `projectcalico.org/v3` resources are served directly by CRDs, with no aggregation API server. Existing and upgraded clusters are unaffected. To install with the aggregation API server instead, apply the v1 CRDs before installing the operator. v3 CRD mode requires Kubernetes 1.32 or later. Native v3 CRDs are the successor to the aggregation API server, which will be removed in a future release. See [Native v3 CRDs](../operations/native-v3-crds.mdx).
 
 ## Technology preview features
 
 ## Deprecated and removed features
-
-- The aggregation API server is deprecated. It remains supported for now but will be removed in a future release. New installs default to native v3 CRD mode. Clusters that use the aggregation API server can [migrate to native v3 CRDs](../operations/crd-migration.mdx).
 
 ## Bug fixes
 

--- a/calico_versioned_docs/version-3.32/operations/install-apiserver.mdx
+++ b/calico_versioned_docs/version-3.32/operations/install-apiserver.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 Install the Calico API server on an existing cluster to enable management of Calico APIs using kubectl.
 
-:::tip[Native v3 CRDs are the successor]
+:::tip[A simpler alternative: native v3 CRDs]
 
 You can use [native v3 CRDs](native-v3-crds.mdx) to manage `projectcalico.org/v3` resources directly with `kubectl` without installing the aggregation API server. If you are setting up a new cluster and want a simpler architecture, consider native v3 CRDs instead.
 

--- a/calico_versioned_docs/version-3.32/operations/install-apiserver.mdx
+++ b/calico_versioned_docs/version-3.32/operations/install-apiserver.mdx
@@ -7,13 +7,6 @@ description: Install the Calico Open Source aggregated API server on an existing
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-:::info[deprecation notice]
-
-The aggregated API server (`calico-apiserver`) is deprecated and will be removed in a future release.
-For new installations, use [native v3 CRDs](./native-v3-crds.mdx). For existing clusters, see [Migrate from API server to native CRDs](./crd-migration.mdx).
-
-:::
-
 ## Big picture
 
 Install the Calico API server on an existing cluster to enable management of Calico APIs using kubectl.

--- a/calico_versioned_docs/version-3.32/operations/install-apiserver.mdx
+++ b/calico_versioned_docs/version-3.32/operations/install-apiserver.mdx
@@ -11,9 +11,11 @@ import TabItem from '@theme/TabItem';
 
 Install the Calico API server on an existing cluster to enable management of Calico APIs using kubectl.
 
-:::tip
+:::tip[Native v3 CRDs are the successor]
 
 You can use [native v3 CRDs](native-v3-crds.mdx) to manage `projectcalico.org/v3` resources directly with `kubectl` without installing the aggregation API server. If you are setting up a new cluster and want a simpler architecture, consider native v3 CRDs instead.
+
+Native v3 CRDs are the successor to the aggregation API server. The aggregation API server will continue to be supported until native v3 CRDs are fully supported on all platforms, and will be removed in a future release.
 
 :::
 

--- a/calico_versioned_docs/version-3.32/operations/native-v3-crds.mdx
+++ b/calico_versioned_docs/version-3.32/operations/native-v3-crds.mdx
@@ -14,6 +14,8 @@ This feature is tech preview. Tech preview features may be subject to significan
 
 Enable native `projectcalico.org/v3` CRDs so that Calico resources are backed directly by CRDs, eliminating the need for the Calico aggregation API server.
 
+Native `projectcalico.org/v3` CRDs are the successor to the Calico aggregation API server. The aggregation API server remains supported for now but will be removed in a future release.
+
 ## Value
 
 By default, $[prodname] uses an aggregation API server to serve `projectcalico.org/v3` APIs, storing resources internally as `crd.projectcalico.org/v1` CRDs. When using native `projectcalico.org/v3` CRDs, Calico resources are CRDs themselves, which provides several benefits:

--- a/calico_versioned_docs/version-3.32/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.32/release-notes/index.mdx
@@ -19,7 +19,7 @@ For existing clusters, a new `DatastoreMigration` controller copies resources fr
 
 Native v3 CRDs require the Kubernetes `MutatingAdmissionPolicy` feature gate, which is beta and not enabled by default.
 
-Native v3 CRDs are the successor to the aggregated API server. In a future release they will become the default install mode, and the aggregated API server will be removed in a later release.
+Native v3 CRDs are the successor to the aggregated API server, and will become the default install mode in a future release. The aggregation API server will continue to be supported until native v3 CRDs are fully supported on all platforms, and will be removed in a future release.
 
 For more information, see [Enable native v3 CRDs](../operations/native-v3-crds.mdx) and [Migrate from API server to native CRDs](../operations/crd-migration.mdx).
 

--- a/calico_versioned_docs/version-3.32/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.32/release-notes/index.mdx
@@ -19,7 +19,7 @@ For existing clusters, a new `DatastoreMigration` controller copies resources fr
 
 Native v3 CRDs require the Kubernetes `MutatingAdmissionPolicy` feature gate, which is beta and not enabled by default.
 
-Native v3 CRDs are the successor to the aggregated API server, and will become the default install mode in a future release. The aggregation API server will continue to be supported until native v3 CRDs are fully supported on all platforms, and will be removed in a future release.
+Native v3 CRDs are the successor to the aggregated API server, and will become the default install mode in a future release.
 
 For more information, see [Enable native v3 CRDs](../operations/native-v3-crds.mdx) and [Migrate from API server to native CRDs](../operations/crd-migration.mdx).
 
@@ -82,6 +82,10 @@ Applications fail immediately and reconnect to a healthy backend instead of hang
 ### Kubernetes 1.36 support
 
 This release adds support for Kubernetes 1.36.
+
+## Deprecated and removed features
+
+* $[prodname] is moving the `projectcalico.org/v3` API from the aggregated API server to native Kubernetes CRDs. Both mechanisms will be supported until native v3 CRDs are compatible with all supported platforms, after which the aggregated API server will be removed.
 
 ## Bug fixes
 

--- a/calico_versioned_docs/version-3.32/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.32/release-notes/index.mdx
@@ -19,7 +19,7 @@ For existing clusters, a new `DatastoreMigration` controller copies resources fr
 
 Native v3 CRDs require the Kubernetes `MutatingAdmissionPolicy` feature gate, which is beta and not enabled by default.
 
-This is the first phase of phasing out the aggregated API server: in a future release, native v3 CRDs will become the default install mode, and in a later release the aggregated API server will be removed entirely.
+Native v3 CRDs are the successor to the aggregated API server. In a future release they will become the default install mode, and the aggregated API server will be removed in a later release.
 
 For more information, see [Enable native v3 CRDs](../operations/native-v3-crds.mdx) and [Migrate from API server to native CRDs](../operations/crd-migration.mdx).
 
@@ -82,10 +82,6 @@ Applications fail immediately and reconnect to a healthy backend instead of hang
 ### Kubernetes 1.36 support
 
 This release adds support for Kubernetes 1.36.
-
-## Deprecations
-
-* The aggregated API server (`calico-apiserver`) is deprecated and will be removed in a future release. See [Native v3 CRDs](../operations/native-v3-crds.mdx) for the recommended replacement.
 
 ## Bug fixes
 


### PR DESCRIPTION
This reframes the aggregated API server messaging across Calico Open Source and Calico Enterprise, in both the current and next release streams. It removes the "deprecated" label and instead presents native projectcalico.org/v3 CRDs as the successor to the aggregated API server, which is supported until native v3 CRDs are compatible with all supported platforms and is then removed.

Background

Earlier the docs labeled the aggregated API server as deprecated. Feedback changed the direction: starting in Open Source 3.32 and Enterprise 3.23, we do not use the deprecated label. The core team asked that the release notes still call out the move in the Deprecated and removed features section, framed as a replacement rather than a deprecation.

Changes

Install API server pages (Open Source 3.32 and next): removed the deprecation admonitions and added a tip titled "A simpler alternative: native v3 CRDs" that positions native v3 CRDs as the successor and states the aggregated API server is supported until native v3 CRDs are compatible with all supported platforms, then removed.

Native v3 CRDs pages (Open Source and Enterprise, current and next): state that native v3 CRDs are the successor to the aggregated API server.

Release notes (Open Source 3.32 and next, Enterprise 3.23 and next):
- The New features write-ups describe native v3 CRDs as the successor.
- The Deprecated and removed features section carries a bullet: "$[prodname] is moving the projectcalico.org/v3 API from the aggregated API server to native Kubernetes CRDs. Both mechanisms will be supported until native v3 CRDs are compatible with all supported platforms, after which the aggregated API server will be removed."

No "deprecated" label is applied to the aggregated API server.

Preview for reviewers

The same change repeats across streams, so these are representative pages:

- https://deploy-preview-2886--tigera.netlify.app/calico/latest/operations/install-apiserver
- https://deploy-preview-2886--tigera.netlify.app/calico/latest/operations/native-v3-crds
- https://deploy-preview-2886--tigera.netlify.app/calico/latest/release-notes/
- https://deploy-preview-2886--tigera.netlify.app/calico-enterprise/latest/release-notes/

Jira: https://tigera.atlassian.net/browse/DOCS-2990