### PR TITLE
Document that the license agent is not upgraded with Calico Enterprise

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.23-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
@@ -52,6 +52,10 @@ owned resources being garbage collected by Kubernetes.
 
 $[prodname] creates a default-deny for the calico-system namespace. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.
 
+### License agent
+
+The license agent is installed from a manifest and is not managed by the operator, so this upgrade leaves it on its current version. If you installed it, follow [Upgrade the license agent](../../../../operations/monitor/metrics/license-agent.mdx#upgrade-the-license-agent) after you upgrade.
+
 ## Upgrade from 3.19 or later
 
 :::note

--- a/calico-enterprise_versioned_docs/version-3.23-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/operator.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/operator.mdx
@@ -77,6 +77,10 @@ These steps differ based on your cluster type. If you are unsure of your cluster
 
 :::
 
+### License agent
+
+The license agent is installed from a manifest and is not managed by the operator, so this upgrade leaves it on its current version. If you installed it, follow [Upgrade the license agent](../../../../operations/monitor/metrics/license-agent.mdx#upgrade-the-license-agent) after you upgrade.
+
 ## Upgrade Calico Enterprise
 
 <Tabs>

--- a/calico-enterprise_versioned_docs/version-3.23-2/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
@@ -87,6 +87,10 @@ pod-security.kubernetes.io/enforce-version: latest
 security.openshift.io/scc.podSecurityLabelSync: "false"
 ```
 
+### License agent
+
+The license agent is installed from a manifest and is not managed by the operator, so this upgrade leaves it on its current version. If you installed it, follow [Upgrade the license agent](../../../operations/monitor/metrics/license-agent.mdx#upgrade-the-license-agent) after you upgrade.
+
 ## Download the new manifests
 
 Make a manifests directory.

--- a/calico-enterprise_versioned_docs/version-3.23-2/operations/monitor/metrics/license-agent.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/operations/monitor/metrics/license-agent.mdx
@@ -27,6 +27,7 @@ The **License Agent** is a containerized application that monitors the following
 ## How to
 
 - [Add license agent in your Kubernetes cluster](#add-license-agent-in-your-kubernetes-cluster)
+- [Upgrade the license agent](#upgrade-the-license-agent)
 - [Create alerts using Prometheus metrics](#create-alerts-using-prometheus-metrics)
 
 ### Add license agent in your Kubernetes cluster
@@ -47,6 +48,24 @@ To add the license-agent component in a Kubernetes cluster for license metrics, 
    ```
     kubectl apply -f $[filesUrl]/manifests/licenseagent.yaml
    ```
+
+### Upgrade the license agent
+
+The license agent is installed from a manifest and is not managed by the $[prodname] operator. Upgrading $[prodname] leaves the license agent running the image from the manifest you last applied, so you must upgrade the license agent yourself after every $[prodname] upgrade. Until you do, license metrics come from the old version of the agent.
+
+1. Apply the manifest for the version of $[prodname] you upgraded to.
+   ```
+    kubectl apply -f $[filesUrl]/manifests/licenseagent.yaml
+   ```
+1. If you upgraded from a version earlier than $[prodname] v3.23, delete the license agent's network policy from the `allow-tigera` tier. From v3.23 the manifest creates this policy in the `calico-system` tier instead, and because the name of a policy includes the name of its tier, applying the new manifest adds a second policy rather than replacing the first: the same rule ends up in both tiers.
+   ```
+    kubectl delete networkpolicies.projectcalico.org allow-tigera.tigera-license-agent-access -n tigera-license-agent
+   ```
+1. Check whether any policy is left in the `allow-tigera` tier.
+   ```
+    kubectl get networkpolicies.projectcalico.org,globalnetworkpolicies.projectcalico.org -A | grep allow-tigera
+   ```
+   The operator removes the deprecated `allow-tigera` tier once no policy is left in it. While any policy remains, the tier stays and the operator logs `Cannot delete a non-empty tier` on every reconcile. So deleting the license agent's policy is enough only if nothing else is left: if the command above still lists policies, expect the tier to remain until those are removed as well. Contact Support if you are unsure what created a policy that is still listed.
 
 ### Create alerts using Prometheus metrics
 


### PR DESCRIPTION
### What this fixes

The license agent is installed from a manifest and is not managed by the operator, so upgrading Calico Enterprise leaves it running the image it was installed with. Nothing in the docs said so, which is how a cluster ends up on the previous agent image after an upgrade and stops reporting license metrics.

The 3.23 tier rename makes it worse. The name of a tiered policy embeds its tier, so `licenseagent.yaml` moved from `allow-tigera.tigera-license-agent-access` to `calico-system.tigera-license-agent-access`. Applying the 3.23 manifest creates the new policy and leaves the old one in place, so the same rule ends up in both tiers, and the operator cannot remove the deprecated `allow-tigera` tier while any policy is left in it — it logs `Cannot delete a non-empty tier` on every reconcile instead. Deleting the license agent's own policy is not always enough, because other leftovers can hold the tier open, so the section says to check rather than to assume.

### Changes

All in `version-3.23-2`, since that is the version being upgraded to and the version where the license agent is still documented. The standalone page was removed from `next` in 0964008c, where license metrics now come from the operator, so there is nothing to add there.

- `operations/monitor/metrics/license-agent.mdx`: new **Upgrade the license agent** section — re-apply the version-matched manifest, delete the stale `allow-tigera` policy if the upgrade came from before 3.23, then check whether anything is still holding the tier open.
- `getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/operator.mdx`, `.../helm.mdx`, `openshift-upgrade.mdx`: a short **License agent** subsection pointing at it, so the reader learns about it while upgrading rather than afterwards.

kubectl only, no Helm flow on the task page.

### Verification

`yarn build` passes. The config has `onBrokenLinks: 'throw'` and `onBrokenMarkdownLinks: 'throw'`, so the three relative links resolve; `onBrokenAnchors` is `'ignore'`, so I checked the anchor by hand — all three render as `href=/calico-enterprise/latest/operations/monitor/metrics/license-agent#upgrade-the-license-agent`, and `id=upgrade-the-license-agent` exists on that page. I also read the rendered section: the steps and code blocks come out right, and `$[filesUrl]` resolves to the v3.23.1 manifest.

Both commands in the new section were run against a live Calico Enterprise cluster in the form they are published.

### Related

- CI-2028 / EV-6872: the support case this comes from.
- EV-6920: separately, the shipped `licenseagent.yaml` admits ingress from `app == 'prometheus'`, a label no pod carries, so the scrape is denied by policy as well.
- tigera/calico-private#12972: the code fix for the v3.23-only change that leaves the agent's `/metrics` port unbound when no certificate is configured.