### PR TITLE
Update the CRD migration docs for DatastoreMigration v1

### DIFF
--- a/calico-enterprise/operations/crd-migration.mdx
+++ b/calico-enterprise/operations/crd-migration.mdx
@@ -69,17 +69,13 @@ The locked window is typically short (seconds to a few minutes depending on clus
 
    :::note
 
-   If you installed the DatastoreMigration CRD on an earlier release, delete it before
-   applying this one:
+   If you installed the DatastoreMigration CRD on an earlier release, delete it before applying this one:
 
    ```bash
    kubectl delete crd datastoremigrations.migration.projectcalico.org
    ```
 
-   The CRD moved from `v1beta1` to `v1`. Kubernetes rejects an update that drops a
-   version still listed in the CRD's `status.storedVersions`, so `kubectl apply` fails
-   with a confusing error otherwise. Deleting the CRD also deletes any DatastoreMigration
-   resource, so only do this if no migration is in progress.
+   The CRD moved from `v1beta1` to `v1`. Kubernetes rejects an update that drops a version still listed in the CRD's `status.storedVersions`, so `kubectl apply` fails with a confusing error otherwise. Deleting the CRD also deletes any DatastoreMigration resource, so only do this if no migration is in progress.
 
    :::
 

--- a/calico-enterprise/operations/crd-migration.mdx
+++ b/calico-enterprise/operations/crd-migration.mdx
@@ -67,11 +67,27 @@ The locked window is typically short (seconds to a few minutes depending on clus
    kubectl apply -f $[manifestsUrl]/manifests/migration.projectcalico.org_datastoremigrations.yaml
    ```
 
+   :::note
+
+   If you installed the DatastoreMigration CRD on an earlier release, delete it before
+   applying this one:
+
+   ```bash
+   kubectl delete crd datastoremigrations.migration.projectcalico.org
+   ```
+
+   The CRD moved from `v1beta1` to `v1`. Kubernetes rejects an update that drops a
+   version still listed in the CRD's `status.storedVersions`, so `kubectl apply` fails
+   with a confusing error otherwise. Deleting the CRD also deletes any DatastoreMigration
+   resource, so only do this if no migration is in progress.
+
+   :::
+
 3. **Create the DatastoreMigration CR.**
 
    ```bash
    kubectl apply -f - <<EOF
-   apiVersion: migration.projectcalico.org/v1beta1
+   apiVersion: migration.projectcalico.org/v1
    kind: DatastoreMigration
    metadata:
      name: v1-to-v3

--- a/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
+++ b/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
@@ -241,14 +241,30 @@ If you have an existing manifest-based $[prodname] install using the legacy `crd
 1. Install the DatastoreMigration CRD.
 
    ```bash
-   kubectl apply --server-side -f $[manifestsUrl]/kube-controllers/pkg/controllers/migration/crd/migration.projectcalico.org_datastoremigrations.yaml
+   kubectl apply --server-side -f $[manifestsUrl]/manifests/migration.projectcalico.org_datastoremigrations.yaml
    ```
+
+   :::note
+
+   If you installed the DatastoreMigration CRD on an earlier release, delete it before
+   applying this one:
+
+   ```bash
+   kubectl delete crd datastoremigrations.migration.projectcalico.org
+   ```
+
+   The CRD moved from `v1beta1` to `v1`. Kubernetes rejects an update that drops a
+   version still listed in the CRD's `status.storedVersions`, so `kubectl apply` fails
+   with a confusing error otherwise. Deleting the CRD also deletes any DatastoreMigration
+   resource, so only do this if no migration is in progress.
+
+   :::
 
 1. Create a DatastoreMigration resource to start the migration. The migration controller copies all Calico resources from v1 CRDs to v3 CRDs.
 
    ```bash
    kubectl apply -f - <<EOF
-   apiVersion: migration.projectcalico.org/v1beta1
+   apiVersion: migration.projectcalico.org/v1
    kind: DatastoreMigration
    metadata:
      name: v1-to-v3

--- a/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
+++ b/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
@@ -246,17 +246,13 @@ If you have an existing manifest-based $[prodname] install using the legacy `crd
 
    :::note
 
-   If you installed the DatastoreMigration CRD on an earlier release, delete it before
-   applying this one:
+   If you installed the DatastoreMigration CRD on an earlier release, delete it before applying this one:
 
    ```bash
    kubectl delete crd datastoremigrations.migration.projectcalico.org
    ```
 
-   The CRD moved from `v1beta1` to `v1`. Kubernetes rejects an update that drops a
-   version still listed in the CRD's `status.storedVersions`, so `kubectl apply` fails
-   with a confusing error otherwise. Deleting the CRD also deletes any DatastoreMigration
-   resource, so only do this if no migration is in progress.
+   The CRD moved from `v1beta1` to `v1`. Kubernetes rejects an update that drops a version still listed in the CRD's `status.storedVersions`, so `kubectl apply` fails with a confusing error otherwise. Deleting the CRD also deletes any DatastoreMigration resource, so only do this if no migration is in progress.
 
    :::
 

--- a/calico/operations/crd-migration.mdx
+++ b/calico/operations/crd-migration.mdx
@@ -70,17 +70,13 @@ The locked window is typically short (seconds to a few minutes depending on clus
 
    :::note
 
-   If you installed the DatastoreMigration CRD on an earlier release, delete it before
-   applying this one:
+   If you installed the DatastoreMigration CRD on an earlier release, delete it before applying this one:
 
    ```bash
    kubectl delete crd datastoremigrations.migration.projectcalico.org
    ```
 
-   The CRD moved from `v1beta1` to `v1`. Kubernetes rejects an update that drops a
-   version still listed in the CRD's `status.storedVersions`, so `kubectl apply` fails
-   with a confusing error otherwise. Deleting the CRD also deletes any DatastoreMigration
-   resource, so only do this if no migration is in progress.
+   The CRD moved from `v1beta1` to `v1`. Kubernetes rejects an update that drops a version still listed in the CRD's `status.storedVersions`, so `kubectl apply` fails with a confusing error otherwise. Deleting the CRD also deletes any DatastoreMigration resource, so only do this if no migration is in progress.
 
    :::
 

--- a/calico/operations/crd-migration.mdx
+++ b/calico/operations/crd-migration.mdx
@@ -68,11 +68,27 @@ The locked window is typically short (seconds to a few minutes depending on clus
    kubectl apply -f $[manifestsUrl]/manifests/migration.projectcalico.org_datastoremigrations.yaml
    ```
 
+   :::note
+
+   If you installed the DatastoreMigration CRD on an earlier release, delete it before
+   applying this one:
+
+   ```bash
+   kubectl delete crd datastoremigrations.migration.projectcalico.org
+   ```
+
+   The CRD moved from `v1beta1` to `v1`. Kubernetes rejects an update that drops a
+   version still listed in the CRD's `status.storedVersions`, so `kubectl apply` fails
+   with a confusing error otherwise. Deleting the CRD also deletes any DatastoreMigration
+   resource, so only do this if no migration is in progress.
+
+   :::
+
 3. **Create the DatastoreMigration CR.**
 
    ```bash
    kubectl apply -f - <<EOF
-   apiVersion: migration.projectcalico.org/v1beta1
+   apiVersion: migration.projectcalico.org/v1
    kind: DatastoreMigration
    metadata:
      name: v1-to-v3


### PR DESCRIPTION
The DatastoreMigration CRD is moving to `migration.projectcalico.org/v1` on master (https://github.com/projectcalico/calico/pull/13383). Bumps the example CR, and adds a note that an existing v1beta1 CRD has to be deleted first: Kubernetes rejects an update that drops a version still listed in `storedVersions`, so `kubectl apply` fails with a fairly confusing error otherwise. Deleting the CRD also deletes any DatastoreMigration resource, so the note calls that out too.

Also fixes the second copy of the migration steps in `onpremises.mdx`, which was still on v1beta1 and pointed at a CRD path inside the kube-controllers source tree. That path is going away, so it now uses the published manifest like the main page does.

Versioned docs are untouched. `version-3.32` correctly documents v1beta1, which is what that release serves.

Related: CORE-12573
