### PR TITLE
DOCS-2991: Add new features to Calico Enterprise 3.24 early preview 1 release notes

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
@@ -23,7 +23,7 @@ This version of Calico Enterprise is based on [Calico Open Source $[openSourceVe
 
 ### Per-namespace deployment for Calico Ingress Gateway
 
-Calico Ingress Gateway now runs each gateway's proxy, `Service`, and load balancer in the same namespace as its `Gateway`, rather than in a single shared namespace.
+Calico Ingress Gateway runs each gateway's proxy, `Service`, and load balancer in the same namespace as its `Gateway`, rather than in a single shared namespace.
 Application teams can deploy and operate their own gateways alongside their workloads, scope network policy and RBAC to a single namespace, and attribute the gateway's resource usage to the team that owns it.
 You can run multiple independent gateway instances across different namespaces.
 
@@ -31,14 +31,14 @@ For more information, see [Create an ingress gateway](../networking/ingress-gate
 
 ### Web application firewall for ingress gateways (tech preview)
 
-You can now attach a web application firewall (WAF) to Calico Ingress Gateway traffic per `Gateway` and per route, and tune it per namespace, instead of applying a single ruleset to everything behind the gateway.
+You can attach a web application firewall (WAF) to Calico Ingress Gateway traffic per `Gateway` and per route, and tune it per namespace, instead of applying a single ruleset to everything behind the gateway.
 A cluster operator sets a security baseline once from the OWASP Core Rule Set, and each application team layers its own rules and exceptions on top — scoped to their own gateways and `HTTPRoute` resources, within guardrails the operator defines.
 
 For more information, see [Gateway WAF](../threat/gateway-waf/overview.mdx).
 
 ### Layer 7 logs from a kernel eBPF collector
 
-$[prodname] can now capture Layer 7 (HTTP and TLS) logs using a kernel TCP-layer eBPF collector, with no data path proxy and no per-workload sidecars.
+A new kernel TCP-layer eBPF collector captures Layer 7 (HTTP and TLS) logs with no data path proxy and no per-workload sidecars.
 You enable it once at the cluster level, and it works with any $[prodname] data plane — iptables, nftables, or eBPF.
 The collected HTTP request/response and TLS handshake metadata feeds the same L7 log pipeline that powers Service Graph, HTTP logs, and the L7 dashboards.
 
@@ -46,7 +46,7 @@ For more information, see [L7 logs overview](../observability/elastic/l7/overvie
 
 ### L2 reachability for pods and services without BGP
 
-$[prodname] can now make pods and LoadBalancer service IPs that share a node's subnet reachable from the local Layer 2 network without configuring BGP.
+$[prodname] can make pods and LoadBalancer service IPs that share a node's subnet reachable from the local Layer 2 network without configuring BGP.
 With `localSubnetL2Reachability` enabled, $[prodname] runs a userspace ARP/NDP responder on the relevant host interfaces and answers for local pod IPs and LoadBalancer VIPs within the host subnet, so external hosts on the same segment can reach them with no overlay encapsulation and no changes to your network infrastructure.
 This is useful for on-premises, edge, and other flat L2 environments where BGP peering is not an option.
 

--- a/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
@@ -19,6 +19,41 @@ This version of Calico Enterprise is based on [Calico Open Source $[openSourceVe
 
 ## New features and enhancements
 
+{/* Start 3.24.0-1.0 features */}
+
+### Per-namespace deployment for Calico Ingress Gateway
+
+Calico Ingress Gateway now runs each gateway's proxy, `Service`, and load balancer in the same namespace as its `Gateway`, rather than in a single shared namespace.
+Application teams can deploy and operate their own gateways alongside their workloads, scope network policy and RBAC to a single namespace, and attribute the gateway's resource usage to the team that owns it.
+You can run multiple independent gateway instances across different namespaces.
+
+For more information, see [Create an ingress gateway](../networking/ingress-gateway/create-ingress-gateway.mdx).
+
+### Web application firewall for ingress gateways (tech preview)
+
+You can now attach a web application firewall (WAF) to Calico Ingress Gateway traffic per `Gateway` and per route, and tune it per namespace, instead of applying a single ruleset to everything behind the gateway.
+A cluster operator sets a security baseline once from the OWASP Core Rule Set, and each application team layers its own rules and exceptions on top — scoped to their own gateways and `HTTPRoute` resources, within guardrails the operator defines.
+
+For more information, see [Gateway WAF](../threat/gateway-waf/overview.mdx).
+
+### Layer 7 logs from a kernel eBPF collector
+
+$[prodname] can now capture Layer 7 (HTTP and TLS) logs using a kernel TCP-layer eBPF collector, with no data path proxy and no per-workload sidecars.
+You enable it once at the cluster level, and it works with any $[prodname] data plane — iptables, nftables, or eBPF.
+The collected HTTP request/response and TLS handshake metadata feeds the same L7 log pipeline that powers Service Graph, HTTP logs, and the L7 dashboards.
+
+For more information, see [L7 logs overview](../observability/elastic/l7/overview.mdx) and [Collect L7 logs using the eBPF collector](../observability/elastic/l7/enable-ebpf-collector.mdx).
+
+### L2 reachability for pods and services without BGP
+
+$[prodname] can now make pods and LoadBalancer service IPs that share a node's subnet reachable from the local Layer 2 network without configuring BGP.
+With `localSubnetL2Reachability` enabled, $[prodname] runs a userspace ARP/NDP responder on the relevant host interfaces and answers for local pod IPs and LoadBalancer VIPs within the host subnet, so external hosts on the same segment can reach them with no overlay encapsulation and no changes to your network infrastructure.
+This is useful for on-premises, edge, and other flat L2 environments where BGP peering is not an option.
+
+For more information, see [L2 reachability for pods and services without BGP](../networking/configuring/local-subnet-l2-reachability.mdx).
+
+{/* End 3.24.0-1.0 features */}
+
 ### Enhancements
 
 * **Enable Calico Ingress Gateway during Helm installation:**


### PR DESCRIPTION
Adds the early preview 1 features to the Calico Enterprise 3.24 release notes, under New features and enhancements in version-3.24-1. The features come from the PMREQ issues tagged with the Enterprise v3.24 EP1 fix version.

Features added:

- Per-namespace deployment for Calico Ingress Gateway (PMREQ-832)
- Web application firewall for ingress gateways, tech preview (PMREQ-384)
- Layer 7 logs from a kernel eBPF collector (PMREQ-841, PMREQ-842, PMREQ-838)
- L2 reachability for pods and services without BGP (PMREQ-827)

Each entry links to the relevant product documentation. The existing enhancements, deprecations, upgrade notes, and release details are unchanged.

Jira: https://tigera.atlassian.net/browse/DOCS-2991

For reviewers, the only changed page is the Calico Enterprise 3.24 release notes. I will add the deploy preview link once it builds.