### PR TITLE
DOCS-2694 [GH#10755]: Stop telling operator users to create a Typha metrics service

### DIFF
--- a/calico/operations/monitor/monitor-component-metrics.mdx
+++ b/calico/operations/monitor/monitor-component-metrics.mdx
@@ -253,13 +253,14 @@ When you set `typhaMetricsPort`, the operator automatically creates a service th
 You can use the following command to verify it.
 
 ```bash
-kubectl get svc -n calico-system
+kubectl get svc -n calico-system calico-typha-metrics
 ```
 
 You should see a result similar to:
 
 ```bash
-calico-typha-metrics   ClusterIP   10.43.164.10    <none>        9093/TCP   39d
+NAME                   TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
+calico-typha-metrics   ClusterIP   10.43.164.10   <none>        9093/TCP   39d
 ```
 
 </TabItem>

--- a/calico/operations/monitor/monitor-component-metrics.mdx
+++ b/calico/operations/monitor/monitor-component-metrics.mdx
@@ -248,21 +248,18 @@ Typha uses **port 9091** TCP by default to publish its metrics. However, if $[pr
 <Tabs>
 <TabItem label="Operator" value="Operator-8">
 
+When you set `typhaMetricsPort`, the operator automatically creates a service that exposes these metrics. You do not need to create one yourself.
+
+You can use the following command to verify it.
+
 ```bash
-kubectl apply -f - <<EOF
-apiVersion: v1
-kind: Service
-metadata:
-  name: typha-metrics-svc
-  namespace: calico-system
-spec:
-  clusterIP: None
-  selector:
-    k8s-app: calico-typha
-  ports:
-  - port: 9093
-    targetPort: 9093
-EOF
+kubectl get svc -n calico-system
+```
+
+You should see a result similar to:
+
+```bash
+calico-typha-metrics   ClusterIP   10.43.164.10    <none>        9093/TCP   39d
 ```
 
 </TabItem>
@@ -491,12 +488,9 @@ data:
       - role: endpoints
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name]
-        regex: typha-metrics-svc
+        regex: calico-typha-metrics
         replacement: $1
         action: keep
-      - source_labels: [__meta_kubernetes_pod_container_port_name]
-        regex: calico-typha
-        action: drop
     - job_name: 'kube_controllers_metrics'
       scrape_interval: 5s
       scheme: http
@@ -656,7 +650,6 @@ First remove the services by executing the following command:
 
 ```bash
 kubectl delete service felix-metrics-svc -n calico-system
-kubectl delete service typha-metrics-svc -n calico-system
 ```
 
 If running $[prodnameWindows], also clean up the Windows nodes service:

--- a/calico_versioned_docs/version-3.29/operations/monitor/monitor-component-metrics.mdx
+++ b/calico_versioned_docs/version-3.29/operations/monitor/monitor-component-metrics.mdx
@@ -253,13 +253,14 @@ When you set `typhaMetricsPort`, the operator automatically creates a service th
 You can use the following command to verify it.
 
 ```bash
-kubectl get svc -n calico-system
+kubectl get svc -n calico-system calico-typha-metrics
 ```
 
 You should see a result similar to:
 
 ```bash
-calico-typha-metrics   ClusterIP   10.43.164.10    <none>        9093/TCP   39d
+NAME                   TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
+calico-typha-metrics   ClusterIP   10.43.164.10   <none>        9093/TCP   39d
 ```
 
 </TabItem>

--- a/calico_versioned_docs/version-3.29/operations/monitor/monitor-component-metrics.mdx
+++ b/calico_versioned_docs/version-3.29/operations/monitor/monitor-component-metrics.mdx
@@ -248,21 +248,18 @@ Typha uses **port 9091** TCP by default to publish its metrics. However, if $[pr
 <Tabs>
 <TabItem label="Operator" value="Operator-8">
 
+When you set `typhaMetricsPort`, the operator automatically creates a service that exposes these metrics. You do not need to create one yourself.
+
+You can use the following command to verify it.
+
 ```bash
-kubectl apply -f - <<EOF
-apiVersion: v1
-kind: Service
-metadata:
-  name: typha-metrics-svc
-  namespace: calico-system
-spec:
-  clusterIP: None
-  selector:
-    k8s-app: calico-typha
-  ports:
-  - port: 9093
-    targetPort: 9093
-EOF
+kubectl get svc -n calico-system
+```
+
+You should see a result similar to:
+
+```bash
+calico-typha-metrics   ClusterIP   10.43.164.10    <none>        9093/TCP   39d
 ```
 
 </TabItem>
@@ -491,12 +488,9 @@ data:
       - role: endpoints
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name]
-        regex: typha-metrics-svc
+        regex: calico-typha-metrics
         replacement: $1
         action: keep
-      - source_labels: [__meta_kubernetes_pod_container_port_name]
-        regex: calico-typha
-        action: drop
     - job_name: 'kube_controllers_metrics'
       scrape_interval: 5s
       scheme: http
@@ -656,7 +650,6 @@ First remove the services by executing the following command:
 
 ```bash
 kubectl delete service felix-metrics-svc -n calico-system
-kubectl delete service typha-metrics-svc -n calico-system
 ```
 
 If running $[prodnameWindows], also clean up the Windows nodes service:

--- a/calico_versioned_docs/version-3.30/operations/monitor/monitor-component-metrics.mdx
+++ b/calico_versioned_docs/version-3.30/operations/monitor/monitor-component-metrics.mdx
@@ -253,13 +253,14 @@ When you set `typhaMetricsPort`, the operator automatically creates a service th
 You can use the following command to verify it.
 
 ```bash
-kubectl get svc -n calico-system
+kubectl get svc -n calico-system calico-typha-metrics
 ```
 
 You should see a result similar to:
 
 ```bash
-calico-typha-metrics   ClusterIP   10.43.164.10    <none>        9093/TCP   39d
+NAME                   TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
+calico-typha-metrics   ClusterIP   10.43.164.10   <none>        9093/TCP   39d
 ```
 
 </TabItem>

--- a/calico_versioned_docs/version-3.30/operations/monitor/monitor-component-metrics.mdx
+++ b/calico_versioned_docs/version-3.30/operations/monitor/monitor-component-metrics.mdx
@@ -248,21 +248,18 @@ Typha uses **port 9091** TCP by default to publish its metrics. However, if $[pr
 <Tabs>
 <TabItem label="Operator" value="Operator-8">
 
+When you set `typhaMetricsPort`, the operator automatically creates a service that exposes these metrics. You do not need to create one yourself.
+
+You can use the following command to verify it.
+
 ```bash
-kubectl apply -f - <<EOF
-apiVersion: v1
-kind: Service
-metadata:
-  name: typha-metrics-svc
-  namespace: calico-system
-spec:
-  clusterIP: None
-  selector:
-    k8s-app: calico-typha
-  ports:
-  - port: 9093
-    targetPort: 9093
-EOF
+kubectl get svc -n calico-system
+```
+
+You should see a result similar to:
+
+```bash
+calico-typha-metrics   ClusterIP   10.43.164.10    <none>        9093/TCP   39d
 ```
 
 </TabItem>
@@ -491,12 +488,9 @@ data:
       - role: endpoints
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name]
-        regex: typha-metrics-svc
+        regex: calico-typha-metrics
         replacement: $1
         action: keep
-      - source_labels: [__meta_kubernetes_pod_container_port_name]
-        regex: calico-typha
-        action: drop
     - job_name: 'kube_controllers_metrics'
       scrape_interval: 5s
       scheme: http
@@ -656,7 +650,6 @@ First remove the services by executing the following command:
 
 ```bash
 kubectl delete service felix-metrics-svc -n calico-system
-kubectl delete service typha-metrics-svc -n calico-system
 ```
 
 If running $[prodnameWindows], also clean up the Windows nodes service:

--- a/calico_versioned_docs/version-3.31/operations/monitor/monitor-component-metrics.mdx
+++ b/calico_versioned_docs/version-3.31/operations/monitor/monitor-component-metrics.mdx
@@ -253,13 +253,14 @@ When you set `typhaMetricsPort`, the operator automatically creates a service th
 You can use the following command to verify it.
 
 ```bash
-kubectl get svc -n calico-system
+kubectl get svc -n calico-system calico-typha-metrics
 ```
 
 You should see a result similar to:
 
 ```bash
-calico-typha-metrics   ClusterIP   10.43.164.10    <none>        9093/TCP   39d
+NAME                   TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
+calico-typha-metrics   ClusterIP   10.43.164.10   <none>        9093/TCP   39d
 ```
 
 </TabItem>

--- a/calico_versioned_docs/version-3.31/operations/monitor/monitor-component-metrics.mdx
+++ b/calico_versioned_docs/version-3.31/operations/monitor/monitor-component-metrics.mdx
@@ -248,21 +248,18 @@ Typha uses **port 9091** TCP by default to publish its metrics. However, if $[pr
 <Tabs>
 <TabItem label="Operator" value="Operator-8">
 
+When you set `typhaMetricsPort`, the operator automatically creates a service that exposes these metrics. You do not need to create one yourself.
+
+You can use the following command to verify it.
+
 ```bash
-kubectl apply -f - <<EOF
-apiVersion: v1
-kind: Service
-metadata:
-  name: typha-metrics-svc
-  namespace: calico-system
-spec:
-  clusterIP: None
-  selector:
-    k8s-app: calico-typha
-  ports:
-  - port: 9093
-    targetPort: 9093
-EOF
+kubectl get svc -n calico-system
+```
+
+You should see a result similar to:
+
+```bash
+calico-typha-metrics   ClusterIP   10.43.164.10    <none>        9093/TCP   39d
 ```
 
 </TabItem>
@@ -491,12 +488,9 @@ data:
       - role: endpoints
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name]
-        regex: typha-metrics-svc
+        regex: calico-typha-metrics
         replacement: $1
         action: keep
-      - source_labels: [__meta_kubernetes_pod_container_port_name]
-        regex: calico-typha
-        action: drop
     - job_name: 'kube_controllers_metrics'
       scrape_interval: 5s
       scheme: http
@@ -656,7 +650,6 @@ First remove the services by executing the following command:
 
 ```bash
 kubectl delete service felix-metrics-svc -n calico-system
-kubectl delete service typha-metrics-svc -n calico-system
 ```
 
 If running $[prodnameWindows], also clean up the Windows nodes service:

--- a/calico_versioned_docs/version-3.32/operations/monitor/monitor-component-metrics.mdx
+++ b/calico_versioned_docs/version-3.32/operations/monitor/monitor-component-metrics.mdx
@@ -253,13 +253,14 @@ When you set `typhaMetricsPort`, the operator automatically creates a service th
 You can use the following command to verify it.
 
 ```bash
-kubectl get svc -n calico-system
+kubectl get svc -n calico-system calico-typha-metrics
 ```
 
 You should see a result similar to:
 
 ```bash
-calico-typha-metrics   ClusterIP   10.43.164.10    <none>        9093/TCP   39d
+NAME                   TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
+calico-typha-metrics   ClusterIP   10.43.164.10   <none>        9093/TCP   39d
 ```
 
 </TabItem>

--- a/calico_versioned_docs/version-3.32/operations/monitor/monitor-component-metrics.mdx
+++ b/calico_versioned_docs/version-3.32/operations/monitor/monitor-component-metrics.mdx
@@ -248,21 +248,18 @@ Typha uses **port 9091** TCP by default to publish its metrics. However, if $[pr
 <Tabs>
 <TabItem label="Operator" value="Operator-8">
 
+When you set `typhaMetricsPort`, the operator automatically creates a service that exposes these metrics. You do not need to create one yourself.
+
+You can use the following command to verify it.
+
 ```bash
-kubectl apply -f - <<EOF
-apiVersion: v1
-kind: Service
-metadata:
-  name: typha-metrics-svc
-  namespace: calico-system
-spec:
-  clusterIP: None
-  selector:
-    k8s-app: calico-typha
-  ports:
-  - port: 9093
-    targetPort: 9093
-EOF
+kubectl get svc -n calico-system
+```
+
+You should see a result similar to:
+
+```bash
+calico-typha-metrics   ClusterIP   10.43.164.10    <none>        9093/TCP   39d
 ```
 
 </TabItem>
@@ -491,12 +488,9 @@ data:
       - role: endpoints
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name]
-        regex: typha-metrics-svc
+        regex: calico-typha-metrics
         replacement: $1
         action: keep
-      - source_labels: [__meta_kubernetes_pod_container_port_name]
-        regex: calico-typha
-        action: drop
     - job_name: 'kube_controllers_metrics'
       scrape_interval: 5s
       scheme: http
@@ -656,7 +650,6 @@ First remove the services by executing the following command:
 
 ```bash
 kubectl delete service felix-metrics-svc -n calico-system
-kubectl delete service typha-metrics-svc -n calico-system
 ```
 
 If running $[prodnameWindows], also clean up the Windows nodes service:


### PR DESCRIPTION
Product Version(s):
Calico next, 3.32, 3.31, 3.30, 3.29

Issue:
https://github.com/projectcalico/calico/issues/10755

Link to docs preview:
- next: https://deploy-preview-2899--calico-docs-preview-next.netlify.app/calico/next/operations/monitor/monitor-component-metrics
- released versions: https://deploy-preview-2899--tigera.netlify.app/calico/latest/operations/monitor/monitor-component-metrics (switch versions with the picker)

SME review:
- [ ] An SME has approved this change.

DOCS review:
- [ ] A member of the docs team has approved this change.

Additional information:
Setting `typhaMetricsPort` already gets you a `calico-typha-metrics` service in `calico-system`, so the tutorial was walking operator users into creating a second, redundant one. The Operator tab now points at the operator's service instead, matching what the kube-controllers section already does.

Merge checklist:
- [ ] Deploy preview inspected wherever changes were made
- [ ] Build completed successfully
- [ ] Test have passed
