### PR TITLE
Document boot-time network protection for non-cluster hosts

### DIFF
--- a/calico-enterprise/getting-started/bare-metal/about.mdx
+++ b/calico-enterprise/getting-started/bare-metal/about.mdx
@@ -165,6 +165,12 @@ cluster will use nftables, but can be configured to use iptables.
    You can configure the Calico node by tuning the environment variables defined in the `/etc/calico/calico-node/calico-node.env` file.
    For more information, see the [Felix configuration reference](../../reference/resources/felixconfig.mdx).
 
+   :::note
+
+   Enabling `calico-node.service` also turns on [boot-time network protection](boot-protection.mdx), which blocks inbound traffic from the start of boot until $[prodname] applies network policy. SSH stays reachable by default.
+
+   :::
+
 ### Configure high availability mode
 
 High availability (HA) mode helps protect workloads running on hosts and VMs by providing an automated disaster recovery setup.
@@ -187,5 +193,6 @@ To enable HA mode, system administrators must perform the following steps:
 
 ## Additional resources
 
+- [Boot-time network protection](boot-protection.mdx)
 - [Protect hosts and VMs](../../network-policy/hosts/protect-hosts.mdx)
 - [Use custom certificates for Node and Typha](typha-node-tls.mdx)

--- a/calico-enterprise/getting-started/bare-metal/boot-protection.mdx
+++ b/calico-enterprise/getting-started/bare-metal/boot-protection.mdx
@@ -1,0 +1,186 @@
+---
+description: Protect a non-cluster host from the moment its network stack starts until Calico Enterprise applies network policy.
+---
+
+# Boot-time network protection
+
+## Big picture
+
+Block inbound traffic to a non-cluster host from the start of boot until $[prodname] applies network policy.
+
+## Value
+
+On a non-cluster host, $[prodname] cannot enforce policy right away.
+The Calico Node service (the agent) must start, connect to Typha, and sync the datastore first.
+Until it does, no policy is in force and nothing blocks inbound traffic.
+
+On a healthy boot this takes a few seconds, but there is no time limit on it.
+If Typha is unreachable, if the certificate cannot be renewed, or if the agent keeps restarting, the host stays unprotected until you fix the problem.
+
+Boot-time network protection closes this gap.
+A small ruleset that denies inbound traffic goes into the kernel before any network interface is configured.
+The agent then replaces it with your policy.
+If the agent never gets that far, the ruleset stays in place, so a broken host stays protected instead of open.
+
+## Concepts
+
+### When protection is active
+
+A systemd unit, `calico-node-boot-protection.service`, runs before `network-pre.target`.
+That is the point in boot where firewalls are set up, and it comes before any network interface is configured.
+The unit is pulled in by `calico-node.service`, so it runs on every host where the Calico Node service is enabled.
+
+```
+boot
+  └─ calico-node-boot-protection.service   boot ruleset applied
+       └─ network interfaces configured
+            └─ calico-node.service          agent starts, connects to Typha
+                 └─ first policy apply      boot ruleset replaced by your policy
+```
+
+The switch at the end is atomic.
+The agent removes the boot ruleset and installs your policy in one data plane update, so there is never a moment when neither is in force.
+
+Protection covers boot only.
+If the agent restarts without a reboot, its rules stay in the kernel and keep enforcing, so there is no gap to cover.
+
+### What the boot ruleset allows
+
+The boot ruleset accepts inbound traffic to these ports:
+
+| Port | Protocol | Purpose                                         |
+| ---- | -------- | ----------------------------------------------- |
+| 22   | TCP      | SSH access, so you can reach a locked-down host |
+| 68   | UDP      | DHCPv4 client                                   |
+| 546  | UDP      | DHCPv6 client                                   |
+
+The DHCP ports are needed because a DHCP offer does not match a connection the host already opened, so a host that uses DHCP cannot get a lease without them.
+
+The ruleset also allows three kinds of traffic that are not ports:
+
+- **Loopback traffic**, so local processes can reach each other.
+- **Established and related connections**, which are replies to connections the host opened itself. This covers DNS, NTP, cloud-init, and the agent's own connection to the cluster.
+- **ICMPv6 neighbor discovery**: router advertisements, neighbor solicitations, and neighbor advertisements. IPv6 does not work without them. They are accepted only at hop limit 255, which blocks forgeries from outside the local link.
+
+All other inbound traffic and all forwarded traffic are dropped.
+Outbound traffic is not restricted.
+
+The list is fixed and is not read from configuration, so it is the same on every host and cannot drift.
+It covers only what a non-cluster host needs during boot; services a cluster node might run, such as BGP or the Kubernetes API server, are not opened.
+
+### Data plane
+
+The boot ruleset uses the same data plane as the agent on that host, either nftables or iptables.
+It follows the `NFTablesMode` setting in the host's local configuration file.
+See [Supported data planes](about.mdx#supported-data-planes).
+
+## How to
+
+- [Verify that protection is active](#verify-that-protection-is-active)
+- [Turn off boot-time protection](#turn-off-boot-time-protection)
+- [Recover a host that is locked down](#recover-a-host-that-is-locked-down)
+- [Recover a host that will not finish booting](#recover-a-host-that-will-not-finish-booting)
+
+### Verify that protection is active
+
+Protection is on by default on every host where `calico-node.service` is enabled.
+There is no step to enable it and nothing to configure.
+
+To see the current state:
+
+```bash
+calico component node boot-protection status
+```
+
+On a healthy host that has finished booting, the boot ruleset is gone, because the agent has replaced it with your policy:
+
+```
+Selected backend: nftables
+nftables ruleset (table calico, cali-boot-* chains): not present
+iptables ruleset (cali-boot-* chains): not present
+Boot protection: removed
+```
+
+While the boot ruleset is still in force, because the agent has not applied policy yet, the ruleset shows as `live` and the last line reads `Boot protection: applied` instead.
+
+To confirm that the ruleset was applied early enough during the last boot, check that the unit finished before the network was set up:
+
+```bash
+journalctl -b -o short-monotonic | grep -E "boot-time network protection|Preparation for Network"
+```
+
+The `Finished Calico boot-time network protection` line should appear before the `Reached target Preparation for Network` line.
+Go by these two systemd lines, not the timestamps on other boot-protection messages: the journal can record those several seconds late during early boot.
+
+### Turn off boot-time protection
+
+Mask the unit.
+A mask lasts across reboots and package upgrades.
+
+```bash
+systemctl mask calico-node-boot-protection.service
+```
+
+The agent still starts normally on a host with the unit masked.
+Only the boot ruleset is skipped.
+
+To turn protection back on:
+
+```bash
+systemctl unmask calico-node-boot-protection.service
+```
+
+### Recover a host that is locked down
+
+If the agent never becomes ready, the boot ruleset stays in force.
+This is intended: the host stays protected instead of falling back to open.
+The boot ruleset keeps SSH open, so you can log in and look at why the agent is not ready:
+
+```bash
+systemctl status calico-node.service
+journalctl -xue calico-node.service
+```
+
+The causes are the same ones that keep the agent from starting at any other time, such as an unreachable Typha endpoint or a certificate that cannot be renewed.
+See [Troubleshoot non-cluster hosts and VMs setup](troubleshoot.mdx).
+
+Once the agent connects and applies policy, it removes the boot ruleset on its own.
+
+### Recover a host that will not finish booting
+
+Sometimes the ruleset cannot be programmed at all, for example when the `nft` or `iptables` binaries are missing or broken.
+The unit keeps retrying, and boot stops at `network-pre.target`.
+The host never reaches the network, so you cannot log in over SSH.
+You cannot log in on the console either, because console logins are not available until the network stage finishes.
+The reason for the hold is printed on the console.
+
+To recover, use the machine's console or BMC.
+At the boot menu, add this to the kernel command line for one boot:
+
+```
+systemd.mask=calico-node-boot-protection.service
+```
+
+The host then boots without boot-time protection.
+Fix the underlying problem.
+If protection should stay off, mask the unit as described in [Turn off boot-time protection](#turn-off-boot-time-protection).
+
+If you would rather have a host boot unprotected than stall, put a time limit on the attempt:
+
+```bash
+systemctl edit calico-node-boot-protection.service
+```
+
+```ini
+[Service]
+TimeoutStartSec=120
+```
+
+The unit then fails after two minutes and boot continues.
+Any rules that were programmed before the deadline stay in force.
+
+## Additional resources
+
+- [Install Calico on non-cluster hosts and VMs](about.mdx)
+- [Troubleshoot non-cluster hosts and VMs setup](troubleshoot.mdx)
+- [Protect hosts and VMs](../../network-policy/hosts/protect-hosts.mdx)

--- a/calico-enterprise/getting-started/bare-metal/troubleshoot.mdx
+++ b/calico-enterprise/getting-started/bare-metal/troubleshoot.mdx
@@ -106,6 +106,30 @@ On the cluster side (`calico-system/calico-typha-noncluster-host` deployment):
 
 ### Certificate is not renewed or updated
 
-The `calico-noncluster-host-init` process runs before the main `calico-node` service is responsible for renewing certificates that are expired or near expiry. Certificates are renewed automatically within 90 days of expiry.
+The `calico component node noncluster-host-init` process runs before the main `calico-node` service and is responsible for renewing certificates that are expired or near expiry. Certificates are renewed automatically within 90 days of expiry.
 
 If you need to force immediate renewal, manually delete the existing certificate (`calico-node.crt`) and private key (`calico-node.key`) under the `/etc/calico/calico-node` folder and restart the service.
+
+### Host is only reachable over SSH after a reboot
+
+This is [boot-time network protection](boot-protection.mdx) working as designed.
+The boot ruleset stays in force until the agent applies policy for the first time, so a host whose agent cannot start remains locked down to SSH and the other default allowances.
+
+Check why the agent is not ready:
+
+```bash
+calico component node boot-protection status
+systemctl status calico-node.service
+journalctl -xue calico-node.service
+```
+
+Once the agent connects and applies policy, it removes the boot ruleset.
+See [Recover a host that is locked down](boot-protection.mdx#recover-a-host-that-is-locked-down).
+
+### Host does not come up on the network after a reboot
+
+If a host stops during boot and never reaches the network, boot-time protection may be unable to program the firewall — for example because the `nft` or `iptables` binaries are missing or broken.
+The unit retries and holds boot at `network-pre.target`, and the reason is printed on the console.
+
+Recover from the console or BMC by adding `systemd.mask=calico-node-boot-protection.service` to the kernel command line for one boot.
+See [Recover a host that will not finish booting](boot-protection.mdx#recover-a-host-that-will-not-finish-booting).

--- a/sidebars-calico-enterprise.js
+++ b/sidebars-calico-enterprise.js
@@ -90,6 +90,7 @@ module.exports = {
           link: { type: 'doc', id: 'getting-started/bare-metal/index' },
           items: [
             'getting-started/bare-metal/about',
+            'getting-started/bare-metal/boot-protection',
             'getting-started/bare-metal/typha-node-tls',
             'getting-started/bare-metal/troubleshoot',
           ],


### PR DESCRIPTION
Add a page for the non-cluster host boot-time network protection landing in Calico Enterprise v3.24.0-3.0 (EV-6755): what the boot ruleset allows, how to check it, how to change the allowed ports, how to opt out, and how to recover a locked-down or stalled host.

The feature is on by default wherever calico-node.service is enabled, so the install page gets a note at the enable step and the troubleshooting page gets the two symptoms an operator is most likely to hit.

Also correct the certificate renewal entry: calico-noncluster-host-init is now the "calico component node noncluster-host-init" subcommand rather than a standalone binary.

<!--- PR title format: [GH#<gh-issue-id>][DOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Product Version(s):
<!--- Specify which versions of Calico, Calico Enterprise, and Calico Cloud your PR applies to. -->

Calico Enterprise v3.24 EP3.

Issue:
<!--- Add a link to the Jira ticket or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->