### PR TITLE
l7-logging: Notes on checking for collector, and finding logs

### DIFF
--- a/calico-enterprise/observability/elastic/l7/enable-waypoint-collector.mdx
+++ b/calico-enterprise/observability/elastic/l7/enable-waypoint-collector.mdx
@@ -45,6 +45,15 @@ Replace the following:
 - `<namespace>`: The namespace your workload is in.
 - `<waypoint-name>`: What you want your waypoint proxy gateway to be called.
 
+## Verify the collector is running
+
+```bash
+kubectl get pods -n <namespace> -l gateway.networking.k8s.io/gateway-name=<waypoint-name> \
+     -o jsonpath='{range.items[*]}{.metadata.name}{"\t"}{.status.phase}{"\t"}{.spec.containers[*].name}{"\n"}{end}'
+```
+
+You should see both the `istio-proxy` and `l7-collector` containers listed.
+
 ## Remove the Waypoint collector
 
 ```bash
@@ -69,6 +78,12 @@ along with the other types of L7 logs.
 
 They will be labeled with the `collector_type`: `envoy-access-log` and the
 `collector_name`: `waypoint`.
+
+:::note
+
+L7 logs take several minutes to appear in the web console after the Waypoint collector is enabled.
+
+:::
 
 ## Additional information
 

--- a/calico-enterprise_versioned_docs/version-3.24-1/observability/elastic/l7/enable-waypoint-collector.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/observability/elastic/l7/enable-waypoint-collector.mdx
@@ -45,6 +45,15 @@ Replace the following:
 - `<namespace>`: The namespace your workload is in.
 - `<waypoint-name>`: What you want your waypoint proxy gateway to be called.
 
+## Verify the collector is running
+
+```bash
+kubectl get pods -n <namespace> -l gateway.networking.k8s.io/gateway-name=<waypoint-name> \
+     -o jsonpath='{range.items[*]}{.metadata.name}{"\t"}{.status.phase}{"\t"}{.spec.containers[*].name}{"\n"}{end}'
+```
+
+You should see both the `istio-proxy` and `l7-collector` containers listed.
+
 ## Remove the Waypoint collector
 
 ```bash
@@ -69,6 +78,12 @@ along with the other types of L7 logs.
 
 They will be labeled with the `collector_type`: `envoy-access-log` and the
 `collector_name`: `waypoint`.
+
+:::note
+
+L7 logs take several minutes to appear in the web console after the Waypoint collector is enabled.
+
+:::
 
 ## Additional information
 


### PR DESCRIPTION
- Add a section on checking if the collector is running.
- Add a note that L7 logs will take several minutes to see in the web UI.

Product Version(s):
* Calico Enterprise 3.24-1 and newer

Link to docs preview:
https://deploy-preview-2906--tigera.netlify.app/calico-enterprise/3.24/observability/elastic/l7/enable-waypoint-collector#verify-the-collector-is-running

SME review:
- [x] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 


<!--- After you open your PR, ask for review from docs team:
  For community authors: tag @tigera/docs to ask for a review when your PR is ready --->