### PR TITLE
Update the CRD migration docs for DatastoreMigration v1

### DIFF
--- a/calico-enterprise/operations/crd-migration.mdx
+++ b/calico-enterprise/operations/crd-migration.mdx
@@ -49,6 +49,14 @@ The locked window is typically short (seconds to a few minutes depending on clus
 - Cluster is currently running in API server mode (the aggregated API server is deployed)
 - **If using GitOps (ArgoCD, Flux):** pause sync before starting the migration. These tools may interfere with the API group switchover. You'll update your manifests to use `projectcalico.org/v3` after migration completes.
 
+:::warning
+
+Never delete the `DatastoreMigration` CRD while a `DatastoreMigration` CR still exists.
+
+Deleting a CRD deletes every custom resource of that type, which runs the finalizer on the CR. If the CR is in `Complete`, that deletes all of your `crd.projectcalico.org` CRDs and the data stored in them. In any other phase, it rolls the migration back. Always delete the CR first, confirm that it is gone, and only then delete the CRD.
+
+:::
+
 ## How to
 
 ### Migrate to native CRDs
@@ -71,7 +79,7 @@ The locked window is typically short (seconds to a few minutes depending on clus
 
    ```bash
    kubectl apply -f - <<EOF
-   apiVersion: migration.projectcalico.org/v1beta1
+   apiVersion: migration.projectcalico.org/v1
    kind: DatastoreMigration
    metadata:
      name: v1-to-v3
@@ -108,7 +116,16 @@ The locked window is typically short (seconds to a few minutes depending on clus
    kubectl delete datastoremigration v1-to-v3
    ```
 
-7. **Resume GitOps sync** (if applicable). Update your manifests to use `projectcalico.org/v3` API versions and resume sync.
+7. **Delete the DatastoreMigration CRD.**
+
+   Only after the CR from the previous step is gone. The CRD is not part of a $[prodname] install and has no reason to outlive the migration. Removing it also means a future release can drop the deprecated `v1beta1` version without you having to run a storage version migration.
+
+   ```bash
+   kubectl get datastoremigration
+   kubectl delete crd datastoremigrations.migration.projectcalico.org
+   ```
+
+8. **Resume GitOps sync** (if applicable). Update your manifests to use `projectcalico.org/v3` API versions and resume sync.
 
 ### Resolve conflicts
 
@@ -129,7 +146,7 @@ After resolving all conflicts, the migration controller automatically resumes on
 
 ### Abort a migration
 
-If something goes wrong, delete the `DatastoreMigration` CR before it reaches `Complete`:
+If something goes wrong, delete the `DatastoreMigration` CR before the migration reaches `Converged`:
 
 ```bash
 kubectl delete datastoremigration v1-to-v3
@@ -141,6 +158,10 @@ The finalizer handles rollback:
 - Components resume normal operation as if the migration never happened
 
 The v1 data is never modified during migration, so it remains authoritative after an abort.
+
+Aborting is only possible up to `Converged`. From `Converged` onwards the resources are already in the v3 CRDs and the components are switching over to them, so let the migration run through to `Complete`.
+
+On a cluster that has already completed a migration there is nothing to abort back to, and once the v1 CRDs are deleted the v1 data is gone. Do not create a second `DatastoreMigration` CR on such a cluster.
 
 ### Known limitations
 

--- a/calico-enterprise/operations/crd-migration.mdx
+++ b/calico-enterprise/operations/crd-migration.mdx
@@ -27,6 +27,7 @@ The migration proceeds through these phases:
 | `WaitingForConflictResolution` | Conflicts found — user action needed (see [resolving conflicts](#resolve-conflicts)) |
 | `Converged` | All resources migrated, datastore unlocked, waiting for components to switch to v3 |
 | `Complete` | All components running against v3 CRDs |
+| `Failed` | Migration hit an unrecoverable error; delete the CR to roll back, then retry |
 
 ### What gets migrated
 

--- a/calico-enterprise/operations/crd-migration.mdx
+++ b/calico-enterprise/operations/crd-migration.mdx
@@ -76,6 +76,8 @@ Deleting a CRD deletes every custom resource of that type, which runs the finali
    kubectl apply -f $[filesUrl]/manifests/migration.projectcalico.org_datastoremigrations.yaml
    ```
 
+   A migration is only driven at `migration.projectcalico.org/v1`. If the cluster still has an older CRD that serves only the pre-GA `v1beta1`, the controller refuses to start a new migration and reports that the v1 CRD needs applying.
+
 3. **Create the DatastoreMigration CR.**
 
    ```bash

--- a/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
+++ b/calico/getting-started/kubernetes/self-managed-onprem/onpremises.mdx
@@ -248,7 +248,7 @@ If you have an existing manifest-based $[prodname] install using the legacy `crd
 
    ```bash
    kubectl apply -f - <<EOF
-   apiVersion: migration.projectcalico.org/v1beta1
+   apiVersion: migration.projectcalico.org/v1
    kind: DatastoreMigration
    metadata:
      name: v1-to-v3
@@ -290,6 +290,15 @@ If you have an existing manifest-based $[prodname] install using the legacy `crd
    ```
 
    The finalizer on the resource deletes all `crd.projectcalico.org` CRDs before removing the resource.
+
+1. Once the DatastoreMigration resource is gone, delete the DatastoreMigration CRD.
+
+   ```bash
+   kubectl get datastoremigration
+   kubectl delete crd datastoremigrations.migration.projectcalico.org
+   ```
+
+   Never delete the CRD while a DatastoreMigration resource still exists. That deletes the resource too, which runs its finalizer and either deletes your `crd.projectcalico.org` CRDs or rolls the migration back, depending on the phase.
 
 1. Install the admission webhook resources. The Deployment, Service, RBAC, `MutatingAdmissionPolicy` resources, and `ValidatingWebhookConfiguration` are bundled into `calico-v3-crds.yaml` alongside the CRDs and core $[prodname] components. Extract just the webhook resources with [`yq`](https://github.com/mikefarah/yq) and apply them, so the existing `calico-node` DaemonSet, `kube-controllers` Deployment, and `calico-typha` Deployment in your cluster (including the `CALICO_API_GROUP` env you set above) are not overwritten.
 

--- a/calico/operations/crd-migration.mdx
+++ b/calico/operations/crd-migration.mdx
@@ -169,6 +169,8 @@ On a cluster that has already completed a migration there is nothing to abort ba
 
 In v3.33, the `DatastoreMigration` CRD moves from `migration.projectcalico.org/v1beta1` to `v1`. The CRD serves both versions, with `v1beta1` deprecated, so applying the v3.33 CRD over the v3.32 one is a plain update. Do not delete the old CRD to make room for it.
 
+From v3.33 a migration is only driven at `migration.projectcalico.org/v1`. A migration that was already in flight when you upgraded still runs through to completion, but a cluster that serves only the pre-GA `v1beta1` CRD refuses to start a new one and reports that the v1 CRD needs applying.
+
 The migration CRD is not part of a $[prodname] install, so for most clusters there is nothing to do here. If you did install it on v3.32, what to do depends on the state of the `DatastoreMigration` CR:
 
 | State on v3.32 | Before you upgrade |

--- a/calico/operations/crd-migration.mdx
+++ b/calico/operations/crd-migration.mdx
@@ -50,6 +50,14 @@ The locked window is typically short (seconds to a few minutes depending on clus
 - **Kubernetes 1.32 or later.** $[prodname] uses the `MutatingAdmissionPolicy` API for defaulting. On clusters where it is not enabled by default, enable the `MutatingAdmissionPolicy` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) on the API server.
 - **If using GitOps (ArgoCD, Flux):** pause sync before starting the migration. These tools may interfere with the API group switchover. You'll update your manifests to use `projectcalico.org/v3` after migration completes.
 
+:::warning
+
+Never delete the `DatastoreMigration` CRD while a `DatastoreMigration` CR still exists.
+
+Deleting a CRD deletes every custom resource of that type, which runs the finalizer on the CR. If the CR is in `Complete`, that deletes all of your `crd.projectcalico.org` CRDs and the data stored in them. In any other phase, it rolls the migration back. Always delete the CR first, confirm that it is gone, and only then delete the CRD.
+
+:::
+
 ## How to
 
 ### Migrate to native CRDs
@@ -72,7 +80,7 @@ The locked window is typically short (seconds to a few minutes depending on clus
 
    ```bash
    kubectl apply -f - <<EOF
-   apiVersion: migration.projectcalico.org/v1beta1
+   apiVersion: migration.projectcalico.org/v1
    kind: DatastoreMigration
    metadata:
      name: v1-to-v3
@@ -109,7 +117,16 @@ The locked window is typically short (seconds to a few minutes depending on clus
    kubectl delete datastoremigration v1-to-v3
    ```
 
-7. **Resume GitOps sync** (if applicable). Update your manifests to use `projectcalico.org/v3` API versions and resume sync.
+7. **Delete the DatastoreMigration CRD.**
+
+   Only after the CR from the previous step is gone. The CRD is not part of a $[prodname] install and has no reason to outlive the migration. Removing it also means a future release can drop the deprecated `v1beta1` version without you having to run a storage version migration.
+
+   ```bash
+   kubectl get datastoremigration
+   kubectl delete crd datastoremigrations.migration.projectcalico.org
+   ```
+
+8. **Resume GitOps sync** (if applicable). Update your manifests to use `projectcalico.org/v3` API versions and resume sync.
 
 ### Resolve conflicts
 
@@ -130,7 +147,7 @@ After resolving all conflicts, the migration controller automatically resumes on
 
 ### Abort a migration
 
-If something goes wrong, delete the `DatastoreMigration` CR before it reaches `Complete`:
+If something goes wrong, delete the `DatastoreMigration` CR before the migration reaches `Converged`:
 
 ```bash
 kubectl delete datastoremigration v1-to-v3
@@ -142,6 +159,26 @@ The finalizer handles rollback:
 - Components resume normal operation as if the migration never happened
 
 The v1 data is never modified during migration, so it remains authoritative after an abort.
+
+Aborting is only possible up to `Converged`. From `Converged` onwards the resources are already in the v3 CRDs and the components are switching over to them, so let the migration run through to `Complete`.
+
+On a cluster that has already completed a migration there is nothing to abort back to, and once the v1 CRDs are deleted the v1 data is gone. Do not create a second `DatastoreMigration` CR on such a cluster.
+
+### Upgrade from v3.32 to v3.33
+
+In v3.33, the `DatastoreMigration` CRD moves from `migration.projectcalico.org/v1beta1` to `v1`. The CRD serves both versions, with `v1beta1` deprecated, so applying the v3.33 CRD over the v3.32 one is a plain update. Do not delete the old CRD to make room for it.
+
+The migration CRD is not part of a $[prodname] install, so for most clusters there is nothing to do here. If you did install it on v3.32, what to do depends on the state of the `DatastoreMigration` CR:
+
+| State on v3.32 | Before you upgrade |
+|---|---|
+| Migration CRD never installed | Nothing. Upgrade normally. |
+| CRD installed, no CR left | Nothing required. Deleting the CRD is optional tidy-up, and only once you have confirmed that no CR exists. |
+| CR in `Complete`, still present | Run the cleanup steps from [Migrate to native CRDs](#migrate-to-native-crds): delete the CR, then the CRD. Then upgrade. |
+| CR in `Pending`, `Migrating`, or `WaitingForConflictResolution` | Do not upgrade. Finish or abort the migration first. |
+| CR in `Converged` | Do not upgrade. Wait for `Complete`; abort is not available from this phase. |
+| CR in `Failed` | Delete the CR to roll back, confirm that the cluster is healthy on v1, then upgrade. |
+| Migration finished and the v1 CRDs already deleted | Nothing to do, and never create another `DatastoreMigration` CR on this cluster. |
 
 ### Known limitations
 

--- a/calico/operations/crd-migration.mdx
+++ b/calico/operations/crd-migration.mdx
@@ -27,6 +27,7 @@ The migration proceeds through these phases:
 | `WaitingForConflictResolution` | Conflicts found — user action needed (see [resolving conflicts](#resolve-conflicts)) |
 | `Converged` | All resources migrated, datastore unlocked, waiting for components to switch to v3 |
 | `Complete` | All components running against v3 CRDs |
+| `Failed` | Migration hit an unrecoverable error; delete the CR to roll back, then retry |
 
 ### What gets migrated
 


### PR DESCRIPTION
Product Version(s): Calico v3.33 (`calico/`), Calico Enterprise next (`calico-enterprise/`)

Issue: https://tigera.atlassian.net/browse/CORE-12573

Link to docs preview:
<!--- filled in once the Netlify preview builds --->

The `DatastoreMigration` CRD is promoted from `migration.projectcalico.org/v1beta1` to `v1` in v3.33. The v3.33 CRD serves both versions, with `v1beta1` deprecated and `v1` as storage, so applying it over the v3.32 CRD is a plain update. Calico-side changes are in https://github.com/projectcalico/calico/pull/13383 and https://github.com/projectcalico/calico/pull/13449.

This supersedes #2888, which documented the earlier plan of deleting the v1beta1 CRD before applying the new one. That turned out to be dangerous: deleting the CRD cascades to the `DatastoreMigration` CR and runs its finalizer, which either deletes every `crd.projectcalico.org` CRD (CR in `Complete`) or rolls the migration back (any other phase).

Changes:

- Example CR uses `migration.projectcalico.org/v1`.
- New final cleanup step: delete the CRD, but only once the CR is gone. This is also what lets a future release drop `v1beta1` without a storage version migration.
- Warning that a `DatastoreMigration` CRD must never be deleted while a CR still exists.
- New upgrade section covering v3.32 to v3.33. The CRD is not part of an install, so the default answer is "nothing to do"; the table covers the cases where it isn't.
- Abort is only possible up to `Converged`, and there is nothing to abort back to on a cluster that already migrated.

The same changes are mirrored on the unversioned Enterprise page, minus the upgrade section, since I don't know which Enterprise release picks this up.

SME review:
- [ ] An SME has approved this change.

DOCS review:
- [ ] A member of the docs team has approved this change.
