### PR TITLE
Explain the two ways to upgrade CRDs with Helm

### DIFF
--- a/calico-enterprise/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
@@ -62,6 +62,11 @@ These steps differ based on your cluster type. If you are unsure of your cluster
 
 :::
 
+The `tigera-operator` chart does not contain the $[prodname] CRDs, since Helm does not upgrade CRDs on `helm upgrade`. There are two ways to get the $[version] `projectcalico.org` and `operator.tigera.io` CRDs into your cluster:
+
+- **Apply the CRDs yourself before running `helm upgrade`.** This is the recommended option, and the one the steps below follow. The new CRDs are in place before the new operator starts, so you can configure any new fields ahead of the upgrade, and the CRDs are managed by whatever tooling you already use for the rest of your manifests.
+- **Let the operator apply them.** With `manageCRDs: true` in your `values.yaml` (the default), the operator applies them itself when the new pod starts. The new CRDs only exist once the new operator is running, so new configuration cannot be applied until after the upgrade. The Prometheus and ECK operator CRDs are not covered by this setting and still need to be applied by hand.
+
 1. Get the Helm chart
 
    <CodeBlock language='bash'>

--- a/calico/operations/upgrading/kubernetes-upgrade.mdx
+++ b/calico/operations/upgrading/kubernetes-upgrade.mdx
@@ -50,15 +50,28 @@ owned resources being garbage collected by Kubernetes.
 
 ## Upgrading an installation that was installed using Helm
 
+The `tigera-operator` chart does not contain the $[prodname] CRDs, since Helm does not upgrade CRDs on `helm upgrade`. There are two ways to get the $[version] CRDs into your cluster:
+
+- **Apply the CRDs yourself before running `helm upgrade`.** This is the recommended option. The new CRDs are in place before the new operator starts, so you can configure any new fields ahead of the upgrade, and the CRDs are managed by whatever tooling you already use for the rest of your manifests.
+- **Let the operator apply them.** With `manageCRDs: true` in your `values.yaml` (the default), the operator applies the CRDs itself when the new pod starts. You do not need a separate step, but the new CRDs only exist once the new operator is running, so new configuration cannot be applied until after the upgrade.
+
+To apply the CRDs yourself:
+
 1. Apply the $[version] CRDs:
 
    ```bash
    kubectl apply --server-side --force-conflicts -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
    ```
 
+   Or, using the CRD chart:
+
+   ```bash
+   helm template calico-crds projectcalico/crd.projectcalico.org.v1 --version $[releaseTitle] | kubectl apply --server-side --force-conflicts -f -
+   ```
+
    :::note
 
-   The command above applies the v1 CRDs, which is correct for clusters using the aggregation API server (the common case). If your cluster uses native v3 CRDs, substitute `v3_projectcalico_org.yaml` for `v1_crd_projectcalico_org.yaml` in the command above.
+   The commands above apply the v1 CRDs, which is correct for clusters using the aggregation API server (the common case). If your cluster uses native v3 CRDs, substitute `v3_projectcalico_org.yaml` for `v1_crd_projectcalico_org.yaml`, or the `projectcalico/projectcalico.org.v3` chart for `projectcalico/crd.projectcalico.org.v1`.
 
    :::
 

--- a/calico_versioned_docs/version-3.32/operations/upgrading/kubernetes-upgrade.mdx
+++ b/calico_versioned_docs/version-3.32/operations/upgrading/kubernetes-upgrade.mdx
@@ -44,10 +44,23 @@ owned resources being garbage collected by Kubernetes.
 
 ## Upgrading an installation that was installed using Helm
 
+The `tigera-operator` chart does not contain the $[prodname] CRDs, since Helm does not upgrade CRDs on `helm upgrade`. There are two ways to get the $[version] CRDs into your cluster:
+
+- **Apply the CRDs yourself before running `helm upgrade`.** This is the recommended option. The new CRDs are in place before the new operator starts, so you can configure any new fields ahead of the upgrade, and the CRDs are managed by whatever tooling you already use for the rest of your manifests.
+- **Let the operator apply them.** With `manageCRDs: true` in your `values.yaml` (the default), the operator applies the CRDs itself when the new pod starts. You do not need a separate step, but the new CRDs only exist once the new operator is running, so new configuration cannot be applied until after the upgrade.
+
+To apply the CRDs yourself:
+
 1. Apply the $[version] CRDs:
 
    ```bash
    kubectl apply --server-side --force-conflicts -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
+   ```
+
+   Or, using the CRD chart:
+
+   ```bash
+   helm template calico-crds projectcalico/crd.projectcalico.org.v1 --version $[releaseTitle] | kubectl apply --server-side --force-conflicts -f -
    ```
 
 1. Run the Helm upgrade:


### PR DESCRIPTION
The `tigera-operator` chart no longer ships the CRDs, and the upgrade docs only showed the manual apply. That leaves users with `manageCRDs: true` in their values wondering whether the manual step is still needed, and users on GitOps tooling wondering whether they need a second HelmRelease. Came up in [Slack](https://calicousers.slack.com/archives/C0BCA117T/p1786105269352289).

Adds a short section to the Helm upgrade instructions covering both options and why we recommend applying the CRDs yourself: the new CRDs land before the new operator starts, so new configuration can be set ahead of the upgrade. Also adds the `helm template` form of the CRD apply next to the raw manifest URL, which is easier to wire into GitOps tooling.

Applied to Calico latest, Calico 3.32, and Calico Enterprise. The Enterprise version also notes that `manageCRDs` does not cover the Prometheus and ECK CRDs.