### PR TITLE
Update Whisker access for HTTPS on port 8443

### DIFF
--- a/calico/getting-started/kubernetes/quickstart.mdx
+++ b/calico/getting-started/kubernetes/quickstart.mdx
@@ -159,18 +159,20 @@ In this step, you will:
 1. From your terminal, run the following command:
 
    ```bash
-   kubectl port-forward -n calico-system service/whisker 8081:8081
+   kubectl port-forward -n calico-system service/whisker 8443:8443
    ```
 
    ```bash title="Expected output"
-   Forwarding from 127.0.0.1:8081 -> 8081
-   Forwarding from [::1]:8081 -> 8081
+   Forwarding from 127.0.0.1:8443 -> 8443
+   Forwarding from [::1]:8443 -> 8443
    ```
 
    Keep this terminal open throughout the rest of this tutorial.
    The Whisker web console needs the port forwarding to be active to receive logs.
 
-2. To open Calico Whisker, open your browser and go to `localhost:8081`.
+2. To open Calico Whisker, open your browser and go to `https://localhost:8443`.
+   Calico Whisker uses a self-signed certificate, so your browser shows a security warning the first time.
+   Accept the warning to continue.
    You won't see any flows at the beginning.
    But in a few moments, as the console receives flow logs, you'll begin to see a list of connections.
 

--- a/calico/observability/view-flow-logs.mdx
+++ b/calico/observability/view-flow-logs.mdx
@@ -109,14 +109,16 @@ Port forwarding the Whisker service is a simple and secure method to view your f
 1. Port forward the Calico Whisker web console to your workstation:
 
    ```bash
-   kubectl port-forward -n calico-system service/whisker 8081:8081
+   kubectl port-forward -n calico-system service/whisker 8443:8443
    ```
 
    ```bash title="Expected output"
-   Forwarding from 127.0.0.1:8081 -> 8081
-   Forwarding from [::1]:8081 -> 8081
+   Forwarding from 127.0.0.1:8443 -> 8443
+   Forwarding from [::1]:8443 -> 8443
    ```
-1. To open Calico Whisker, open your browser and go to `localhost:8081`.
+1. To open Calico Whisker, open your browser and go to `https://localhost:8443`.
+   Calico Whisker uses a self-signed certificate, so your browser shows a security warning the first time.
+   Accept the warning to continue.
    You may not see any flows at the beginning.
    But in a few moments, as the console receives data, you'll begin to see a list of flow logs.
 


### PR DESCRIPTION
Product Version(s):
Calico Open Source vNext (master / next release only — the change ships with projectcalico/calico#13436)

Issue:
projectcalico/calico#13436 and tigera/operator#5140 (both merged): Whisker now serves HTTPS on port 8443 instead of HTTP on 8081.

Link to docs preview:
<!--- to be added from the preview build --->

SME review:
- [ ] An SME has approved this change.

DOCS review:
- [ ] A member of the docs team has approved this change.

Additional information:
Updates the two pages in the latest (next) docs tree that carry Whisker port-forward instructions:

- `calico/observability/view-flow-logs.mdx`
- `calico/getting-started/kubernetes/quickstart.mdx`

Changes: the port-forward command moves to `8443:8443`, the URL becomes `https://localhost:8443`, and a note explains the self-signed certificate warning. Versioned docs are untouched — released versions still serve HTTP on 8081.

🤖 Generated with [Claude Code](https://claude.com/claude-code)