### PR TITLE
DOCS-2996: Add all-versions sitemap and full-coverage link check

### DIFF
--- a/.github/workflows/link-check-weekly.yml
+++ b/.github/workflows/link-check-weekly.yml
@@ -44,6 +44,10 @@ jobs:
         run: make test 2>&1 | tee link-check.log
         env:
           CI: 'true'
+          # Crawl every built version (via sitemap-full.xml), not just latest. This job is
+          # non-blocking and files an issue on failure, so it is the safe place to surface the
+          # full-version backlog. PR CI stays latest-only until the backlog is cleared.
+          FULL_COVERAGE: 'true'
 
       - name: Upload the link-check log
         if: always()

--- a/__tests__/crawler.test.js
+++ b/__tests__/crawler.test.js
@@ -22,7 +22,10 @@ test('Crawl the docs and execute tests', async () => {
   const varSkipList = ['{{end}}'];
   const liquidRegex = /\{%.*?%}/gs;
   const liquidSkipList = [];
-  const SITEMAP = 'sitemap.xml';
+  // FULL_COVERAGE seeds the crawl from the all-versions sitemap (sitemap-full.xml) instead of the
+  // latest-only sitemap.xml. Used by the weekly job; leave off for PR CI until the backlog is fixed.
+  const fullCoverage = process.env.FULL_COVERAGE === 'true';
+  const SITEMAP = fullCoverage ? 'sitemap-full.xml' : 'sitemap.xml';
   const SITEMAP_URL = `${DOCS}/${SITEMAP}`;
   const USE_LC = [
     { regex: inspectFilesRegExp(), processContent: true },
@@ -612,6 +615,7 @@ test('Crawl the docs and execute tests', async () => {
   await crawler.addRequests(urls);
 
   console.log(`Crawling the docs (${DOCS}) and executing tests.`);
+  console.log(`Coverage: ${fullCoverage ? 'FULL (all versions)' : 'latest only'} via ${SITEMAP}.`);
   console.log(`Localhost mode is ${isLocalHost ? 'ON' : 'OFF'}.`);
   console.log(`Validity tests on code blocks: ${validityTest.length ? validityTest.join(',') : 'none'}`);
   console.log(`Validity tests on files: ${validityTestFiles.length ? validityTestFiles.join(',') : 'none'}`);

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -411,6 +411,19 @@ export default async function createAsyncConfig() {
         },
       },
     plugins: [
+      // Second sitemap instance for the internal link checker only. The preset sitemap above
+      // stays latest-only for SEO (sitemap.xml, the one advertised in robots.txt). This one has
+      // no version ignorePatterns, so it lists every built version at sitemap-full.xml. The
+      // crawler seeds from it when FULL_COVERAGE=true; it is not referenced in robots.txt.
+      [
+        '@docusaurus/plugin-sitemap',
+        {
+          id: 'full',
+          filename: 'sitemap-full.xml',
+          lastmod: 'date',
+          ignorePatterns: [],
+        },
+      ],
       'docusaurus-plugin-sass',
       [
         '@docusaurus/plugin-content-docs',

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@docusaurus/core": "^3.10.1",
     "@docusaurus/faster": "^3.10.1",
     "@docusaurus/plugin-content-docs": "^3.10.1",
+    "@docusaurus/plugin-sitemap": "3.10.1",
     "@docusaurus/preset-classic": "^3.10.1",
     "@docusaurus/theme-common": "^3.10.1",
     "@docusaurus/theme-search-algolia": "^3.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20109,6 +20109,7 @@ __metadata:
     "@docusaurus/faster": "npm:^3.10.1"
     "@docusaurus/module-type-aliases": "npm:^3.10.1"
     "@docusaurus/plugin-content-docs": "npm:^3.10.1"
+    "@docusaurus/plugin-sitemap": "npm:3.10.1"
     "@docusaurus/preset-classic": "npm:^3.10.1"
     "@docusaurus/theme-common": "npm:^3.10.1"
     "@docusaurus/theme-search-algolia": "npm:^3.10.1"


### PR DESCRIPTION
The build link checker only verifies pages in the latest version of each product, because the crawler seeds from sitemap.xml, which is deliberately latest only. Older and preview versions are built and served but never link-checked, so a dead link on an older page passes CI while the same link on latest fails. This was the root cause behind the split behavior seen in DOCS-2995.

This is phase one: produce full-version coverage and start surfacing the backlog, without changing what gates pull requests.

Changes:

- Add a second sitemap plugin instance that emits sitemap-full.xml with no version ignorePatterns, so it lists every built version. The preset sitemap.xml is unchanged and stays latest only for search engines, and it remains the only sitemap referenced in robots.txt.
- Add a FULL_COVERAGE env switch to the crawler so it seeds from sitemap-full.xml when set. Default is off, so PR CI keeps crawling latest only.
- Turn FULL_COVERAGE on in the weekly link check workflow. That job is non-blocking and files an issue on failure, so it is the safe place to surface the full-version backlog.

What this does not do: it does not gate any pull request on older versions. Enforcement policy for PR CI is a later decision, to be made only after the backlog surfaced by the weekly job is triaged and fixed. See DOCS-2996 for the full plan and the enforcement options.

Verification: once the deploy preview builds, sitemap-full.xml lists numbered versions in addition to latest, while sitemap.xml is unchanged. The tigera deploy preview link check runs without FULL_COVERAGE, so its behavior is unchanged.

https://tigera.atlassian.net/browse/DOCS-2996