### PR TITLE
DOCS-3004: Fix undefined manifestsUrl variable on the native CRDs page for latest

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.23-2/operations/native-v3-crds.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/operations/native-v3-crds.mdx
@@ -99,7 +99,7 @@ Select the method below based on your preferred installation method.
 1. Install the v3 CRDs:
 
    ```bash
-   kubectl create -f $[manifestsUrl]/manifests/v3_projectcalico_org.yaml
+   kubectl create -f $[filesUrl]/manifests/v3_projectcalico_org.yaml
    ```
 
    :::note
@@ -111,13 +111,13 @@ Select the method below based on your preferred installation method.
 1. Install the Tigera Operator:
 
    ```bash
-   kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
+   kubectl create -f $[filesUrl]/manifests/tigera-operator.yaml
    ```
 
 1. Install $[prodname] by creating the necessary custom resources:
 
    ```bash
-   kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml
+   kubectl create -f $[filesUrl]/manifests/custom-resources.yaml
    ```
 
 </TabItem>


### PR DESCRIPTION
The native v3 CRDs page for Calico Enterprise latest (version 3.23) used the undefined variable manifestsUrl in three manifest install commands, so they rendered literally as $[manifestsUrl]/manifests/... instead of a real download URL. Calico Enterprise never defines manifestsUrl; the correct variable is filesUrl.

This is the same class of bug as DOCS-2995 on the CRD migration page, on a page that was missed. It was never caught by the link checker because an undefined variable renders as literal text, with no URL for the crawler to test.

The three target manifests (v3_projectcalico_org.yaml, tigera-operator.yaml, custom-resources.yaml) are published at the filesUrl location for v3.23.1, so the corrected links resolve.

Scope is limited to version-3.23-2/operations/native-v3-crds.mdx (three commands). Newer versions already use filesUrl.

Reviewers can check the changed page once the deploy preview builds:
- /calico-enterprise/latest/operations/native-v3-crds

https://tigera.atlassian.net/browse/DOCS-3004