### PR TITLE
DOCS-3006: Point the CRD migration manifest link at the public OSS copy (stopgap)

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.23-2/operations/crd-migration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/operations/crd-migration.mdx
@@ -69,8 +69,10 @@ The locked window is typically short (seconds to a few minutes depending on clus
 
 2. **Install the DatastoreMigration CRD.**
 
+   {/* Stopgap (DE-4494): this CRD is not yet published to downloads.tigera.io for this release. The manifest is byte-identical to the public open-source copy, so we point at that until the Calico Enterprise artifact ships, then revert to $[filesUrl]/manifests/migration.projectcalico.org_datastoremigrations.yaml */}
+
    ```bash
-   kubectl apply -f $[filesUrl]/manifests/migration.projectcalico.org_datastoremigrations.yaml
+   kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.32.1/kube-controllers/pkg/controllers/migration/crd/migration.projectcalico.org_datastoremigrations.yaml
    ```
 
 3. **Create the DatastoreMigration CR.**

--- a/calico-enterprise_versioned_docs/version-3.24-1/operations/crd-migration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/operations/crd-migration.mdx
@@ -63,8 +63,10 @@ The locked window is typically short (seconds to a few minutes depending on clus
 
 2. **Install the DatastoreMigration CRD.**
 
+   {/* Stopgap (DE-4494): this CRD is not yet published to downloads.tigera.io for this release. The manifest is byte-identical to the public open-source copy, so we point at that until the Calico Enterprise artifact ships, then revert to $[filesUrl]/manifests/migration.projectcalico.org_datastoremigrations.yaml */}
+
    ```bash
-   kubectl apply -f $[filesUrl]/manifests/migration.projectcalico.org_datastoremigrations.yaml
+   kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.32.1/kube-controllers/pkg/controllers/migration/crd/migration.projectcalico.org_datastoremigrations.yaml
    ```
 
 3. **Create the DatastoreMigration CR.**


### PR DESCRIPTION
The DatastoreMigration CRD manifest is not published to downloads.tigera.io for the released Calico Enterprise versions, so step 2 of the CRD migration page returns 403 for users. This is tracked with the Delivery Engineering team in DE-4494.

The manifest is byte-identical across CE 3.23, CE 3.24, and open-source Calico 3.32.1 (verified by SHA-256), because it is controller-gen output from the shared kube-controllers source. As a stopgap, this points the install command at the already-public open-source copy so the step works today. It should be reverted to $[filesUrl]/manifests/ once DE-4494 publishes the Calico Enterprise artifact. An MDX comment next to each command records this.

Applied to the two versions served in prod:
- version-3.23-2 (latest)
- version-3.24-1

The next version is intentionally left on $[filesUrl], because DE-4494 fixes the master publish that feeds it, and pinning next to a v3.32.1 tag would be wrong for a future release.

The DOCS-2995 link-checker skip entry stays in place until the artifact is published and these links revert.

Reviewers can check the changed pages once the deploy preview builds:
- /calico-enterprise/latest/operations/crd-migration
- /calico-enterprise/3.24/operations/crd-migration

https://tigera.atlassian.net/browse/DOCS-3006