### PR TITLE
Fix grammar in Tier defaultAction description: takes not action -> takes no action

### DIFF
--- a/calico-cloud/reference/resources/tier.mdx
+++ b/calico-cloud/reference/resources/tier.mdx
@@ -57,6 +57,6 @@ spec:
 | Field         | Description                                                                                                                          | Accepted Values | Schema | Default               |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------ | --------------------- |
 | order         | (Optional) Indicates priority of this Tier, with lower order taking precedence. No value indicates highest order (lowest precedence) |                 | float  | `nil` (highest order) |
-| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes not action on the packet                   | `Deny`, `Pass`  | string | `Deny`                |
+| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes no action on the packet                    | `Deny`, `Pass`  | string | `Deny`                |
 
 All Policies created by $[prodname] orchestrator integrations are created in the default (last) Tier.

--- a/calico-cloud_versioned_docs/version-22-2/reference/resources/tier.mdx
+++ b/calico-cloud_versioned_docs/version-22-2/reference/resources/tier.mdx
@@ -57,6 +57,6 @@ spec:
 | Field         | Description                                                                                                                          | Accepted Values | Schema | Default               |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------ | --------------------- |
 | order         | (Optional) Indicates priority of this Tier, with lower order taking precedence. No value indicates highest order (lowest precedence) |                 | float  | `nil` (highest order) |
-| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes not action on the packet                   | `Deny`, `Pass`  | string | `Deny`                |
+| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes no action on the packet                    | `Deny`, `Pass`  | string | `Deny`                |
 
 All Policies created by $[prodname] orchestrator integrations are created in the default (last) Tier.

--- a/calico-cloud_versioned_docs/version-23-2/reference/resources/tier.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/reference/resources/tier.mdx
@@ -57,6 +57,6 @@ spec:
 | Field         | Description                                                                                                                          | Accepted Values | Schema | Default               |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------ | --------------------- |
 | order         | (Optional) Indicates priority of this Tier, with lower order taking precedence. No value indicates highest order (lowest precedence) |                 | float  | `nil` (highest order) |
-| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes not action on the packet                   | `Deny`, `Pass`  | string | `Deny`                |
+| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes no action on the packet                    | `Deny`, `Pass`  | string | `Deny`                |
 
 All Policies created by $[prodname] orchestrator integrations are created in the default (last) Tier.

--- a/calico-enterprise/reference/resources/tier.mdx
+++ b/calico-enterprise/reference/resources/tier.mdx
@@ -57,6 +57,6 @@ spec:
 | Field         | Description                                                                                                                          | Accepted Values | Schema | Default               |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------ | --------------------- |
 | order         | (Optional) Indicates priority of this Tier, with lower order taking precedence. No value indicates highest order (lowest precedence) |                 | float  | `nil` (highest order) |
-| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes not action on the packet                   | `Deny`, `Pass`  | string | `Deny`                |
+| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes no action on the packet                    | `Deny`, `Pass`  | string | `Deny`                |
 
 All Policies created by $[prodname] orchestrator integrations are created in the default (last) Tier.

--- a/calico-enterprise_versioned_docs/version-3.20-2/reference/resources/tier.mdx
+++ b/calico-enterprise_versioned_docs/version-3.20-2/reference/resources/tier.mdx
@@ -57,6 +57,6 @@ spec:
 | Field         | Description                                                                                                                          | Accepted Values | Schema | Default               |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------ | --------------------- |
 | order         | (Optional) Indicates priority of this Tier, with lower order taking precedence. No value indicates highest order (lowest precedence) |                 | float  | `nil` (highest order) |
-| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes not action on the packet                   | `Deny`, `Pass`  | string | `Deny`                |
+| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes no action on the packet                    | `Deny`, `Pass`  | string | `Deny`                |
 
 All Policies created by $[prodname] orchestrator integrations are created in the default (last) Tier.

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/resources/tier.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/resources/tier.mdx
@@ -57,6 +57,6 @@ spec:
 | Field         | Description                                                                                                                          | Accepted Values | Schema | Default               |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------ | --------------------- |
 | order         | (Optional) Indicates priority of this Tier, with lower order taking precedence. No value indicates highest order (lowest precedence) |                 | float  | `nil` (highest order) |
-| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes not action on the packet                   | `Deny`, `Pass`  | string | `Deny`                |
+| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes no action on the packet                    | `Deny`, `Pass`  | string | `Deny`                |
 
 All Policies created by $[prodname] orchestrator integrations are created in the default (last) Tier.

--- a/calico-enterprise_versioned_docs/version-3.22-2/reference/resources/tier.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/reference/resources/tier.mdx
@@ -57,6 +57,6 @@ spec:
 | Field         | Description                                                                                                                          | Accepted Values | Schema | Default               |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------ | --------------------- |
 | order         | (Optional) Indicates priority of this Tier, with lower order taking precedence. No value indicates highest order (lowest precedence) |                 | float  | `nil` (highest order) |
-| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes not action on the packet                   | `Deny`, `Pass`  | string | `Deny`                |
+| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes no action on the packet                    | `Deny`, `Pass`  | string | `Deny`                |
 
 All Policies created by $[prodname] orchestrator integrations are created in the default (last) Tier.

--- a/calico-enterprise_versioned_docs/version-3.23-2/reference/resources/tier.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/reference/resources/tier.mdx
@@ -57,6 +57,6 @@ spec:
 | Field         | Description                                                                                                                          | Accepted Values | Schema | Default               |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------ | --------------------- |
 | order         | (Optional) Indicates priority of this Tier, with lower order taking precedence. No value indicates highest order (lowest precedence) |                 | float  | `nil` (highest order) |
-| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes not action on the packet                   | `Deny`, `Pass`  | string | `Deny`                |
+| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes no action on the packet                    | `Deny`, `Pass`  | string | `Deny`                |
 
 All Policies created by $[prodname] orchestrator integrations are created in the default (last) Tier.

--- a/calico-enterprise_versioned_docs/version-3.24-1/reference/resources/tier.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/reference/resources/tier.mdx
@@ -57,6 +57,6 @@ spec:
 | Field         | Description                                                                                                                          | Accepted Values | Schema | Default               |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------ | --------------------- |
 | order         | (Optional) Indicates priority of this Tier, with lower order taking precedence. No value indicates highest order (lowest precedence) |                 | float  | `nil` (highest order) |
-| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes not action on the packet                   | `Deny`, `Pass`  | string | `Deny`                |
+| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes no action on the packet                    | `Deny`, `Pass`  | string | `Deny`                |
 
 All Policies created by $[prodname] orchestrator integrations are created in the default (last) Tier.

--- a/calico/reference/resources/tier.mdx
+++ b/calico/reference/resources/tier.mdx
@@ -57,6 +57,6 @@ spec:
 | Field         | Description                                                                                                                          | Accepted Values | Schema | Default               |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------ | --------------------- |
 | order         | (Optional) Indicates priority of this Tier, with lower order taking precedence. No value indicates highest order (lowest precedence) |                 | float  | `nil` (highest order) |
-| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes not action on the packet                   | `Deny`, `Pass`  | string | `Deny`                |
+| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes no action on the packet                    | `Deny`, `Pass`  | string | `Deny`                |
 
 All Policies created by $[prodname] orchestrator integrations are created in the default (last) Tier.

--- a/calico_versioned_docs/version-3.29/reference/resources/tier.mdx
+++ b/calico_versioned_docs/version-3.29/reference/resources/tier.mdx
@@ -57,6 +57,6 @@ spec:
 | Field         | Description                                                                                                                          | Accepted Values | Schema | Default               |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------ | --------------------- |
 | order         | (Optional) Indicates priority of this Tier, with lower order taking precedence. No value indicates highest order (lowest precedence) |                 | float  | `nil` (highest order) |
-| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes not action on the packet                   | `Deny`, `Pass`  | string | `Deny`                |
+| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes no action on the packet                    | `Deny`, `Pass`  | string | `Deny`                |
 
 All Policies created by $[prodname] orchestrator integrations are created in the default (last) Tier.

--- a/calico_versioned_docs/version-3.30/reference/resources/tier.mdx
+++ b/calico_versioned_docs/version-3.30/reference/resources/tier.mdx
@@ -57,6 +57,6 @@ spec:
 | Field         | Description                                                                                                                          | Accepted Values | Schema | Default               |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------ | --------------------- |
 | order         | (Optional) Indicates priority of this Tier, with lower order taking precedence. No value indicates highest order (lowest precedence) |                 | float  | `nil` (highest order) |
-| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes not action on the packet                   | `Deny`, `Pass`  | string | `Deny`                |
+| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes no action on the packet                    | `Deny`, `Pass`  | string | `Deny`                |
 
 All Policies created by $[prodname] orchestrator integrations are created in the default (last) Tier.

--- a/calico_versioned_docs/version-3.31/reference/resources/tier.mdx
+++ b/calico_versioned_docs/version-3.31/reference/resources/tier.mdx
@@ -57,6 +57,6 @@ spec:
 | Field         | Description                                                                                                                          | Accepted Values | Schema | Default               |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------ | --------------------- |
 | order         | (Optional) Indicates priority of this Tier, with lower order taking precedence. No value indicates highest order (lowest precedence) |                 | float  | `nil` (highest order) |
-| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes not action on the packet                   | `Deny`, `Pass`  | string | `Deny`                |
+| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes no action on the packet                    | `Deny`, `Pass`  | string | `Deny`                |
 
 All Policies created by $[prodname] orchestrator integrations are created in the default (last) Tier.

--- a/calico_versioned_docs/version-3.32/reference/resources/tier.mdx
+++ b/calico_versioned_docs/version-3.32/reference/resources/tier.mdx
@@ -57,6 +57,6 @@ spec:
 | Field         | Description                                                                                                                          | Accepted Values | Schema | Default               |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------ | --------------------- |
 | order         | (Optional) Indicates priority of this Tier, with lower order taking precedence. No value indicates highest order (lowest precedence) |                 | float  | `nil` (highest order) |
-| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes not action on the packet                   | `Deny`, `Pass`  | string | `Deny`                |
+| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes no action on the packet                    | `Deny`, `Pass`  | string | `Deny`                |
 
 All Policies created by $[prodname] orchestrator integrations are created in the default (last) Tier.

--- a/static/calico-cloud/llms-full.txt
+++ b/static/calico-cloud/llms-full.txt
@@ -48556,7 +48556,7 @@ spec:
 | Field         | Description                                                                                                                          | Accepted Values | Schema | Default               |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------ | --------------------- |
 | order         | (Optional) Indicates priority of this Tier, with lower order taking precedence. No value indicates highest order (lowest precedence) |                 | float  | `nil` (highest order) |
-| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes not action on the packet                   | `Deny`, `Pass`  | string | `Deny`                |
+| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes no action on the packet                    | `Deny`, `Pass`  | string | `Deny`                |
 
 All Policies created by Calico Cloud orchestrator integrations are created in the default (last) Tier.
 

--- a/static/calico-enterprise/llms-full.txt
+++ b/static/calico-enterprise/llms-full.txt
@@ -70711,7 +70711,7 @@ spec:
 | Field         | Description                                                                                                                          | Accepted Values | Schema | Default               |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------ | --------------------- |
 | order         | (Optional) Indicates priority of this Tier, with lower order taking precedence. No value indicates highest order (lowest precedence) |                 | float  | `nil` (highest order) |
-| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes not action on the packet                   | `Deny`, `Pass`  | string | `Deny`                |
+| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes no action on the packet                    | `Deny`, `Pass`  | string | `Deny`                |
 
 All Policies created by Calico Enterprise orchestrator integrations are created in the default (last) Tier.
 

--- a/static/calico/llms-full.txt
+++ b/static/calico/llms-full.txt
@@ -52185,7 +52185,7 @@ spec:
 | Field         | Description                                                                                                                          | Accepted Values | Schema | Default               |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------- | ------ | --------------------- |
 | order         | (Optional) Indicates priority of this Tier, with lower order taking precedence. No value indicates highest order (lowest precedence) |                 | float  | `nil` (highest order) |
-| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes not action on the packet                   | `Deny`, `Pass`  | string | `Deny`                |
+| defaultAction | (Optional) Indicates the default action, when this Tier applies to an endpoint, but takes no action on the packet                    | `Deny`, `Pass`  | string | `Deny`                |
 
 All Policies created by Calico orchestrator integrations are created in the default (last) Tier.
 


### PR DESCRIPTION
Product Version(s):
All published trees — current `calico`, `calico-enterprise` and `calico-cloud`, plus versioned Calico 3.29–3.32, Calico Enterprise 3.20-2 through 3.24-1, and Calico Cloud 22-2 / 23-2.

Issue:
None — reported by a reader of the Calico Enterprise Tier reference.

Link to docs preview:
To be added once the deploy preview builds. Affected page in each tree is `reference/resources/tier`, in the `defaultAction` row of the field table.

SME review:
- [ ] An SME has approved this change.

Grammar-only fix, no change in meaning, so this should not need SME sign-off.

DOCS review:
- [ ] A member of the docs team has approved this change.

Additional information:

The `defaultAction` row read "but takes **not** action on the packet"; corrected to "takes **no** action", matching the prose directly above the same table.

Two notes for review:

- One space was added to the same table cell so the row keeps its original width and the tables stay aligned.
- The three `static/*/llms-full.txt` files are `make generate-llms` artifacts. I applied the same one-line substitution by hand instead of running a full build, to avoid unrelated drift. Happy to drop them if you'd rather they only change via `make`.

Merge checklist:
- [ ] Deploy preview inspected wherever changes were made
- [ ] Build completed successfully
- [ ] Test have passed
