### PR TITLE
DOCS-3008: Add Calico Cloud 23.0.1 and delist 23.0.0

### DIFF
--- a/calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx
@@ -10,13 +10,11 @@ import IconUser from '/img/icons/user-icon.svg';
 
 <h2 id="23.0.1">August 14, 2026 (version 23.0.1)</h2>
 
-Version 23.0.1 replaces version 23.0.0, which is no longer available to install.
-If a cluster runs version 23.0.0, upgrade it to version 23.0.1.
-
 ### Bug fixes
 
-* Fixed a problem that denied cluster DNS traffic when a cluster upgraded from version 22 to version 23.0.0.
-  The Tigera Operator now adds the cluster DNS policy to the `calico-system` tier before it removes the policy from the `allow-tigera` tier, so $[prodname] components can resolve names for the whole upgrade.
+* Fixed a problem introduced in version 23.0.0 that denied cluster DNS traffic when a cluster upgraded from version 22.
+  The Tigera Operator now adds the cluster DNS policy to the `calico-system` tier before it removes the policy from the `allow-tigera` tier.
+  $[prodname] components keep resolving names for the whole upgrade, Guardian connects without crash looping, and the upgrade finishes.
 
 <h2 id="july-28-2026">July 28, 2026 (version 23.0.0)</h2>
 
@@ -73,16 +71,11 @@ This release adds support for Kubernetes 1.36.
 
 ### Known issues
 
-:::warning[version 23.0.0 is no longer available to install]
-Upgrading a cluster to version 23.0.0 can deny cluster DNS traffic and leave the upgrade unfinished.
-When the Tigera Operator moves the cluster DNS policy to the new `calico-system` tier, the `allow-tigera` tier remains in place with the same order and a default action of `Deny`, so DNS requests to `kube-dns` hit the implicit deny in `allow-tigera`.
-Guardian cannot resolve the address of $[prodname], so its pod enters `CrashLoopBackOff` and the upgrade does not finish.
-If `calico-node` reaches the Kubernetes API server by domain name, `calico-node`, `calico-apiserver`, and `calico-kube-controllers` can fail for the same reason.
+Upgrading from version 22 to version 23.0.0 can deny cluster DNS traffic and leave the upgrade unfinished.
+The Tigera Operator moves the cluster DNS policy into the new `calico-system` tier while the `allow-tigera` tier is still in place, so $[prodname] components lose name resolution partway through the upgrade.
 
 Version 23.0.0 is no longer available to install.
-Upgrade to [version 23.0.1](#23.0.1) instead, which fixes the problem.
-If a cluster already runs version 23.0.0, upgrade it to version 23.0.1.
-:::
+Upgrade to [version 23.0.1](#23.0.1), which fixes the problem.
 
 <h2 id="june-22-2026">June 22, 2026 (version 22.5.0)</h2>
 

--- a/calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx
@@ -15,7 +15,7 @@ If a cluster runs version 23.0.0, upgrade it to version 23.0.1.
 
 ### Bug fixes
 
-* Fixed a problem that denied cluster DNS traffic during an upgrade to version 23.
+* Fixed a problem that denied cluster DNS traffic when a cluster upgraded from version 22 to version 23.0.0.
   The Tigera Operator now adds the cluster DNS policy to the `calico-system` tier before it removes the policy from the `allow-tigera` tier, so $[prodname] components can resolve names for the whole upgrade.
 
 <h2 id="july-28-2026">July 28, 2026 (version 23.0.0)</h2>
@@ -76,7 +76,7 @@ This release adds support for Kubernetes 1.36.
 :::warning[version 23.0.0 is no longer available to install]
 Upgrading a cluster to version 23.0.0 can deny cluster DNS traffic and leave the upgrade unfinished.
 When the Tigera Operator moves the cluster DNS policy to the new `calico-system` tier, the `allow-tigera` tier remains in place with the same order and a default action of `Deny`, so DNS requests to `kube-dns` hit the implicit deny in `allow-tigera`.
-The guardian pod cannot resolve the address of $[prodname], so it enters `CrashLoopBackOff` and the upgrade does not finish.
+Guardian cannot resolve the address of $[prodname], so its pod enters `CrashLoopBackOff` and the upgrade does not finish.
 If `calico-node` reaches the Kubernetes API server by domain name, `calico-node`, `calico-apiserver`, and `calico-kube-controllers` can fail for the same reason.
 
 Version 23.0.0 is no longer available to install.

--- a/calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx
@@ -8,6 +8,16 @@ import IconUser from '/img/icons/user-icon.svg';
 
 # Calico Cloud release notes
 
+<h2 id="23.0.1">August 14, 2026 (version 23.0.1)</h2>
+
+Version 23.0.1 replaces version 23.0.0, which is no longer available to install.
+If a cluster runs version 23.0.0, upgrade it to version 23.0.1.
+
+### Bug fixes
+
+* Fixed a problem that denied cluster DNS traffic during an upgrade to version 23.
+  The Tigera Operator now adds the cluster DNS policy to the `calico-system` tier before it removes the policy from the `allow-tigera` tier, so $[prodname] components can resolve names for the whole upgrade.
+
 <h2 id="july-28-2026">July 28, 2026 (version 23.0.0)</h2>
 
 ### New features and enhancements
@@ -60,6 +70,19 @@ This release adds support for Kubernetes 1.36.
 
 * Image Assurance, Container Threat Detection, and Kibana are removed in this release.
   These features were previously deprecated and are no longer available in $[prodname] 23.
+
+### Known issues
+
+:::warning[version 23.0.0 is no longer available to install]
+Upgrading a cluster to version 23.0.0 can deny cluster DNS traffic and leave the upgrade unfinished.
+When the Tigera Operator moves the cluster DNS policy to the new `calico-system` tier, the `allow-tigera` tier remains in place with the same order and a default action of `Deny`, so DNS requests to `kube-dns` hit the implicit deny in `allow-tigera`.
+The guardian pod cannot resolve the address of $[prodname], so it enters `CrashLoopBackOff` and the upgrade does not finish.
+If `calico-node` reaches the Kubernetes API server by domain name, `calico-node`, `calico-apiserver`, and `calico-kube-controllers` can fail for the same reason.
+
+Version 23.0.0 is no longer available to install.
+Upgrade to [version 23.0.1](#23.0.1) instead, which fixes the problem.
+If a cluster already runs version 23.0.0, upgrade it to version 23.0.1.
+:::
 
 <h2 id="june-22-2026">June 22, 2026 (version 22.5.0)</h2>
 

--- a/calico-cloud_versioned_docs/version-23-2/variables.js
+++ b/calico-cloud_versioned_docs/version-23-2/variables.js
@@ -2,7 +2,7 @@ const releases = require('./releases.json');
 
 const variables = {
   releaseTitle: 'v3.23.1',
-  cloudUserVersion: 'v23.0.0',
+  cloudUserVersion: 'v23.0.1',
   prodname: 'Calico Cloud',
   manifestsUrl: 'https://raw.githubusercontent.com/projectcalico/calico/v3.32.0',
   prodnamedash: 'calico-cloud',

--- a/calico/reference/involved.mdx
+++ b/calico/reference/involved.mdx
@@ -12,7 +12,7 @@ project, please take a look at the following.
 
 ## Join us on Slack
 
-Our [public slack](https://calicousers.slack.com) is the quickest way to get
+Our [public slack](https://calicousers.slack.com/) is the quickest way to get
 in touch for help debugging any issues with Calico.
 
 ## Read the source, Luke!

--- a/calico_versioned_docs/version-3.32/reference/involved.mdx
+++ b/calico_versioned_docs/version-3.32/reference/involved.mdx
@@ -12,7 +12,7 @@ project, please take a look at the following.
 
 ## Join us on Slack
 
-Our [public slack](https://calicousers.slack.com) is the quickest way to get
+Our [public slack](https://calicousers.slack.com/) is the quickest way to get
 in touch for help debugging any issues with Calico.
 
 ## Read the source, Luke!

--- a/src/___new___/data/ccImageLists.js
+++ b/src/___new___/data/ccImageLists.js
@@ -1,6 +1,8 @@
 const ccImageLists = {
-  // curl -0 https://installer.calicocloud.io/manifests/v3.23.1-4/image-list
-  'v23.0.0 (latest)': `quay.io/calico/istio-pilot:v3.32.1
+  // TODO(DOCS-3008): placeholder copied from the v23.0.0 list. Replace it with
+  // the v23.0.1 list once the release is in staging:
+  // curl -0 https://installer.calicocloud.io/manifests/<v23.0.1 manifest>/image-list
+  'v23.0.1 (latest)': `quay.io/calico/istio-pilot:v3.32.1
 quay.io/calico/istio-install-cni:v3.32.1
 quay.io/calico/istio-ztunnel:v3.32.1
 quay.io/calico/istio-proxyv2:v3.32.1

--- a/use-cases/cluster-mesh.mdx
+++ b/use-cases/cluster-mesh.mdx
@@ -302,7 +302,7 @@ Cluster mesh is proven to work in a multiregion Cockroach DB deployment, where d
 The blog post “[Build and secure multi-cluster CockroachDB using the Calico cluster mesh: A step-by-step guide](https://www.tigera.io/blog/build-and-secure-multi-cluster-cockroachdb-using-the-calico-clustermesh-a-step-by-step-guide/)” shows you how to replicate a multiregion CockroachDB deployment with endpoint federation.
 
 Another example, [using Redis](https://www.tigera.io/blog/achieving-high-availabilityha-redis-kubernetes-clusters-with-calico-clustermesh-in-microsoft-aks/), shows how cluster mesh can federate services across multiple clusters to ensure continuous uptime.
-[Redis](https://redis.io/docs/latest/operate/kubernetes/architecture/), just like [CockroachDB](https://www.cockroachlabs.com/docs/stable/orchestrate-cockroachdb-with-kubernetes-multi-cluster), has been built specifically for Kubernetes environments.
+[Redis](https://redis.io/docs/latest/operate/kubernetes/architecture/), just like [CockroachDB](https://docs.cockroachlabs.com/docs/v26.3/orchestrate-cockroachdb-with-kubernetes-multi-cluster), has been built specifically for Kubernetes environments.
 By federating an Active-Active Redis service, any services that rely on Redis will be able to access any active instances through the federated service, even if the Redis service in their local cluster were to become unavailable.
 You can read more, and see instructions to set up the environment for yourself, in our blog post “[Achieving high availability (HA) Redis Kubernetes clusters with Calico cluster mesh in Microsoft AKS](https://www.tigera.io/blog/achieving-high-availabilityha-redis-kubernetes-clusters-with-calico-clustermesh-in-microsoft-aks/)”.
 


### PR DESCRIPTION
Calico Cloud 23.0.1 fixes CI-2032, an upgrade failure that three customers have hit: PlaytechIMS, Insight Investment, and the Bain Capital POC. Upgrading to 23.0.0 moves the cluster DNS policy into the new calico-system tier while the allow-tigera tier remains in place at the same order with defaultAction Deny, so DNS to kube-dns hits the implicit deny in allow-tigera. Guardian cannot resolve the Calico Cloud address, it crash loops, and the upgrade never finishes. Where calico-node reaches the API server by domain name, calico-node, calico-apiserver, and calico-kube-controllers fail for the same reason.

Engineering is removing 23.0.0 as an available version to install and shipping 23.0.1 in its place, so the docs need to match.

Changes:

- Replace the 23.0.0 image list with 23.0.1 on the private registry page, so air-gapped users mirror the fixed release.
- Add a known issue to the 23.0.0 release notes that describes the DNS denial, states that 23.0.0 is no longer available to install, and points to 23.0.1.
- Add a 23.0.1 release note with the single bug fix.
- Point cloudUserVersion at v23.0.1, so the install and system requirements pages name the installable version.

Two values are placeholders until the staging build is confirmed. Do not merge before they are replaced:

- The 23.0.1 image list is copied from 23.0.0 and carries a TODO in src/___new___/data/ccImageLists.js. Replace it with the output of the v23.0.1 image-list manifest.
- The release date is August 14, 2026, which was the target date. Correct it if the release lands on a different day.

The second commit fixes two dead links that were failing the link check in make netlify, which blocked the main site deploy preview on every pull request, including this one:

- calicousers.slack.com returns 403 to the crawler on calico/reference/involved. Every other page links that host with a trailing slash, and that form is already in the crawler skip list, so the two involved pages now match instead of growing the skip list.
- Cockroach Labs moved their docs to docs.cockroachlabs.com and dropped the stable alias, so the multi-cluster page linked from use-cases/cluster-mesh returned 404. It now points at the pinned version path, which resolves.

Out of scope: the allow-tigera to calico-system rename and the missed breaking change note are DOCS-3007, in #2918.

Reviewers, the deploy preview is up. Please check these pages:

- Release notes, for the new 23.0.1 entry and the Known issues section under version 23.0.0: https://deploy-preview-2919--tigera.netlify.app/calico-cloud/release-notes
- Private registry, where the version selector should offer v23.0.1 (latest) and no longer offer 23.0.0: https://deploy-preview-2919--tigera.netlify.app/calico-cloud/get-started/setup-private-registry
- System requirements, which should name Calico Cloud v23.0.1: https://deploy-preview-2919--tigera.netlify.app/calico-cloud/get-started/system-requirements
- The two link fixes: https://deploy-preview-2919--tigera.netlify.app/use-cases/cluster-mesh and https://deploy-preview-2919--tigera.netlify.app/calico/latest/reference/involved

CI-2032: https://tigera.atlassian.net/browse/CI-2032
DOCS-3008: https://tigera.atlassian.net/browse/DOCS-3008
