### PR TITLE
DOCS-3007: Tweak the breaking change note for Calico Cloud v23

### DIFF
--- a/calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx
@@ -69,6 +69,21 @@ This release adds support for Kubernetes 1.36.
 * Image Assurance, Container Threat Detection, and Kibana are removed in this release.
   These features were previously deprecated and are no longer available in $[prodname] 23.
 
+### Updating
+
+* ***Potential breaking change:*** If you have dependencies on the `allow-tigera` tier those dependencies will need to be updated.
+  $[prodname] moves its own policies into the new `calico-system` tier during the upgrade, but it does not update resources that you created.
+  Before you upgrade, review anything that refers to the tier by name, including:
+  * Network policies that you added to the `allow-tigera` tier, these must be removed before starting the upgrade.
+    * If you do not remove your network policies from the `allow-tigera` tier, the install will block until they are removed.
+  * Tiers that you ordered relative to `allow-tigera`, the new `calico-system` tier is the same order as `allow-tigera`.
+  * RBAC rules that name `allow-tigera` in `resourceNames`.
+  * Dashboards, alerts, and queries that filter on `tier="allow-tigera"`.
+
+  **Recommendation:** Do not add policies to the $[prodname] tier, if changes are needed create a separate tier and add your policies there.
+
+  For more information, see [Change allow-tigera tier behavior](../network-policy/policy-tiers/allow-tigera.mdx).
+
 ### Known issues
 
 Upgrading to version 23.0.0 from any earlier version of $[prodname] can deny cluster DNS traffic and leave the upgrade unfinished.


### PR DESCRIPTION
Calico Cloud 23.0.0 renamed the allow-tigera tier to calico-system, and the 23.0.0 release notes never flagged it. This adds Erik Stidham's version of that note, taken from ctauchen/docs#16 and rebased onto main. The commit keeps his authorship.

What the note says that the earlier draft did not:

- It is a potential breaking change, because it only breaks clusters that depend on the allow-tigera tier.
- Network policies that you added to allow-tigera must be removed before the upgrade starts. If they are not, the install blocks until they are removed.
- The new calico-system tier keeps the same order as allow-tigera.
- Do not add policies to the Calico Cloud tier. Create a separate tier instead.

One deviation from Erik's commit. He wrote it against the DOCS-3007 branch, where the policy-tiers page is already renamed, so his link points at calico-system.mdx. That page does not exist on main yet and onBrokenLinks is set to throw, so the link here points at the current allow-tigera.mdx. It moves with the rename when #2918 merges.

#2918 also adds a version of this note. Its release-notes change should be dropped once this merges, or the two will conflict.

Reviewers, once the deploy preview builds, the note is in the version 23.0.0 section under Updating: /calico-cloud/release-notes

DOCS-3007: https://tigera.atlassian.net/browse/DOCS-3007
CI-2032: https://tigera.atlassian.net/browse/CI-2032
