### PR TITLE
Document the netkit attach mechanism and the downgrade path

### DIFF
--- a/.github/styles/config/vocabularies/CalicoTerminology/accept.txt
+++ b/.github/styles/config/vocabularies/CalicoTerminology/accept.txt
@@ -67,6 +67,7 @@ adjacencies
 [mM]ultitenant
 navbar
 [nN]amespace[ds]?
+[nN]etkit
 [nN]etmask
 [nN]etwork[Pp]olic(y|ies)
 [nN]etwork[Ss]et[s]?

--- a/calico/operations/ebpf/enabling-ebpf.mdx
+++ b/calico/operations/ebpf/enabling-ebpf.mdx
@@ -458,8 +458,39 @@ To revert to veth, set the field back to `Veth` (or remove it):
 kubectl patch installation.operator.tigera.io default --type merge -p '{"spec":{"calicoNetwork":{"linuxPodInterfaceType":"Veth"}}}'
 ```
 
-Existing pods keep their netkit interfaces, but the eBPF data plane treats those as veth (programs attach via TC/TCX, the same path used for actual veth interfaces).
+Existing pods keep their netkit interfaces, and the eBPF data plane keeps driving those through netkit attachment unless `bpfAttachType` says otherwise (see below).
 Only newly created pods get veth interfaces.
+
+***Attach mechanism***
+
+The `bpfAttachType` field of the `FelixConfiguration` selects how the eBPF data plane attaches its programs:
+
+* `Netkit` (default) — netkit attachment on netkit interfaces, TCX on every other interface.
+* `TCX` — TCX on every interface, including netkit interfaces.
+* `TC` — the legacy qdisc-based attachment on every interface. Pod bandwidth QoS annotations are not supported with `TC`.
+
+Setting `TCX` or `TC` also moves existing netkit interfaces onto that mechanism.
+The interfaces stay netkit and no pod is recreated; only the attachment changes.
+Changing the field restarts Felix on every node.
+
+***Downgrading to a release without netkit support***
+
+A release that has no concept of netkit attachment cannot remove netkit programs.
+If you downgrade such a node directly, its pods keep the netkit programs attached — still enforcing the policy that was in force at downgrade time — while the downgraded Felix programs the same interfaces through TC/TCX, leaving two data planes on one interface.
+
+Move the interfaces off netkit attachment before you downgrade:
+
+```bash
+kubectl patch felixconfiguration default --type merge -p '{"spec":{"bpfAttachType":"TCX"}}'
+```
+
+Felix restarts on each node and re-attaches its programs, removing the netkit links.
+
+After upgrading again, remove the field to return to the default:
+
+```bash
+kubectl patch felixconfiguration default --type json -p '[{"op":"remove","path":"/spec/bpfAttachType"}]'
+```
 
 ## Reversing the process
 


### PR DESCRIPTION
Product Version(s):
Calico next (the `calico/` tree only — the netkit section is tech preview and not yet in a versioned tree).

Issue:
CORE-13281. Documents the user-facing side of https://github.com/projectcalico/calico/pull/13462.

Link to docs preview:
<!-- to be added once the preview build finishes -->

SME review:
- [ ] An SME has approved this change.

DOCS review:
- [ ] A member of the docs team has approved this change.

Additional information:

The netkit section on the eBPF page covers how to get netkit pod interfaces but not how the eBPF data plane attaches to them, so there is no documented way *off* netkit attachment. That matters for downgrades: a Calico release that has no concept of netkit attachment cannot remove netkit programs, so downgrading a node directly leaves the old programs attached and enforcing the policy that was in force at downgrade time, while the downgraded Felix programs the same interfaces through TC/TCX — two data planes on one interface.

This PR adds two short subsections:

* **Attach mechanism** — the three `bpfAttachType` values, the fact that `TCX`/`TC` also migrate existing netkit interfaces (the interfaces stay netkit, no pod is recreated), and that changing the field restarts Felix. It also notes that pod bandwidth QoS annotations are not supported with `TC`, so nobody picks `TC` thinking it is the safer target.
* **Downgrading to a release without netkit support** — the procedure: set `TCX`, let Felix restart, then downgrade; and removing the field to return to the default afterwards.

It also corrects one existing sentence. The page said that after reverting `linuxPodInterfaceType` to `Veth`, "the eBPF data plane treats those as veth (programs attach via TC/TCX)". That is not what happens: `linuxPodInterfaceType` only controls what the CNI plugin creates for new pods, while the attach mechanism follows each interface's own type. Existing netkit interfaces keep netkit attachment.

The behaviour described here was verified on a GCP cluster (kernel 6.17, eBPF data plane, netkit pod interfaces): flipping `bpfAttachType` between the default and `TCX` moved the programs on netkit interfaces between netkit and TCX attachment in both directions, with the interfaces staying netkit and no pod recreated; under `TC` the bandwidth QoS qdiscs were torn down.

Merge checklist:
- [ ] Deploy preview inspected wherever changes were made
- [ ] Build completed successfully
- [ ] Test have passed
