### PR TITLE
DOCS-3009: Add technology preview tables to the Calico Open Source release notes

### DIFF
--- a/calico_versioned_docs/version-3.30/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.30/release-notes/index.mdx
@@ -148,6 +148,19 @@ This release adds support for Kubernetes versions 1.32 and 1.33.
 - Calico now reconciles its VXLAN tunnel interface MAC address if it changes. [calico 8924](https://github.com/projectcalico/calico/pull/8924) (@MageekChiu)
 - Support for using named ports in NetworkPolicy when exposed via an initContainer. [calico 8885](https://github.com/projectcalico/calico/pull/8885) (@george-angel)
 
+## Technology preview features
+
+This table shows the status of features that were in technology preview at any point in the releases covered here.
+Technology preview features can change significantly before they become generally available.
+
+| Feature | 3.28 | 3.29 | 3.30 |
+| --- | --- | --- | --- |
+| Flow logs API and Whisker | – | – | TP |
+| Calico Ingress Gateway | – | – | TP |
+| nftables data plane | – | TP | TP |
+
+TP = technology preview, GA = generally available, – = not available in that release.
+
 {/* ## Known issues */}
 
 ## Bug fixes

--- a/calico_versioned_docs/version-3.30/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.30/release-notes/index.mdx
@@ -151,7 +151,7 @@ This release adds support for Kubernetes versions 1.32 and 1.33.
 ## Technology preview features
 
 This table shows the status of features that were in technology preview at any point in the releases covered here.
-Technology preview features can change significantly before they become generally available.
+Technology preview features are for evaluation and feedback only and are **not supported for production use**. Behavior, APIs, and configuration may change before a feature reaches general availability.
 
 | Feature | 3.28 | 3.29 | 3.30 |
 | --- | --- | --- | --- |

--- a/calico_versioned_docs/version-3.31/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.31/release-notes/index.mdx
@@ -165,6 +165,18 @@ With this enhancement, Calico responds to all QoS policy and rule changes on the
 - eBPF: Fix forwarding of packets to kubevirt pods when in bridge mode. [calico 10308](https://github.com/projectcalico/calico/pull/10308) (@sridhartigera)
 - Add new manifests to install Calico with the eBPF data plane in an OpenShift cluster. [calico 10015](https://github.com/projectcalico/calico/pull/10015) (@lucastigera)
 
+## Technology preview features
+
+This table shows the status of features that were in technology preview at any point in the releases covered here.
+Technology preview features can change significantly before they become generally available.
+
+| Feature | 3.29 | 3.30 | 3.31 |
+| --- | --- | --- | --- |
+| Flow logs API and Whisker | – | TP | TP |
+| Calico Ingress Gateway | – | TP | GA |
+| nftables data plane | TP | TP | GA |
+
+TP = technology preview, GA = generally available, – = not available in that release.
 
 ## Bug fixes
 

--- a/calico_versioned_docs/version-3.31/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.31/release-notes/index.mdx
@@ -177,7 +177,7 @@ With this enhancement, Calico responds to all QoS policy and rule changes on the
 ## Technology preview features
 
 This table shows the status of features that were in technology preview at any point in the releases covered here.
-Technology preview features can change significantly before they become generally available.
+Technology preview features are for evaluation and feedback only and are **not supported for production use**. Behavior, APIs, and configuration may change before a feature reaches general availability.
 
 | Feature | 3.29 | 3.30 | 3.31 |
 | --- | --- | --- | --- |

--- a/calico_versioned_docs/version-3.31/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.31/release-notes/index.mdx
@@ -32,6 +32,15 @@ You can deploy Calico Open Source in nftables mode to provide a robust networkin
 
 For more information, see the [nftables data plane guide](../getting-started/kubernetes/nftables.mdx).
 
+### Calico Ingress Gateway
+
+Calico Ingress Gateway is now generally available.
+
+Calico Ingress Gateway manages cluster ingress traffic using the Kubernetes Gateway API, the standardized successor to the Ingress resource.
+It is a hardened distribution of the Envoy Gateway project, and the Tigera Operator manages its full lifecycle.
+
+For more information, see [Calico Ingress Gateway](../networking/ingress-gateway/about-calico-ingress-gateway.mdx).
+
 ### DSCP marking
 
 This release enhances your Quality of Service (QoS) controls by enabling you to set Differentiated Services Code Point (DSCP) markings on your outgoing network traffic.

--- a/calico_versioned_docs/version-3.32/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.32/release-notes/index.mdx
@@ -86,7 +86,7 @@ This release adds support for Kubernetes 1.36.
 ## Technology preview features
 
 This table shows the status of features that were in technology preview at any point in the releases covered here.
-Technology preview features can change significantly before they become generally available.
+Technology preview features are for evaluation and feedback only and are **not supported for production use**. Behavior, APIs, and configuration may change before a feature reaches general availability.
 
 | Feature | 3.30 | 3.31 | 3.32 |
 | --- | --- | --- | --- |

--- a/calico_versioned_docs/version-3.32/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.32/release-notes/index.mdx
@@ -83,6 +83,22 @@ Applications fail immediately and reconnect to a healthy backend instead of hang
 
 This release adds support for Kubernetes 1.36.
 
+## Technology preview features
+
+This table shows the status of features that were in technology preview at any point in the releases covered here.
+Technology preview features can change significantly before they become generally available.
+
+| Feature | 3.30 | 3.31 | 3.32 |
+| --- | --- | --- | --- |
+| Flow logs API and Whisker | TP | TP | TP |
+| Calico Ingress Gateway | TP | GA | GA |
+| nftables data plane | TP | GA | GA |
+| Native v3 CRDs | – | – | TP |
+| Istio ambient mode | – | – | TP |
+| Selector-scoped Felix configuration | – | – | TP |
+
+TP = technology preview, GA = generally available, – = not available in that release.
+
 ## Deprecated and removed features
 
 * $[prodname] is moving the `projectcalico.org/v3` API from the aggregated API server to native Kubernetes CRDs. Both mechanisms will be supported until native v3 CRDs are compatible with all supported platforms, after which the aggregated API server will be removed.


### PR DESCRIPTION
The release notes announce a feature when it enters technology preview, but nothing records what happened to it afterwards. This adds a Technology preview features section to the Calico Open Source 3.30, 3.31, and 3.32 release notes, following the release notes template. Each table covers a rolling window of three releases and lists every feature that was in technology preview at any point in that window.

Changes:

- Add a Technology preview features section to the 3.30, 3.31, and 3.32 release notes, after New features and enhancements.
- Announce that Calico Ingress Gateway is generally available in the 3.31 release notes. Please confirm this status before merge.

Deploy preview: https://deploy-preview-2924--tigera.netlify.app/calico/latest/release-notes

DOCS-3009: https://tigera.atlassian.net/browse/DOCS-3009
