### PR TITLE
DOCS-3009: Add tech preview feature status tables to the Calico Enterprise release notes

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -71,13 +71,12 @@ From the **Web Application Firewall** page, click the **Rulesets** tab to open a
 ## Technology preview features
 
 This table shows the status of features that were in technology preview at any point in the releases covered here.
-Technology preview features can change significantly before they become generally available.
+Technology preview features are for evaluation and feedback only and are **not supported for production use**. Behavior, APIs, and configuration may change before a feature reaches general availability.
 
 | Feature | 3.19 | 3.20 | 3.21 |
 | --- | --- | --- | --- |
 | Workload WAF | TP | TP | TP |
 | DNS policy for Windows | TP | TP | TP |
-| Non-cluster hosts and VMs | – | TP | TP |
 | Calico Ingress Gateway | – | – | TP |
 
 TP = technology preview, – = not available in that release.

--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -77,6 +77,7 @@ Technology preview features can change significantly before they become generall
 | --- | --- | --- | --- |
 | Workload WAF | TP | TP | TP |
 | DNS policy for Windows | TP | TP | TP |
+| Non-cluster hosts and VMs | – | TP | TP |
 | Calico Ingress Gateway | – | – | TP |
 
 TP = technology preview, – = not available in that release.

--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -70,8 +70,8 @@ From the **Web Application Firewall** page, click the **Rulesets** tab to open a
 
 ## Technology preview features
 
-This table shows the status of features that are in tech preview in this release.
-Tech preview features can change significantly before they become generally available.
+This table shows the status of features that are in technology preview in this release.
+Technology preview features can change significantly before they become generally available.
 
 | Feature | 3.21 |
 | --- | --- |
@@ -79,7 +79,7 @@ Tech preview features can change significantly before they become generally avai
 | DNS policy for Windows | TP |
 | Calico Ingress Gateway | TP |
 
-TP = tech preview.
+TP = technology preview.
 
 ## Release details
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -68,6 +68,18 @@ From the **Web Application Firewall** page, click the **Rulesets** tab to open a
 * Improved scaling for non-cluster hosts by having them connect to Typha, rather than the Kubernetes apiserver directly.
 * Added web console support for `AdminNetworkPolicy` and `BaseAdminNetworkPolicy` tiers (view-only).
 
+## Technology preview features
+
+This table shows the status of features that are in tech preview in this release.
+Tech preview features can change significantly before they become generally available.
+
+| Feature | 3.21 |
+| --- | --- |
+| Workload WAF | TP |
+| DNS policy for Windows | TP |
+| Calico Ingress Gateway | TP |
+
+TP = tech preview.
 
 ## Release details
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -70,16 +70,16 @@ From the **Web Application Firewall** page, click the **Rulesets** tab to open a
 
 ## Technology preview features
 
-This table shows the status of features that are in technology preview in this release.
+This table shows the status of features that were in technology preview at any point in the releases covered here.
 Technology preview features can change significantly before they become generally available.
 
-| Feature | 3.21 |
-| --- | --- |
-| Workload WAF | TP |
-| DNS policy for Windows | TP |
-| Calico Ingress Gateway | TP |
+| Feature | 3.19 | 3.20 | 3.21 |
+| --- | --- | --- | --- |
+| Workload WAF | TP | TP | TP |
+| DNS policy for Windows | TP | TP | TP |
+| Calico Ingress Gateway | – | – | TP |
 
-TP = technology preview.
+TP = technology preview, – = not available in that release.
 
 ## Release details
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -80,7 +80,7 @@ This support is now available for **OIDC**, **Google**, and **LDAP** identity co
 For complete configuration instructions, see [Configure an external identity provider](../operations/cnx/configure-identity-provider.mdx).
 
 
-### Enhanced observability with built-in dashboards
+### Enhanced observability with built-in dashboards (tech preview)
 
 Calico Enterprise now includes a comprehensive set of built-in observability dashboards, making it easier for you to quickly assess cluster activity, network health, and security posture without having to navigate to a separate Kibana instance.
 
@@ -119,13 +119,14 @@ that were previously bound to service accounts in those namespaces have been mov
 This table shows the status of features that were in technology preview at any point in the releases covered here.
 Technology preview features can change significantly before they become generally available.
 
-| Feature | 3.21 | 3.22 |
-| --- | --- | --- |
-| Workload WAF | TP | TP |
-| DNS policy for Windows | TP | TP |
-| Calico Ingress Gateway | TP | GA |
-| Gateway WAF | – | TP |
-| Istio ambient mode | – | TP |
+| Feature | 3.20 | 3.21 | 3.22 |
+| --- | --- | --- | --- |
+| Workload WAF | TP | TP | TP |
+| DNS policy for Windows | TP | TP | TP |
+| Calico Ingress Gateway | – | TP | GA |
+| Gateway WAF | – | – | TP |
+| Istio ambient mode | – | – | TP |
+| Built-in dashboards | – | – | TP |
 
 TP = technology preview, GA = generally available, – = not available in that release.
 
@@ -159,7 +160,7 @@ It is not supported for use in production.
 
 This release adds the following features:
 * [External secret provider support](#external-secret-provider-support)
-* [Enhanced observability with built-in dashboards](#enhanced-observability-with-built-in-dashboards)
+* [Enhanced observability with built-in dashboards (tech preview)](#enhanced-observability-with-built-in-dashboards-tech-preview)
 * [High availability for hosts and VMs](#high-availability-for-hosts-and-vms)
 
 This Calico Enterprise release is based on [Calico Open Source 3.31](https://docs.tigera.io/calico/3.31/release-notes).

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -114,6 +114,22 @@ have been moved from the `tigera-system` namespace to the `calico-system` namesp
 namespaces `tigera-manager`, `tigera-policy-recommendation` and `tigera-elasticsearch` have been removed. Permissions
 that were previously bound to service accounts in those namespaces have been moved to Guardian's cluster role.
 
+## Technology preview features
+
+This table shows the status of features that were in tech preview at any point in the releases covered here.
+Tech preview features can change significantly before they become generally available.
+
+| Feature | 3.21 | 3.22 |
+| --- | --- | --- |
+| Workload WAF | TP | TP |
+| DNS policy for Windows | TP | TP |
+| Calico Ingress Gateway | TP | GA |
+| Gateway WAF | – | TP |
+| Istio ambient mode | – | TP |
+| Built-in dashboards | – | TP |
+
+TP = tech preview, GA = generally available, – = not available in that release.
+
 ## Release details
 
 ### Calico Enterprise 3.22.0-1.0 (early preview)

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -116,8 +116,8 @@ that were previously bound to service accounts in those namespaces have been mov
 
 ## Technology preview features
 
-This table shows the status of features that were in tech preview at any point in the releases covered here.
-Tech preview features can change significantly before they become generally available.
+This table shows the status of features that were in technology preview at any point in the releases covered here.
+Technology preview features can change significantly before they become generally available.
 
 | Feature | 3.21 | 3.22 |
 | --- | --- | --- |
@@ -127,7 +127,7 @@ Tech preview features can change significantly before they become generally avai
 | Gateway WAF | – | TP |
 | Istio ambient mode | – | TP |
 
-TP = tech preview, GA = generally available, – = not available in that release.
+TP = technology preview, GA = generally available, – = not available in that release.
 
 ## Release details
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -80,7 +80,7 @@ This support is now available for **OIDC**, **Google**, and **LDAP** identity co
 For complete configuration instructions, see [Configure an external identity provider](../operations/cnx/configure-identity-provider.mdx).
 
 
-### Enhanced observability with built-in dashboards (tech preview)
+### Enhanced observability with built-in dashboards
 
 Calico Enterprise now includes a comprehensive set of built-in observability dashboards, making it easier for you to quickly assess cluster activity, network health, and security posture without having to navigate to a separate Kibana instance.
 
@@ -127,7 +127,6 @@ Technology preview features can change significantly before they become generall
 | Calico Ingress Gateway | – | TP | GA |
 | Gateway WAF | – | – | TP |
 | Istio ambient mode | – | – | TP |
-| Built-in dashboards | – | – | TP |
 
 TP = technology preview, GA = generally available, – = not available in that release.
 
@@ -161,7 +160,7 @@ It is not supported for use in production.
 
 This release adds the following features:
 * [External secret provider support](#external-secret-provider-support)
-* [Enhanced observability with built-in dashboards (tech preview)](#enhanced-observability-with-built-in-dashboards-tech-preview)
+* [Enhanced observability with built-in dashboards](#enhanced-observability-with-built-in-dashboards)
 * [High availability for hosts and VMs](#high-availability-for-hosts-and-vms)
 
 This Calico Enterprise release is based on [Calico Open Source 3.31](https://docs.tigera.io/calico/3.31/release-notes).

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -80,7 +80,7 @@ This support is now available for **OIDC**, **Google**, and **LDAP** identity co
 For complete configuration instructions, see [Configure an external identity provider](../operations/cnx/configure-identity-provider.mdx).
 
 
-### Enhanced observability with built-in dashboards (tech preview)
+### Enhanced observability with built-in dashboards
 
 Calico Enterprise now includes a comprehensive set of built-in observability dashboards, making it easier for you to quickly assess cluster activity, network health, and security posture without having to navigate to a separate Kibana instance.
 
@@ -126,7 +126,6 @@ Tech preview features can change significantly before they become generally avai
 | Calico Ingress Gateway | TP | GA |
 | Gateway WAF | – | TP |
 | Istio ambient mode | – | TP |
-| Built-in dashboards | – | TP |
 
 TP = tech preview, GA = generally available, – = not available in that release.
 
@@ -160,7 +159,7 @@ It is not supported for use in production.
 
 This release adds the following features:
 * [External secret provider support](#external-secret-provider-support)
-* [Enhanced observability with built-in dashboards (tech preview)](#enhanced-observability-with-built-in-dashboards-tech-preview)
+* [Enhanced observability with built-in dashboards](#enhanced-observability-with-built-in-dashboards)
 * [High availability for hosts and VMs](#high-availability-for-hosts-and-vms)
 
 This Calico Enterprise release is based on [Calico Open Source 3.31](https://docs.tigera.io/calico/3.31/release-notes).

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -123,6 +123,7 @@ Technology preview features can change significantly before they become generall
 | --- | --- | --- | --- |
 | Workload WAF | TP | TP | TP |
 | DNS policy for Windows | TP | TP | TP |
+| Non-cluster hosts and VMs | TP | TP | GA |
 | Calico Ingress Gateway | – | TP | GA |
 | Gateway WAF | – | – | TP |
 | Istio ambient mode | – | – | TP |

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -117,13 +117,12 @@ that were previously bound to service accounts in those namespaces have been mov
 ## Technology preview features
 
 This table shows the status of features that were in technology preview at any point in the releases covered here.
-Technology preview features can change significantly before they become generally available.
+Technology preview features are for evaluation and feedback only and are **not supported for production use**. Behavior, APIs, and configuration may change before a feature reaches general availability.
 
 | Feature | 3.20 | 3.21 | 3.22 |
 | --- | --- | --- | --- |
 | Workload WAF | TP | TP | TP |
 | DNS policy for Windows | TP | TP | TP |
-| Non-cluster hosts and VMs | TP | TP | GA |
 | Calico Ingress Gateway | – | TP | GA |
 | Gateway WAF | – | – | TP |
 | Istio ambient mode | – | – | TP |

--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -133,6 +133,26 @@ For more information, see [vSphere Kubernetes Service (VKS)](../getting-started/
   Logs and Service Graph now prioritize namespace-specific matches over GlobalNetworkSets and other namespace matches to ensure more accurate identity attribution.
 * User experience improvements to the Flow Summary card.
 
+## Technology preview features
+
+This table shows the status of features that were in tech preview at any point in the releases covered here.
+Tech preview features can change significantly before they become generally available.
+
+| Feature | 3.21 | 3.22 | 3.23 |
+| --- | --- | --- | --- |
+| Workload WAF | TP | TP | TP |
+| DNS policy for Windows | TP | TP | TP |
+| Calico Ingress Gateway | TP | GA | GA |
+| Gateway WAF | – | TP | TP |
+| Istio ambient mode | – | TP | TP |
+| Built-in dashboards | – | TP | TP |
+| Multi-VRF networking | – | – | TP |
+| Native v3 CRDs | – | – | TP |
+| Live migration for KubeVirt VMs | – | – | TP |
+| Selector-scoped Felix configuration | – | – | TP |
+
+TP = tech preview, GA = generally available, – = not available in that release.
+
 ## Deprecated and removed features
 
 * $[prodname] is moving the `projectcalico.org/v3` API from the aggregated API server to native Kubernetes CRDs. Both mechanisms will be supported until native v3 CRDs are compatible with all supported platforms, after which the aggregated API server will be removed.

--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -136,13 +136,12 @@ For more information, see [vSphere Kubernetes Service (VKS)](../getting-started/
 ## Technology preview features
 
 This table shows the status of features that were in technology preview at any point in the releases covered here.
-Technology preview features can change significantly before they become generally available.
+Technology preview features are for evaluation and feedback only and are **not supported for production use**. Behavior, APIs, and configuration may change before a feature reaches general availability.
 
 | Feature | 3.21 | 3.22 | 3.23 |
 | --- | --- | --- | --- |
 | Workload WAF | TP | TP | TP |
 | DNS policy for Windows | TP | TP | TP |
-| Non-cluster hosts and VMs | TP | GA | GA |
 | Calico Ingress Gateway | TP | GA | GA |
 | Gateway WAF | – | TP | TP |
 | Istio ambient mode | – | TP | TP |

--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -145,6 +145,7 @@ Technology preview features can change significantly before they become generall
 | Calico Ingress Gateway | TP | GA | GA |
 | Gateway WAF | – | TP | TP |
 | Istio ambient mode | – | TP | TP |
+| Built-in dashboards | – | TP | TP |
 | Multi-VRF networking | – | – | TP |
 | Native v3 CRDs | – | – | TP |
 | Live migration for KubeVirt VMs | – | – | TP |

--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -145,7 +145,6 @@ Tech preview features can change significantly before they become generally avai
 | Calico Ingress Gateway | TP | GA | GA |
 | Gateway WAF | – | TP | TP |
 | Istio ambient mode | – | TP | TP |
-| Built-in dashboards | – | TP | TP |
 | Multi-VRF networking | – | – | TP |
 | Native v3 CRDs | – | – | TP |
 | Live migration for KubeVirt VMs | – | – | TP |

--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -135,8 +135,8 @@ For more information, see [vSphere Kubernetes Service (VKS)](../getting-started/
 
 ## Technology preview features
 
-This table shows the status of features that were in tech preview at any point in the releases covered here.
-Tech preview features can change significantly before they become generally available.
+This table shows the status of features that were in technology preview at any point in the releases covered here.
+Technology preview features can change significantly before they become generally available.
 
 | Feature | 3.21 | 3.22 | 3.23 |
 | --- | --- | --- | --- |
@@ -150,7 +150,7 @@ Tech preview features can change significantly before they become generally avai
 | Live migration for KubeVirt VMs | – | – | TP |
 | Selector-scoped Felix configuration | – | – | TP |
 
-TP = tech preview, GA = generally available, – = not available in that release.
+TP = technology preview, GA = generally available, – = not available in that release.
 
 ## Deprecated and removed features
 

--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -142,6 +142,7 @@ Technology preview features can change significantly before they become generall
 | --- | --- | --- | --- |
 | Workload WAF | TP | TP | TP |
 | DNS policy for Windows | TP | TP | TP |
+| Non-cluster hosts and VMs | TP | GA | GA |
 | Calico Ingress Gateway | TP | GA | GA |
 | Gateway WAF | – | TP | TP |
 | Istio ambient mode | – | TP | TP |

--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -146,7 +146,6 @@ Technology preview features can change significantly before they become generall
 | Calico Ingress Gateway | TP | GA | GA |
 | Gateway WAF | – | TP | TP |
 | Istio ambient mode | – | TP | TP |
-| Built-in dashboards | – | TP | TP |
 | Multi-VRF networking | – | – | TP |
 | Native v3 CRDs | – | – | TP |
 | Live migration for KubeVirt VMs | – | – | TP |

--- a/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
@@ -59,12 +59,6 @@ For more information, see [L2 reachability for pods and services without BGP](..
 * You can now enable Calico Ingress Gateway when you install $[prodname] with Helm, by setting `gatewayAPI.enabled: true` in your `values.yaml`.
   For more information, see the [Helm installation reference](../reference/installation/helm_customization.mdx).
 
-### Deprecated and removed features
-
-* The compliance reporting feature has been removed from the $[prodname] web console.
-* $[prodname] is moving the `projectcalico.org/v3` API from the aggregated API server to native Kubernetes CRDs.
-  Both mechanisms will be supported until native v3 CRDs are compatible with all supported platforms, after which the aggregated API server will be removed.
-
 ## Technology preview features
 
 This table shows the status of features that were in tech preview at any point in the releases covered here.
@@ -76,13 +70,18 @@ Tech preview features can change significantly before they become generally avai
 | DNS policy for Windows | TP | TP | TP |
 | Gateway WAF | TP | TP | TP |
 | Istio ambient mode | TP | TP | TP |
-| Built-in dashboards | TP | TP | TP |
 | Multi-VRF networking | – | TP | TP |
 | Native v3 CRDs | – | TP | GA |
 | Live migration for KubeVirt VMs | – | TP | TP |
 | Selector-scoped Felix configuration | – | TP | TP |
 
 TP = tech preview, GA = generally available, – = not available in that release.
+
+## Deprecated and removed features
+
+* The compliance reporting feature has been removed from the $[prodname] web console.
+* $[prodname] is moving the `projectcalico.org/v3` API from the aggregated API server to native Kubernetes CRDs.
+  Both mechanisms will be supported until native v3 CRDs are compatible with all supported platforms, after which the aggregated API server will be removed.
 
 {/* ### Known issues */}
 

--- a/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
@@ -70,7 +70,6 @@ Technology preview features can change significantly before they become generall
 | DNS policy for Windows | TP | TP | TP |
 | Gateway WAF | TP | TP | TP |
 | Istio ambient mode | TP | TP | TP |
-| Built-in dashboards | TP | TP | TP |
 | Multi-VRF networking | – | TP | TP |
 | Native v3 CRDs | – | TP | GA |
 | Live migration for KubeVirt VMs | – | TP | TP |

--- a/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
@@ -61,8 +61,8 @@ For more information, see [L2 reachability for pods and services without BGP](..
 
 ## Technology preview features
 
-This table shows the status of features that were in tech preview at any point in the releases covered here.
-Tech preview features can change significantly before they become generally available.
+This table shows the status of features that were in technology preview at any point in the releases covered here.
+Technology preview features can change significantly before they become generally available.
 
 | Feature | 3.22 | 3.23 | 3.24 |
 | --- | --- | --- | --- |
@@ -75,7 +75,7 @@ Tech preview features can change significantly before they become generally avai
 | Live migration for KubeVirt VMs | – | TP | TP |
 | Selector-scoped Felix configuration | – | TP | TP |
 
-TP = tech preview, GA = generally available, – = not available in that release.
+TP = technology preview, GA = generally available, – = not available in that release.
 
 ## Deprecated and removed features
 

--- a/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
@@ -70,6 +70,7 @@ Technology preview features can change significantly before they become generall
 | DNS policy for Windows | TP | TP | TP |
 | Gateway WAF | TP | TP | TP |
 | Istio ambient mode | TP | TP | TP |
+| Built-in dashboards | TP | TP | TP |
 | Multi-VRF networking | – | TP | TP |
 | Native v3 CRDs | – | TP | GA |
 | Live migration for KubeVirt VMs | – | TP | TP |

--- a/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
@@ -62,7 +62,7 @@ For more information, see [L2 reachability for pods and services without BGP](..
 ## Technology preview features
 
 This table shows the status of features that were in technology preview at any point in the releases covered here.
-Technology preview features can change significantly before they become generally available.
+Technology preview features are for evaluation and feedback only and are **not supported for production use**. Behavior, APIs, and configuration may change before a feature reaches general availability.
 
 | Feature | 3.22 | 3.23 | 3.24 |
 | --- | --- | --- | --- |

--- a/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
@@ -65,7 +65,24 @@ For more information, see [L2 reachability for pods and services without BGP](..
 * $[prodname] is moving the `projectcalico.org/v3` API from the aggregated API server to native Kubernetes CRDs.
   Both mechanisms will be supported until native v3 CRDs are compatible with all supported platforms, after which the aggregated API server will be removed.
 
-{/* ## Technology Preview features */}
+## Technology preview features
+
+This table shows the status of features that were in tech preview at any point in the releases covered here.
+Tech preview features can change significantly before they become generally available.
+
+| Feature | 3.22 | 3.23 | 3.24 |
+| --- | --- | --- | --- |
+| Workload WAF | TP | TP | TP |
+| DNS policy for Windows | TP | TP | TP |
+| Gateway WAF | TP | TP | TP |
+| Istio ambient mode | TP | TP | TP |
+| Built-in dashboards | TP | TP | TP |
+| Multi-VRF networking | – | TP | TP |
+| Native v3 CRDs | – | TP | GA |
+| Live migration for KubeVirt VMs | – | TP | TP |
+| Selector-scoped Felix configuration | – | TP | TP |
+
+TP = tech preview, GA = generally available, – = not available in that release.
 
 {/* ### Known issues */}
 


### PR DESCRIPTION
Readers cannot tell which Calico Enterprise features are in technology preview without opening each feature page, and cannot tell whether a feature they read about two releases ago has since gone GA.

This adds a Technology preview features section to the 3.21, 3.22, 3.23, and 3.24 release notes, matching the tables added for Calico Open Source in #2924. Each table covers three releases, with a column per release. Status for 3.19 and 3.20 comes from the 3.19 release notes, which already carried a Technology preview features section. The intro uses the disclaimer from the release notes template, as #2924 does.

- Add the section to the 3.24, 3.23, 3.22, and 3.21 release notes.
- Promote Deprecated and removed features to a heading level 2 in the 3.24 release notes, so it is a sibling of New features and enhancements rather than a child of it, as it already is in 3.23. The anchor does not change.
- Remove the stale technology preview suffix from the 3.22 heading for built-in dashboards, and update the link to it. #2324 removed those markers from the dashboard pages three weeks before the 3.22-2 docs were cut.

Non-cluster hosts and VMs is not in these tables. Its status is being confirmed and the row will be added separately.

DOCS-3009: https://tigera.atlassian.net/browse/DOCS-3009

Deploy preview, 3.24 release notes, which has the largest table: https://deploy-preview-2925--tigera.netlify.app/calico-enterprise/3.24/release-notes
