### PR TITLE
DOCS-3011: Add selector-scoped FelixConfiguration to the Felix precedence list

### DIFF
--- a/calico-enterprise/reference/component-resources/node/felix/configuration.mdx
+++ b/calico-enterprise/reference/component-resources/node/felix/configuration.mdx
@@ -14,12 +14,13 @@ refer to [Felix Configuration Resource](../../../resources/felixconfig.mdx).
 
 :::
 
-Configuration for Felix is read from one of four possible locations, in order, as follows.
+Configuration for Felix is read from one of five possible locations, in order, as follows.
 
 1.  Environment variables.
 2.  The Felix configuration file.
 3.  Host-specific `FelixConfiguration` resources (`node.<nodename>`).
-4.  The global `FelixConfiguration` resource (`default`).
+4.  Selector-scoped `FelixConfiguration` resources (tech preview — see [Selector-scoped configuration](../../../resources/felixconfig.mdx#selector-scoped-configuration)).
+5.  The global `FelixConfiguration` resource (`default`).
 
 The value of any configuration parameter is the value read from the
 _first_ location containing a value. For example, if an environment variable

--- a/calico-enterprise/reference/component-resources/node/felix/configuration.mdx
+++ b/calico-enterprise/reference/component-resources/node/felix/configuration.mdx
@@ -19,7 +19,7 @@ Configuration for Felix is read from one of five possible locations, in order, a
 1.  Environment variables.
 2.  The Felix configuration file.
 3.  Host-specific `FelixConfiguration` resources (`node.<nodename>`).
-4.  Selector-scoped `FelixConfiguration` resources (tech preview — see [Selector-scoped configuration](../../../resources/felixconfig.mdx#selector-scoped-configuration)).
+4.  Selector-scoped `FelixConfiguration` resources (technology preview — see [Selector-scoped configuration](../../../resources/felixconfig.mdx#selector-scoped-configuration)).
 5.  The global `FelixConfiguration` resource (`default`).
 
 The value of any configuration parameter is the value read from the

--- a/calico-enterprise_versioned_docs/version-3.23-2/reference/component-resources/node/felix/configuration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/reference/component-resources/node/felix/configuration.mdx
@@ -14,12 +14,13 @@ refer to [Felix Configuration Resource](../../../resources/felixconfig.mdx).
 
 :::
 
-Configuration for Felix is read from one of four possible locations, in order, as follows.
+Configuration for Felix is read from one of five possible locations, in order, as follows.
 
 1.  Environment variables.
 2.  The Felix configuration file.
 3.  Host-specific `FelixConfiguration` resources (`node.<nodename>`).
-4.  The global `FelixConfiguration` resource (`default`).
+4.  Selector-scoped `FelixConfiguration` resources (tech preview — see [Selector-scoped configuration](../../../resources/felixconfig.mdx#selector-scoped-configuration)).
+5.  The global `FelixConfiguration` resource (`default`).
 
 The value of any configuration parameter is the value read from the
 _first_ location containing a value. For example, if an environment variable

--- a/calico-enterprise_versioned_docs/version-3.23-2/reference/component-resources/node/felix/configuration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/reference/component-resources/node/felix/configuration.mdx
@@ -19,7 +19,7 @@ Configuration for Felix is read from one of five possible locations, in order, a
 1.  Environment variables.
 2.  The Felix configuration file.
 3.  Host-specific `FelixConfiguration` resources (`node.<nodename>`).
-4.  Selector-scoped `FelixConfiguration` resources (tech preview — see [Selector-scoped configuration](../../../resources/felixconfig.mdx#selector-scoped-configuration)).
+4.  Selector-scoped `FelixConfiguration` resources (technology preview — see [Selector-scoped configuration](../../../resources/felixconfig.mdx#selector-scoped-configuration)).
 5.  The global `FelixConfiguration` resource (`default`).
 
 The value of any configuration parameter is the value read from the

--- a/calico-enterprise_versioned_docs/version-3.24-1/reference/component-resources/node/felix/configuration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/reference/component-resources/node/felix/configuration.mdx
@@ -14,12 +14,13 @@ refer to [Felix Configuration Resource](../../../resources/felixconfig.mdx).
 
 :::
 
-Configuration for Felix is read from one of four possible locations, in order, as follows.
+Configuration for Felix is read from one of five possible locations, in order, as follows.
 
 1.  Environment variables.
 2.  The Felix configuration file.
 3.  Host-specific `FelixConfiguration` resources (`node.<nodename>`).
-4.  The global `FelixConfiguration` resource (`default`).
+4.  Selector-scoped `FelixConfiguration` resources (tech preview — see [Selector-scoped configuration](../../../resources/felixconfig.mdx#selector-scoped-configuration)).
+5.  The global `FelixConfiguration` resource (`default`).
 
 The value of any configuration parameter is the value read from the
 _first_ location containing a value. For example, if an environment variable

--- a/calico-enterprise_versioned_docs/version-3.24-1/reference/component-resources/node/felix/configuration.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/reference/component-resources/node/felix/configuration.mdx
@@ -19,7 +19,7 @@ Configuration for Felix is read from one of five possible locations, in order, a
 1.  Environment variables.
 2.  The Felix configuration file.
 3.  Host-specific `FelixConfiguration` resources (`node.<nodename>`).
-4.  Selector-scoped `FelixConfiguration` resources (tech preview — see [Selector-scoped configuration](../../../resources/felixconfig.mdx#selector-scoped-configuration)).
+4.  Selector-scoped `FelixConfiguration` resources (technology preview — see [Selector-scoped configuration](../../../resources/felixconfig.mdx#selector-scoped-configuration)).
 5.  The global `FelixConfiguration` resource (`default`).
 
 The value of any configuration parameter is the value read from the


### PR DESCRIPTION
The Felix configuration reference lists the locations that Felix reads configuration from, in precedence order, but omits selector-scoped FelixConfiguration resources. The list is one entry short, so a reader cannot tell where selector-scoped configuration sits relative to the host-specific and global resources.

- Add selector-scoped FelixConfiguration resources as the fourth entry, and change the count from four to five, in the 3.23, 3.24, and next trees.

The wording, the position, and the tech preview label match the Calico Open Source page. Calico Cloud is not affected, because it does not document the feature, so its list of four locations is correct.

Deploy preview, 3.24: https://deploy-preview-2926--tigera.netlify.app/calico-enterprise/3.24/reference/component-resources/node/felix/configuration

DOCS-3011: https://tigera.atlassian.net/browse/DOCS-3011
