### PR TITLE
DOCS-3009: Add the feature status data file

### DIFF
--- a/data/feature-status.yaml
+++ b/data/feature-status.yaml
@@ -1,0 +1,97 @@
+# Feature status by product and release line.
+#
+# Record only status changes. A status carries forward until the next entry.
+# Before a feature's first entry, the feature did not exist in that release.
+#
+# status: tech-preview | ga | deprecated | removed
+# confirmed: false  keeps an entry in the file without rendering it
+#
+# Version keys match the table column labels. Docusaurus adds a suffix to
+# Enterprise versions: 3.24-1 is release line 3.24.
+
+features:
+  - id: calico-ingress-gateway
+    name: Calico Ingress Gateway
+    products:
+      calico:
+        "3.30": tech-preview
+        "3.31": ga
+      calico-enterprise:
+        "3.21": tech-preview
+        "3.22": ga
+
+  - id: dns-policy-windows
+    name: DNS policy for Windows
+    products:
+      calico-enterprise:
+        "3.19": tech-preview
+
+  - id: flow-logs-api-whisker
+    name: Flow logs API and Whisker
+    products:
+      calico:
+        "3.30": tech-preview
+
+  - id: gateway-waf
+    name: Gateway WAF
+    products:
+      calico-enterprise:
+        "3.22": tech-preview
+
+  - id: istio-ambient-mode
+    name: Istio ambient mode
+    products:
+      calico:
+        "3.32": tech-preview
+      calico-enterprise:
+        "3.22": tech-preview
+
+  - id: kubevirt-live-migration
+    name: Live migration for KubeVirt VMs
+    products:
+      calico-enterprise:
+        "3.23": tech-preview
+
+  - id: multi-vrf-networking
+    name: Multi-VRF networking
+    products:
+      calico-enterprise:
+        "3.23": tech-preview
+
+  - id: native-v3-crds
+    name: Native v3 CRDs
+    products:
+      calico:
+        "3.32": tech-preview
+      calico-enterprise:
+        "3.23": tech-preview
+        "3.24": ga
+
+  - id: nftables-dataplane
+    name: nftables data plane
+    products:
+      calico:
+        "3.29": tech-preview
+        "3.31": ga
+
+  - id: non-cluster-hosts-vms
+    name: Non-cluster hosts and VMs
+    products:
+      calico-enterprise:
+        confirmed: false
+        "3.20": tech-preview
+        "3.22": ga
+
+  - id: selector-scoped-felix-config
+    name: Selector-scoped Felix configuration
+    products:
+      calico:
+        "3.32": tech-preview
+      calico-enterprise:
+        "3.24": tech-preview
+
+  - id: workload-waf
+    name: Workload WAF
+    products:
+      calico-enterprise:
+        "3.19": tech-preview


### PR DESCRIPTION
The status tables are maintained by hand across seven release notes pages and two products. The same feature appears in several tables with different columns, so a status change means editing several tables, and a mistake in one is invisible from the others. This adds a single data file to hold that information, so the tables can be generated from it later.

The file records the whole feature lifecycle, so it drives both the technology preview tables and the deprecated and removed tables. It records only status changes, and a status carries forward until the next entry. A feature that ships in more than one product gets one entry with a per-product timeline.

Nothing reads the file yet.

Changes:

- Add data/feature-status.yaml, covering fourteen features across Calico Open Source and Calico Enterprise.

The file reproduces all seven technology preview tables, with one exception: selector-scoped Felix configuration starts in Enterprise 3.24, not 3.23. That correction is in #2927.

DOCS-3009: https://tigera.atlassian.net/browse/DOCS-3009
