### PR TITLE
DOCS-3009: Populate the deprecated and removed features sections

### DIFF
--- a/calico_versioned_docs/version-3.30/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.30/release-notes/index.mdx
@@ -161,6 +161,19 @@ Technology preview features are for evaluation and feedback only and are **not s
 
 TP = technology preview, GA = generally available, – = not available in that release.
 
+## Deprecated and removed features
+
+This table shows the status of features that were deprecated or removed at any point in the releases covered here.
+Deprecated features are still present and supported, but they are scheduled for removal. Migrate away from a deprecated feature before it is removed.
+
+* FIPS mode is deprecated and scheduled for removal in an upcoming release. See [FIPS mode](../operations/fips.mdx).
+
+| Feature | 3.28 | 3.29 | 3.30 |
+| --- | --- | --- | --- |
+| FIPS mode | GA | GA | Deprecated |
+
+GA = generally available, Deprecated = scheduled for removal, Removed = no longer present, – = not available in that release.
+
 {/* ## Known issues */}
 
 ## Bug fixes

--- a/calico_versioned_docs/version-3.30/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.30/release-notes/index.mdx
@@ -163,16 +163,19 @@ TP = technology preview, GA = generally available, – = not available in that r
 
 ## Deprecated and removed features
 
-This table shows the status of features that were deprecated or removed at any point in the releases covered here.
-Deprecated features are still present and supported, but they are scheduled for removal. Migrate away from a deprecated feature before it is removed.
-
-* FIPS mode is deprecated and scheduled for removal in an upcoming release. See [FIPS mode](../operations/fips.mdx).
+Review the following table to see what features have recently been deprecated or removed.
+Deprecated features are still present and supported, but they are scheduled for removal.
+You should consider migrating away from a deprecated feature before it is removed.
 
 | Feature | 3.28 | 3.29 | 3.30 |
 | --- | --- | --- | --- |
 | FIPS mode | GA | GA | Deprecated |
 
-GA = generally available, Deprecated = scheduled for removal, Removed = no longer present, – = not available in that release.
+GA = generally available, Deprecated = scheduled for removal, Removed = no longer present.
+
+### Deprecated and removed features in this release
+
+* FIPS mode is deprecated and scheduled for removal in an upcoming release. See [FIPS mode](../operations/fips.mdx).
 
 {/* ## Known issues */}
 

--- a/calico_versioned_docs/version-3.31/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.31/release-notes/index.mdx
@@ -192,7 +192,7 @@ TP = technology preview, GA = generally available, – = not available in that r
 This table shows the status of features that were deprecated or removed at any point in the releases covered here.
 Deprecated features are still present and supported, but they are scheduled for removal. Migrate away from a deprecated feature before it is removed.
 
-* FIPS mode is deprecated and scheduled for removal in an upcoming release. See [FIPS mode](../operations/fips.mdx).
+* FIPS mode was deprecated in 3.30 and is scheduled for removal in an upcoming release. See [FIPS mode](../operations/fips.mdx).
 
 | Feature | 3.29 | 3.30 | 3.31 |
 | --- | --- | --- | --- |

--- a/calico_versioned_docs/version-3.31/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.31/release-notes/index.mdx
@@ -187,6 +187,19 @@ Technology preview features are for evaluation and feedback only and are **not s
 
 TP = technology preview, GA = generally available, – = not available in that release.
 
+## Deprecated and removed features
+
+This table shows the status of features that were deprecated or removed at any point in the releases covered here.
+Deprecated features are still present and supported, but they are scheduled for removal. Migrate away from a deprecated feature before it is removed.
+
+* FIPS mode is deprecated and scheduled for removal in an upcoming release. See [FIPS mode](../operations/fips.mdx).
+
+| Feature | 3.29 | 3.30 | 3.31 |
+| --- | --- | --- | --- |
+| FIPS mode | GA | Deprecated | Deprecated |
+
+GA = generally available, Deprecated = scheduled for removal, Removed = no longer present, – = not available in that release.
+
 ## Bug fixes
 
 - Fix slow IPAM release performance when releasing IPs from disabled or deleted pools (especially for bulk deletions like those done by IPAM GC). Consider disabled pools as potential IP owners and cache any loaded blocks for fast access. [calico 11094](https://github.com/projectcalico/calico/pull/11094) (@fasaxc)

--- a/calico_versioned_docs/version-3.31/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.31/release-notes/index.mdx
@@ -189,16 +189,15 @@ TP = technology preview, GA = generally available, – = not available in that r
 
 ## Deprecated and removed features
 
-This table shows the status of features that were deprecated or removed at any point in the releases covered here.
-Deprecated features are still present and supported, but they are scheduled for removal. Migrate away from a deprecated feature before it is removed.
-
-* FIPS mode was deprecated in 3.30 and is scheduled for removal in an upcoming release. See [FIPS mode](../operations/fips.mdx).
+Review the following table to see what features have recently been deprecated or removed.
+Deprecated features are still present and supported, but they are scheduled for removal.
+You should consider migrating away from a deprecated feature before it is removed.
 
 | Feature | 3.29 | 3.30 | 3.31 |
 | --- | --- | --- | --- |
 | FIPS mode | GA | Deprecated | Deprecated |
 
-GA = generally available, Deprecated = scheduled for removal, Removed = no longer present, – = not available in that release.
+GA = generally available, Deprecated = scheduled for removal, Removed = no longer present.
 
 ## Bug fixes
 

--- a/calico_versioned_docs/version-3.32/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.32/release-notes/index.mdx
@@ -12,14 +12,14 @@ Learn about the new features, bug fixes, and other updates in this release of $[
 
 ### Native v3 CRDs (tech preview)
 
-$[prodname] now supports installation with native `projectcalico.org/v3` CRDs as an alternative to the aggregation API server.
+$[prodname] now supports installation with native `projectcalico.org/v3` CRDs as an alternative to the aggregated API server.
 The Tigera Operator registers `projectcalico.org/v3` resources directly as native Kubernetes CRDs — no host-network pods, no ordering dependencies between CRDs and the API server, and `kubectl` manages v3 resources without an extra install step.
 This removes a long-standing source of installation friction on managed Kubernetes platforms like EKS and AKS.
-For existing clusters, a new `DatastoreMigration` controller copies resources from the aggregation API server to native CRDs in place; the datastore is briefly locked but workload connectivity is preserved through the migration window.
+For existing clusters, a new `DatastoreMigration` controller copies resources from the aggregated API server to native CRDs in place; the datastore is briefly locked but workload connectivity is preserved through the migration window.
 
 Native v3 CRDs require the Kubernetes `MutatingAdmissionPolicy` feature gate, which is beta and not enabled by default.
 
-Native v3 CRDs are the successor to the aggregation API server, and will become the default install mode in a future release.
+Native v3 CRDs are the successor to the aggregated API server, and will become the default install mode in a future release.
 
 For more information, see [Enable native v3 CRDs](../operations/native-v3-crds.mdx) and [Migrate from API server to native CRDs](../operations/crd-migration.mdx).
 
@@ -104,12 +104,12 @@ TP = technology preview, GA = generally available, – = not available in that r
 This table shows the status of features that were deprecated or removed at any point in the releases covered here.
 Deprecated features are still present and supported, but they are scheduled for removal. Migrate away from a deprecated feature before it is removed.
 
-* Support for the aggregation API server is deprecated and scheduled for removal in an upcoming release. $[prodname] is moving the `projectcalico.org/v3` API to native Kubernetes CRDs. Both mechanisms are supported until native v3 CRDs are compatible with all supported platforms. See [Enable native v3 CRDs](../operations/native-v3-crds.mdx).
+* API server mode is deprecated and scheduled for removal in an upcoming release. In API server mode, the Calico API server serves the `projectcalico.org/v3` API through the Kubernetes aggregation layer. Both modes are supported until native v3 CRDs are compatible with all supported platforms. Migrate to CRD mode; see [Enable native v3 CRDs](../operations/native-v3-crds.mdx).
 * FIPS mode was deprecated in 3.30 and is scheduled for removal in an upcoming release. See [FIPS mode](../operations/fips.mdx).
 
 | Feature | 3.30 | 3.31 | 3.32 |
 | --- | --- | --- | --- |
-| Aggregation API server | GA | GA | Deprecated |
+| API server mode | GA | GA | Deprecated |
 | FIPS mode | Deprecated | Deprecated | Deprecated |
 
 GA = generally available, Deprecated = scheduled for removal, Removed = no longer present, – = not available in that release.

--- a/calico_versioned_docs/version-3.32/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.32/release-notes/index.mdx
@@ -101,18 +101,20 @@ TP = technology preview, GA = generally available, – = not available in that r
 
 ## Deprecated and removed features
 
-This table shows the status of features that were deprecated or removed at any point in the releases covered here.
-Deprecated features are still present and supported, but they are scheduled for removal. Migrate away from a deprecated feature before it is removed.
-
-* API server mode is deprecated and scheduled for removal in an upcoming release. In API server mode, the Calico API server serves the `projectcalico.org/v3` API through the Kubernetes aggregation layer. Both modes are supported until native v3 CRDs are compatible with all supported platforms. Migrate to CRD mode; see [Enable native v3 CRDs](../operations/native-v3-crds.mdx).
-* FIPS mode was deprecated in 3.30 and is scheduled for removal in an upcoming release. See [FIPS mode](../operations/fips.mdx).
+Review the following table to see what features have recently been deprecated or removed.
+Deprecated features are still present and supported, but they are scheduled for removal.
+You should consider migrating away from a deprecated feature before it is removed.
 
 | Feature | 3.30 | 3.31 | 3.32 |
 | --- | --- | --- | --- |
-| API server mode | GA | GA | Deprecated |
+| Aggregation API server | GA | GA | Deprecated |
 | FIPS mode | Deprecated | Deprecated | Deprecated |
 
-GA = generally available, Deprecated = scheduled for removal, Removed = no longer present, – = not available in that release.
+GA = generally available, Deprecated = scheduled for removal, Removed = no longer present.
+
+### Deprecated and removed features in this release
+
+* Support for the aggregation API server is deprecated and scheduled for removal in an upcoming release. $[prodname] is moving the `projectcalico.org/v3` API to native Kubernetes CRDs. Both mechanisms are supported until native v3 CRDs are compatible with all supported platforms. Migrate to native v3 CRDs; see [Enable native v3 CRDs](../operations/native-v3-crds.mdx).
 
 ## Bug fixes
 

--- a/calico_versioned_docs/version-3.32/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.32/release-notes/index.mdx
@@ -12,14 +12,14 @@ Learn about the new features, bug fixes, and other updates in this release of $[
 
 ### Native v3 CRDs (tech preview)
 
-$[prodname] now supports installation with native `projectcalico.org/v3` CRDs as an alternative to the aggregated API server.
+$[prodname] now supports installation with native `projectcalico.org/v3` CRDs as an alternative to the aggregation API server.
 The Tigera Operator registers `projectcalico.org/v3` resources directly as native Kubernetes CRDs — no host-network pods, no ordering dependencies between CRDs and the API server, and `kubectl` manages v3 resources without an extra install step.
 This removes a long-standing source of installation friction on managed Kubernetes platforms like EKS and AKS.
-For existing clusters, a new `DatastoreMigration` controller copies resources from the aggregated API server to native CRDs in place; the datastore is briefly locked but workload connectivity is preserved through the migration window.
+For existing clusters, a new `DatastoreMigration` controller copies resources from the aggregation API server to native CRDs in place; the datastore is briefly locked but workload connectivity is preserved through the migration window.
 
 Native v3 CRDs require the Kubernetes `MutatingAdmissionPolicy` feature gate, which is beta and not enabled by default.
 
-Native v3 CRDs are the successor to the aggregated API server, and will become the default install mode in a future release.
+Native v3 CRDs are the successor to the aggregation API server, and will become the default install mode in a future release.
 
 For more information, see [Enable native v3 CRDs](../operations/native-v3-crds.mdx) and [Migrate from API server to native CRDs](../operations/crd-migration.mdx).
 
@@ -101,7 +101,18 @@ TP = technology preview, GA = generally available, – = not available in that r
 
 ## Deprecated and removed features
 
-* $[prodname] is moving the `projectcalico.org/v3` API from the aggregated API server to native Kubernetes CRDs. Both mechanisms will be supported until native v3 CRDs are compatible with all supported platforms, after which the aggregated API server will be removed.
+This table shows the status of features that were deprecated or removed at any point in the releases covered here.
+Deprecated features are still present and supported, but they are scheduled for removal. Migrate away from a deprecated feature before it is removed.
+
+* Support for the aggregation API server is deprecated and scheduled for removal in an upcoming release. $[prodname] is moving the `projectcalico.org/v3` API to native Kubernetes CRDs. Both mechanisms are supported until native v3 CRDs are compatible with all supported platforms. See [Enable native v3 CRDs](../operations/native-v3-crds.mdx).
+* FIPS mode is deprecated and scheduled for removal in an upcoming release. See [FIPS mode](../operations/fips.mdx).
+
+| Feature | 3.30 | 3.31 | 3.32 |
+| --- | --- | --- | --- |
+| Aggregation API server | GA | GA | Deprecated |
+| FIPS mode | Deprecated | Deprecated | Deprecated |
+
+GA = generally available, Deprecated = scheduled for removal, Removed = no longer present, – = not available in that release.
 
 ## Bug fixes
 

--- a/calico_versioned_docs/version-3.32/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.32/release-notes/index.mdx
@@ -105,7 +105,7 @@ This table shows the status of features that were deprecated or removed at any p
 Deprecated features are still present and supported, but they are scheduled for removal. Migrate away from a deprecated feature before it is removed.
 
 * Support for the aggregation API server is deprecated and scheduled for removal in an upcoming release. $[prodname] is moving the `projectcalico.org/v3` API to native Kubernetes CRDs. Both mechanisms are supported until native v3 CRDs are compatible with all supported platforms. See [Enable native v3 CRDs](../operations/native-v3-crds.mdx).
-* FIPS mode is deprecated and scheduled for removal in an upcoming release. See [FIPS mode](../operations/fips.mdx).
+* FIPS mode was deprecated in 3.30 and is scheduled for removal in an upcoming release. See [FIPS mode](../operations/fips.mdx).
 
 | Feature | 3.30 | 3.31 | 3.32 |
 | --- | --- | --- | --- |

--- a/data/feature-status.yaml
+++ b/data/feature-status.yaml
@@ -10,6 +10,13 @@
 # Enterprise versions: 3.24-1 is release line 3.24.
 
 features:
+  - id: api-server-mode
+    name: API server mode
+    products:
+      calico:
+        "3.28": ga
+        "3.32": deprecated
+
   - id: calico-ingress-gateway
     name: Calico Ingress Gateway
     products:
@@ -31,6 +38,13 @@ features:
     products:
       calico:
         "3.30": tech-preview
+
+  - id: fips-mode
+    name: FIPS mode
+    products:
+      calico:
+        "3.28": ga
+        "3.30": deprecated
 
   - id: gateway-waf
     name: Gateway WAF

--- a/data/feature-status.yaml
+++ b/data/feature-status.yaml
@@ -10,8 +10,8 @@
 # Enterprise versions: 3.24-1 is release line 3.24.
 
 features:
-  - id: api-server-mode
-    name: API server mode
+  - id: aggregation-api-server
+    name: Aggregation API server
     products:
       calico:
         "3.28": ga


### PR DESCRIPTION
The release notes record a deprecation once, in the release it happens, and often not at all. FIPS mode is deprecated in 3.30, 3.31, and 3.32 and appears in no release notes. This adds a Deprecated and removed features section to the 3.30 and 3.31 release notes, completes the section in 3.32, and gives each one a table covering a rolling window of three releases.

The 3.32 entry names API server mode, not the Calico API server. The component is not being removed: in CRD mode the APIServer resource still deploys a webhooks pod, and the architecture reference has called it the Calico API server in every release since 3.28. What is deprecated is the mode in which it serves the projectcalico.org/v3 API through the Kubernetes aggregation layer.

Changes:

- Add the section to the 3.30 and 3.31 release notes, covering FIPS mode.
- Complete the section in 3.32, covering API server mode and FIPS mode.
- Record both deprecations in data/feature-status.yaml. The tables in this pull request match what that file generates.

Deploy preview: https://deploy-preview-2929--tigera.netlify.app/calico/latest/release-notes

DOCS-3009: https://tigera.atlassian.net/browse/DOCS-3009
