### PR TITLE
DOCS-3009: Add deprecation lifecycle tables to the Calico Enterprise release notes

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -81,6 +81,19 @@ Technology preview features are for evaluation and feedback only and are **not s
 
 TP = technology preview, – = not available in that release.
 
+## Deprecated and removed features
+
+Review the following table to see what features have recently been deprecated or removed.
+Deprecated features are still present and supported, but they are scheduled for removal.
+You should consider migrating away from a deprecated feature before it is removed.
+
+| Feature | 3.19 | 3.20 | 3.21 |
+| --- | --- | --- | --- |
+| Compliance reporting | GA | Deprecated | Deprecated |
+| Fortinet integration | Deprecated | Deprecated | Deprecated |
+
+GA = generally available, Deprecated = scheduled for removal, Removed = no longer present.
+
 ## Release details
 
 ### Calico Enterprise 3.21.0-1.0 (early preview)

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -129,6 +129,19 @@ Technology preview features are for evaluation and feedback only and are **not s
 
 TP = technology preview, GA = generally available, – = not available in that release.
 
+## Deprecated and removed features
+
+Review the following table to see what features have recently been deprecated or removed.
+Deprecated features are still present and supported, but they are scheduled for removal.
+You should consider migrating away from a deprecated feature before it is removed.
+
+| Feature | 3.20 | 3.21 | 3.22 |
+| --- | --- | --- | --- |
+| Compliance reporting | Deprecated | Deprecated | Deprecated |
+| Fortinet integration | Deprecated | Deprecated | Deprecated |
+
+GA = generally available, Deprecated = scheduled for removal, Removed = no longer present.
+
 ## Release details
 
 ### Calico Enterprise 3.22.0-1.0 (early preview)

--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -153,6 +153,22 @@ TP = technology preview, GA = generally available, – = not available in that r
 
 ## Deprecated and removed features
 
+Review the following table to see what features have recently been deprecated or removed.
+Deprecated features are still present and supported, but they are scheduled for removal.
+You should consider migrating away from a deprecated feature before it is removed.
+
+| Feature | 3.21 | 3.22 | 3.23 |
+| --- | --- | --- | --- |
+| Aggregation API server | GA | GA | Deprecated |
+| Application layer policy based on Envoy | GA | GA | Deprecated |
+| L7 logging with Envoy | GA | GA | Deprecated |
+| Compliance reporting | Deprecated | Deprecated | Deprecated |
+| Fortinet integration | Deprecated | Deprecated | Deprecated |
+
+GA = generally available, Deprecated = scheduled for removal, Removed = no longer present.
+
+### Deprecated and removed features in this release
+
 * $[prodname] is moving the `projectcalico.org/v3` API from the aggregated API server to native Kubernetes CRDs. Both mechanisms will be supported until native v3 CRDs are compatible with all supported platforms, after which the aggregated API server will be removed.
 * Support for RHEL 8 and Windows 1809 has been removed in this release.
 * Support for the x86-64 v2 chip architecture is deprecated and scheduled for removal in an upcoming release.

--- a/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
@@ -79,6 +79,22 @@ TP = technology preview, GA = generally available, – = not available in that r
 
 ## Deprecated and removed features
 
+Review the following table to see what features have recently been deprecated or removed.
+Deprecated features are still present and supported, but they are scheduled for removal.
+You should consider migrating away from a deprecated feature before it is removed.
+
+| Feature | 3.22 | 3.23 | 3.24 |
+| --- | --- | --- | --- |
+| Compliance reporting | Deprecated | Deprecated | Removed |
+| Aggregation API server | GA | Deprecated | Deprecated |
+| Application layer policy based on Envoy | GA | Deprecated | Deprecated |
+| L7 logging with Envoy | GA | Deprecated | Deprecated |
+| Fortinet integration | Deprecated | Deprecated | Deprecated |
+
+GA = generally available, Deprecated = scheduled for removal, Removed = no longer present.
+
+### Deprecated and removed features in this release
+
 * The compliance reporting feature has been removed from the $[prodname] web console.
 * $[prodname] is moving the `projectcalico.org/v3` API from the aggregated API server to native Kubernetes CRDs.
   Both mechanisms will be supported until native v3 CRDs are compatible with all supported platforms, after which the aggregated API server will be removed.

--- a/data/feature-status.yaml
+++ b/data/feature-status.yaml
@@ -16,6 +16,16 @@ features:
       calico:
         "3.28": ga
         "3.32": deprecated
+      calico-enterprise:
+        "3.19": ga
+        "3.23": deprecated
+
+  - id: application-layer-policy-envoy
+    name: Application layer policy based on Envoy
+    products:
+      calico-enterprise:
+        "3.19": ga
+        "3.23": deprecated
 
   - id: calico-ingress-gateway
     name: Calico Ingress Gateway
@@ -26,6 +36,14 @@ features:
       calico-enterprise:
         "3.21": tech-preview
         "3.22": ga
+
+  - id: compliance-reporting
+    name: Compliance reporting
+    products:
+      calico-enterprise:
+        "3.19": ga
+        "3.20": deprecated
+        "3.24": removed
 
   - id: dns-policy-windows
     name: DNS policy for Windows
@@ -46,6 +64,13 @@ features:
         "3.28": ga
         "3.30": deprecated
 
+  - id: fortinet-integration
+    name: Fortinet integration
+    products:
+      calico-enterprise:
+        # GA before 3.18; no rendered window reaches that far
+        "3.18": deprecated
+
   - id: gateway-waf
     name: Gateway WAF
     products:
@@ -65,6 +90,13 @@ features:
     products:
       calico-enterprise:
         "3.23": tech-preview
+
+  - id: l7-logging-envoy
+    name: L7 logging with Envoy
+    products:
+      calico-enterprise:
+        "3.19": ga
+        "3.23": deprecated
 
   - id: multi-vrf-networking
     name: Multi-VRF networking


### PR DESCRIPTION
The release notes record a deprecation once, in the release it happens, and often not at all. The Fortinet integration has been deprecated on every one of its pages since 3.18 and appears in no release notes. This adds a Deprecated and removed features section to the 3.21 and 3.22 release notes, gives the 3.23 and 3.24 sections a table, and matches the open source sections added in #2929.

Rows cover the five features that carry a deprecation admonition on their pages: the Fortinet integration, compliance features, application layer policy based on Envoy, L7 logging with Envoy, and the aggregation API server.

Changes:

- Add the section to the 3.21 and 3.22 release notes, each with a table covering a rolling window of three releases.
- Add the table to the 3.23 and 3.24 sections, and move their existing bullets into a Deprecated and removed features in this release subsection.
- Record all five deprecations in data/feature-status.yaml, and add the Calico Enterprise release line to the existing aggregation API server entry. The tables here match what that file generates.

The 3.21 and 3.22 sections have a table but no bulleted subsection, because neither release deprecated or removed anything new.

Compliance features read Removed in 3.24 on the evidence of the docs, where the compliance reports reference section is deleted and the compliance section drops from six pages to three. The 3.24 release note claims removal from the web console only, so please confirm whether the backend feature is also gone.

DOCS-3009: https://tigera.atlassian.net/browse/DOCS-3009

Deploy preview, 3.24 release notes, which has the largest table: https://deploy-preview-2931--tigera.netlify.app/calico-enterprise/3.24/release-notes
