### PR TITLE
DOCS-3012: Remove duplicate headings from the web console access page

### DIFF
--- a/calico-enterprise/operations/cnx/access-the-manager.mdx
+++ b/calico-enterprise/operations/cnx/access-the-manager.mdx
@@ -31,7 +31,7 @@ For security, the $[prodname] web console is not exposed outside of the cluster 
 
 ## How to
 
-### Configure access to the $[prodname] web console
+Select the tab for the access option that you chose.
 
 <Tabs>
 <TabItem label="Ingress" value="Ingress-0">
@@ -82,7 +82,7 @@ spec:
                   number: 9443
 ```
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser using the URL for your ingress controller. For example: `https://<ingress-url>`.
 
@@ -110,7 +110,7 @@ spec:
 
 After creating the service, it may take a few minutes for the load balancer to be created. Once complete, the load balancer IP address appears as an `ExternalIP` in `kubectl get services -n calico-system calico-manager-external`.
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser using the load balancer's external IP address. For example: `https://<ExternalIP>:9443`.
 
@@ -123,7 +123,7 @@ To forward traffic locally, use the following command:
 kubectl port-forward -n calico-system service/calico-manager 9443:9443
 ```
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser at: `https://localhost:9443`
 
@@ -170,7 +170,7 @@ spec:
   wildcardPolicy: None
 ```
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser using the URL with clustername. For example: `https://manager.apps.demo-ocp.tigera-solutions.io`
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/operations/cnx/access-the-manager.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/operations/cnx/access-the-manager.mdx
@@ -31,7 +31,7 @@ For security, the $[prodname] web console is not exposed outside of the cluster 
 
 ## How to
 
-### Configure access to the $[prodname] web console
+Select the tab for the access option that you chose.
 
 <Tabs>
 <TabItem label="Ingress" value="Ingress-0">
@@ -82,7 +82,7 @@ spec:
                   number: 9443
 ```
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser using the URL for your ingress controller. For example: `https://<ingress-url>`.
 
@@ -110,7 +110,7 @@ spec:
 
 After creating the service, it may take a few minutes for the load balancer to be created. Once complete, the load balancer IP address appears as an `ExternalIP` in `kubectl get services -n tigera-manager tigera-manager-external`.
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser using the load balancer's external IP address. For example: `https://<ExternalIP>:9443`.
 
@@ -123,7 +123,7 @@ To forward traffic locally, use the following command:
 kubectl port-forward -n tigera-manager service/tigera-manager 9443:9443
 ```
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser at: `https://localhost:9443`
 
@@ -170,7 +170,7 @@ spec:
   wildcardPolicy: None
 ```
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser using the URL with clustername. For example: `https://manager.apps.demo-ocp.tigera-solutions.io`
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/cnx/access-the-manager.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/cnx/access-the-manager.mdx
@@ -31,7 +31,7 @@ For security, the $[prodname] web console is not exposed outside of the cluster 
 
 ## How to
 
-### Configure access to the $[prodname] web console
+Select the tab for the access option that you chose.
 
 <Tabs>
 <TabItem label="Ingress" value="Ingress-0">
@@ -82,7 +82,7 @@ spec:
                   number: 9443
 ```
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser using the URL for your ingress controller. For example: `https://<ingress-url>`.
 
@@ -110,7 +110,7 @@ spec:
 
 After creating the service, it may take a few minutes for the load balancer to be created. Once complete, the load balancer IP address appears as an `ExternalIP` in `kubectl get services -n tigera-manager tigera-manager-external`.
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser using the load balancer's external IP address. For example: `https://<ExternalIP>:9443`.
 
@@ -123,7 +123,7 @@ To forward traffic locally, use the following command:
 kubectl port-forward -n tigera-manager service/tigera-manager 9443:9443
 ```
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser at: `https://localhost:9443`
 
@@ -170,7 +170,7 @@ spec:
   wildcardPolicy: None
 ```
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser using the URL with clustername. For example: `https://manager.apps.demo-ocp.tigera-solutions.io`
 

--- a/calico-enterprise_versioned_docs/version-3.23-2/operations/cnx/access-the-manager.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/operations/cnx/access-the-manager.mdx
@@ -31,7 +31,7 @@ For security, the $[prodname] web console is not exposed outside of the cluster 
 
 ## How to
 
-### Configure access to the $[prodname] web console
+Select the tab for the access option that you chose.
 
 <Tabs>
 <TabItem label="Ingress" value="Ingress-0">
@@ -82,7 +82,7 @@ spec:
                   number: 9443
 ```
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser using the URL for your ingress controller. For example: `https://<ingress-url>`.
 
@@ -110,7 +110,7 @@ spec:
 
 After creating the service, it may take a few minutes for the load balancer to be created. Once complete, the load balancer IP address appears as an `ExternalIP` in `kubectl get services -n calico-system calico-manager-external`.
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser using the load balancer's external IP address. For example: `https://<ExternalIP>:9443`.
 
@@ -123,7 +123,7 @@ To forward traffic locally, use the following command:
 kubectl port-forward -n calico-system service/calico-manager 9443:9443
 ```
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser at: `https://localhost:9443`
 
@@ -170,7 +170,7 @@ spec:
   wildcardPolicy: None
 ```
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser using the URL with clustername. For example: `https://manager.apps.demo-ocp.tigera-solutions.io`
 

--- a/calico-enterprise_versioned_docs/version-3.24-1/operations/cnx/access-the-manager.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/operations/cnx/access-the-manager.mdx
@@ -31,7 +31,7 @@ For security, the $[prodname] web console is not exposed outside of the cluster 
 
 ## How to
 
-### Configure access to the $[prodname] web console
+Select the tab for the access option that you chose.
 
 <Tabs>
 <TabItem label="Ingress" value="Ingress-0">
@@ -82,7 +82,7 @@ spec:
                   number: 9443
 ```
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser using the URL for your ingress controller. For example: `https://<ingress-url>`.
 
@@ -110,7 +110,7 @@ spec:
 
 After creating the service, it may take a few minutes for the load balancer to be created. Once complete, the load balancer IP address appears as an `ExternalIP` in `kubectl get services -n calico-system calico-manager-external`.
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser using the load balancer's external IP address. For example: `https://<ExternalIP>:9443`.
 
@@ -123,7 +123,7 @@ To forward traffic locally, use the following command:
 kubectl port-forward -n calico-system service/calico-manager 9443:9443
 ```
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser at: `https://localhost:9443`
 
@@ -170,7 +170,7 @@ spec:
   wildcardPolicy: None
 ```
 
-### Log in to the $[prodname] web console
+**Log in to the $[prodname] web console**
 
 Access the $[prodname] web console in your browser using the URL with clustername. For example: `https://manager.apps.demo-ocp.tigera-solutions.io`
 


### PR DESCRIPTION
The "Configure access to the web console" page listed "Log in to the Calico Enterprise web console" four times in the table of contents. The page has four tabs in the How to section, and each tab ended with its own H3 heading. Docusaurus builds the table of contents from the headings in the source, not from the tab the reader has selected, so all four headings appeared at once and generated duplicate anchor slugs.

Changes:

- Change the four in-tab headings to bold text. The same tabs already use bold labels for "Basic ingress controller, no modification" and "Example", so this matches the page.
- Replace the "Configure access to the Calico Enterprise web console" heading with a line that tells the reader to select a tab. That heading restated the page title one level down.

The table of contents now reads: Big picture, Value, Before you begin, How to, Additional resources.

Applied to Calico Enterprise 3.21, 3.22, 3.23, 3.24, and next. Calico Enterprise 3.20 has the same problem but is not in onlyIncludeVersions, so it is not built. Calico Cloud and Calico Open Source have no equivalent page.

No page links to the removed anchors. The similar link in quickstart.mdx points to a heading on that page.

Ticket: https://tigera.atlassian.net/browse/DOCS-3012

Follow-up: 57 files across the repo put headings inside Tabs, and 11 distinct pages repeat a heading text that way, including the Windows demo, the IP pool migration pages, and the Kubernetes audit log pages. Those need a separate ticket.

When the deploy preview builds, check the table of contents on:

- /calico-enterprise/3.22/operations/cnx/access-the-manager