### PR TITLE
DOCS-2966: Skip the bare calicousers.slack.com URL in the link check

### DIFF
--- a/__tests__/crawler.test.js
+++ b/__tests__/crawler.test.js
@@ -139,8 +139,10 @@ test('Crawl the docs and execute tests', async () => {
     'https://downloads.tigera.io/ee/archives/release-master-master.tgz', //==> This started after redesigning the archive procedure.
     'http://nginx-svc.curl-ns.svc.cluster.local:80',
     'http://nginx-svc.service-ns.svc.cluster.local:80',
-    'https://calicousers.slack.com/',
-    'https://calicousers.slack.com/archives/C017220EXU1',
+    // Slack workspace URLs return 403 to datacenter crawlers; the links are fine in a browser.
+    // Matched as a pattern so the bare host, the trailing-slash form and channel links are all
+    // covered. The bare host is linked from /calico/latest/reference/involved.
+    /^https:\/\/calicousers\.slack\.com/,
     'https://tigera-manager.mycompany.com',
     'https://kb.isc.org/article/AA-01141/31/How-to-workaround-IPv6-prefix-length-issues-with-ISC-DHCP-clients.html',
     'https://www.snort.org/documents',


### PR DESCRIPTION
The Netlify deploy preview for the tigera site fails on the 3.22.7 publishing PR #2917. The build itself succeeds. The failure is in the link check that runs after it, and it reports one dead link:

  https://calicousers.slack.com is dead (403)
  ==>Origin: http://localhost:4242/calico/latest/reference/involved

The skip list in __tests__/crawler.test.js already covered this Slack workspace, but as two exact strings, https://calicousers.slack.com/ with a trailing slash and one channel URL. Entries given as strings are matched exactly, so the bare host linked from the get involved page was still checked. Slack returns 403 to datacenter crawlers, and the link is correct in a browser.

This replaces both strings with an anchored pattern for the host, which covers the bare host, the trailing slash form and channel links in one entry. The pattern is anchored so it does not match a lookalike host.

The 403 is intermittent, so the failure does not reproduce reliably. A local run of make netlify passed against the same content while the Netlify build was failing, which is why the pattern is the right fix rather than adding one more exact string.

This failure has nothing to do with the 3.22.7 release. Only latest is crawled, seeded from sitemap.xml, and Calico Enterprise latest maps to 3.23, so no page under version-3.22-2 is checked at all. The same dead link fails every open pull request's tigera preview, so this unblocks more than the publishing PR.

Based on the publication branch so the fix reaches #2917 and its preview can rebuild.

Netlify does not build a deploy preview for a pull request based on a publish branch, so there is no preview link here, and the pull request checks do not run the link check. The verification is the tigera preview on #2917 once this merges.
