### PR TITLE
Wait for the Envoy proxy Deployment in the Gateway WAF tutorial

### DIFF
--- a/calico-enterprise/threat/gateway-waf/tutorial.mdx
+++ b/calico-enterprise/threat/gateway-waf/tutorial.mdx
@@ -114,6 +114,15 @@ This tutorial takes you from a running Ingress Gateway to a blocked attack in ab
    kubectl wait --for=condition=Accepted gateway/httpbin-gateway -n httpbin --timeout=60s
    ```
 
+   At this point `Accepted` only means Gateway passed validation. Let's now wait for the Envoy proxy
+   Deployment that Ingress Gateway creates:
+
+   ```bash
+   kubectl wait --for=condition=Available deployment \
+     -l gateway.envoyproxy.io/owning-gateway-name=httpbin-gateway \
+     -n httpbin --timeout=180s
+   ```
+
 1. Confirm traffic flows. Find the Envoy service the Ingress Gateway created for this Gateway (the service lands in the Gateway's own namespace, `httpbin`):
 
    ```bash

--- a/calico-enterprise_versioned_docs/version-3.24-1/threat/gateway-waf/tutorial.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/threat/gateway-waf/tutorial.mdx
@@ -114,6 +114,15 @@ This tutorial takes you from a running Ingress Gateway to a blocked attack in ab
    kubectl wait --for=condition=Accepted gateway/httpbin-gateway -n httpbin --timeout=60s
    ```
 
+   At this point `Accepted` only means Gateway passed validation. Let's now wait for the Envoy proxy
+   Deployment that Ingress Gateway creates:
+
+   ```bash
+   kubectl wait --for=condition=Available deployment \
+     -l gateway.envoyproxy.io/owning-gateway-name=httpbin-gateway \
+     -n httpbin --timeout=180s
+   ```
+
 1. Confirm traffic flows. Find the Envoy service the Ingress Gateway created for this Gateway (the service lands in the Gateway's own namespace, `httpbin`):
 
    ```bash


### PR DESCRIPTION
Product Version(s):
Calico Enterprise 3.24 (both `next` and `version-3.24-1`; the two files were byte-identical, so the change is the same in each)

Issue:
None. Found while running the tutorial end to end on a fresh 3.24 cluster.

Link to docs preview:
To be added once the Netlify deploy preview builds. The page is `calico-enterprise/threat/gateway-waf/tutorial`.

SME review:
- [ ] An SME has approved this change.

DOCS review:
- [ ] A member of the docs team has approved this change.

Additional information:

Step 2 of the tutorial waits on the Gateway's `Accepted` condition, then step 3 immediately sends a request through the gateway. `Accepted` only means the Gateway passed validation. Envoy Gateway still has to create the Envoy proxy Deployment, and Envoy still has to finish starting, so that first request can fail with a connection error.

I hit this following the tutorial verbatim on a fresh cluster. The first request failed at 39 seconds of gateway pod age and returned 200 on a retry once Envoy had settled.

Timings I measured, with the Gateway applied at a known time and an in-cluster poller requesting the gateway service every 2 seconds:

| signal | time after the Gateway is applied |
|---|---|
| Gateway `Accepted=True` | 2 s |
| Gateway `listeners[0]` `Programmed=True` | 2 s |
| Gateway top-level `Programmed` | never True on this cluster, stays `False (AddressNotAssigned)` with no load balancer provider |
| Envoy proxy Deployment `Available=True` | 20.2 s |
| first successful request | 21 s |

So both Gateway conditions fire about 19 seconds too early to be useful as a readiness gate, and the Deployment's `Available` condition lands one second before traffic starts flowing.

The added command waits on the Deployment rather than the pod on purpose. `kubectl wait` resolves a label selector once and then watches only the objects it matched at that moment. A pod wait can latch onto a pod that is shutting down from an earlier attempt and then time out while the new pod is already serving. I reproduced that: a pod wait timed out after its full 180 seconds while the gateway was returning 200.

There is no race in the added command. Envoy Gateway creates the Deployment within 1 second of the Gateway apply, so the selector always matches something.

Tested on Calico Enterprise `v3.24.0-3.0-calient-0.dev-1305-g13d6dbddb5fd`, operator `v1.45.0-0.dev-13-g5615c1ab5e8e`, kubectl `v1.35.2`, on a GCP kubeadm cluster with no load balancer provider.

`scripts/vale-lint.sh --no-exit --minAlertLevel=warning` reports 0 errors, 0 warnings and 0 suggestions on both files.

Merge checklist:
- [ ] Deploy preview inspected wherever changes were made
- [ ] Build completed successfully
- [ ] Test have passed
