### PR TITLE
DOCS-3000: Publish Calico Enterprise 3.23.2

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -268,3 +268,13 @@ This release is supported for use in production.
 #### Upgrading
 
 To update an existing installation of Calico Enterprise 3.23, see [Install a patch release](../getting-started/manifest-archive.mdx).
+
+### Calico Enterprise 3.23.2 bug fix release
+
+August 20, 2026
+
+#### Bug fixes
+
+* TBD
+
+To update an existing installation of Calico Enterprise 3.23, see [Install a patch release](../getting-started/manifest-archive.mdx).

--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -179,6 +179,7 @@ GA = generally available, Deprecated = scheduled for removal, Removed = no longe
 * In clusters using the eBPF data plane with strict reverse path forwarding (RPF) enabled, link-local discovery packets may be incorrectly dropped. This can interfere with neighbor discovery and local network communication. A fix is planned for an upcoming release.
 * The eBPF data plane on EKS with Kubernetes 1.36 is currently not working, including in combination with Bottlerocket; the issue is under investigation.
 * On ARM64 with the eBPF data plane, the DNS parser can fail to load, which can result in timeouts.
+* On clusters where the Kubernetes API server is reachable only by DNS name and cluster DNS is not yet running — most commonly EKS with the eBPF data plane and `kube-proxy` disabled — an install or upgrade can deadlock, because calico-node inherits the operator's `ClusterFirstWithHostNet` DNS policy. As a workaround, set `dnsPolicy` and `dnsConfig` in the `tigera-operator` Helm chart values; calico-node inherits them. A fix is planned for an upcoming release.
 
 ## Upgrading
 

--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -273,8 +273,37 @@ To update an existing installation of Calico Enterprise 3.23, see [Install a pat
 
 August 20, 2026
 
+#### Enhancements
+
+* The operator-generated CNI config now declares `cniVersion` 1.0.0, as Multus requires on OpenShift 4.23 and later. The new `spec.cni.specVersion` field pins a different version or leaves it operator-managed (`Auto`).
+* Added a startup probe to the calico-node DaemonSet, shortening calico-node rolling updates on large clusters.
+* The DatastoreMigration CRD is now published to the release manifests directory, so it can be installed with `kubectl apply` instead of a path into the source tree.
+
 #### Bug fixes
 
-* TBD
+* Fixed an upgrade failure on eBPF clusters where ordinary pod egress carried the ext-to-service connmark into the FIB lookup, breaking cross-node connectivity including DNS on nodes that use source-based routing.
+* Fixed a deadlock on upgrade where the Calico API server was moved before a deprecated policy blocking it was removed, leaving the `projectcalico.org/v3` API permanently unavailable.
+* Fixed license-agent failing to serve its Prometheus `/metrics` endpoint when no certificate and key are configured, and fixed the shipped network policy selecting Prometheus by a label its pods do not carry.
+* Fixed Felix splitting a flow or DNS log record across a rotation boundary, causing downstream consumers to drop one record per rotation.
+* Fixed Felix dataplane delays under load that could hold up policy programming for new pods: IP set resyncs are now incremental, and the flow log collector's policy re-evaluation is time-boxed so it no longer blocks conntrack and NFLOG processing.
+* Fixed eBPF nodes running a kernel with `lockdown=confidentiality`, such as Talos, spewing `could not enable bpf_trace_printk events` into dmesg on every BPF program load.
+* Fixed HostEndpoint policy blocking UDP return traffic for SNAT'd pod egress in the eBPF dataplane.
+* Fixed Linseed rejecting valid service account tokens after a cluster's service account issuer changed. Unrecognized issuers are now validated via TokenReview.
+* Fixed a BPF program leak in the iptables dataplane with `flowLogsCollectTcpStats` enabled: on kernels without TCX support, each endpoint update stacked a duplicate `calico_tcp_stats` filter, eventually degrading node performance and Felix startup. Existing duplicates are cleaned up.
+* Fixed the Calico Ingress Gateway control plane crash-looping on clusters whose Gateway API CRD set omits `ListenerSet`, `TLSRoute`, or `BackendTLSPolicy`, such as OpenShift. The bundled Envoy Gateway is updated to v1.8.2.
+* Fixed several issues that could stop an egress gateway becoming or staying ready: incorrect egress selector reference counting, the gateway's own health probes and DNS not using its ExternalNetwork in the eBPF dataplane, and ExternalNetwork exit device state being pruned on Felix restart.
+* Fixed a slow memory leak in the eBPF dataplane, where interface state for deleted egress gateway and egress client pods was retained indefinitely.
+* Fixed a window in the eBPF dataplane where a new connection could skip a local workload's ingress policy while that workload's route was still being programmed.
+* Fixed stalled connections in the eBPF dataplane between a client pod and a VM workload on the same node.
+* Fixed Calico advertising a Service IP over BGP from a node whose only local endpoint was not Ready, black-holing traffic for services using `externalTrafficPolicy: Local`.
+* Fixed restarting the `calico-early` container while calico-node was running causing a transient BGP flap that briefly withdrew pod and egress gateway routes.
+* Fixed managed cluster connection status showing "Disconnected" rather than "Not connected yet" before a cluster has connected for the first time.
+* Fixed an Elasticsearch NodeSet being renamed on every reconcile when the LogStorage CR used a non-canonical storage quantity such as `1024Gi`, which repeatedly recreated the Elasticsearch StatefulSet and its PVCs.
+* Fixed a non-deterministic key and certificate pair selection when a secret holds more than one recognized pair, such as during a certificate-rotation overlap.
+* Fixed an "unrecognized format" warning printed by Kubernetes 1.36 when applying the IPReservation CRD.
+* Fixed installing $[prodname] as a Supervisor Service on vSphere Kubernetes Service (VKS), which could fail to deploy to guest clusters. Relocated bundles now install end to end, including in air-gapped registries.
+* Reduced Dikastes CPU and allocation overhead when many policies apply to an endpoint.
+* Updated the ECK operator to 3.4.1, fixing Elasticsearch nodes failing to rejoin after a transport CA rotation, which could stall an upgrade.
+* Security updates.
 
 To update an existing installation of Calico Enterprise 3.23, see [Install a patch release](../getting-started/manifest-archive.mdx).

--- a/calico-enterprise_versioned_docs/version-3.23-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.23-2/releases.json
@@ -1,5 +1,297 @@
 [
   {
+    "title": "v3.23.2",
+    "tigera-operator": {
+      "version": "v1.42.5",
+      "image": "tigera/operator",
+      "registry": "quay.io"
+    },
+    "calico": {
+      "minor_version": "v3.32",
+      "archive_path": "archive"
+    },
+    "components": {
+      "alertmanager": {
+        "version": "v3.23.2",
+        "image": "tigera/alertmanager"
+      },
+      "apiserver": {
+        "version": "v3.23.2",
+        "image": "tigera/apiserver"
+      },
+      "calicoctl": {
+        "version": "v3.23.2",
+        "image": "tigera/calicoctl"
+      },
+      "calicoq": {
+        "version": "v3.23.2",
+        "image": "tigera/calicoq"
+      },
+      "compliance-benchmarker": {
+        "version": "v3.23.2",
+        "image": "tigera/compliance-benchmarker"
+      },
+      "compliance-controller": {
+        "version": "v3.23.2",
+        "image": "tigera/compliance-controller"
+      },
+      "compliance-reporter": {
+        "version": "v3.23.2",
+        "image": "tigera/compliance-reporter"
+      },
+      "compliance-server": {
+        "version": "v3.23.2",
+        "image": "tigera/compliance-server"
+      },
+      "compliance-snapshotter": {
+        "version": "v3.23.2",
+        "image": "tigera/compliance-snapshotter"
+      },
+      "coreos-alertmanager": {
+        "version": "v0.33.0"
+      },
+      "coreos-config-reloader": {
+        "version": "v0.91.0"
+      },
+      "coreos-dex": {
+        "version": "v2.45.1"
+      },
+      "coreos-fluentd": {
+        "version": "1.19.3"
+      },
+      "coreos-prometheus": {
+        "version": "v3.12.0"
+      },
+      "coreos-prometheus-operator": {
+        "version": "v0.91.0"
+      },
+      "csi": {
+        "version": "v3.23.2",
+        "image": "tigera/csi"
+      },
+      "csi-node-driver-registrar": {
+        "version": "v3.23.2",
+        "image": "tigera/node-driver-registrar"
+      },
+      "deep-packet-inspection": {
+        "version": "v3.23.2",
+        "image": "tigera/deep-packet-inspection"
+      },
+      "dex": {
+        "version": "v3.23.2",
+        "image": "tigera/dex"
+      },
+      "dikastes": {
+        "version": "v3.23.2",
+        "image": "tigera/dikastes"
+      },
+      "eck-elasticsearch": {
+        "version": "8.19.16"
+      },
+      "eck-elasticsearch-operator": {
+        "version": "2.16.0"
+      },
+      "eck-kibana": {
+        "version": "8.19.16"
+      },
+      "egress-gateway": {
+        "version": "v3.23.2",
+        "image": "tigera/egress-gateway"
+      },
+      "elastic-tsee-installer": {
+        "version": "v3.23.2",
+        "image": "tigera/intrusion-detection-job-installer"
+      },
+      "elasticsearch": {
+        "version": "v3.23.2",
+        "image": "tigera/elasticsearch"
+      },
+      "elasticsearch-metrics": {
+        "version": "v3.23.2",
+        "image": "tigera/elasticsearch-metrics"
+      },
+      "elasticsearch-operator": {
+        "version": "v3.23.2",
+        "image": "tigera/eck-operator"
+      },
+      "envoy": {
+        "version": "v3.23.2",
+        "image": "tigera/envoy"
+      },
+      "es-gateway": {
+        "version": "v3.23.2",
+        "image": "tigera/es-gateway"
+      },
+      "firewall-integration": {
+        "version": "v3.23.2",
+        "image": "tigera/firewall-integration"
+      },
+      "flexvol": {
+        "version": "v3.23.2",
+        "image": "tigera/pod2daemon-flexvol"
+      },
+      "fluentd": {
+        "version": "v3.23.2",
+        "image": "tigera/fluentd"
+      },
+      "fluentd-windows": {
+        "version": "v3.23.2",
+        "image": "tigera/fluentd-windows"
+      },
+      "gateway-api-envoy-gateway": {
+        "version": "v3.23.2",
+        "image": "tigera/envoy-gateway"
+      },
+      "gateway-api-envoy-proxy": {
+        "version": "v3.23.2",
+        "image": "tigera/envoy-proxy"
+      },
+      "gateway-api-envoy-ratelimit": {
+        "version": "v3.23.2",
+        "image": "tigera/envoy-ratelimit"
+      },
+      "gateway-l7-collector": {
+        "version": "v3.23.2",
+        "image": "tigera/gateway-l7-collector"
+      },
+      "guardian": {
+        "version": "v3.23.2",
+        "image": "tigera/guardian"
+      },
+      "ingress-collector": {
+        "version": "v3.23.2",
+        "image": "tigera/ingress-collector"
+      },
+      "intrusion-detection-controller": {
+        "version": "v3.23.2",
+        "image": "tigera/intrusion-detection-controller"
+      },
+      "istio-install-cni": {
+        "version": "v3.23.2",
+        "image": "tigera/istio-install-cni"
+      },
+      "istio-pilot": {
+        "version": "v3.23.2",
+        "image": "tigera/istio-pilot"
+      },
+      "istio-proxyv2": {
+        "version": "v3.23.2",
+        "image": "tigera/istio-proxyv2"
+      },
+      "istio-ztunnel": {
+        "version": "v3.23.2",
+        "image": "tigera/istio-ztunnel"
+      },
+      "key-cert-provisioner": {
+        "version": "v3.23.2",
+        "image": "tigera/key-cert-provisioner"
+      },
+      "kibana": {
+        "version": "v3.23.2",
+        "image": "tigera/kibana"
+      },
+      "kube-controllers": {
+        "version": "v3.23.2",
+        "image": "tigera/kube-controllers"
+      },
+      "l7-admission-controller": {
+        "version": "v3.23.2",
+        "image": "tigera/l7-admission-controller"
+      },
+      "l7-collector": {
+        "version": "v3.23.2",
+        "image": "tigera/l7-collector"
+      },
+      "license-agent": {
+        "version": "v3.23.2",
+        "image": "tigera/license-agent"
+      },
+      "linseed": {
+        "version": "v3.23.2",
+        "image": "tigera/linseed"
+      },
+      "manager": {
+        "version": "v3.23.2",
+        "image": "tigera/manager"
+      },
+      "node": {
+        "version": "v3.23.2",
+        "image": "tigera/node"
+      },
+      "node-windows": {
+        "version": "v3.23.2",
+        "image": "tigera/node-windows"
+      },
+      "packetcapture": {
+        "version": "v3.23.2",
+        "image": "tigera/packetcapture"
+      },
+      "policy-recommendation": {
+        "version": "v3.23.2",
+        "image": "tigera/policy-recommendation"
+      },
+      "prometheus": {
+        "version": "v3.23.2",
+        "image": "tigera/prometheus"
+      },
+      "prometheus-config-reloader": {
+        "version": "v3.23.2",
+        "image": "tigera/prometheus-config-reloader"
+      },
+      "prometheus-operator": {
+        "version": "v3.23.2",
+        "image": "tigera/prometheus-operator"
+      },
+      "queryserver": {
+        "version": "v3.23.2",
+        "image": "tigera/queryserver"
+      },
+      "test-signer": {
+        "version": "v3.23.2",
+        "image": "tigera/test-signer"
+      },
+      "tigera-cni": {
+        "version": "v3.23.2",
+        "image": "tigera/cni"
+      },
+      "tigera-cni-windows": {
+        "version": "v3.23.2",
+        "image": "tigera/cni-windows"
+      },
+      "tigera-prometheus-service": {
+        "version": "v3.23.2",
+        "image": "tigera/prometheus-service"
+      },
+      "typha": {
+        "version": "v3.23.2",
+        "image": "tigera/typha"
+      },
+      "ui-apis": {
+        "version": "v3.23.2",
+        "image": "tigera/ui-apis"
+      },
+      "upstream-istio": {
+        "version": "1.28.1"
+      },
+      "voltron": {
+        "version": "v3.23.2",
+        "image": "tigera/voltron"
+      },
+      "waf-http-filter": {
+        "version": "v3.23.2",
+        "image": "tigera/waf-http-filter"
+      },
+      "webhooks": {
+        "version": "v3.23.2",
+        "image": "tigera/webhooks"
+      },
+      "webhooks-processor": {
+        "version": "v3.23.2",
+        "image": "tigera/webhooks-processor"
+      }
+    }
+  },
+  {
     "title": "v3.23.1",
     "tigera-operator": {
       "version": "v1.42.4",

--- a/calico-enterprise_versioned_docs/version-3.23-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.23-2/releases.json
@@ -48,7 +48,7 @@
         "image": "tigera/compliance-snapshotter"
       },
       "coreos-alertmanager": {
-        "version": "v0.33.0"
+        "version": "v0.33.1"
       },
       "coreos-config-reloader": {
         "version": "v0.91.0"
@@ -60,7 +60,7 @@
         "version": "1.19.3"
       },
       "coreos-prometheus": {
-        "version": "v3.12.0"
+        "version": "v3.13.2"
       },
       "coreos-prometheus-operator": {
         "version": "v0.91.0"
@@ -86,13 +86,13 @@
         "image": "tigera/dikastes"
       },
       "eck-elasticsearch": {
-        "version": "8.19.16"
+        "version": "8.19.20"
       },
       "eck-elasticsearch-operator": {
-        "version": "2.16.0"
+        "version": "3.4.1"
       },
       "eck-kibana": {
-        "version": "8.19.16"
+        "version": "8.19.20"
       },
       "egress-gateway": {
         "version": "v3.23.2",
@@ -271,7 +271,7 @@
         "image": "tigera/ui-apis"
       },
       "upstream-istio": {
-        "version": "1.28.1"
+        "version": "1.29.6"
       },
       "voltron": {
         "version": "v3.23.2",

--- a/calico-enterprise_versioned_docs/version-3.23-2/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.23-2/variables.js
@@ -21,7 +21,7 @@ const variables = {
   noderunning: 'calico-node',
   rootDirWindows: 'C:\\TigeraCalico',
   registry: 'quay.io/',
-  envoyVersion: '1.8.0',
+  envoyVersion: '1.8.3',
   chart_version_name: 'v3.23.2-0',
   tigeraOperator: releases[0]['tigera-operator'],
   dikastesVersion: releases[0].components.dikastes.version,

--- a/calico-enterprise_versioned_docs/version-3.23-2/variables.js
+++ b/calico-enterprise_versioned_docs/version-3.23-2/variables.js
@@ -2,14 +2,14 @@ const releases = require('./releases.json');
 const componentImage = require('../../src/components/utils/componentImage');
 
 const variables = {
-  releaseTitle: 'v3.23.1',
-  helmPre: 'v3.23.1'.includes('-') ? ' --devel' : '',
+  releaseTitle: 'v3.23.2',
+  helmPre: 'v3.23.2'.includes('-') ? ' --devel' : '',
   prodname: 'Calico Enterprise',
   prodnamedash: 'calico-enterprise',
   version: 'v3.23',
   openSourceVersion: releases[0].calico.minor_version.slice(1),
   baseUrl: '/calico-enterprise/latest',
-  filesUrl: 'https://downloads.tigera.io/ee/v3.23.1',
+  filesUrl: 'https://downloads.tigera.io/ee/v3.23.2',
   rhelPkgUrl: 'https://downloads.tigera.io/ee/rpms/' + releases[0].title.slice(0, 5),
   debPkgUrl: 'https://downloads.tigera.io/ee/debs/' + releases[0].title.slice(0, 5),
   tutorialFilesURL: 'https://docs.tigera.io/files',
@@ -22,7 +22,7 @@ const variables = {
   rootDirWindows: 'C:\\TigeraCalico',
   registry: 'quay.io/',
   envoyVersion: '1.8.0',
-  chart_version_name: 'v3.23.1-0',
+  chart_version_name: 'v3.23.2-0',
   tigeraOperator: releases[0]['tigera-operator'],
   dikastesVersion: releases[0].components.dikastes.version,
   releases,


### PR DESCRIPTION
Starter PR for the Calico Enterprise 3.23.2 patch release. It adds the release to the 3.23-2 docs stream and changes three files: releases.json, variables.js, and release-notes/index.mdx.

Ticket: https://tigera.atlassian.net/browse/DOCS-3000

Left to do, by Delivery Engineering:

- Replace the TBD bug fix list with the real one.
- Add known issues, if there are any.
- Confirm the release date, currently August 20, 2026.
- Run the third-party version sync from release-calient-v3.23, once that branch is ready.
- Update the operator API reference, if it changed.

Two things to flag:

- The operator version v1.42.5 is an expectation, not a verified value. It is not yet tagged in tigera/operator.
- The deploy preview fails, and it will keep failing until the release artifacts are published. The link checker reports 45 dead links. All 45 are v3.23.2 files on downloads.tigera.io that return 403 today. There are no other failures, and the site build itself passes. Calico Enterprise latest is 3.23, which is why these links are checked at all.
