### PR TITLE
DOCS-2997: Add the L2 bridge networking page structure

### DIFF
--- a/calico-enterprise/networking/l2-bridge/about-l2-bridge.mdx
+++ b/calico-enterprise/networking/l2-bridge/about-l2-bridge.mdx
@@ -1,0 +1,97 @@
+---
+description: How Calico Enterprise puts VMs and pods on your existing VLANs, which bridge mode your nodes need, and where network policy is enforced.
+---
+
+# About L2 bridge networking
+
+:::note
+
+L2 bridge networking is a tech preview feature. APIs and behavior may change before GA.
+
+:::
+
+## Why L2 networking in $[prodname]
+
+Why the feature exists, and what $[prodname] adds that a hand-built bridge cannot.
+
+## What it is
+
+L2 bridge networking is additive and opt-in. A cluster that creates no `Network` resources is unchanged.
+
+## VMs and pods are not the same here
+
+The feature is aimed at VMs, and VMs are configured differently from pods. This shapes every procedure that follows.
+
+## The model
+
+The objects and devices involved, and how a frame gets from a workload to your fabric.
+
+### Networks, VLANs, and subnets
+
+What a `Network` resource models, and why one network with several VLANs is usually the right shape.
+
+### Bridges, trunk ports, and access ports
+
+The three roles a device plays in an L2 network.
+
+### How tagging works
+
+Where VLAN tags are added and removed, and what the workload sees on its interface.
+
+### What is not supported
+
+The bridge and trunk topologies $[prodname] does not handle in this release.
+
+## Which bridge mode do you need
+
+The choice is not about how many network cards a node has. It is about whether $[prodname] can have an uplink of its own.
+
+### $[prodname] can have its own uplink
+
+Managed mode, and why it is the simpler option wherever it applies.
+
+### The uplink is shared with the host
+
+Why a shared uplink means you prepare the bridge, and why managed mode cannot work in that case.
+
+## Who owns the host network configuration
+
+Why $[prodname] refuses to reconfigure a bridge it did not create, and what it still does on a bridge you own.
+
+### How the host shares the bridge
+
+Where the node's own address sits when the bridge carries both host and workload traffic.
+
+## Where policy is enforced
+
+An L2 workload gets the same policy enforcement as any other $[prodname] workload. This section explains why.
+
+## How a workload is brought up safely
+
+The ordering rule that keeps an unpoliced interface from ever being live on a shared segment.
+
+## What protects the segment
+
+An L2 segment reintroduces spoofing and flooding surfaces that a routed network does not have. This is what $[prodname] does about them.
+
+## How traffic flows
+
+Three paths, with different consequences for your fabric and your firewall rules.
+
+### Same VLAN, same host
+
+### Same VLAN, across the fabric
+
+### Between an L2 network and the pod network
+
+## Why the eBPF data plane only
+
+The reasoning behind the constraint, rather than just the constraint.
+
+## What $[prodname] must own
+
+Why addressing runs through $[prodname] IPAM rather than an external DHCP server.
+
+## What is not in this release
+
+## Additional resources

--- a/calico-enterprise/networking/l2-bridge/byo-bridge.mdx
+++ b/calico-enterprise/networking/l2-bridge/byo-bridge.mdx
@@ -1,0 +1,71 @@
+---
+description: Configure a Linux bridge on your nodes so Calico Enterprise can use it, for nodes whose only uplink also carries the node's own IP address.
+---
+
+# Prepare an existing bridge for $[prodname]
+
+:::note
+
+L2 bridge networking is a tech preview feature. APIs and behavior may change before GA.
+
+:::
+
+Use this guide when the uplink that must carry your VLANs is also the one your node's IP address depends on. $[prodname] cannot take that interface over on its own, so you build the bridge and $[prodname] uses it.
+
+The goal is not to move a running address onto a bridge. It is to have the host bring the bridge up correctly at boot, so the node's address arrives in the right place the first time.
+
+## Before you begin
+
+This procedure changes how your nodes get their IP addresses. Read this section before you start.
+
+## What you are building
+
+Before and after, so the configuration further down makes sense.
+
+## What $[prodname] requires
+
+Three settings on the bridge. $[prodname] checks all three and will not use a bridge that is missing any of them.
+
+### Why the MAC address must be pinned, and must not be the trunk's
+
+Two separate failures, both avoided by the same setting.
+
+### What $[prodname] does not require
+
+Just as useful as the required list, and it keeps the required list credible.
+
+### Two hazards that are not settings
+
+A naming collision that deletes your bridge, and an option that quietly slows workload startup.
+
+## Configure the host
+
+Write this as persistent configuration. A change that does not survive a reboot is a trap.
+
+### Where the host's address goes
+
+Two shapes, depending on whether your host's own traffic is tagged.
+
+### Self VLAN membership
+
+The step that is easiest to miss, and the one most likely to take a node off the network.
+
+### An annotated example
+
+A complete configuration with every line explained.
+
+## Point Felix at the right L3 device
+
+Once the node's address lives on the bridge, $[prodname] needs to be told where to find it.
+
+## Verify before handing the bridge over
+
+Two rounds of checks. Some failures only appear when the first workload attaches.
+
+## Reference the bridge from a Network
+
+## If $[prodname] will not use your bridge
+
+What the refusal looks like, and where to look first.
+
+## Additional resources

--- a/calico-enterprise/networking/l2-bridge/connect-vlan.mdx
+++ b/calico-enterprise/networking/l2-bridge/connect-vlan.mdx
@@ -1,0 +1,65 @@
+---
+description: Expose one of your existing VLANs to the cluster with a Calico-managed bridge, then attach a KubeVirt VM or a pod to it.
+---
+
+# Connect workloads to an existing VLAN
+
+:::note
+
+L2 bridge networking is a tech preview feature. APIs and behavior may change before GA.
+
+:::
+
+Use this guide when $[prodname] can take over an uplink of its own. If the only uplink on your nodes also carries the node's own IP address, start with [Prepare an existing bridge](byo-bridge.mdx) and return here afterwards.
+
+## Before you begin
+
+Check all of these before you start. Each one is a hard requirement, and the failures they cause are easier to avoid than to diagnose.
+
+## Set the multi-interface mode
+
+$[prodname] needs to know that Multus is in use. Nothing warns you if this is missed, so do it before anything else.
+
+## Gather your network details
+
+Collect these values first. Getting the subnet or the interface name wrong surfaces later as a workload that will not start.
+
+## Create an IP pool for each workload VLAN
+
+The pool must exist before the `Network`, and its CIDR must line up with the VLAN's subnet.
+
+## Create the Network resource
+
+One `Network` describes the whole L2 network: its VLANs, and how each node reaches them.
+
+### Tagged trunk
+
+### Untagged traffic and the native VLAN
+
+For a segment your switch presents untagged.
+
+### Nodes with different interface names
+
+When the trunk interface is not called the same thing on every node.
+
+## Create a NetworkAttachmentDefinition for each VLAN
+
+Multus needs one attachment definition per VLAN you want workloads on.
+
+## Attach a VM
+
+For a VM, declare the interface in the VM specification. Do not edit the launcher pod's annotations.
+
+### Attaching a pod instead
+
+### Attaching a workload to more than one VLAN
+
+### Using an L2 network as the primary interface
+
+Possible for both VMs and pods, with a significant trade-off.
+
+## Verify
+
+Work outwards from the node to the fabric, so a failure tells you where to look.
+
+## Additional resources

--- a/calico-enterprise/networking/l2-bridge/index.mdx
+++ b/calico-enterprise/networking/l2-bridge/index.mdx
@@ -1,0 +1,11 @@
+---
+description: Put KubeVirt VMs and pods directly on your existing VLANs, keeping their IP addresses, MAC addresses, and L2 adjacency.
+hide_table_of_contents: true
+---
+
+# L2 bridge networking
+
+import DocCardList from '@theme/DocCardList';
+import { useCurrentSidebarCategory } from '@docusaurus/theme-common';
+
+<DocCardList items={useCurrentSidebarCategory().items} />

--- a/calico-enterprise/networking/l2-bridge/troubleshoot.mdx
+++ b/calico-enterprise/networking/l2-bridge/troubleshoot.mdx
@@ -1,0 +1,49 @@
+---
+description: Diagnose connectivity problems on Calico Enterprise L2 bridge networks, from bridge prerequisites to VLAN and trunk misconfiguration.
+---
+
+# Troubleshoot L2 network connectivity
+
+:::note
+
+L2 bridge networking is a tech preview feature. APIs and behavior may change before GA.
+
+:::
+
+Most L2 problems fall into a handful of shapes. Find your symptom below.
+
+## Where the signals are
+
+Read this first. L2 bridge problems report themselves in an unusual place, and looking anywhere else wastes time.
+
+## Collect diagnostic information
+
+What to gather before opening a support case, including the bridge state that the standard bundle does not capture.
+
+## $[prodname] will not use the bridge I prepared
+
+## A workload came up with two eth0 interfaces and no connectivity
+
+## The workload has no IP address, or will not start
+
+## The bridge was never created on this node
+
+## The node lost connectivity while I was configuring the bridge
+
+## The workload cannot reach its gateway
+
+## Traffic works on one node but not across the fabric
+
+## Source IP policy is not matching
+
+## A pod on an L2 network cannot reach cluster IP addresses
+
+## The MAC address is not what I asked for
+
+## Capturing traffic hides the problem
+
+On some network cards, the act of capturing changes the behavior you are trying to observe.
+
+## Workloads lost connectivity after a Network was deleted
+
+## Additional resources

--- a/calico-enterprise/networking/l2-bridge/vm-identity.mdx
+++ b/calico-enterprise/networking/l2-bridge/vm-identity.mdx
@@ -1,0 +1,47 @@
+---
+description: Bring a KubeVirt VM onto an L2 network holding its original IP address and MAC address, so the systems that depend on it keep working.
+---
+
+# Bring a VM over with its IP and MAC
+
+:::note
+
+L2 bridge networking is a tech preview feature. APIs and behavior may change before GA.
+
+:::
+
+A VM that keeps its address and MAC keeps its identity: DNS entries, firewall rules, license servers, and monitoring all continue to work without being updated.
+
+## Before you begin
+
+## How identity is preserved
+
+The address and MAC are declared before the VM starts. Nothing is renumbered afterwards.
+
+## Set the MAC address
+
+Two mechanisms, either of which works. Setting both to conflicting values is rejected.
+
+## Set the IP address
+
+### Use ipAddrs rather than ipAddrsNoIpam
+
+Both request a specific address. Only one leaves $[prodname] able to enforce policy on it.
+
+### One address per family
+
+## Confirm what was configured
+
+$[prodname] writes back what it actually applied. This is the authoritative record.
+
+## Verify from the network
+
+Check from outside the cluster, because that is what the VM's identity is for.
+
+## Using Forklift
+
+Where a migration tool sets these values for you.
+
+## What to expect during migration
+
+## Additional resources

--- a/calico-enterprise/reference/l2-bridge-support.mdx
+++ b/calico-enterprise/reference/l2-bridge-support.mdx
@@ -1,0 +1,41 @@
+---
+description: What Calico Enterprise L2 bridge networking supports and does not support - data plane, platform, topology, addressing, and Kubernetes integration.
+---
+
+# L2 bridge support and limitations
+
+:::note
+
+L2 bridge networking is a tech preview feature. APIs and behavior may change before GA.
+
+:::
+
+Check this page before you design around L2 bridge networking. The constraints are narrower than the rest of $[prodname] networking.
+
+## Status
+
+## Data plane support
+
+## Platform requirements
+
+## Prerequisites
+
+## Bridge and topology support
+
+## Addressing
+
+## Traffic types
+
+## Kubernetes integration
+
+## Primary and secondary interfaces
+
+## Observability
+
+## Sizing guidance
+
+## Lifecycle
+
+## Not in this release
+
+Features that are planned or under consideration, with no committed timing.

--- a/data/feature-status.yaml
+++ b/data/feature-status.yaml
@@ -91,6 +91,12 @@ features:
       calico-enterprise:
         "3.23": tech-preview
 
+  - id: l2-bridge-networking
+    name: L2 bridge networking
+    products:
+      calico-enterprise:
+        "3.24": tech-preview
+
   - id: l7-logging-envoy
     name: L7 logging with Envoy
     products:

--- a/sidebars-calico-enterprise.js
+++ b/sidebars-calico-enterprise.js
@@ -195,6 +195,19 @@ module.exports = {
         },
         {
           type: 'category',
+          label: 'L2 bridge networking',
+          link: { type: 'doc', id: 'networking/l2-bridge/index' },
+          items: [
+            'networking/l2-bridge/about-l2-bridge',
+            'networking/l2-bridge/connect-vlan',
+            'networking/l2-bridge/byo-bridge',
+            'networking/l2-bridge/vm-identity',
+            'networking/l2-bridge/troubleshoot',
+            'reference/l2-bridge-support',
+          ],
+        },
+        {
+          type: 'category',
           label: 'Calico Enterprise networking for KubeVirt',
           link: { type: 'doc', id: 'networking/kubevirt/index' },
           items: [


### PR DESCRIPTION
Adds the page structure for L2 bridge networking in Calico Enterprise next. This is the first of a sequence of PRs. It lands the architecture so the page PRs that follow can each be reviewed on their own.

What this PR does:

- Adds a new L2 bridge networking category under Networking, with the category landing page.
- Adds a skeleton for each page in the set: the concept page, the two setup guides, the VM identity guide, and the troubleshooting guide.
- Adds a skeleton for the support and limitations reference page.
- Wires all of it into the Calico Enterprise sidebar.
- Adds the feature-status entry so the tech preview status renders in the feature status table.

Each skeleton carries its headings and a short note under each heading saying what the section covers, so this reviews as an outline. The page bodies follow in later PRs, in the order a reader needs them: concept, then support and limitations, then the two setup guides, then VM identity, then troubleshooting, then the API reference.

Two things worth a reviewer's attention:

- The support and limitations page lives under reference, following strict Diataxis, but appears inside the L2 bridge category in the sidebar so readers meet it beside the pages that cite it. Easy to move if you would rather it sat under Reference.
- The feature ships as tech preview, so every page carries a tech preview admonition.

The plan behind this sequence, including the user stories each page serves and the open questions still with engineering, is tracked in DOCS-2997.