### PR TITLE
DOCS-2997: Write the guide for connecting workloads to a VLAN

### DIFF
--- a/calico-enterprise/networking/l2-bridge/connect-vlan.mdx
+++ b/calico-enterprise/networking/l2-bridge/connect-vlan.mdx
@@ -35,7 +35,9 @@ Every item here is a hard requirement.
 The failures they cause are cheaper to avoid than to diagnose.
 
 - $[prodname] running the eBPF data plane.
-- Linux kernel 5.18 or later on every node that will carry the network.
+- A kernel supporting the bridge port `locked` flag on every node that will carry the network.
+  That arrived upstream in 5.18, but some distributions backport it: RHEL 9 and RHCOS report 5.14 and meet the requirement.
+  See [Platform requirements](../../reference/l2-bridge-support.mdx#platform-requirements).
 - An active $[prodname] license.
 - [Multus](../configuring/multiple-networks.mdx) installed.
   Every procedure on this page attaches the L2 network as an additional interface, which is what Multus does, so it is required here.

--- a/calico-enterprise/networking/l2-bridge/connect-vlan.mdx
+++ b/calico-enterprise/networking/l2-bridge/connect-vlan.mdx
@@ -25,7 +25,9 @@ Use this guide when your L2 trunk is separate from your host's primary NIC — f
 $[prodname] creates the bridge, enslaves that interface as the trunk, and attaches your workloads to it.
 
 If the only uplink on your nodes also carries the node's own IP address, $[prodname] cannot create the bridge.
-Start with [Prepare an existing bridge](byo-bridge.mdx), then return here from step 3 onwards.
+Start with [Prepare an existing bridge](byo-bridge.mdx), which covers building the bridge and writing the `Network` for it.
+Come back here for the IP pools, the reserved addresses, the attachment definitions, and attaching your first workload.
+Skip [Create the Network resource](#create-the-network-resource): the examples in it use `managedBridge`, which is the case where $[prodname] builds the bridge, not yours.
 
 ## Before you begin
 
@@ -35,7 +37,9 @@ The failures they cause are cheaper to avoid than to diagnose.
 - $[prodname] running the eBPF data plane.
 - Linux kernel 5.18 or later on every node that will carry the network.
 - An active $[prodname] license.
-- [Multus](../configuring/multiple-networks.mdx) installed, for attaching the L2 network as an additional interface.
+- [Multus](../configuring/multiple-networks.mdx) installed.
+  Every procedure on this page attaches the L2 network as an additional interface, which is what Multus does, so it is required here.
+  A workload taking an L2 network as its primary interface is configured with annotations instead and does not need Multus; see [Primary and secondary interfaces](../../reference/l2-bridge-support.mdx#primary-and-secondary-interfaces).
   OpenShift includes Multus by default.
   On other platforms it is a third-party component that $[prodname] does not ship.
 - KubeVirt installed, if you are attaching VMs.

--- a/calico-enterprise/networking/l2-bridge/connect-vlan.mdx
+++ b/calico-enterprise/networking/l2-bridge/connect-vlan.mdx
@@ -6,60 +6,361 @@ description: Expose one of your existing VLANs to the cluster with a Calico-mana
 
 :::note
 
-L2 bridge networking is a tech preview feature. APIs and behavior may change before GA.
+L2 bridge networking is a tech preview feature.
+APIs and behavior may change before GA.
 
 :::
 
-Use this guide when $[prodname] can take over an uplink of its own. If the only uplink on your nodes also carries the node's own IP address, start with [Prepare an existing bridge](byo-bridge.mdx) and return here afterwards.
+Use this guide when $[prodname] can take over an interface of its own.
+$[prodname] creates the bridge, enslaves that interface as the trunk, and attaches your workloads to it.
+
+If the only uplink on your nodes also carries the node's own IP address, $[prodname] cannot create the bridge.
+Start with [Prepare an existing bridge](byo-bridge.mdx), then return here from step 3 onwards.
 
 ## Before you begin
 
-Check all of these before you start. Each one is a hard requirement, and the failures they cause are easier to avoid than to diagnose.
+Every item here is a hard requirement.
+The failures they cause are cheaper to avoid than to diagnose.
+
+- $[prodname] running the eBPF data plane.
+- Linux kernel 5.18 or later on every node that will carry the network.
+- An active $[prodname] license.
+- [Multus](../configuring/multiple-networks.mdx) installed.
+  Multus is a third-party component and $[prodname] does not ship it.
+- KubeVirt installed, if you are attaching VMs.
+- An interface on each node that $[prodname] can take over, carrying your VLANs as a trunk, and **not** carrying the node's own IP address.
+
+For the full set of constraints, see [L2 bridge support and limitations](../../reference/l2-bridge-support.mdx).
 
 ## Set the multi-interface mode
 
-$[prodname] needs to know that Multus is in use. Nothing warns you if this is missed, so do it before anything else.
+$[prodname] has to be told that Multus is in use.
+This is a separate setting from installing Multus itself, and nothing reports its absence.
+The symptom appears much later, as a workload that comes up with two interfaces called `eth0` and no connectivity at all.
+
+1. Check the current value:
+
+   ```bash
+   kubectl get installation default -o jsonpath='{.spec.calicoNetwork.multiInterfaceMode}'
+   ```
+
+2. If it is not `Multus`, set it:
+
+   ```bash
+   kubectl patch installation default --type=merge \
+     -p '{"spec":{"calicoNetwork":{"multiInterfaceMode":"Multus"}}}'
+   ```
+
+3. Wait for `tigerastatus` to report all components as available:
+
+   ```bash
+   kubectl get tigerastatus
+   ```
 
 ## Gather your network details
 
-Collect these values first. Getting the subnet or the interface name wrong surfaces later as a workload that will not start.
+Collect these before you write any manifests.
+A subnet or interface name that does not match reality surfaces later as a workload that will not start.
+
+For each VLAN you intend to use:
+
+- The VLAN ID.
+- The subnet on that VLAN, in CIDR notation.
+- The default gateway on that subnet.
+- The range of addresses you are willing to let $[prodname] assign.
+
+And for the nodes:
+
+- The name of the trunk interface.
+- Whether that name is the same on every node.
+  If it is not, you need one host configuration entry per naming scheme.
 
 ## Create an IP pool for each workload VLAN
 
-The pool must exist before the `Network`, and its CIDR must line up with the VLAN's subnet.
+The pool has to exist before the `Network`.
+$[prodname] IPAM chooses a pool by checking which pools fall inside the VLAN's subnet, so a pool that does not match fails at workload creation with an error that does not obviously point back here.
+
+A VLAN that carries only host traffic does not need a pool.
+Create pools only for the VLANs your workloads will use.
+
+1. Create a pool whose CIDR sits inside the VLAN's subnet:
+
+   ```yaml
+   apiVersion: projectcalico.org/v3
+   kind: IPPool
+   metadata:
+     name: vlan-10-pool
+   spec:
+     cidr: 10.10.0.0/24
+     allowedUses:
+       - L2Workload
+     disableBGPExport: true
+   ```
+
+2. Apply it, and repeat for each workload VLAN.
+
+`allowedUses: L2Workload` marks the pool as belonging to an L2 network.
+Without it, $[prodname] treats the block as part of the routed pod network: it programs a blackhole route for it and advertises it over BGP, neither of which is correct for addresses that live on your VLAN.
+
+$[prodname] does not assign the first and last addresses of a subnet, or the gateway address.
+Size the pool with that in mind.
 
 ## Create the Network resource
 
-One `Network` describes the whole L2 network: its VLANs, and how each node reaches them.
+One `Network` describes the whole L2 network: the VLANs it carries, and how each node reaches them.
+
+Prefer one `Network` carrying several VLANs over several Networks carrying one each.
+Every `Network` adds work for $[prodname] on each node it selects.
+
+1. Write the `Network`, listing each VLAN with its subnet, and one host configuration entry describing the bridge and the trunk:
+
+   ```yaml
+   apiVersion: projectcalico.org/v3
+   kind: Network
+   metadata:
+     name: vlan-trunk
+   spec:
+     l2Bridge:
+       hostConfig:
+         - nodeSelector: ''
+           bridge:
+             managedBridge: {}
+           hostConnections:
+             - trunkPort:
+                 interface:
+                   name: eno2
+       vlans:
+         - vlan: { id: 10 }
+           subnets:
+             - cidr: 10.10.0.0/24
+         - vlan: { id: 20 }
+           subnets:
+             - cidr: 10.20.0.0/24
+   ```
+
+2. Apply it.
+3. Confirm $[prodname] created the bridge on a node that the selector matches:
+
+   ```bash
+   ip -br link show type bridge
+   ```
+
+`managedBridge: {}` tells $[prodname] to create and own the bridge.
+It derives the bridge name per node, so do not expect a name you chose.
+An empty `nodeSelector` applies the entry to every node.
 
 ### Tagged trunk
 
+The configuration above is the strict case: every VLAN is tagged on the wire, and the switch port facing the node is configured as a trunk carrying VLANs 10 and 20.
+
+This is the arrangement to prefer.
+Tagging is explicit in both directions, so there is no ambiguity about which VLAN a frame belongs to.
+
 ### Untagged traffic and the native VLAN
 
-For a segment your switch presents untagged.
+If your switch presents one segment untagged, set a native VLAN on the trunk port.
+It tells $[prodname] which VLAN untagged traffic arriving on that interface belongs to.
+
+```yaml
+hostConnections:
+  - trunkPort:
+      interface:
+        name: eno2
+      nativeVLAN: 10
+```
+
+The native VLAN must be one the `Network` defines.
+$[prodname] rejects a `Network` that names a native VLAN not present in its `vlans` list.
 
 ### Nodes with different interface names
 
-When the trunk interface is not called the same thing on every node.
+If the trunk is not called the same thing on every node, add one host configuration entry per naming scheme and select nodes with `nodeSelector`.
+
+```yaml
+hostConfig:
+  - nodeSelector: has(hardware) && hardware == "gen2"
+    bridge:
+      managedBridge: {}
+    hostConnections:
+      - trunkPort:
+          interface:
+            name: eno2
+  - nodeSelector: ''
+    bridge:
+      managedBridge: {}
+    hostConnections:
+      - trunkPort:
+          interface:
+            name: ens1f1
+```
+
+Entries are evaluated in order and **the first match wins**.
+Everything after it is ignored for that node — entries are not merged.
+Put your most specific selectors first and a catch-all last.
 
 ## Create a NetworkAttachmentDefinition for each VLAN
 
 Multus needs one attachment definition per VLAN you want workloads on.
+The definition names the `Network` and the VLAN within it.
+
+1. Create the definition:
+
+   ```yaml
+   apiVersion: 'k8s.cni.cncf.io/v1'
+   kind: NetworkAttachmentDefinition
+   metadata:
+     name: vlan-10
+   spec:
+     config: '{
+       "cniVersion": "0.3.1",
+       "type": "calico",
+       "network": "vlan-trunk",
+       "vlan": 10,
+       "log_level": "info",
+       "datastore_type": "kubernetes",
+       "nodename_file_optional": false,
+       "ipam": {
+         "type": "calico-ipam",
+         "assign_ipv4": "true",
+         "assign_ipv6": "false",
+         "ipv4_pools": ["vlan-10-pool"]
+       },
+       "policy": {
+         "type": "k8s"
+       },
+       "kubernetes": {
+         "kubeconfig": "/etc/cni/net.d/calico-kubeconfig"
+       }
+       }'
+   ```
+
+2. Apply it in the namespace where your workloads will run, and repeat for each VLAN.
+
+Set `vlan` explicitly.
+Create the definition in the same namespace as the workloads that reference it, or reference it across namespaces with the `namespace/name` form.
 
 ## Attach a VM
 
-For a VM, declare the interface in the VM specification. Do not edit the launcher pod's annotations.
+This is the main path for the feature.
+For a VM you declare the interface in the VM specification, alongside the VM's other devices.
+Do not annotate the launcher pod that KubeVirt creates — KubeVirt builds it from the specification below.
+
+1. Add an interface to the VM's device list, and a matching network referencing the attachment definition:
+
+   ```yaml
+   apiVersion: kubevirt.io/v1
+   kind: VirtualMachine
+   metadata:
+     name: app-server
+   spec:
+     template:
+       spec:
+         domain:
+           devices:
+             interfaces:
+               - name: vlan10
+                 bridge: {}
+         networks:
+           - name: vlan10
+             multus:
+               networkName: vlan-10
+   ```
+
+2. Start the VM and confirm it received an address from the pool:
+
+   ```bash
+   kubectl get vmi app-server -o jsonpath='{.status.interfaces}'
+   ```
+
+3. From inside the VM, confirm the interface is up and the address is configured.
+   KubeVirt serves the address over DHCP inside the VM, so the guest configures itself as it would on any network.
+
+The `bridge: {}` here is KubeVirt's own interface binding, which attaches the VM to the interface $[prodname] built.
+It is unrelated to the $[prodname] L2 bridge — the two uses of the word are unfortunate but distinct.
+
+To give the VM a specific address and MAC address rather than whatever the pool offers, see [Bring a VM over with its IP and MAC](vm-identity.mdx).
 
 ### Attaching a pod instead
 
+A pod references the attachment definition through an annotation, giving the interface a name inside the pod.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-with-vlan10
+  annotations:
+    k8s.v1.cni.cncf.io/networks: vlan-10@vlan10
+spec:
+  containers:
+    - name: app
+      image: nginx
+```
+
+The name after `@` is the interface name inside the pod.
+It is also the name that scopes per-interface annotations, such as a requested address, so choose it deliberately.
+
 ### Attaching a workload to more than one VLAN
+
+List one attachment definition per VLAN, each with its own interface name.
+A workload gets one access port per VLAN, and each port belongs to exactly one VLAN.
+
+```yaml
+annotations:
+  k8s.v1.cni.cncf.io/networks: vlan-10@vlan10,vlan-20@vlan20
+```
+
+For a VM, add a second interface and network pair to the specification in the same way.
 
 ### Using an L2 network as the primary interface
 
-Possible for both VMs and pods, with a significant trade-off.
+A workload can take an L2 network as its primary interface instead of an additional one, set with annotations rather than through Multus.
+See the [Network resource](../../reference/resources/network.mdx) for the annotations.
+
+Understand the trade-off before you do this.
+The workload has no route to or from the Kubernetes network.
+For a pod that is normally unacceptable, because kubelet cannot reach it for readiness and liveness checks.
+For a VM meant to behave like a traditional server on a VLAN, it is often what you want.
 
 ## Verify
 
-Work outwards from the node to the fabric, so a failure tells you where to look.
+Work outward from the node to your fabric, so that a failure tells you where to look.
+
+1. Confirm the `Network` exists and $[prodname] accepted it:
+
+   ```bash
+   kubectl get network vlan-trunk -o yaml
+   ```
+
+2. On a node running one of your workloads, confirm the trunk is enslaved to the bridge:
+
+   ```bash
+   ip link show master <bridge-name>
+   ```
+
+3. Confirm VLAN membership on the trunk port and on the workload's port:
+
+   ```bash
+   bridge vlan show
+   ```
+
+4. Confirm the bridge has learned the workload's MAC address:
+
+   ```bash
+   bridge fdb show
+   ```
+
+5. From the workload, ping its default gateway.
+   This proves the path out through the trunk to your fabric.
+6. From an existing machine on the same VLAN, outside the cluster, ping the workload.
+   This proves the return path, which is the half that fabric misconfiguration breaks.
+
+If any step fails, see [Troubleshoot L2 network connectivity](troubleshoot.mdx).
 
 ## Additional resources
+
+- [About L2 bridge networking](about-l2-bridge.mdx)
+- [Prepare an existing bridge](byo-bridge.mdx)
+- [Bring a VM over with its IP and MAC](vm-identity.mdx)
+- [L2 bridge support and limitations](../../reference/l2-bridge-support.mdx)
+- [Network resource](../../reference/resources/network.mdx)

--- a/calico-enterprise/networking/l2-bridge/connect-vlan.mdx
+++ b/calico-enterprise/networking/l2-bridge/connect-vlan.mdx
@@ -2,6 +2,16 @@
 description: Expose one of your existing VLANs to the cluster with a Calico-managed bridge, then attach a KubeVirt VM or a pod to it.
 ---
 
+{/*
+  User story, primary
+  S4: As a network engineer, I want to expose one of my existing VLANs to the cluster and put a VM on it, so that cluster workloads share a broadcast domain with my existing servers.
+
+  User stories, subsidiary
+  S5: completes the prepared-bridge path, for readers who arrive here from that guide.
+
+  Story ladder and page plan: DOCS-2997.
+*/}
+
 # Connect workloads to an existing VLAN
 
 :::note

--- a/calico-enterprise/networking/l2-bridge/connect-vlan.mdx
+++ b/calico-enterprise/networking/l2-bridge/connect-vlan.mdx
@@ -21,7 +21,7 @@ APIs and behavior may change before GA.
 
 :::
 
-Use this guide when $[prodname] can take over an interface of its own.
+Use this guide when your L2 trunk is separate from your host's primary NIC — for example, the primary NIC is `eth0` and the L2 trunk is `eth1`.
 $[prodname] creates the bridge, enslaves that interface as the trunk, and attaches your workloads to it.
 
 If the only uplink on your nodes also carries the node's own IP address, $[prodname] cannot create the bridge.
@@ -35,10 +35,14 @@ The failures they cause are cheaper to avoid than to diagnose.
 - $[prodname] running the eBPF data plane.
 - Linux kernel 5.18 or later on every node that will carry the network.
 - An active $[prodname] license.
-- [Multus](../configuring/multiple-networks.mdx) installed.
-  Multus is a third-party component and $[prodname] does not ship it.
+- [Multus](../configuring/multiple-networks.mdx) installed, for attaching the L2 network as an additional interface.
+  OpenShift includes Multus by default.
+  On other platforms it is a third-party component that $[prodname] does not ship.
 - KubeVirt installed, if you are attaching VMs.
-- An interface on each node that $[prodname] can take over, carrying your VLANs as a trunk, and **not** carrying the node's own IP address.
+- On each node, an interface cabled to a switch port configured as a trunk carrying your workload VLANs.
+  $[prodname] attaches to the trunk you already have: it does not configure the switch, and it cannot turn an access port into a trunk.
+- That interface must not carry the node's own IP address.
+  If your only uplink does, use [Prepare an existing bridge](byo-bridge.mdx) instead.
 
 For the full set of constraints, see [L2 bridge support and limitations](../../reference/l2-bridge-support.mdx).
 
@@ -78,6 +82,7 @@ For each VLAN you intend to use:
 - The subnet on that VLAN, in CIDR notation.
 - The default gateway on that subnet.
 - The range of addresses you are willing to let $[prodname] assign.
+- Any addresses on the subnet that are already in use or reserved — gateways, DNS servers, storage, and any machines you are not migrating.
 
 And for the nodes:
 
@@ -87,13 +92,14 @@ And for the nodes:
 
 ## Create an IP pool for each workload VLAN
 
-The pool has to exist before the `Network`.
+The pool and the `Network` can be created in either order, but both must exist before a workload attaches to the VLAN.
 $[prodname] IPAM chooses a pool by checking which pools fall inside the VLAN's subnet, so a pool that does not match fails at workload creation with an error that does not obviously point back here.
 
 A VLAN that carries only host traffic does not need a pool.
 Create pools only for the VLANs your workloads will use.
 
-1. Create a pool whose CIDR sits inside the VLAN's subnet:
+1. Create a pool whose CIDR is **equal to the VLAN's subnet**.
+   Use a smaller pool, or several pools, only if you have a reason to subdivide:
 
    ```yaml
    apiVersion: projectcalico.org/v3
@@ -112,14 +118,49 @@ Create pools only for the VLANs your workloads will use.
 `allowedUses: L2Workload` marks the pool as belonging to an L2 network.
 Without it, $[prodname] treats the block as part of the routed pod network: it programs a blackhole route for it and advertises it over BGP, neither of which is correct for addresses that live on your VLAN.
 
-$[prodname] does not assign the first and last addresses of a subnet, or the gateway address.
-Size the pool with that in mind.
+:::caution
+
+A pool must cover the addresses of any VMs you plan to migrate in.
+A VM keeps its address by having that address assigned in $[prodname] IPAM, which is only possible if the address falls inside a pool.
+A pool that covers part of the VLAN silently rules out every VM addressed outside it, and the failure appears later, when the VM is created.
+
+:::
+
+## Reserve addresses that are already in use
+
+Skip this if nothing outside the cluster uses the VLAN.
+
+An L2 VLAN is usually shared with machines that are not part of the cluster, and $[prodname] IPAM has no way to know which addresses they hold.
+Without a reservation, $[prodname] can assign a workload the address of an existing machine on the VLAN.
+
+1. Create an [IPReservation](../../reference/resources/ipreservation.mdx) covering every address that is already in use and falls inside a pool you created:
+
+   ```yaml
+   apiVersion: projectcalico.org/v3
+   kind: IPReservation
+   metadata:
+     name: vlan-10-reserved
+   spec:
+     reservedCIDRs:
+       - 10.10.0.10/32
+       - 10.10.0.50/31
+       - 10.10.0.128/25
+   ```
+
+2. Apply it before you create any workload on the VLAN.
+
+$[prodname] automatically reserves the first and last addresses of the **VLAN's subnet**, and the gateway address of any route you declare on it.
+Those are properties of the L2 segment rather than of a pool, so splitting a VLAN's subnet across several pools costs no extra addresses.
+Every other address in use on the VLAN is yours to declare here.
 
 ## Create the Network resource
 
 One `Network` describes the whole L2 network: the VLANs it carries, and how each node reaches them.
 
-Prefer one `Network` carrying several VLANs over several Networks carrying one each.
+A trunk belongs to exactly one `Network`, so if your nodes have a single trunk — the usual case — you need a single `Network` carrying all your VLANs.
+Do not create a second `Network` pointing at the same trunk: the two conflict over the bridge.
+
+Each `Network` creates a VLAN-aware bridge device on every node it selects, which is the cost of adding one.
 Every `Network` adds work for $[prodname] on each node it selects.
 
 1. Write the `Network`, listing each VLAN with its subnet, and one host configuration entry describing the bridge and the trunk:
@@ -143,25 +184,40 @@ Every `Network` adds work for $[prodname] on each node it selects.
          - vlan: { id: 10 }
            subnets:
              - cidr: 10.10.0.0/24
+               routes:
+                 - destination: 0.0.0.0/0
+                   action:
+                     nextHop: 10.10.0.1
          - vlan: { id: 20 }
            subnets:
              - cidr: 10.20.0.0/24
+               routes:
+                 - destination: 0.0.0.0/0
+                   action:
+                     nextHop: 10.20.0.1
    ```
 
 2. Apply it.
-3. Confirm $[prodname] created the bridge on a node that the selector matches:
+3. Confirm $[prodname] created the bridge on a node that the selector matches.
+   Look for `calb-vlan-trunk`:
 
    ```bash
    ip -br link show type bridge
    ```
 
 `managedBridge: {}` tells $[prodname] to create and own the bridge.
-It derives the bridge name per node, so do not expect a name you chose.
+It names the bridge after the `Network`, so a `Network` called `vlan-trunk` gives a bridge called `calb-vlan-trunk` on every node the entry selects.
 An empty `nodeSelector` applies the entry to every node.
+
+Declare the VLAN's gateway as a route on the subnet.
+A workload whose only interface is on this VLAN needs a default route, as above.
+A workload that also has a primary interface on the pod network already has a default route, so give it specific routes to the destinations it needs instead, or its cluster networking breaks.
+
+$[prodname] also uses a route's `nextHop` address to reserve the gateway, so a subnet with no routes has no reserved gateway and the address can be assigned to a workload.
 
 ### Tagged trunk
 
-The configuration above is the strict case: every VLAN is tagged on the wire, and the switch port facing the node is configured as a trunk carrying VLANs 10 and 20.
+The configuration above is the strict case: every VLAN is tagged on the wire, and the switch port facing `eno2` is configured as a trunk carrying VLANs 10 and 20.
 
 This is the arrangement to prefer.
 Tagging is explicit in both directions, so there is no ambiguity about which VLAN a frame belongs to.
@@ -188,14 +244,14 @@ If the trunk is not called the same thing on every node, add one host configurat
 
 ```yaml
 hostConfig:
-  - nodeSelector: has(hardware) && hardware == "gen2"
+  - nodeSelector: hardware == "gen2"
     bridge:
       managedBridge: {}
     hostConnections:
       - trunkPort:
           interface:
             name: eno2
-  - nodeSelector: ''
+  - nodeSelector: ''   # catch-all: matches every node
     bridge:
       managedBridge: {}
     hostConnections:
@@ -204,9 +260,20 @@ hostConfig:
             name: ens1f1
 ```
 
-Entries are evaluated in order and **the first match wins**.
+Entries are evaluated in order and **the first matching `nodeSelector` wins**.
 Everything after it is ignored for that node — entries are not merged.
-Put your most specific selectors first and a catch-all last.
+Put your most specific selectors first.
+
+End with a catch-all if every node should carry the network.
+Leave it out to confine the network to the nodes you select: a node that matches no entry ignores the `Network` entirely, which is how you limit L2 to a specific pool of hardware.
+
+:::caution
+
+Selecting nodes here does not affect scheduling.
+If only some nodes carry the network, give every pod and VM that attaches to it a `nodeSelector` matching the same nodes.
+Otherwise Kubernetes can schedule a workload onto a node with no bridge, and its interface never comes up.
+
+:::
 
 ## Create a NetworkAttachmentDefinition for each VLAN
 
@@ -215,7 +282,7 @@ The definition names the `Network` and the VLAN within it.
 
 1. Create the definition:
 
-   ```yaml
+   ```yaml {9-10}
    apiVersion: 'k8s.cni.cncf.io/v1'
    kind: NetworkAttachmentDefinition
    metadata:
@@ -226,23 +293,25 @@ The definition names the `Network` and the VLAN within it.
        "type": "calico",
        "network": "vlan-trunk",
        "vlan": 10,
-       "log_level": "info",
        "datastore_type": "kubernetes",
-       "nodename_file_optional": false,
        "ipam": {
          "type": "calico-ipam",
-         "assign_ipv4": "true",
-         "assign_ipv6": "false",
          "ipv4_pools": ["vlan-10-pool"]
        },
        "policy": {
          "type": "k8s"
        },
        "kubernetes": {
-         "kubeconfig": "/etc/cni/net.d/calico-kubeconfig"
+         "kubeconfig": "/var/run/multus/cni/net.d/calico-kubeconfig"
        }
        }'
    ```
+
+   The highlighted fields are the only ones specific to your setup: `network` names the `Network` you created, and `vlan` selects one VLAN within it.
+   The rest is standard $[prodname] CNI configuration.
+
+   Declare `cniVersion` as `1.0.0` or lower.
+   The $[prodname] CNI plugin does not support later versions, and a definition that declares one fails when the interface is created.
 
 2. Apply it in the namespace where your workloads will run, and repeat for each VLAN.
 
@@ -285,10 +354,15 @@ Do not annotate the launcher pod that KubeVirt creates — KubeVirt builds it fr
 3. From inside the VM, confirm the interface is up and the address is configured.
    KubeVirt serves the address over DHCP inside the VM, so the guest configures itself as it would on any network.
 
+**What you get:** a VM with one interface, on VLAN 10.
+KubeVirt's launcher pod still has a primary interface on the pod network, but the VM cannot use it — the VM is on your VLAN and nothing else.
+To give the VM both, declare the pod network as a second interface alongside `vlan10`.
+See [Attaching a workload to more than one VLAN](#attaching-a-workload-to-more-than-one-vlan).
+
 The `bridge: {}` here is KubeVirt's own interface binding, which attaches the VM to the interface $[prodname] built.
 It is unrelated to the $[prodname] L2 bridge — the two uses of the word are unfortunate but distinct.
 
-To give the VM a specific address and MAC address rather than whatever the pool offers, see [Bring a VM over with its IP and MAC](vm-identity.mdx).
+To give the VM a specific address and MAC address rather than letting $[prodname] assign them — either because it is migrating in with an identity it already has, or because it needs a fixed one — see [Set a VM's IP and MAC address](vm-identity.mdx).
 
 ### Attaching a pod instead
 
@@ -307,6 +381,9 @@ spec:
       image: nginx
 ```
 
+**What you get:** a pod with its primary interface on the pod network and a secondary interface on VLAN 10.
+Cluster networking is unaffected.
+
 The name after `@` is the interface name inside the pod.
 It is also the name that scopes per-interface annotations, such as a requested address, so choose it deliberately.
 
@@ -321,6 +398,28 @@ annotations:
 ```
 
 For a VM, add a second interface and network pair to the specification in the same way.
+One of them can be the pod network, which is how a VM gets both cluster networking and an address on your VLAN:
+
+```yaml
+spec:
+  template:
+    spec:
+      nodeSelector:
+        l2-bridge: 'true'   # only if the Network does not select every node
+      domain:
+        devices:
+          interfaces:
+            - name: default
+              bridge: {}
+            - name: vlan10
+              bridge: {}
+      networks:
+        - name: default
+          pod: {}
+        - name: vlan10
+          multus:
+            networkName: vlan-10
+```
 
 ### Using an L2 network as the primary interface
 
@@ -371,6 +470,6 @@ If any step fails, see [Troubleshoot L2 network connectivity](troubleshoot.mdx).
 
 - [About L2 bridge networking](about-l2-bridge.mdx)
 - [Prepare an existing bridge](byo-bridge.mdx)
-- [Bring a VM over with its IP and MAC](vm-identity.mdx)
+- [Set a VM's IP and MAC address](vm-identity.mdx)
 - [L2 bridge support and limitations](../../reference/l2-bridge-support.mdx)
 - [Network resource](../../reference/resources/network.mdx)


### PR DESCRIPTION
Fills in the main setup guide for L2 bridge networking. Fifth in the DOCS-2997 sequence. It follows the guide for preparing an existing bridge, because a reader on a shared uplink needs that first.

This is the path for nodes where Calico can take over an interface of its own, so Calico creates and owns the bridge.

The guide leads with VMs. The feature is aimed at them, and a VM is configured differently from a pod: the interface is declared in the VM specification, and the guide says plainly that the launcher pod KubeVirt creates is not annotated by hand. Pods follow as the secondary case.

Points worth a reviewer's attention:

- Setting the multi-interface mode gets a step of its own. Installing Multus is not sufficient, nothing reports the omission, and the symptom shows up much later as a workload with two interfaces called eth0 and no connectivity.
- The IP pool step explains why the pool is marked as an L2 workload pool. Leaving it out gives you a blackhole route and a BGP advertisement for addresses that live on your own VLAN.
- The first-match-wins rule for host configuration entries is stated explicitly, since nothing in the API hints at it.
- The guide notes that KubeVirt's bridge interface binding is unrelated to the Calico L2 bridge. The same word means two different things in adjacent configuration and readers will trip on it.

Three things I could not verify and would like checked:

- The VM specification example is written from KubeVirt's documented API rather than copied from a working VM. Alex has manifests from the EP2 hash release that would be better.
- The attachment definition sets vlan as a JSON number. Confirm that is the expected type.
- The section on using an L2 network as the primary interface describes the capability and its consequence, but points at the Network reference for the annotation names rather than naming them, because I could not confirm the exact keys. That reference page is still to be written, so the pointer needs filling in.

Changed page: https://deploy-preview-2947--calico-docs-preview-next.netlify.app/calico-enterprise/next/networking/l2-bridge/connect-vlan