### PR TITLE
DOCS-2997: Write the guide for preserving a VM IP and MAC address

### DIFF
--- a/calico-enterprise/networking/l2-bridge/vm-identity.mdx
+++ b/calico-enterprise/networking/l2-bridge/vm-identity.mdx
@@ -6,42 +6,173 @@ description: Bring a KubeVirt VM onto an L2 network holding its original IP addr
 
 :::note
 
-L2 bridge networking is a tech preview feature. APIs and behavior may change before GA.
+L2 bridge networking is a tech preview feature.
+APIs and behavior may change before GA.
 
 :::
 
-A VM that keeps its address and MAC keeps its identity: DNS entries, firewall rules, license servers, and monitoring all continue to work without being updated.
+A VM that keeps its IP address and MAC address keeps its identity.
+DNS entries still resolve to it, firewall rules still match it, license servers still recognise it, and monitoring still charts it — none of which has to be updated as part of the move.
+
+This guide covers a VM you are bringing onto an L2 network for the first time.
 
 ## Before you begin
 
+- An L2 network already created and verified.
+  See [Connect workloads to an existing VLAN](connect-vlan.mdx).
+- KubeVirt installed.
+- The VM's current IP address, prefix length, and MAC address, recorded from wherever it runs now.
+- Confirmation that the target VLAN's subnet contains that IP address.
+  $[prodname] assigns the address from an IP pool inside that subnet, so an address outside it cannot be assigned.
+- Confirmation that the address is not already in use.
+  $[prodname] fails the request rather than issuing a duplicate.
+
 ## How identity is preserved
 
-The address and MAC are declared before the VM starts. Nothing is renumbered afterwards.
+The order matters, so it is worth being explicit about it.
+
+The address and the MAC address are declared **on the VM before it starts**.
+$[prodname] assigns exactly those values when the interface is created, and the VM comes up already holding them.
+
+Nothing is renumbered afterwards.
+Do not start the VM, observe what it got, and then move it to the address you wanted: that sequence breaks every connection the VM makes in between, and defeats the point of preserving the address at all.
 
 ## Set the MAC address
 
-Two mechanisms, either of which works. Setting both to conflicting values is rejected.
+There are two ways to specify a MAC address, and either is sufficient.
+
+KubeVirt's own `macAddress` field on the interface is honored by $[prodname]:
+
+```yaml
+domain:
+  devices:
+    interfaces:
+      - name: vlan10
+        bridge: {}
+        macAddress: '52:54:00:3a:1c:04'
+```
+
+The `hwAddr` annotation is the other, scoped to the interface name:
+
+```yaml
+metadata:
+  annotations:
+    cni.projectcalico.org/vlan10.hwAddr: '52:54:00:3a:1c:04'
+```
+
+Use whichever fits how you generate the VM.
+The KubeVirt field is usually the better choice, because it lives with the rest of the interface configuration.
+
+:::caution
+
+If you set both, they must agree.
+When they conflict, $[prodname] rejects the interface rather than guessing which one you meant, and the VM does not start.
+
+On OpenShift this is easy to hit by accident.
+OpenShift ships a MAC address allocator that fills in the `macAddress` field on newly created VMs, so a VM may already carry a value before you add an annotation.
+Check the specification before you annotate.
+
+:::
 
 ## Set the IP address
 
+The address is requested with the `ipAddrs` annotation, scoped to the same interface name you gave the interface.
+
+```yaml
+metadata:
+  annotations:
+    cni.projectcalico.org/vlan10.ipAddrs: '["10.10.0.42"]'
+```
+
+The value is a JSON array, and the annotation prefix is the interface name followed by a dot.
+An annotation with no interface name applies to the primary interface.
+
+$[prodname] takes the address from the pool covering that VLAN and records the assignment, so the address is reserved for as long as the VM exists.
+
 ### Use ipAddrs rather than ipAddrsNoIpam
 
-Both request a specific address. Only one leaves $[prodname] able to enforce policy on it.
+Both request a specific address.
+Only one leaves $[prodname] able to enforce policy on it.
+
+`ipAddrsNoIpam` configures the address on the interface but bypasses IPAM entirely, so $[prodname] holds no record of it.
+On an L2 network that matters more than it does on the pod network: $[prodname] uses its knowledge of a workload's address to make policy decisions and to distinguish legitimate traffic from spoofed traffic.
+An address it does not know about cannot be protected.
+
+Use `ipAddrs`.
 
 ### One address per family
 
+An interface takes at most one IPv4 address.
+IPv6 is not supported on L2 networks in this release.
+
+Addresses cannot be added to or removed from an interface after it is set up.
+To change them, delete the VM and recreate it with the values you want.
+
 ## Confirm what was configured
 
-$[prodname] writes back what it actually applied. This is the authoritative record.
+$[prodname] writes back what it actually applied, which is the authoritative record of what the VM got.
+
+1. Read the status annotation from the VM's launcher pod:
+
+   ```bash
+   kubectl get pod -l vm.kubevirt.io/name=app-server \
+     -o jsonpath='{.items[0].metadata.annotations.cni\.projectcalico\.org/vlan10\.network-status}'
+   ```
+
+2. Check the reported `ipv4`, `mac`, `network`, and `vlan` against what you asked for.
+
+An admission policy restricts this annotation so that only the CNI plugin can write it.
+If it disagrees with your request, the request was not honored — it does not mean somebody edited the record.
 
 ## Verify from the network
 
-Check from outside the cluster, because that is what the VM's identity is for.
+Check from outside the cluster.
+The point of preserving an address is that other systems reach the VM at it, so that is what to test.
+
+1. From an existing machine on the same VLAN, ping the VM at its original address.
+2. On that machine, confirm the ARP entry for the address shows the original MAC address:
+
+   ```bash
+   ip neigh show 10.10.0.42
+   ```
+
+3. Confirm the workload endpoint carries the network and VLAN you expect:
+
+   ```bash
+   kubectl get workloadendpoints -o wide
+   ```
+
+4. If the VM is registered in DNS, confirm the name still resolves to the same address and that traffic to the name reaches the VM.
 
 ## Using Forklift
 
-Where a migration tool sets these values for you.
+Forklift copies a VM's configuration to the target KubeVirt VM as part of a migration, including the values this guide sets by hand.
+Where you use it, you are unlikely to be writing these annotations yourself.
+
+:::caution
+
+$[prodname] support for L2 networks is being contributed to Forklift and is not in a released version.
+Do not expect a stock Forklift installation to preserve addresses onto an L2 network.
+If you want to try this now, talk to your support contact rather than working from the upstream documentation.
+
+:::
 
 ## What to expect during migration
 
+What follows describes what this release implements.
+It is not a statement about what a particular migration will feel like, and it has not been through a full test cycle.
+
+$[prodname] preserves the address and the MAC address across a live migration between KubeVirt nodes, and announces the VM's new location with a gratuitous ARP so the fabric updates its forwarding.
+Established TCP connections are admitted on arrival rather than dropped for want of a handshake, which is intended to let sessions continue.
+
+Bringing a VM in from outside the cluster is a different matter.
+That is an offline operation: the VM is shut down while its disks are copied, so connections in progress do not survive, and clients reconnect once it starts.
+
+Plan for a disruption window and confirm the behavior you need in your own environment before you rely on it.
+
 ## Additional resources
+
+- [Connect workloads to an existing VLAN](connect-vlan.mdx)
+- [About L2 bridge networking](about-l2-bridge.mdx)
+- [Troubleshoot L2 network connectivity](troubleshoot.mdx)
+- [L2 bridge support and limitations](../../reference/l2-bridge-support.mdx)

--- a/calico-enterprise/networking/l2-bridge/vm-identity.mdx
+++ b/calico-enterprise/networking/l2-bridge/vm-identity.mdx
@@ -2,6 +2,16 @@
 description: Bring a KubeVirt VM onto an L2 network holding its original IP address and MAC address, so the systems that depend on it keep working.
 ---
 
+{/*
+  User story, primary
+  S6: As a VM admin, I want a VM to arrive on Kubernetes already holding its original IP address and MAC address, so that DNS, firewall rules, license servers, and monitoring keep working untouched.
+
+  User stories, subsidiary
+  S10: documents the per-interface annotation contract, until the CNI annotations reference exists.
+
+  Story ladder and page plan: DOCS-2997.
+*/}
+
 # Bring a VM over with its IP and MAC
 
 :::note

--- a/calico-enterprise/networking/l2-bridge/vm-identity.mdx
+++ b/calico-enterprise/networking/l2-bridge/vm-identity.mdx
@@ -1,5 +1,5 @@
 ---
-description: Bring a KubeVirt VM onto an L2 network holding its original IP address and MAC address, so the systems that depend on it keep working.
+description: Set a specific IP address and MAC address on a KubeVirt VM attached to an L2 network, so a migrated VM keeps its identity and a new VM gets a fixed one.
 ---
 
 {/*
@@ -12,7 +12,7 @@ description: Bring a KubeVirt VM onto an L2 network holding its original IP addr
   Story ladder and page plan: DOCS-2997.
 */}
 
-# Bring a VM over with its IP and MAC
+# Set a VM's IP and MAC address
 
 :::note
 
@@ -24,7 +24,8 @@ APIs and behavior may change before GA.
 A VM that keeps its IP address and MAC address keeps its identity.
 DNS entries still resolve to it, firewall rules still match it, license servers still recognise it, and monitoring still charts it — none of which has to be updated as part of the move.
 
-This guide covers a VM you are bringing onto an L2 network for the first time.
+This guide covers both cases: a VM arriving on an L2 network with an address it already had, and a new VM that needs a fixed address from the start.
+The configuration is the same either way.
 
 ## Before you begin
 
@@ -32,8 +33,9 @@ This guide covers a VM you are bringing onto an L2 network for the first time.
   See [Connect workloads to an existing VLAN](connect-vlan.mdx).
 - KubeVirt installed.
 - The VM's current IP address, prefix length, and MAC address, recorded from wherever it runs now.
-- Confirmation that the target VLAN's subnet contains that IP address.
-  $[prodname] assigns the address from an IP pool inside that subnet, so an address outside it cannot be assigned.
+- Confirmation that the address falls inside an `IPPool` on the target VLAN.
+  $[prodname] assigns the address from a pool covering that VLAN, so an address outside every pool cannot be assigned.
+  See [Create an IP pool for each workload VLAN](connect-vlan.mdx#create-an-ip-pool-for-each-workload-vlan).
 - Confirmation that the address is not already in use.
   $[prodname] fails the request rather than issuing a duplicate.
 
@@ -49,9 +51,7 @@ Do not start the VM, observe what it got, and then move it to the address you wa
 
 ## Set the MAC address
 
-There are two ways to specify a MAC address, and either is sufficient.
-
-KubeVirt's own `macAddress` field on the interface is honored by $[prodname]:
+Set the MAC address on the VM's interface, using KubeVirt's `macAddress` field:
 
 ```yaml
 domain:
@@ -62,40 +62,57 @@ domain:
         macAddress: '52:54:00:3a:1c:04'
 ```
 
-The `hwAddr` annotation is the other, scoped to the interface name:
+:::caution
+
+Use the interface field, not the `hwAddr` annotation, for any VM you may live migrate.
+KubeVirt does not know about the annotation, so it is not carried to the target node: the VM comes up there with a different MAC address and loses L2 connectivity.
+
+:::
+
+The `hwAddr` annotation sets the same value for a workload that is not a VM, or a VM that will never migrate:
 
 ```yaml
 metadata:
   annotations:
-    cni.projectcalico.org/vlan10.hwAddr: '52:54:00:3a:1c:04'
+    cni.projectcalico.org/net-0.hwAddr: '52:54:00:3a:1c:04'
 ```
-
-Use whichever fits how you generate the VM.
-The KubeVirt field is usually the better choice, because it lives with the rest of the interface configuration.
-
-:::caution
 
 If you set both, they must agree.
 When they conflict, $[prodname] rejects the interface rather than guessing which one you meant, and the VM does not start.
 
-On OpenShift this is easy to hit by accident.
-OpenShift ships a MAC address allocator that fills in the `macAddress` field on newly created VMs, so a VM may already carry a value before you add an annotation.
-Check the specification before you annotate.
-
-:::
+Keeping a MAC address across a live migration also needs a MAC address allocator in the cluster.
+OpenShift ships one, which fills in `macAddress` on newly created VMs — so on OpenShift a VM may already carry a value before you set one, and you should check the specification first.
+On other platforms you need to provide one yourself; the upstream project is [kubemacpool](https://github.com/k8snetworkplumbingwg/kubemacpool), which has not been verified with this feature outside OpenShift.
 
 ## Set the IP address
 
-The address is requested with the `ipAddrs` annotation, scoped to the same interface name you gave the interface.
+The address is requested with the `ipAddrs` annotation, scoped to the interface it applies to.
 
 ```yaml
 metadata:
   annotations:
-    cni.projectcalico.org/vlan10.ipAddrs: '["10.10.0.42"]'
+    cni.projectcalico.org/net-0.ipAddrs: '["10.10.0.42"]'
 ```
 
 The value is a JSON array, and the annotation prefix is the interface name followed by a dot.
 An annotation with no interface name applies to the primary interface.
+
+### Which interface name to use
+
+Four different names describe the same interface, and the annotation takes only one of them.
+
+| Name | Where it appears | Example |
+| ---- | ---------------- | ------- |
+| VM interface name | `spec.template.spec.domain.devices.interfaces[].name` on the VM, matched by an entry in `spec.template.spec.networks[]` | `vlan10` |
+| Attachment definition | The `NetworkAttachmentDefinition` the network entry references | `vlan-10` |
+| Pod-side interface name | The interface KubeVirt creates in the launcher pod. **This is the name the annotation uses.** | `net-0` |
+| Host device | The veth $[prodname] creates on the node | `cali0156c97a553` |
+
+For a VM, KubeVirt names the pod-side interface itself — `net-0` for the first Multus secondary interface, `net-1` for the second, and so on.
+Use that name in the annotation, not the name you gave the interface in the VM specification.
+
+For a pod, you choose the pod-side name yourself in the `k8s.v1.cni.cncf.io/networks` annotation, with the `attachment@name` form.
+See [Attaching a pod instead](connect-vlan.mdx#attaching-a-pod-instead).
 
 $[prodname] takes the address from the pool covering that VLAN and records the assignment, so the address is reserved for as long as the VM exists.
 
@@ -120,19 +137,27 @@ To change them, delete the VM and recreate it with the values you want.
 
 ## Confirm what was configured
 
-$[prodname] writes back what it actually applied, which is the authoritative record of what the VM got.
+Three sources answer different questions, so check the one that reports the value you care about.
 
-1. Read the status annotation from the VM's launcher pod:
+1. Read the address KubeVirt reports for the VM:
 
    ```bash
-   kubectl get pod -l vm.kubevirt.io/name=app-server \
-     -o jsonpath='{.items[0].metadata.annotations.cni\.projectcalico\.org/vlan10\.network-status}'
+   kubectl get vmi app-server -o jsonpath='{.status.interfaces}'
    ```
 
-2. Check the reported `ipv4`, `mac`, `network`, and `vlan` against what you asked for.
+2. Read the MAC address, network, and VLAN that $[prodname] applied.
+   KubeVirt rewrites the interface name in this annotation to a generated one, such as `pod900d2c01c91`, so match the annotation by its suffix rather than naming it:
 
-An admission policy restricts this annotation so that only the CNI plugin can write it.
-If it disagrees with your request, the request was not honored — it does not mean somebody edited the record.
+   ```bash
+   kubectl get pod -l vm.kubevirt.io/name=app-server -o json \
+     | jq -r '.items[0].metadata.annotations | to_entries[]
+              | select(.key | endswith(".network-status")) | .value'
+   ```
+
+   The payload carries `name`, `mac`, and `vlan`.
+   It does not carry the address; use the VMI status above for that.
+
+If what $[prodname] applied disagrees with what you asked for, the request was not honored.
 
 ## Verify from the network
 
@@ -149,8 +174,11 @@ The point of preserving an address is that other systems reach the VM at it, so 
 3. Confirm the workload endpoint carries the network and VLAN you expect:
 
    ```bash
-   kubectl get workloadendpoints -o wide
+   MULTI_INTERFACE_MODE=multus calicoctl get wep -o wide
    ```
+
+   A `WorkloadEndpoint` is derived from pod annotations rather than stored as a Kubernetes resource, so `kubectl` cannot list it.
+   Set `MULTI_INTERFACE_MODE=multus`: without it, `calicoctl` reads in single-interface mode and reports incorrect values rather than failing.
 
 4. If the VM is registered in DNS, confirm the name still resolves to the same address and that traffic to the name reaches the VM.
 

--- a/calico-enterprise/networking/l2-bridge/vm-identity.mdx
+++ b/calico-enterprise/networking/l2-bridge/vm-identity.mdx
@@ -32,12 +32,14 @@ The configuration is the same either way.
 - An L2 network already created and verified.
   See [Connect workloads to an existing VLAN](connect-vlan.mdx).
 - KubeVirt installed.
-- The VM's current IP address, prefix length, and MAC address, recorded from wherever it runs now.
+- The VM's current IP address and MAC address, recorded from wherever it runs now.
+  The prefix length comes from the VLAN's subnet in the `Network`, so you do not supply it here.
 - Confirmation that the address falls inside an `IPPool` on the target VLAN.
   $[prodname] assigns the address from a pool covering that VLAN, so an address outside every pool cannot be assigned.
   See [Create an IP pool for each workload VLAN](connect-vlan.mdx#create-an-ip-pool-for-each-workload-vlan).
-- Confirmation that the address is not already in use.
+- Confirmation that the address is not already in use by another workload.
   $[prodname] fails the request rather than issuing a duplicate.
+  There is one exception, described under [Recreating a VM with the same name](#recreating-a-vm-with-the-same-name).
 
 ## How identity is preserved
 
@@ -69,13 +71,16 @@ KubeVirt does not know about the annotation, so it is not carried to the target 
 
 :::
 
-The `hwAddr` annotation sets the same value for a workload that is not a VM, or a VM that will never migrate:
+The `hwAddr` annotation sets the same value for a workload that is not a VM, or a VM that will never migrate.
+Scope it to the interface it applies to, using the name that interface has inside the pod — for a pod, the name you chose after `@` in the `k8s.v1.cni.cncf.io/networks` annotation:
 
 ```yaml
 metadata:
   annotations:
-    cni.projectcalico.org/net-0.hwAddr: '52:54:00:3a:1c:04'
+    cni.projectcalico.org/vlan10.hwAddr: '52:54:00:3a:1c:04'
 ```
+
+Without an interface name, the annotation applies to the workload's primary interface.
 
 If you set both, they must agree.
 When they conflict, $[prodname] rejects the interface rather than guessing which one you meant, and the VM does not start.
@@ -116,6 +121,19 @@ See [Attaching a pod instead](connect-vlan.mdx#attaching-a-pod-instead).
 
 $[prodname] takes the address from the pool covering that VLAN and records the assignment, so the address is reserved for as long as the VM exists.
 
+### Recreating a VM with the same name
+
+The reservation outlives the VM.
+A VM's IPAM handle survives deletion of the VM, and of its namespace, until kube-controllers reclaims it, which takes around 15 minutes.
+
+:::caution
+
+Recreate a VM with the same name inside that window and $[prodname] reuses the old handle's address, ignoring the `ipAddrs` annotation without reporting an error.
+The VM comes up holding the address it had before, not the one you asked for.
+Either wait for the reclaim, or recreate the VM under a different name.
+
+:::
+
 ### Use ipAddrs rather than ipAddrsNoIpam
 
 Both request a specific address.
@@ -137,7 +155,8 @@ To change them, delete the VM and recreate it with the values you want.
 
 ## Confirm what was configured
 
-Three sources answer different questions, so check the one that reports the value you care about.
+Two sources answer different questions here, and a third, the workload endpoint, is in [Verify from the network](#verify-from-the-network).
+Check the one that reports the value you care about.
 
 1. Read the address KubeVirt reports for the VM:
 

--- a/calico-enterprise/networking/l2-bridge/vm-identity.mdx
+++ b/calico-enterprise/networking/l2-bridge/vm-identity.mdx
@@ -72,11 +72,12 @@ KubeVirt does not know about the annotation, so it is not carried to the target 
 :::
 
 The `hwAddr` annotation sets the same value for a workload that is not a VM, or a VM that will never migrate.
-Scope it to the interface it applies to, using the name that interface has inside the pod — for a pod, the name you chose after `@` in the `k8s.v1.cni.cncf.io/networks` annotation:
+Scope it to the name the interface has inside the pod, which differs by workload type: for a pod, the name you chose after `@` in the `k8s.v1.cni.cncf.io/networks` annotation; for a VM, the name KubeVirt generates, as described in [Which interface name to use](#which-interface-name-to-use).
 
 ```yaml
 metadata:
   annotations:
+    # on a pod whose networks annotation is vlan-10@vlan10
     cni.projectcalico.org/vlan10.hwAddr: '52:54:00:3a:1c:04'
 ```
 


### PR DESCRIPTION
Fills in the guide for bringing a VM onto an L2 network with its original IP address and MAC address. Sixth in the DOCS-2997 sequence, and it depends on an L2 network already existing.

The guide states the order plainly, because getting it wrong is destructive. The address and MAC address are declared on the VM before it starts, so the VM comes up already holding them. The review of the plan flagged that an earlier outline read as though you would start the VM and then move it to its old address, which breaks every connection made in between. The page now rules that out explicitly.

Other points:

- KubeVirt's own macAddress field is honored alongside the hwAddr annotation, so the page presents both and warns that conflicting values are rejected rather than resolved. OpenShift's MAC allocator fills that field in on new VMs, which makes the conflict easy to hit by accident.
- The page recommends ipAddrs over ipAddrsNoIpam, with the reason: bypassing IPAM leaves Calico unable to tell the workload's traffic from spoofed traffic.
- The write-back annotation is documented under its current name, network-status.
- The migration section describes what the release implements rather than what a reader will experience, and says it has not been through a full test cycle. No claim of seamlessness anywhere.
- Forklift carries a warning that Calico support for L2 networks is not in a released version, so a stock installation will not do this.

Two things to check:

- The status annotation is read here from the launcher pod. Confirm that is where a reader should look for a VM, rather than somewhere on the VM or the instance.
- The live migration paragraph is deliberately conservative while CORE-13289 is open. If that is closed and there is a test result, the wording can firm up.

Changed page: https://deploy-preview-2948--calico-docs-preview-next.netlify.app/calico-enterprise/next/networking/l2-bridge/vm-identity