### PR TITLE
DOCS-3007: Fix the tier link in the Calico Cloud v23 breaking change note

### DIFF
--- a/calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx
@@ -95,7 +95,7 @@ This release adds support for Kubernetes 1.36.
 
   **Recommendation:** Do not add policies to the $[prodname] tier, if changes are needed create a separate tier and add your policies there.
 
-  For more information, see [Change allow-tigera tier behavior](../network-policy/policy-tiers/allow-tigera.mdx).
+  For more information, see [Change calico-system tier behavior](../network-policy/policy-tiers/calico-system.mdx).
 
 ### Known issues
 


### PR DESCRIPTION
main is currently broken. Every build fails, so no pull request can get a deploy preview.

The breaking change note added in 55c7d745 links to ../network-policy/policy-tiers/allow-tigera.mdx. That page was renamed to calico-system.mdx in 9208dd84, which landed first. Docusaurus is configured with onBrokenMarkdownLinks set to throw, so the MDX compile fails:

Markdown link with URL ../network-policy/policy-tiers/allow-tigera.mdx in source file calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx (98:29) couldn't be resolved.

This points the note at the renamed page, the same way the two other release notes on the same page already do.

One line, one file. Verified locally: yarn build fails on main with the error above, and succeeds with this change applied.
