### PR TITLE
DOCS-3014: Follow-ups from review, and show Cloud's user-facing version

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -574,6 +574,13 @@ export default async function createAsyncConfig() {
           // 'last' covers only the version served at /latest; 'all' covers every
           // built version, at roughly three times the generation cost.
           versions: 'last',
+          // Docusaurus version names are navigation labels. Where a product has a
+          // user-facing version that differs, name the variables.js key holding it
+          // so frontmatter reports something a reader can corroborate. Calico Cloud's
+          // Docusaurus label is "23-2", which appears in no URL and no dropdown.
+          versionVariables: {
+            'calico-cloud': 'cloudUserVersion',
+          },
         },
       ],
     ],

--- a/src/plugins/docusaurus-plugin-llms-txt/__test__/guards.test.js
+++ b/src/plugins/docusaurus-plugin-llms-txt/__test__/guards.test.js
@@ -1,0 +1,78 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { emptyPageAllowance } from '../index.js';
+import { createCache } from '../cache.js';
+
+describe('emptyPageAllowance', () => {
+  // The guard fires when empty > allowance. If the allowance ever reaches the size of
+  // the version, it can never fire — which is what a minimum of 5 did to the five-doc
+  // use-cases instance.
+  it.each([
+    ['use-cases', 5],
+    ['a small version', 12],
+    ['calico latest', 337],
+    ['calico-enterprise latest', 415],
+  ])('can still fire for %s', (_name, docCount) => {
+    expect(emptyPageAllowance(docCount)).toBeLessThan(docCount);
+  });
+
+  it('leaves room for the real rate of empty pages', () => {
+    // Today: one client-rendered page per product, against hundreds of docs.
+    expect(emptyPageAllowance(337)).toBeGreaterThanOrEqual(17);
+    expect(emptyPageAllowance(286)).toBeGreaterThanOrEqual(15);
+  });
+
+  it('tolerates a stub or two in a small instance', () => {
+    expect(emptyPageAllowance(5)).toBe(2);
+  });
+});
+
+describe('cache write failures', () => {
+  let tmp;
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'llms-cache-fail-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  it('degrades to a warning rather than failing the build', async () => {
+    // A file where the cache directory should be: mkdir fails with ENOTDIR/EEXIST.
+    const blocked = path.join(tmp, 'blocker');
+    await fs.writeFile(blocked, 'not a directory');
+
+    const cache = createCache({ cacheDir: path.join(blocked, 'nested'), fingerprint: 'v1' });
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(cache.set('abc', { markdown: '# Title' })).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('conversion cache'));
+
+    warn.mockRestore();
+  });
+
+  it('warns once, not once per page', async () => {
+    const blocked = path.join(tmp, 'blocker');
+    await fs.writeFile(blocked, 'not a directory');
+
+    const cache = createCache({ cacheDir: path.join(blocked, 'nested'), fingerprint: 'v1' });
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    for (let i = 0; i < 5; i++) {
+      await cache.set(`key-${i}`, { markdown: 'x' });
+    }
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('still reports a miss so the page is reconverted', async () => {
+    const cache = createCache({ cacheDir: path.join(tmp, 'fresh'), fingerprint: 'v1' });
+
+    expect(await cache.get('never-written')).toBeNull();
+    expect(cache.stats.misses).toBe(1);
+  });
+});

--- a/src/plugins/docusaurus-plugin-llms-txt/cache.js
+++ b/src/plugins/docusaurus-plugin-llms-txt/cache.js
@@ -25,8 +25,14 @@ const LINK_TAGS = /<link\b[^>]*>/gi;
  * Webpack fingerprints its bundles, so `runtime~main.<hash>.js` differs after any
  * edit anywhere on the site, and every page references it in <head>. Hashing raw
  * HTML would therefore invalidate the entire cache whenever a single page changed,
- * which defeats the point. Script and link tags never contribute to the extracted
- * content, so removing them before hashing is safe.
+ * which defeats the point.
+ *
+ * This is safe, but not for the obvious reason. Stripped tags *can* reach the
+ * extracted fragment — the Swagger pages carry a <link rel="stylesheet"> inside
+ * their content — so the property that holds is the weaker, sufficient one: removing
+ * them cannot change the resulting Markdown. That is asserted directly, over a set of
+ * fixtures including a stylesheet link in content, in __test__/conversion.test.js.
+ * Check those still pass before changing anything here.
  *
  * @param {string} html
  * @returns {string}
@@ -40,6 +46,7 @@ export function contentOnly(html) {
  */
 export function createCache({ cacheDir, fingerprint }) {
   const used = new Set();
+  let warnedAboutWrites = false;
   let hits = 0;
   let misses = 0;
 
@@ -82,8 +89,23 @@ export function createCache({ cacheDir, fingerprint }) {
      */
     async set(key, value) {
       used.add(key);
-      await fs.mkdir(cacheDir, { recursive: true });
-      await fs.writeFile(path.join(cacheDir, `${key}.json`), JSON.stringify(value));
+
+      // The cache only ever saves work; nothing downstream reads it for correctness.
+      // A read-only directory or a stray file where the cache belongs should cost a
+      // slow build, not a failed one. Contrast fingerprintConverter, which must fail
+      // closed because a fingerprint it cannot compute would let stale entries serve.
+      try {
+        await fs.mkdir(cacheDir, { recursive: true });
+        await fs.writeFile(path.join(cacheDir, `${key}.json`), JSON.stringify(value));
+      } catch (error) {
+        if (!warnedAboutWrites) {
+          warnedAboutWrites = true;
+          console.warn(
+            `[llms-txt] Could not write to the conversion cache at ${cacheDir}, so every ` +
+              `build will reconvert every page: ${error.message}`
+          );
+        }
+      }
     },
 
     /**
@@ -106,8 +128,13 @@ export function createCache({ cacheDir, fingerprint }) {
         if (!entry.endsWith('.json') || used.has(entry.slice(0, -'.json'.length))) {
           continue;
         }
-        await fs.rm(path.join(cacheDir, entry), { force: true });
-        removed++;
+
+        try {
+          await fs.rm(path.join(cacheDir, entry), { force: true });
+          removed++;
+        } catch {
+          // Same reasoning as set(): an unprunable entry wastes disk, nothing more.
+        }
       }
 
       return removed;

--- a/src/plugins/docusaurus-plugin-llms-txt/index.js
+++ b/src/plugins/docusaurus-plugin-llms-txt/index.js
@@ -11,6 +11,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
 import { walkSidebar } from './sidebar-utils.js';
 import { extractFromHtmlString } from './extract.js';
 import { convertToMarkdown } from './convert.js';
@@ -38,11 +39,64 @@ const USE_CASES_NAME = 'Calico use cases';
  * guards exist to prevent. A proportion catches that while leaving room for stubs.
  *
  * The real figure today is 3 of 1,043 pages, or 0.3%, so this has ample headroom.
- * The absolute minimum keeps small versions from tripping on one or two stubs.
+ * The absolute minimum keeps small versions from tripping on a single stub, but it
+ * must stay below the size of the smallest instance or the guard cannot fire there
+ * at all: use-cases has five docs, so a minimum of five made it dead exactly where
+ * a proportion is least meaningful.
  */
-const EMPTY_PAGE_LIMIT = { rate: 0.05, minimum: 5 };
+const EMPTY_PAGE_LIMIT = { rate: 0.05, minimum: 2 };
+
+/**
+ * How many empty pages a version of this size may have before the build fails.
+ *
+ * Exported so the arithmetic is testable: the previous minimum exceeded the size of
+ * the smallest instance, which made the guard silently unable to fire there, and no
+ * test would have noticed.
+ *
+ * @param {number} docCount
+ * @returns {number}
+ */
+export function emptyPageAllowance(docCount) {
+  return Math.max(EMPTY_PAGE_LIMIT.minimum, Math.ceil(docCount * EMPTY_PAGE_LIMIT.rate));
+}
 
 const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const requireFromHere = createRequire(import.meta.url);
+
+/**
+ * Read a display version out of a docs version's variables.js.
+ *
+ * Docusaurus version names are navigation labels, not product versions. Calico
+ * Cloud's is "23-2", which appears in no URL and no version dropdown, so an agent
+ * has nothing to corroborate it against. The docs themselves render $[cloudUserVersion],
+ * and that is the string a reader would recognise.
+ *
+ * The location mirrors src/utils/getVariableByFilePath.js, which resolves the same
+ * files for the remark plugin.
+ *
+ * @returns {string | null}
+ */
+function versionLabelFromVariables(variableName, docsPath, version, siteDir) {
+  const versionDir =
+    version.versionName === 'current'
+      ? path.join(siteDir, docsPath)
+      : path.join(siteDir, `${docsPath}_versioned_docs`, `version-${version.versionName}`);
+  const variablesPath = path.join(versionDir, 'variables.js');
+
+  try {
+    const value = requireFromHere(variablesPath)[variableName];
+    if (typeof value === 'string' && value) {
+      return value;
+    }
+    console.warn(`${LOG_PREFIX} ${variablesPath} has no string "${variableName}"`);
+  } catch (error) {
+    console.warn(`${LOG_PREFIX} Could not read ${variablesPath}: ${error.message}`);
+  }
+
+  // Fall back to the Docusaurus label rather than failing; a display string is not
+  // worth a red build.
+  return null;
+}
 
 /**
  * Modules whose contents determine the *cached* value.
@@ -183,7 +237,7 @@ async function processVersion(version, outDir, siteUrl, cache) {
   // three quarters of its twins would still pass while llms-full.txt quietly shrank
   // by the same amount.
   const empty = [...processedById.values()].filter((doc) => !hasContent(doc)).length;
-  const allowed = Math.max(EMPTY_PAGE_LIMIT.minimum, Math.ceil(version.docs.length * EMPTY_PAGE_LIMIT.rate));
+  const allowed = emptyPageAllowance(version.docs.length);
 
   if (empty > allowed) {
     throw new Error(
@@ -222,6 +276,7 @@ async function processVersion(version, outDir, siteUrl, cache) {
  */
 async function processProduct(docsPlugin, outDir, siteUrl, options, cache) {
   const content = docsPlugin.content;
+  const docsPath = docsPlugin.options?.path;
   if (!content?.loadedVersions?.length) {
     console.warn(`${LOG_PREFIX} No loaded versions for plugin instance`);
     return null;
@@ -240,11 +295,17 @@ async function processProduct(docsPlugin, outDir, siteUrl, options, cache) {
   const versions = [];
   for (const version of selected) {
     const result = await processVersion(version, outDir, siteUrl, cache);
-    versions.push({
-      ...result,
-      versionLabel: options.unversioned ? '' : result.versionLabel,
-      isLast: Boolean(version.isLast),
-    });
+    // Precedence: unversioned wins, then a variables.js label, then Docusaurus's own.
+    let versionLabel = result.versionLabel;
+    if (options.unversioned) {
+      versionLabel = '';
+    } else if (options.versionVariable && docsPath && options.siteDir) {
+      versionLabel =
+        versionLabelFromVariables(options.versionVariable, docsPath, version, options.siteDir) ??
+        result.versionLabel;
+    }
+
+    versions.push({ ...result, versionLabel, isLast: Boolean(version.isLast) });
   }
 
   const lastVersion = versions.find((v) => v.isLast) || versions[0];
@@ -349,6 +410,7 @@ export default function llmsTxtPlugin(context, options) {
         topPages = [],
         optionalSections = [],
         versions = 'last',
+        versionVariables = {},
       } = options;
 
       // Find all docs plugin instances
@@ -419,7 +481,13 @@ export default function llmsTxtPlugin(context, options) {
             plugin,
             outDir,
             siteUrl,
-            { ...options, versions, unversioned },
+            {
+              ...options,
+              versions,
+              unversioned,
+              siteDir,
+              versionVariable: versionVariables[instanceId],
+            },
             cache
           );
 


### PR DESCRIPTION
Follow-ups on DOCS-3014, on top of the merged #2958. Three came out of the final review pass on that PR; the fourth is the Calico Cloud version question.

Calico Cloud twins reported version: "23-2". That is a Docusaurus navigation label. Calico Cloud has no version dropdown and no version segment in its URLs, so 23-2 appears nowhere a reader or an agent could corroborate it — which undermines the point of carrying the field at all. The docs themselves render $[cloudUserVersion], which is v23.0.1.

A new versionVariables option names the variables.js key holding a product's user-facing version:

    versionVariables: {
      'calico-cloud': 'cloudUserVersion',
    },

Calico and Calico Enterprise are unaffected and keep the Docusaurus label, which for them matches the version in the URL. The variables file is located the same way src/utils/getVariableByFilePath.js locates it for the remark plugin, rather than inventing a second convention. A missing file or key warns and falls back to the Docusaurus label; a display string is not worth failing a build over.

Before and after:

    version: "23-2"        ->  version: "v23.0.1"
    > Complete documentation for Calico Cloud (version 23-2).
    > Complete documentation for Calico Cloud (version v23.0.1).

The empty-page guard could not fire for use-cases. Its allowance is the larger of 5% of a version's pages and an absolute minimum, and that minimum was 5 against a five-page instance. The allowance equalled the size of the instance, so the comparison was never true and only total loss was caught, by a different guard. The minimum is now 2. emptyPageAllowance is exported so the arithmetic is testable — this is a bug that reads as correct and is only visible if you check the numbers.

cache.js justified its own safety with a claim its tests refute. The comment said script and link tags never reach the extracted content. The tests say the opposite, because the Swagger pages carry a stylesheet link inside theirs, and assert the weaker sufficient property instead: stripping them cannot change the resulting Markdown. The code was correct; the false rationale was sitting in the file someone reads before editing the stripping logic.

A cache write failure could fail the whole build. A read-only directory, or a file where .llms-cache belongs, propagated out of cache.set and took the build down having published nothing. The cache only ever saves work, so writes and prunes now warn and continue, once per build rather than once per page. fingerprintConverter still fails closed, because a fingerprint it cannot compute would let stale entries serve.

Tests: four new ones covering the allowance arithmetic and cache resilience. All four fail against the previous code and pass against this, which I checked rather than assumed. 12 suites, 78 passing.

On the deploy preview, the Cloud change:

- https://deploy-preview-2961--tigera.netlify.app/calico-cloud/get-started/connect-cluster.md
- https://deploy-preview-2961--tigera.netlify.app/calico-cloud/llms-full.txt

and a Calico page to confirm nothing else moved:

- https://deploy-preview-2961--tigera.netlify.app/calico/latest/networking/configuring/bgp.md
