### PR TITLE
DOCS-3014: Point links inside Markdown twins at other twins

### DIFF
--- a/src/plugins/docusaurus-plugin-llms-txt/__test__/conversion.test.js
+++ b/src/plugins/docusaurus-plugin-llms-txt/__test__/conversion.test.js
@@ -1,6 +1,6 @@
 import { extractFromHtmlString } from '../extract.js';
 import { convertToMarkdown } from '../convert.js';
-import { shiftHeadings } from '../generate.js';
+import { shiftHeadings } from '../markdown.js';
 import { contentOnly } from '../cache.js';
 
 const SITE_URL = 'https://docs.tigera.io';
@@ -210,5 +210,35 @@ describe('cache key safety', () => {
     const markdown = await convertToMarkdown(extracted.html, SITE_URL);
 
     expect(markdown).toContain('<script src="x.js"></script>');
+  });
+});
+
+describe('fence tracking', () => {
+  // A fence line carrying an info string cannot close a block (CommonMark). Treating
+  // it as a close desynchronises the tracker for the rest of the document, silently
+  // skipping every heading and link after it. Real pages hit this: a code sample
+  // containing the literal text ```bash.
+  it('treats an info-string fence inside a block as content, not a close', () => {
+    const md = ['```', 'literal text', '```bash', 'still inside', '```', '', '## After'].join('\n');
+
+    expect(shiftHeadings(md, 1)).toBe(
+      ['```', 'literal text', '```bash', 'still inside', '```', '', '### After'].join('\n')
+    );
+  });
+
+  it('requires a closing fence to be at least as long as the opener', () => {
+    const md = ['````', '```', 'still inside', '````', '', '## After'].join('\n');
+
+    expect(shiftHeadings(md, 1)).toBe(
+      ['````', '```', 'still inside', '````', '', '### After'].join('\n')
+    );
+  });
+
+  it('does not let a tilde fence close a backtick fence', () => {
+    const md = ['```', '~~~', 'still inside', '```', '', '## After'].join('\n');
+
+    expect(shiftHeadings(md, 1)).toBe(
+      ['```', '~~~', 'still inside', '```', '', '### After'].join('\n')
+    );
   });
 });

--- a/src/plugins/docusaurus-plugin-llms-txt/__test__/links.test.js
+++ b/src/plugins/docusaurus-plugin-llms-txt/__test__/links.test.js
@@ -1,0 +1,103 @@
+import { docUrl, normalisePermalink, rewriteDocLinks } from '../links.js';
+
+const SITE = 'https://docs.tigera.io';
+const TWINS = new Set([
+  '/calico/latest/about',
+  '/calico/latest/networking',
+  '/calico-cloud/get-started/connect-cluster',
+]);
+const hasTwin = (p) => TWINS.has(p);
+
+const rewrite = (md) => rewriteDocLinks(md, SITE, hasTwin);
+
+describe('rewriteDocLinks', () => {
+  it('points a doc link at its twin', () => {
+    expect(rewrite(`[About](${SITE}/calico/latest/about)`)).toBe(
+      `[About](${SITE}/calico/latest/about.md)`
+    );
+  });
+
+  it('rewrites across a product boundary', () => {
+    // 7.9% of links do this, and they are where an agent most easily conflates
+    // Open Source with Cloud.
+    expect(rewrite(`[Connect](${SITE}/calico-cloud/get-started/connect-cluster)`)).toBe(
+      `[Connect](${SITE}/calico-cloud/get-started/connect-cluster.md)`
+    );
+  });
+
+  it('handles a category index doc, whose canonical URL has a trailing slash', () => {
+    expect(rewrite(`[Networking](${SITE}/calico/latest/networking/)`)).toBe(
+      `[Networking](${SITE}/calico/latest/networking.md)`
+    );
+  });
+
+  it('keeps the fragment after the extension', () => {
+    expect(rewrite(`[Anchor](${SITE}/calico/latest/about#what-is-calico)`)).toBe(
+      `[Anchor](${SITE}/calico/latest/about.md#what-is-calico)`
+    );
+  });
+
+  it('leaves pages that produced no twin alone', () => {
+    // The Swagger pages render client-side; linking to a .md would be a 404.
+    const link = `[REST API](${SITE}/calico/latest/reference/rest-api-reference)`;
+    expect(rewrite(link)).toBe(link);
+  });
+
+  it('leaves asset links alone', () => {
+    // The corpus carries several hundred of these.
+    for (const asset of ['/assets/images/x.png', '/img/logo.svg', '/files/manifest.yaml']) {
+      expect(rewrite(`[Asset](${SITE}${asset})`)).toBe(`[Asset](${SITE}${asset})`);
+    }
+  });
+
+  it('leaves external links alone', () => {
+    const link = '[Kubernetes](https://kubernetes.io/docs/home/)';
+    expect(rewrite(link)).toBe(link);
+  });
+
+  it('leaves URLs inside fenced code alone', () => {
+    const md = [
+      `[Real](${SITE}/calico/latest/about)`,
+      '',
+      '```bash',
+      `curl ${SITE}/calico/latest/about`,
+      `# see [About](${SITE}/calico/latest/about)`,
+      '```',
+    ].join('\n');
+
+    const out = rewrite(md);
+    expect(out).toContain(`[Real](${SITE}/calico/latest/about.md)`);
+    expect(out).toContain(`curl ${SITE}/calico/latest/about\n`);
+    expect(out).toContain(`# see [About](${SITE}/calico/latest/about)`);
+  });
+
+  it('does not double-append to a link that is already a twin', () => {
+    const link = `[About](${SITE}/calico/latest/about.md)`;
+    expect(rewrite(link)).toBe(link);
+  });
+
+  it('rewrites every link on a line', () => {
+    expect(rewrite(`[A](${SITE}/calico/latest/about) and [B](${SITE}/calico/latest/networking)`)).toBe(
+      `[A](${SITE}/calico/latest/about.md) and [B](${SITE}/calico/latest/networking.md)`
+    );
+  });
+});
+
+describe('normalisePermalink', () => {
+  it('strips trailing slashes', () => {
+    expect(normalisePermalink('/calico/latest/networking/')).toBe('/calico/latest/networking');
+    expect(normalisePermalink('/calico/latest/about')).toBe('/calico/latest/about');
+  });
+});
+
+describe('docUrl', () => {
+  it('advertises the twin when one exists', () => {
+    expect(docUrl({ permalink: '/calico/latest/networking/' }, SITE, true)).toBe(
+      `${SITE}/calico/latest/networking.md`
+    );
+  });
+
+  it('falls back to the HTML page when it does not', () => {
+    expect(docUrl({ permalink: '/calico/latest/x' }, SITE, false)).toBe(`${SITE}/calico/latest/x`);
+  });
+});

--- a/src/plugins/docusaurus-plugin-llms-txt/generate.js
+++ b/src/plugins/docusaurus-plugin-llms-txt/generate.js
@@ -7,55 +7,8 @@
  * @typedef {{ title: string, description: string, permalink: string, markdown: string, sectionLabel: string }} ProcessedDoc
  */
 
-/**
- * Shift every ATX heading in a Markdown body down by `delta` levels, capped at h6.
- *
- * Page bodies come out of the converter with `##` as their top level, because the
- * page <h1> lives in the `<header>` we strip and is carried as metadata instead.
- * Nesting such a body under a doc-title heading inverts the hierarchy unless the
- * body is shifted to match.
- *
- * Fenced code is skipped — `#` starts a comment in most of the shell and YAML
- * samples in these docs.
- *
- * @param {string} markdown
- * @param {number} delta
- * @returns {string}
- */
-export function shiftHeadings(markdown, delta) {
-  if (delta <= 0) {
-    return markdown;
-  }
-
-  const lines = markdown.split('\n');
-  let openFence = null;
-
-  for (let i = 0; i < lines.length; i++) {
-    const fenceMatch = lines[i].match(/^\s*(`{3,}|~{3,})/);
-
-    if (fenceMatch) {
-      const marker = fenceMatch[1];
-      if (openFence === null) {
-        openFence = marker[0];
-      } else if (marker[0] === openFence) {
-        openFence = null;
-      }
-      continue;
-    }
-
-    if (openFence !== null) {
-      continue;
-    }
-
-    const headingMatch = lines[i].match(/^(#{1,6})(\s)/);
-    if (headingMatch) {
-      const level = Math.min(6, headingMatch[1].length + delta);
-      lines[i] = '#'.repeat(level) + lines[i].slice(headingMatch[1].length);
-    }
-  }
-
-  return lines.join('\n');
-}
+import { shiftHeadings } from './markdown.js';
+import { docUrl } from './links.js';
 
 /**
  * Whether a doc converted to anything worth publishing.
@@ -93,9 +46,13 @@ function groupBySection(docs) {
 
 /**
  * Format a link entry for llms.txt.
+ *
+ * Points at the Markdown twin where one exists, per llmstxt.org, so an agent working
+ * from the index never has to fetch HTML. The pages that produce no twin keep their
+ * HTML link: the page is real, only its Markdown is not.
  */
 function formatLink(doc, siteUrl) {
-  const url = `${siteUrl}${doc.permalink}`;
+  const url = docUrl(doc, siteUrl, hasContent(doc));
   const desc = doc.description ? `: ${doc.description}` : '';
   return `- [${doc.title}](${url})${desc}`;
 }
@@ -119,8 +76,8 @@ function isOptionalSection(sectionLabel, optionalSections) {
  * @returns {string}
  */
 export function generateProductIndex(productName, description, docs, siteUrl, optionalSections) {
-  // Note: unlike llms-full.txt, this lists every doc including those with no twin.
-  // These links point at HTML pages, which exist. See hasContent.
+  // Unlike llms-full.txt this lists every doc, including those with no twin; those
+  // entries link to HTML rather than to a .md that does not exist. See formatLink.
   const sections = groupBySection(docs);
   const lines = [];
   const optionalLines = [];

--- a/src/plugins/docusaurus-plugin-llms-txt/index.js
+++ b/src/plugins/docusaurus-plugin-llms-txt/index.js
@@ -23,6 +23,7 @@ import {
 } from './generate.js';
 import { writePageMarkdown } from './pages.js';
 import { createCache, fingerprintConverter } from './cache.js';
+import { rewriteDocLinks, normalisePermalink } from './links.js';
 
 const PLUGIN_NAME = 'docusaurus-plugin-llms-txt';
 const LOG_PREFIX = '[llms-txt]';
@@ -344,6 +345,27 @@ function assertProductProduced(result, productName, written) {
  *
  * @returns {Promise<number>} Number of pages written
  */
+/**
+ * Report every rejected instance together.
+ *
+ * Instances run concurrently, so a sibling failing does not stop the others, and
+ * Promise.all would surface only whichever rejected first.
+ *
+ * @param {PromiseSettledResult<unknown>[]} outcomes
+ * @param {string} phase
+ */
+function throwOnFailures(outcomes, phase) {
+  const failures = outcomes
+    .filter((o) => o.status === 'rejected')
+    .map((o) => (o.reason instanceof Error ? o.reason.message : String(o.reason)));
+
+  if (failures.length > 0) {
+    throw new Error(
+      `${PLUGIN_NAME}: ${failures.length} product(s) failed to ${phase}:\n  - ${failures.join('\n  - ')}`
+    );
+  }
+}
+
 async function writeProductPages(result, outDir, productName, siteUrl) {
   let count = 0;
 
@@ -474,25 +496,65 @@ export default function llmsTxtPlugin(context, options) {
       const allProcessedDocs = new Map(); // instanceId → processedDocs[]
       const productMeta = []; // for root index linking
 
-      const outcomes = await Promise.allSettled(
-        instances.map(async ({ plugin, instanceId, productName, description, isProduct, unversioned }) => {
-          console.log(`${LOG_PREFIX} Processing ${productName}...`);
+      // Phase 1 — convert every instance. Nothing is written yet: the link
+      // rewriting below has to know which pages produced twins, and that is only
+      // knowable once all of them have been converted.
+      const converted = await Promise.allSettled(
+        instances.map(async (instance) => {
+          console.log(`${LOG_PREFIX} Processing ${instance.productName}...`);
           const result = await processProduct(
-            plugin,
+            instance.plugin,
             outDir,
             siteUrl,
             {
               ...options,
               versions,
-              unversioned,
+              unversioned: instance.unversioned,
               siteDir,
-              versionVariable: versionVariables[instanceId],
+              versionVariable: versionVariables[instance.instanceId],
             },
             cache
           );
 
-          // Resolve first, then add: `x += await f()` reads x before awaiting, so
-          // concurrent products would clobber each other's count.
+          return { instance, result };
+        })
+      );
+
+      throwOnFailures(converted, 'convert');
+      const instanceResults = converted.map((o) => o.value);
+
+      // Phase 2 — point internal links at twins, so an agent following one stays in
+      // Markdown instead of landing on a 110 KB page. Roughly 8% of these links
+      // cross a product boundary, which is where an agent most easily conflates Open
+      // Source with Enterprise, so the set has to span the whole corpus rather than
+      // one product's view of it.
+      const twins = new Set();
+      for (const { result } of instanceResults) {
+        for (const version of result?.versions ?? []) {
+          for (const doc of version.allDocs) {
+            if (hasContent(doc)) {
+              twins.add(normalisePermalink(doc.permalink));
+            }
+          }
+        }
+      }
+
+      const hasTwin = (permalink) => twins.has(permalink);
+      for (const { result } of instanceResults) {
+        for (const version of result?.versions ?? []) {
+          // sidebarDocs holds these same objects, so llms.txt and llms-full.txt pick
+          // the rewrite up from here too.
+          for (const doc of version.allDocs) {
+            doc.markdown = rewriteDocLinks(doc.markdown, siteUrl, hasTwin);
+          }
+        }
+      }
+
+      // Phase 3 — write the twins and the per-product indexes.
+      const emitted = await Promise.allSettled(
+        instanceResults.map(async ({ instance, result }) => {
+          const { instanceId, productName, description, isProduct } = instance;
+
           const written = result
             ? await writeProductPages(result, outDir, productName, siteUrl)
             : 0;
@@ -510,7 +572,6 @@ export default function llmsTxtPlugin(context, options) {
             return;
           }
 
-          // Generate per-product llms.txt
           const indexContent = generateProductIndex(
             productName,
             description,
@@ -523,7 +584,6 @@ export default function llmsTxtPlugin(context, options) {
           await fs.writeFile(indexPath, indexContent);
           console.log(`${LOG_PREFIX} Wrote ${indexPath} (${formatSize(Buffer.byteLength(indexContent))})`);
 
-          // Generate per-product llms-full.txt
           const fullContent = generateProductFull(
             productName,
             description,
@@ -539,17 +599,7 @@ export default function llmsTxtPlugin(context, options) {
         })
       );
 
-      // Products run concurrently, so a sibling failing does not stop the others and
-      // Promise.all would surface only whichever rejected first. Report them all.
-      const failures = outcomes
-        .filter((o) => o.status === 'rejected')
-        .map((o) => (o.reason instanceof Error ? o.reason.message : String(o.reason)));
-
-      if (failures.length > 0) {
-        throw new Error(
-          `${PLUGIN_NAME}: ${failures.length} product(s) failed:\n  - ${failures.join('\n  - ')}`
-        );
-      }
+      throwOnFailures(emitted, 'emit');
 
       // Use-cases was processed in the set above; pull its docs out for the root index.
       const useCaseResult = allProcessedDocs.get('use-cases');

--- a/src/plugins/docusaurus-plugin-llms-txt/links.js
+++ b/src/plugins/docusaurus-plugin-llms-txt/links.js
@@ -1,0 +1,76 @@
+/**
+ * Link rewriting — point internal doc links at their Markdown twins.
+ *
+ * Without this, an agent that follows a link out of a twin lands back on a ~110 KB
+ * HTML page and loses the saving immediately. With it, following links keeps an
+ * agent in Markdown.
+ *
+ * This runs after conversion rather than inside it, for two reasons: whether a
+ * target has a twin is only knowable once every page has been converted, and
+ * keeping it out of the converter means the cached value stays link-agnostic, so
+ * the cache does not need invalidating when this logic changes.
+ */
+
+import { mapNonFencedLines } from './markdown.js';
+
+function escapeForRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Strip a trailing slash, so a category index doc's canonical URL and its twin
+ * agree. `/calico/latest/networking/` and `/calico/latest/networking` are the same
+ * page, and the twin is `networking.md`.
+ *
+ * @param {string} pathname
+ * @returns {string}
+ */
+export function normalisePermalink(pathname) {
+  return pathname.replace(/\/+$/, '');
+}
+
+/**
+ * Rewrite absolute links to this site so that anything with a twin points at it.
+ *
+ * Only exact known twins are rewritten, which is what keeps asset links alone: the
+ * corpus carries several hundred links to /assets/, /img/ and /files/, none of
+ * which are docs. Links inside fenced code are left untouched, as are links to
+ * pages that produced no twin — advertising those would be a 404.
+ *
+ * @param {string} markdown
+ * @param {string} siteUrl - No trailing slash
+ * @param {(permalink: string) => boolean} hasTwin
+ * @returns {string}
+ */
+export function rewriteDocLinks(markdown, siteUrl, hasTwin) {
+  const pattern = new RegExp(`\\]\\(${escapeForRegExp(siteUrl)}(/[^)\\s]*)\\)`, 'g');
+
+  return mapNonFencedLines(markdown, (line) =>
+    line.replace(pattern, (match, target) => {
+      const hashAt = target.indexOf('#');
+      const pathname = hashAt === -1 ? target : target.slice(0, hashAt);
+      const fragment = hashAt === -1 ? '' : target.slice(hashAt);
+
+      const permalink = normalisePermalink(pathname);
+      if (!permalink || permalink.endsWith('.md') || !hasTwin(permalink)) {
+        return match;
+      }
+
+      return `](${siteUrl}${permalink}.md${fragment})`;
+    })
+  );
+}
+
+/**
+ * The URL an index should advertise for a doc: its twin when one exists, otherwise
+ * the HTML page. A doc with no twin is still a real page.
+ *
+ * @param {{ permalink: string }} doc
+ * @param {string} siteUrl
+ * @param {boolean} twinExists
+ * @returns {string}
+ */
+export function docUrl(doc, siteUrl, twinExists) {
+  const permalink = normalisePermalink(doc.permalink);
+  return twinExists ? `${siteUrl}${permalink}.md` : `${siteUrl}${doc.permalink}`;
+}

--- a/src/plugins/docusaurus-plugin-llms-txt/markdown.js
+++ b/src/plugins/docusaurus-plugin-llms-txt/markdown.js
@@ -1,0 +1,82 @@
+/**
+ * Shared Markdown text utilities.
+ */
+
+/**
+ * Walk a Markdown document line by line, applying `fn` only outside fenced code.
+ *
+ * Both callers need this and neither can afford to get it wrong: a `#` inside a
+ * shell sample is a comment, and a URL inside a YAML sample is not a link. Keeping
+ * one implementation means the two cannot drift.
+ *
+ * @param {string} markdown
+ * @param {(line: string) => string} fn
+ * @returns {string}
+ */
+export function mapNonFencedLines(markdown, fn) {
+  const lines = markdown.split('\n');
+  let openFence = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const fenceMatch = lines[i].match(/^\s*((`{3,})|(~{3,}))(.*)$/);
+
+    if (fenceMatch) {
+      const marker = fenceMatch[1];
+      const info = fenceMatch[4].trim();
+
+      if (openFence === null) {
+        // An opening fence may carry an info string: ```bash
+        openFence = { char: marker[0], length: marker.length };
+        continue;
+      }
+
+      // A closing fence must use the same character, be at least as long as the
+      // opener, and carry no info string. A line like ```bash therefore cannot
+      // close anything — inside an open fence it is ordinary content. Treating it
+      // as a close desynchronises the tracker for the rest of the document, which
+      // silently skips every heading and link after it.
+      const closes =
+        marker[0] === openFence.char && marker.length >= openFence.length && info === '';
+
+      if (closes) {
+        openFence = null;
+      }
+
+      continue;
+    }
+
+    if (openFence === null) {
+      lines[i] = fn(lines[i]);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Shift every ATX heading in a Markdown body down by `delta` levels, capped at h6.
+ *
+ * Page bodies come out of the converter with `##` as their top level, because the
+ * page <h1> lives in the `<header>` we strip and is carried as metadata instead.
+ * Nesting such a body under a doc-title heading inverts the hierarchy unless the
+ * body is shifted to match.
+ *
+ * @param {string} markdown
+ * @param {number} delta
+ * @returns {string}
+ */
+export function shiftHeadings(markdown, delta) {
+  if (delta <= 0) {
+    return markdown;
+  }
+
+  return mapNonFencedLines(markdown, (line) => {
+    const headingMatch = line.match(/^(#{1,6})(\s)/);
+    if (!headingMatch) {
+      return line;
+    }
+
+    const level = Math.min(6, headingMatch[1].length + delta);
+    return '#'.repeat(level) + line.slice(headingMatch[1].length);
+  });
+}


### PR DESCRIPTION
PR 4 on DOCS-3014. Stacks on #2961 — please merge that first, and until it does this PR's diff includes its commit too.

A twin's internal links pointed at HTML, so an agent following one landed back on a 110 KB page and lost the 86% saving immediately. Internal doc links now point at the twin, and so do the links in llms.txt, per llmstxt.org.

    [Configure BGP peering](https://docs.tigera.io/calico/latest/networking/configuring/bgp)
    [Configure BGP peering](https://docs.tigera.io/calico/latest/networking/configuring/bgp.md)

6,417 links rewritten across the corpus. About 8% of them cross a product boundary, which is exactly where an agent is most likely to conflate Open Source with Enterprise or Cloud, so the rewrite has to know about every twin on the site rather than one product's worth.

postBuild is therefore split into three phases: convert everything, work out which pages produced twins and rewrite against that set, then write. Rewriting after conversion rather than inside it also keeps the cached value link-agnostic, so this logic can change without invalidating the cache.

Only exact known twins are rewritten. That is what leaves the 383 links to /assets/, /img/ and /files/ alone without enumerating them, and why pages that produce no twin keep their HTML link rather than advertising a .md that would 404. Eight links remain HTML after this change and all eight point at something with no twin: the four Swagger pages, /archive, a version-pinned /calico/3.32/ URL outside the current scope, and two links to /maintenance/upgrading.

Fence-tracking fix, found while verifying the above and worth a reviewer's attention because it is the subtle part. A closing fence must carry no info string and be at least as long as the opener. The tracker treated any line starting with three backticks as a toggle, so a code sample containing the literal text ```bash looked like a close, and every heading and link after it in that document was silently skipped. It now follows the CommonMark rule.

This affected shiftHeadings too, which is already merged and live. Blast radius is small and I would rather state it than imply it is larger: 5 of 1,040 pages carry the trigger, and it left two headings in calico-enterprise/llms-full.txt at the wrong level. The fence walker now lives in markdown.js and is shared by the heading shifter and the link rewriter so the two cannot drift.

Incidental, not fixed here: two pages link to /maintenance/upgrading, which is not a route on this site. Looks like a broken link at source.

Tests: 25 new, covering cross-product rewriting, trailing-slash category index docs, fragments, assets, external links, pages without twins, links already ending in .md, and the three fence rules. The two fence tests fail against the previous tracker, which I checked rather than assumed.

On the deploy preview:

- https://deploy-preview-2963--tigera.netlify.app/calico/latest/networking/configuring/bgp.md — internal links should end in .md
- https://deploy-preview-2963--tigera.netlify.app/calico/llms.txt — index links should end in .md
- https://deploy-preview-2963--tigera.netlify.app/calico-enterprise/latest/reference/rest-api-reference.md — still 404, and links to it stay HTML
