### PR TITLE
DOCS-3014: Serve Markdown to clients that ask for it

### DIFF
--- a/netlify/edge-functions/markdown-negotiation.js
+++ b/netlify/edge-functions/markdown-negotiation.js
@@ -1,0 +1,151 @@
+/**
+ * Serve the Markdown twin to clients that ask for Markdown.
+ *
+ * Appending ".md" to a URL only helps agents that know to try it. Several do not:
+ * of seven coding agents surveyed in February 2026, Claude Code, Cursor and OpenCode
+ * announce `Accept: text/markdown` but never guess a suffix, while Codex, Gemini CLI,
+ * Copilot and Windsurf announce nothing useful. Content negotiation is the only way
+ * to reach the first group.
+ *
+ * The `header` condition in the config below means this function does not run at all
+ * for ordinary browser traffic, so it costs nothing on the overwhelming majority of
+ * requests.
+ *
+ * Deliberately does not run on the production domain yet. Netlify excludes `Accept`
+ * from `Netlify-Vary` because of its cardinality, and while the standard `Vary` header
+ * is documented as feeding cache keys, the failure mode if it does not — a browser
+ * served raw Markdown out of the CDN — is bad enough to prove on a preview first.
+ */
+
+/**
+ * Whether to negotiate on this host.
+ *
+ * Allow-listed rather than deny-listed, so an unrecognised host means "do not
+ * negotiate". Netlify preview and branch deploys are served from *.netlify.app;
+ * docs.tigera.io is not, and stays on HTML until the caching behaviour is proven.
+ * Promoting it is a deliberate one-line change here.
+ *
+ * This is decided from the request rather than from an env var because environment
+ * plumbing turned out to be the least reliable part of this: CONTEXT is undefined
+ * under `netlify dev`, which also ignores [context.dev.environment] in netlify.toml.
+ *
+ * @param {URL} url
+ * @returns {boolean}
+ */
+export function negotiationEnabled(url) {
+  return url.hostname.endsWith('.netlify.app') || url.hostname === 'localhost';
+}
+
+/**
+ * Quality value for a media type in an Accept header, or null if absent.
+ *
+ * @param {string} accept
+ * @param {string} mediaType
+ * @returns {number | null}
+ */
+function qualityFor(accept, mediaType) {
+  for (const entry of accept.split(',')) {
+    const [type, ...params] = entry.split(';').map((part) => part.trim());
+    if (type.toLowerCase() !== mediaType) {
+      continue;
+    }
+
+    const q = params.map((p) => p.match(/^q=([0-9.]+)$/i)).find(Boolean);
+    return q ? Number.parseFloat(q[1]) : 1;
+  }
+
+  return null;
+}
+
+/**
+ * Whether the client genuinely prefers Markdown over HTML.
+ *
+ * Substring-matching "text/markdown" is not enough: a client may list it purely as a
+ * fallback below HTML. Ties go to Markdown, since a client that names it at all and
+ * ranks it level with HTML is signalling it can use it.
+ *
+ * @param {string | null} accept
+ * @returns {boolean}
+ */
+export function prefersMarkdown(accept) {
+  if (!accept) {
+    return false;
+  }
+
+  const markdown = qualityFor(accept, 'text/markdown');
+  if (markdown === null || markdown === 0) {
+    return false;
+  }
+
+  const html = qualityFor(accept, 'text/html');
+  return html === null || markdown >= html;
+}
+
+/**
+ * The twin path for a doc route, or null if this is not one.
+ *
+ * Mirrors the emitter: a trailing slash is dropped, because a category index doc's
+ * canonical URL carries one while its twin does not.
+ *
+ * @param {string} pathname
+ * @returns {string | null}
+ */
+export function markdownTwinFor(pathname) {
+  // Anything with an extension is an asset or an already-Markdown request.
+  if (/\.[a-z0-9]+$/i.test(pathname)) {
+    return null;
+  }
+
+  const trimmed = pathname.replace(/\/+$/, '');
+  return trimmed ? `${trimmed}.md` : null;
+}
+
+export default async (request, context) => {
+  const url = new URL(request.url);
+
+  if (!negotiationEnabled(url) || !prefersMarkdown(request.headers.get('accept'))) {
+    return;
+  }
+
+  const twin = markdownTwinFor(url.pathname);
+  if (!twin) {
+    return;
+  }
+
+  // `Accept: */*` on the internal fetch so this cannot re-enter itself, whatever the
+  // path matching does later.
+  const response = await fetch(new URL(twin, url), { headers: { accept: '*/*' } });
+
+  // No twin for this page — the client gets the HTML it would have got anyway.
+  if (!response.ok) {
+    return;
+  }
+
+  const headers = {
+    'content-type': 'text/markdown; charset=utf-8',
+    // Tells every cache between here and the client that this URL has more than one
+    // representation. Without it a shared cache could hand this body to a browser.
+    vary: 'Accept',
+    'x-robots-tag': 'noindex',
+    // The HTML page is the canonical one; this is an alternate representation.
+    link: `<${url.href}>; rel="canonical"`,
+  };
+
+  return new Response(response.body, { headers });
+};
+
+export const config = {
+  // Doc routes only. Everything else — the landing page, /archive, /lynx — is left
+  // alone even if something asks it for Markdown.
+  path: ['/calico/*', '/calico-enterprise/*', '/calico-cloud/*', '/use-cases/*'],
+  excludedPath: ['/*.md', '/*.txt', '/*.json', '/*.yaml', '/*.html', '/*.xml'],
+  // GET only. Netlify's manifest schema allows GET, POST, PUT, PATCH, DELETE and
+  // OPTIONS — not HEAD — and rejects the whole manifest if HEAD appears, failing the
+  // build. A HEAD request therefore gets the HTML page's headers; agents use GET, so
+  // this only affects `curl -I` style probing, which needs `curl -sD - -o /dev/null`
+  // against a GET instead.
+  method: 'GET',
+  // The whole point: this function is invisible to clients that do not ask for
+  // Markdown, so browser traffic never reaches it.
+  header: { accept: 'text/markdown' },
+};

--- a/src/__tests__/markdown-negotiation.test.js
+++ b/src/__tests__/markdown-negotiation.test.js
@@ -1,0 +1,123 @@
+import {
+  config,
+  markdownTwinFor,
+  negotiationEnabled,
+  prefersMarkdown,
+} from '../../netlify/edge-functions/markdown-negotiation.js';
+
+describe('prefersMarkdown', () => {
+  it('accepts what Claude Code sends', () => {
+    expect(prefersMarkdown('text/markdown, text/html, */*')).toBe(true);
+  });
+
+  it('accepts what Cursor and OpenCode send', () => {
+    expect(prefersMarkdown('text/markdown;q=1.0, text/html;q=0.9, */*;q=0.8')).toBe(true);
+    expect(prefersMarkdown('text/markdown;q=1.0')).toBe(true);
+  });
+
+  it('declines when HTML outranks Markdown', () => {
+    // Listing Markdown as a fallback is not a request for it.
+    expect(prefersMarkdown('text/html;q=1.0, text/markdown;q=0.5')).toBe(false);
+  });
+
+  it('declines an explicit q=0', () => {
+    expect(prefersMarkdown('text/markdown;q=0, text/html')).toBe(false);
+  });
+
+  it('declines a browser Accept header', () => {
+    expect(
+      prefersMarkdown('text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,*/*;q=0.8')
+    ).toBe(false);
+  });
+
+  it('declines when there is no Accept header at all', () => {
+    expect(prefersMarkdown(null)).toBe(false);
+    expect(prefersMarkdown('')).toBe(false);
+  });
+
+  it('serves Markdown on a tie, and tolerates odd spacing and case', () => {
+    expect(prefersMarkdown('TEXT/MARKDOWN , text/html')).toBe(true);
+    expect(prefersMarkdown('text/markdown;q=0.7,text/html;q=0.7')).toBe(true);
+  });
+
+  it('is not fooled by a media type that merely contains the string', () => {
+    expect(prefersMarkdown('text/markdown-x, text/html')).toBe(false);
+  });
+});
+
+describe('markdownTwinFor', () => {
+  it('maps a leaf doc route to its twin', () => {
+    expect(markdownTwinFor('/calico/latest/networking/configuring/bgp')).toBe(
+      '/calico/latest/networking/configuring/bgp.md'
+    );
+  });
+
+  it('drops the trailing slash a category index doc carries', () => {
+    expect(markdownTwinFor('/calico/latest/networking/')).toBe('/calico/latest/networking.md');
+  });
+
+  it('leaves anything with an extension alone', () => {
+    // Guards against re-entering on the twin itself, and against assets.
+    for (const p of ['/calico/latest/about.md', '/llms.txt', '/assets/js/main.abc.js']) {
+      expect(markdownTwinFor(p)).toBeNull();
+    }
+  });
+
+  it('returns null for the site root', () => {
+    expect(markdownTwinFor('/')).toBeNull();
+  });
+});
+
+describe('negotiationEnabled', () => {
+  const on = (host) => negotiationEnabled(new URL(`https://${host}/calico/latest/about`));
+
+  it('is off on the production domain', () => {
+    // Until Vary: Accept is proven against Netlify's CDN, docs.tigera.io stays HTML.
+    expect(on('docs.tigera.io')).toBe(false);
+  });
+
+  it('is on for Netlify preview and branch deploys', () => {
+    expect(on('deploy-preview-2964--tigera.netlify.app')).toBe(true);
+    expect(on('calico-docs-preview-next.netlify.app')).toBe(true);
+  });
+
+  it('is on for local development', () => {
+    expect(negotiationEnabled(new URL('http://localhost:8888/calico/latest/about'))).toBe(true);
+  });
+
+  it('is off for any host it does not recognise', () => {
+    // Allow-listed, not deny-listed: an unexpected host must not negotiate.
+    for (const host of ['example.com', 'netlify.app.evil.com', 'docs.tigera.io.evil.com']) {
+      expect(on(host)).toBe(false);
+    }
+  });
+});
+
+describe('edge function declaration', () => {
+  // Netlify validates the generated manifest at bundle time and fails the whole build
+  // if it does not match this enum. Adding HEAD here — which seems harmless, and which
+  // only existed so `curl -I` would work — broke every deploy on both sites.
+  const NETLIFY_ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
+
+  it('declares only methods Netlify accepts', () => {
+    const methods = Array.isArray(config.method) ? config.method : [config.method];
+
+    expect(methods.length).toBeGreaterThan(0);
+    for (const method of methods) {
+      expect(NETLIFY_ALLOWED_METHODS).toContain(method);
+    }
+  });
+
+  it('runs only when the client mentions markdown', () => {
+    // Without this condition the function would execute on every documentation
+    // request rather than the small fraction that could use the result.
+    expect(config.header).toEqual({ accept: 'text/markdown' });
+  });
+
+  it('scopes itself to documentation routes', () => {
+    expect(config.path).toEqual(
+      expect.arrayContaining(['/calico/*', '/calico-enterprise/*', '/calico-cloud/*', '/use-cases/*'])
+    );
+    expect(config.excludedPath).toEqual(expect.arrayContaining(['/*.md']));
+  });
+});


### PR DESCRIPTION
PR 5 on DOCS-3014, on top of the merged #2963. This is the one with runtime behaviour, so it is deliberately off on the production domain until we have proof from a preview.

Appending .md to a URL only reaches agents that know to try it. Of seven coding agents surveyed in February 2026, Claude Code, Cursor and OpenCode announce Accept: text/markdown but never guess a suffix, so content negotiation is the only way to reach them. The other four announce nothing useful and are unreachable either way.

A Netlify edge function serves the Markdown twin when the client genuinely prefers Markdown. Its declaration carries a header condition, so the function does not run at all for ordinary browser traffic and costs nothing on the overwhelming majority of requests.

Preferring Markdown is not the same as mentioning it. A client may list text/markdown below text/html as a fallback, so quality values are compared rather than the header being substring-matched. Ties go to Markdown, on the grounds that a client naming it and ranking it level with HTML is signalling it can use it.

Scope shrank from the original plan. The edge function was also going to set Content-Type and X-Robots-Tag on .md paths, but production showed both are already correct: Netlify serves .md as text/markdown unprompted, and the /*.md rule in _headers applies the noindex. So this is negotiation only, and this PR adds two files and changes no configuration.

On the production gate. Negotiation is decided from the request hostname, allow-listed rather than deny-listed, so docs.tigera.io stays on HTML and an unrecognised host does not negotiate either. Netlify excludes Accept from Netlify-Vary because of its cardinality; the standard Vary header is documented as feeding cache keys, but if it does not, the failure mode is a browser served raw Markdown out of the CDN, and that is worth proving before it reaches production. Promoting it is one line.

Deciding that in the function rather than in configuration is deliberate. Environment plumbing proved the least reliable part of this: CONTEXT is undefined under netlify dev, which also ignores [context.dev.environment] in netlify.toml and does not forward process environment to edge functions. Keeping the decision in the function means it behaves the same everywhere.

Worth knowing for review, because it cost four failed builds on two sites. Netlify validates the edge function manifest at bundle time and permits only GET, POST, PUT, PATCH, DELETE and OPTIONS. HEAD is not on that list, and including it fails the whole build rather than just the function. I had added HEAD purely so curl -I would exercise the function during testing. There is now a test asserting the declaration only uses methods Netlify accepts, because the mistake is invisible in review and surfaces only at deploy time. Note also that netlify build --dry validates configuration but does not run the bundling step; netlify build --offline does, and reproduces the failure locally.

Consequence: HEAD requests get the HTML page's headers. Agents use GET, so this only affects curl -I probing, which needs curl -sD - -o /dev/null against a GET instead.

Verified against the local emulator: an agent header returns text/markdown with Vary: Accept, a canonical Link header and noindex; a browser header returns HTML; Markdown ranked below HTML returns HTML; a page with no twin falls through to HTML rather than erroring; a category index doc resolves despite its trailing slash; llms.txt is out of scope.

What to check on the deploy preview, which is what local testing cannot cover:

    P=https://deploy-preview-2964--tigera.netlify.app/calico/latest/networking/configuring/bgp
    curl -sD - -o /dev/null -H 'Accept: text/markdown, text/html, */*' $P   # text/markdown, Vary: Accept
    curl -sD - -o /dev/null -H 'Accept: text/html' $P                       # text/html
    curl -sD - -o /dev/null $P                                              # text/html
    # then repeat the last two, twice each, in both orders, watching for a poisoned cache entry

A browser request returning Markdown at any point means Vary: Accept is not being honoured, and negotiation should not be promoted to production.

Tests: 19 unit tests over the Accept parsing, twin-path derivation, host gating and the declaration itself, including the exact headers Claude Code, Cursor and OpenCode send, a real browser header, an explicit q=0, and a media type that merely contains the string "text/markdown".
