### PR TITLE
DOCS-3014: Publish Markdown twins for every version, not just latest

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -573,7 +573,7 @@ export default async function createAsyncConfig() {
           optionalSections: ['release notes'],
           // 'last' covers only the version served at /latest; 'all' covers every
           // built version, at roughly three times the generation cost.
-          versions: 'last',
+          versions: 'all',
           // Docusaurus version names are navigation labels. Where a product has a
           // user-facing version that differs, name the variables.js key holding it
           // so frontmatter reports something a reader can corroborate. Calico Cloud's


### PR DESCRIPTION
PR on DOCS-3014, on top of the merged #2964. One line of configuration; the rest of this description is the measurement behind it.

Twins existed only for the version served at /latest, so an agent handed a version-pinned URL got a 404 and fell back to HTML. Those URLs are most of what appears in support threads, release notes and customer tickets, so it is a real gap rather than a theoretical one. Coverage now runs across every built version: 2,921 twins over 2,930 doc pages.

The nine pages without a twin are the eight client-rendered Swagger API browsers and one static licenses page. All nine convert to an empty body and are skipped deliberately, exactly as before.

Cost, measured locally:

- generation: 20s to 60s on a cold cache, unchanged at 1.8s warm
- .md files: 2,080 to 5,842
- Markdown on disk: 26 MB to 68 MB
- conversion cache: 15 MB to 40 MB

Deploy weight is the figure worth a second opinion, not build time. The warm path is what almost every build takes, and it does not move; only a first build after a dependency bump pays the 60s. But 68 MB and 5,842 extra files per deploy is a real change in what we ship, and if that is unwelcome the fallback is latest plus the one previous minor per product, which covers most version-pinned URLs at roughly half the cost.

This also unblocks the next PR. A rel=alternate link tag has to be suppressed on any page without a twin, and the theme cannot know which those are — only the plugin does. While twins covered latest alone, roughly 2,200 live pages had none, so the tag would have advertised that many URLs that 404. Widening first cuts the exception list to nine, which a small configured exclusion can carry honestly. I reordered the remaining work for that reason.

Negotiation stays off in production. That is a separate decision from coverage, and better made once the preview has seen real traffic for a while.

On the deploy preview, version-pinned twins that 404 on production today:

- https://deploy-preview-2965--tigera.netlify.app/calico/3.31/networking/configuring/bgp.md
- https://deploy-preview-2965--tigera.netlify.app/calico-enterprise/3.22/network-policy/policy-tiers/tiered-policy.md

and one that should still 404, being client-rendered:

- https://deploy-preview-2965--tigera.netlify.app/calico/3.31/reference/rest-api-reference.md

Worth confirming in the build log that the second deploy of this branch reports the pages as cached rather than converted, and that deploy time has not moved much.
