### PR TITLE
DOCS-3014: Advertise the Markdown twin on the page itself

### DIFF
--- a/algolia-crawler-config.json
+++ b/algolia-crawler-config.json
@@ -1,7 +1,7 @@
 {
   "index_name": "calico",
   "start_urls": ["https://docs.tigera.io/calico", "https://docs.tigera.io/calico-enterprise", "https://docs.tigera.io/calico-cloud"],
-  "stop_urls": [],
+  "stop_urls": ["\\.md$"],
   "selectors": {
     "lvl0": {
       "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -586,6 +586,18 @@ export default async function createAsyncConfig() {
     ],
     customFields: {
       isTesting: process.env.TESTING || false,
+      // Doc routes that render entirely client-side, so the generator produces no
+      // Markdown twin for them and nothing should link to one. Matched as path
+      // suffixes, so a single entry covers the page across every product and
+      // version. The llms-txt plugin checks this against the pages it actually
+      // skipped and warns on drift, so the list cannot silently go stale.
+      markdownTwinExclusions: [
+        // Swagger API browsers: rendered client-side, so they convert to nothing.
+        '/reference/rest-api-reference',
+        // The placeholder page the multi-instance 'default' docs instance requires.
+        // No Markdown is generated for that instance at all.
+        '/docs',
+      ],
     },
   };
 

--- a/src/components/MarkdownActions/__test__/markdownTwin.test.js
+++ b/src/components/MarkdownActions/__test__/markdownTwin.test.js
@@ -1,0 +1,50 @@
+import { hasMarkdownTwin, twinPathFor } from '../../../utils/markdownTwin';
+
+describe('twinPathFor', () => {
+  it('appends .md to a leaf doc route', () => {
+    expect(twinPathFor('/calico/latest/networking/configuring/bgp')).toBe(
+      '/calico/latest/networking/configuring/bgp.md'
+    );
+  });
+
+  it('drops the trailing slash a category index doc carries', () => {
+    // Its canonical URL ends in a slash; the twin is a sibling file, not a child.
+    expect(twinPathFor('/calico/latest/networking/')).toBe('/calico/latest/networking.md');
+  });
+});
+
+describe('hasMarkdownTwin', () => {
+  const EXCLUSIONS = ['/reference/rest-api-reference'];
+
+  it('is true for an ordinary doc page', () => {
+    expect(hasMarkdownTwin('/calico/latest/about', EXCLUSIONS)).toBe(true);
+  });
+
+  it('is false for a client-rendered page, in every product and version', () => {
+    // One suffix has to cover all eight of these, or the list needs an entry per
+    // version and goes stale at the next version cut.
+    for (const permalink of [
+      '/calico/latest/reference/rest-api-reference',
+      '/calico/3.31/reference/rest-api-reference',
+      '/calico-enterprise/latest/reference/rest-api-reference',
+      '/calico-enterprise/3.22/reference/rest-api-reference',
+      '/calico-cloud/reference/rest-api-reference',
+    ]) {
+      expect(hasMarkdownTwin(permalink, EXCLUSIONS)).toBe(false);
+    }
+  });
+
+  it('matches an excluded route that carries a trailing slash', () => {
+    expect(hasMarkdownTwin('/calico/latest/reference/rest-api-reference/', EXCLUSIONS)).toBe(false);
+  });
+
+  it('does not match a page that merely starts the same way', () => {
+    expect(hasMarkdownTwin('/calico/latest/reference/rest-api-reference-guide', EXCLUSIONS)).toBe(
+      true
+    );
+  });
+
+  it('treats an absent list as excluding nothing', () => {
+    expect(hasMarkdownTwin('/calico/latest/about')).toBe(true);
+  });
+});

--- a/src/components/MarkdownActions/index.js
+++ b/src/components/MarkdownActions/index.js
@@ -1,0 +1,239 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react';
+import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import { useDoc } from '@docusaurus/plugin-content-docs/client';
+import IconCopy from '@theme/Icon/Copy';
+import IconSuccess from '@theme/Icon/Success';
+
+import { hasMarkdownTwin, twinPathFor } from '@site/src/utils/markdownTwin';
+
+import styles from './styles.module.css';
+
+const COPIED_FOR_MS = 2000;
+
+// Docusaurus's themed icons default to their intrinsic size, which is far larger
+// than this control; they take props straight through to the svg.
+const ICON_SIZE = { width: 15, height: 15 };
+
+/** The conventional "M↓" markdown mark, as used on the reference design. */
+function IconMarkdown({ width, height }) {
+  return (
+    <svg width={width} height={height} viewBox='0 0 16 12' aria-hidden='true' focusable='false'>
+      <rect x='0.6' y='0.6' width='14.8' height='10.8' rx='1.6' fill='none'
+        stroke='currentColor' strokeWidth='1.1' />
+      <path d='M3 8.6V3.4l2 2.6 2-2.6v5.2M11 3.4v4.2M9.4 6.2 11 8l1.6-1.8'
+        fill='none' stroke='currentColor' strokeWidth='1.1'
+        strokeLinecap='round' strokeLinejoin='round' />
+    </svg>
+  );
+}
+
+/**
+ * Chevron matching the sidebar's collapse carets. Infima tints those with a filter
+ * over a background image, which an inline SVG cannot reuse, so `.chevron` takes
+ * --ifm-menu-color directly.
+ */
+function ChevronIcon({ flipped }) {
+  return (
+    <svg
+      className={flipped ? `${styles.chevron} ${styles.chevronFlipped}` : styles.chevron}
+      viewBox='0 0 16 16'
+      aria-hidden='true'
+      focusable='false'
+    >
+      <path d='M4.5 6.25 8 9.75l3.5-3.5' />
+    </svg>
+  );
+}
+
+/**
+ * The dropdown panel, styled from Infima variables rather than the repo's Chakra
+ * Menu theme. That theme hard-codes light-mode colours and nothing renders a Chakra
+ * Menu today, so it is untested; Infima variables are what the rest of this control
+ * already uses and Docusaurus switches them on the colour mode.
+ */
+const MENU_SX = {
+  bg: 'var(--ifm-background-surface-color, var(--ifm-background-color))',
+  border: '1px solid var(--ifm-color-emphasis-200)',
+  // Must be set explicitly. The repo's Chakra Menu theme hard-codes
+  // color: 'tigeraBlack' on the list with no colour-mode branch, and items inherit
+  // it, so without this the item titles are dark on dark in dark mode.
+  color: 'var(--ifm-font-color-base)',
+  borderRadius: '12px',
+  boxShadow: '0 8px 24px rgb(0 0 0 / 12%)',
+  minW: '17rem',
+  p: '6px',
+  zIndex: 'var(--ifm-z-index-dropdown, 100)',
+};
+
+const ITEM_SX = {
+  alignItems: 'center',
+  bg: 'transparent',
+  // Explicitly none: Root.js sets resetCSS={false}, so the <button> a MenuItem
+  // renders keeps the user agent's 2px outset border. The link item is an <a> and
+  // has none, which is why only the first item showed one.
+  border: 'none',
+  borderRadius: '8px',
+  color: 'inherit',
+  display: 'flex',
+  gap: '0.7rem',
+  px: '0.6rem',
+  py: '0.5rem',
+  textDecoration: 'none',
+  _hover: { bg: 'var(--ifm-color-emphasis-100)', color: 'inherit', textDecoration: 'none' },
+  _focus: { bg: 'var(--ifm-color-emphasis-100)' },
+};
+
+function Item({ icon, title, description }) {
+  return (
+    <>
+      <span className={styles.itemIcon}>{icon}</span>
+      <span className={styles.itemText}>
+        <span className={styles.itemTitle}>{title}</span>
+        <span className={styles.itemDescription}>{description}</span>
+      </span>
+    </>
+  );
+}
+
+/**
+ * Advertise the page's Markdown twin, to machines and to people.
+ *
+ * The link tag is the machine-readable half: a crawler or agent that fetches the
+ * HTML can discover the Markdown without guessing a URL convention. The split
+ * button is the human half, for anyone pasting a page into an assistant — copying
+ * is the common case, so it is the primary action rather than a menu item.
+ *
+ * Renders nothing for pages with no twin, so neither half ever points at a 404.
+ */
+export default function MarkdownActions() {
+  const { metadata } = useDoc();
+  const { siteConfig } = useDocusaurusContext();
+  const [copied, setCopied] = useState(false);
+
+  const exclusions = siteConfig.customFields?.markdownTwinExclusions ?? [];
+  const twin = hasMarkdownTwin(metadata.permalink, exclusions)
+    ? twinPathFor(metadata.permalink)
+    : null;
+
+  // Cleared on unmount and before each new one, so a quick second click or a
+  // navigation inside the two seconds cannot leave a timer setting state behind it.
+  const resetTimer = useRef(undefined);
+  useEffect(() => () => window.clearTimeout(resetTimer.current), []);
+
+  const markCopied = useCallback(() => {
+    setCopied(true);
+    window.clearTimeout(resetTimer.current);
+    resetTimer.current = window.setTimeout(() => setCopied(false), COPIED_FOR_MS);
+  }, []);
+
+  const copyMarkdown = useCallback(async () => {
+    // fetch only rejects on network failure, so a 404 would otherwise put an HTML
+    // error page on the clipboard and report success.
+    const fetchTwin = () =>
+      fetch(twin).then((response) => {
+        if (!response.ok) {
+          throw new Error(`${twin} responded ${response.status}`);
+        }
+        return response;
+      });
+
+    try {
+      if (typeof ClipboardItem === 'function') {
+        // The fetch stays inside the ClipboardItem rather than being awaited first.
+        // WebKit requires the clipboard write to happen in the same user gesture,
+        // and an intervening await forfeits it — writeText then rejects with
+        // NotAllowedError, which is why the obvious version of this silently did
+        // nothing in Safari. Passing a pending promise keeps the gesture, and
+        // Chromium and Firefox accept it too.
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            // Re-wrap as text/plain rather than passing the response blob straight
+            // through. The twin is served as text/markdown, and Chromium rejects a
+            // ClipboardItem whose key does not match its blob's type.
+            'text/plain': fetchTwin()
+              .then((response) => response.text())
+              .then((text) => new Blob([text], { type: 'text/plain' })),
+          }),
+        ]);
+      } else {
+        await navigator.clipboard.writeText(await (await fetchTwin()).text());
+      }
+      markCopied();
+    } catch {
+      // The clipboard needs a secure context and permission, and either can refuse.
+      // Nothing to recover with, but the View item beside this reaches the same file.
+      setCopied(false);
+    }
+  }, [twin, markCopied]);
+
+  if (!twin) {
+    return null;
+  }
+
+  return (
+    <>
+      <Head>
+        {/* Relative on purpose: siteConfig.url is the production domain, so an
+            absolute href would point every deploy preview at docs.tigera.io. */}
+        <link rel='alternate' type='text/markdown' href={twin} />
+      </Head>
+
+      {/* isLazy so the panel is not in the DOM until opened; without it Chakra
+          mounts it on every page and hides it with visibility. autoSelect is left
+          on, so opening from the keyboard lands on the first item, which is the
+          behaviour the menu pattern calls for. */}
+      <Menu placement='bottom-end' isLazy>
+        {({ isOpen }) => (
+          <div className={styles.wrapper}>
+            <div className={styles.split}>
+              <button
+                type='button'
+                className={styles.primary}
+                onClick={copyMarkdown}
+                aria-label={copied ? 'Page copied as Markdown' : 'Copy page as Markdown'}
+              >
+                {copied ? <IconSuccess {...ICON_SIZE} /> : <IconCopy {...ICON_SIZE} />}
+                <span aria-hidden='true'>{copied ? 'Copied' : 'Copy page'}</span>
+              </button>
+
+              <MenuButton
+                type='button'
+                className={styles.toggle}
+                aria-label='More Markdown options'
+              >
+                <ChevronIcon flipped={isOpen} />
+              </MenuButton>
+            </div>
+
+            <MenuList sx={MENU_SX}>
+              <MenuItem sx={ITEM_SX} onClick={copyMarkdown}>
+                <Item
+                  icon={<IconCopy {...ICON_SIZE} />}
+                  title='Copy page'
+                  description='Copy page as Markdown for LLMs'
+                />
+              </MenuItem>
+
+              <MenuItem
+                as='a'
+                sx={ITEM_SX}
+                href={twin}
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                <Item
+                  icon={<IconMarkdown {...ICON_SIZE} />}
+                  title='View as Markdown ↗'
+                  description='View this page as plain text'
+                />
+              </MenuItem>
+            </MenuList>
+          </div>
+        )}
+      </Menu>
+    </>
+  );
+}

--- a/src/components/MarkdownActions/styles.module.css
+++ b/src/components/MarkdownActions/styles.module.css
@@ -1,0 +1,122 @@
+/* The menu panel and its items are styled in the component with Chakra's sx, since
+   Chakra owns that markup. Everything here is the split button, which is ours.
+
+   Deliberately not built on Infima's .dropdown__* classes: src/css/custom.css
+   restyles those globally for the navbar, including a blue hover with white text and
+   a grey panel in dark mode. Adopting them here would mean overriding all of that
+   back, which is more CSS rather than less. */
+
+.wrapper {
+  display: flex;
+  /* Floated so the page title, which is rendered by DocItemContent below this, flows
+     up alongside rather than the control claiming a row of its own. */
+  float: right;
+  margin-left: 1rem;
+  /* Sit on the title's baseline — level with the bottom of "n", not the tail of "g".
+     Calibrated against --ifm-h1-font-size at its desktop value of 48px; if that
+     changes, re-measure with a zero-height inline probe, which reports the baseline
+     without perturbing the line box the way a probe with content does. */
+  margin-top: 1rem;
+  position: relative;
+}
+
+.split {
+  align-items: stretch;
+  background: var(--ifm-background-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 999px;
+  display: inline-flex;
+  overflow: hidden;
+}
+
+.primary,
+.toggle {
+  align-items: center;
+  background: none;
+  border: 0;
+  color: var(--ifm-color-emphasis-800);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 0.875rem;
+  line-height: 1;
+  padding: 0.4rem 0.75rem;
+}
+
+.primary {
+  gap: 0.45rem;
+}
+
+.toggle {
+  border-left: 1px solid var(--ifm-color-emphasis-300);
+  padding: 0.4rem 0.55rem;
+}
+
+.primary:hover,
+.toggle:hover,
+.primary:focus-visible,
+.toggle:focus-visible {
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-color-emphasis-900);
+}
+
+/* Match the sidebar's collapse carets, which resolve to --ifm-menu-color rather than
+   the button's own text colour. Infima tints those with a filter over a background
+   image, which an inline SVG cannot reuse, so the colour is taken directly. */
+.chevron {
+  fill: none;
+  height: 15px;
+  stroke: var(--ifm-menu-color);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.4;
+  width: 15px;
+}
+
+.chevronFlipped {
+  transform: rotate(180deg);
+}
+
+.primary svg,
+.toggle svg {
+  flex: 0 0 auto;
+}
+
+/* Icons sit in a bordered rounded square, so each item reads as a distinct action
+   rather than as text with a glyph in front of it. */
+.itemIcon {
+  align-items: center;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 7px;
+  color: var(--ifm-color-emphasis-700);
+  display: flex;
+  flex: 0 0 auto;
+  height: 28px;
+  justify-content: center;
+  width: 28px;
+}
+
+.itemText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.itemTitle {
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.itemDescription {
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.8125rem;
+  line-height: 1.25;
+}
+
+/* A convenience, not part of the page. On narrow screens the reading column has no
+   room to spare, so drop it rather than crowd the heading area. */
+@media (max-width: 996px) {
+  .wrapper {
+    display: none;
+  }
+}

--- a/src/plugins/docusaurus-plugin-llms-txt/index.js
+++ b/src/plugins/docusaurus-plugin-llms-txt/index.js
@@ -539,6 +539,41 @@ export default function llmsTxtPlugin(context, options) {
         }
       }
 
+      // Keep customFields.markdownTwinExclusions honest. The theme uses that list
+      // to decide where to advertise a twin and cannot know which pages produced
+      // one, so a disagreement either links to a 404 or hides a real twin. Checks
+      // every docs instance, not just the ones generated for: the theme renders on
+      // all of them, including the 'default' placeholder this plugin skips.
+      const withoutTwin = [];
+      for (const docsPlugin of docsPlugins) {
+        for (const version of docsPlugin.content?.loadedVersions ?? []) {
+          for (const doc of version.docs) {
+            const permalink = normalisePermalink(doc.permalink);
+            if (permalink && !twins.has(permalink)) {
+              withoutTwin.push(permalink);
+            }
+          }
+        }
+      }
+
+      const exclusions = siteConfig.customFields?.markdownTwinExclusions ?? [];
+      const matches = (permalink) => exclusions.some((suffix) => permalink.endsWith(suffix));
+      const unlisted = withoutTwin.filter((permalink) => !matches(permalink));
+      const unused = exclusions.filter((suffix) => !withoutTwin.some((p) => p.endsWith(suffix)));
+
+      if (unlisted.length > 0) {
+        console.warn(
+          `${LOG_PREFIX} ${unlisted.length} page(s) have no twin and are not excluded, ` +
+            `so each will link to a .md that 404s: ${unlisted.slice(0, 5).join(', ')}`
+        );
+      }
+      if (unused.length > 0) {
+        console.warn(
+          `${LOG_PREFIX} These exclusions matched no twinless page and now suppress the ` +
+            `Markdown link on pages that have one: ${unused.join(', ')}`
+        );
+      }
+
       const hasTwin = (permalink) => twins.has(permalink);
       for (const { result } of instanceResults) {
         for (const version of result?.versions ?? []) {

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -13,6 +13,7 @@ import DocItemContent from '@theme/DocItem/Content';
 import DocBreadcrumbs from '@theme/DocBreadcrumbs';
 
 import useToc from '@site/src/utils/useToc';
+import MarkdownActions from '@site/src/components/MarkdownActions';
 
 import styles from './styles.module.css';
 /**
@@ -41,8 +42,18 @@ export default function DocItemLayout({ children }) {
         <div className={styles.docItemContainer}>
           <article>
             <DocBreadcrumbs />
-            <DocVersionBadge />
+            {/* The badge renders an inline span; wrapping it closes that line so the
+                floated control below aligns with the page title rather than joining
+                the badge's line. */}
+            <div>
+              <DocVersionBadge />
+            </div>
             {docTOC.mobile}
+            {/* Before the content, and floated, so the page title flows alongside it
+                rather than the control taking a row of its own. The title lives
+                inside DocItemContent, so this is the only way to share its line
+                without swizzling the content component too. */}
+            <MarkdownActions />
             <DocItemContent>{children}</DocItemContent>
             <DocItemFooter />
           </article>

--- a/src/utils/markdownTwin.js
+++ b/src/utils/markdownTwin.js
@@ -1,0 +1,36 @@
+/**
+ * Where a doc page's Markdown twin lives, and whether it has one.
+ */
+
+/**
+ * The twin path for a permalink.
+ *
+ * The trailing slash goes first: a category index doc's canonical URL carries one
+ * while its twin, a sibling file, does not. netlify/edge-functions/markdown-negotiation.js
+ * repeats this rule rather than importing it — that file is bundled separately for
+ * Deno and has to stay self-contained.
+ *
+ * @param {string} permalink
+ * @returns {string}
+ */
+export function twinPathFor(permalink) {
+  return `${permalink.replace(/\/+$/, '')}.md`;
+}
+
+/**
+ * Whether a doc page has a Markdown twin.
+ *
+ * A few pages render entirely client-side, so they convert to an empty body and the
+ * generator publishes no twin. Linking to one would advertise a 404, so those routes
+ * are listed in `customFields.markdownTwinExclusions` as path suffixes, which keeps
+ * one entry covering the same page across every product and version. The generator
+ * checks that list against the pages it actually skipped, so the two cannot drift.
+ *
+ * @param {string} permalink
+ * @param {string[]} exclusions - Path suffixes
+ * @returns {boolean}
+ */
+export function hasMarkdownTwin(permalink, exclusions = []) {
+  const route = permalink.replace(/\/+$/, '');
+  return !exclusions.some((suffix) => route.endsWith(suffix));
+}


### PR DESCRIPTION
Last PR on DOCS-3014, on top of the merged #2965. Twins have been reachable only by guessing the URL convention or by asking for Markdown in an Accept header. Each doc page now points at its own twin, for machines and for people.

For machines, a link tag in the page head:

    <link rel="alternate" type="text/markdown" href="/calico/latest/networking/configuring/bgp.md" />

so a crawler or agent holding the HTML can discover the Markdown without guessing. The href is relative on purpose: siteConfig.url is the production domain, so an absolute one would point every deploy preview at docs.tigera.io.

For people, a split button sitting on the page title's baseline. Copying is the common case — it is what someone pasting a page into an assistant wants — so it is the primary target, and the chevron opens a menu with the same copy action plus a link to view the Markdown. The whole control is hidden below 996px, where the reading column has no room to spare. This is the only user-visible change in the entire stack, so it is worth looking at on the preview rather than only in the diff.

Neither half renders for a page without a twin, so nothing advertises a 404. Those are declared as path suffixes in customFields.markdownTwinExclusions, one entry covering the same page across every product and version: the eight client-rendered Swagger API browsers, and the placeholder page the multi-instance 'default' docs instance requires. The generator checks that list against reality on every build and warns if the two disagree in either direction. It checks every docs instance rather than only the ones it generates for, and that distinction is what found the /docs placeholder: the theme renders on any docs page, including instances the plugin skips.

Three things came out of review and are worth calling out.

Copying was broken in Safari. Awaiting a fetch before calling navigator.clipboard.writeText forfeits the user gesture WebKit requires, so the write rejected with NotAllowedError — and the window.open fallback was popup-blocked for the same reason, so the button did nothing at all. The fetch now stays inside a ClipboardItem, which is the sanctioned way to keep the gesture. Confirmed by driving WebKit directly: the old code raises NotAllowedError there, the new code succeeds. The earlier verification on this PR was Chromium-only, which is how it was missed.

The menu is Chakra's rather than hand-rolled. Chakra already wraps every page via src/theme/Root.js, and its Menu brings the keyboard contract that role=menu promises: arrow keys move between items, opening from the keyboard focuses the first, Escape closes and returns focus to the trigger. The hand-rolled version declared role=menu and implemented none of that, which puts NVDA and JAWS into application mode where arrow keys then do nothing — worse than declaring no role at all. It is styled from Infima variables rather than the repo's Chakra Menu theme: that theme hard-codes color: tigeraBlack on the list with no colour-mode branch, and nothing else in the repo renders a Chakra Menu, so it is untested. Without an explicit colour the item titles come out dark on dark.

Icons are Docusaurus's own @theme/Icon/Copy, Success and ExternalLink rather than hand-drawn SVGs. They are already on the page — the code block copy buttons use them — so the reader meets the same glyph for the same action.

The CSS deliberately does not build on Infima's .dropdown__* classes. src/css/custom.css restyles those globally for the navbar, including a blue hover with white text and a grey panel in dark mode, so adopting them here would mean overriding all of it back: more CSS, not less.

Also stops the Algolia crawler indexing twins, which has to land with this rather than after it, since this is the first thing to link to them. The pattern is anchored, "\.md$" rather than ".md$", because stop_urls are regular expressions and an unescaped dot would also match a route ending in "amd".

Needs a human step: nothing in the repo reads algolia-crawler-config.json — it is a checked-in copy of what goes in the crawler console. The stop_urls entry needs applying there too, ideally before this merges.

Not needed, in case it comes up: Google is already handled. The /*.md X-Robots-Tag: noindex rule went in with #2958 and is live in production today.

Verified against a full build: 2,921 pages advertise a twin and none of those links is dangling; excluded pages advertise nothing; removing an entry from the exclusion list makes the build warn, naming the page. Driven in a browser: the clipboard receives the page's own twin in both Chromium and WebKit, keyboard navigation behaves, and the control sits on the h1 baseline in both colour modes.

On the deploy preview:

- https://deploy-preview-2966--tigera.netlify.app/calico/latest/networking/configuring/bgp — control on the title line, rel=alternate in the head
- https://deploy-preview-2966--tigera.netlify.app/calico/latest/networking/ — a category index doc, whose twin drops the trailing slash
- https://deploy-preview-2966--tigera.netlify.app/calico/latest/reference/rest-api-reference — no control and no link tag, since it has no twin

Worth checking the menu in both colour modes and with the keyboard, and that Copy page lands on your clipboard — in Safari as well as Chrome, given the above.

With this merged, DOCS-3014 is complete. The remaining decision is whether to promote content negotiation to production, which is one line in the edge function's host check and better made after the preview has seen real traffic.
