### PR TITLE
DOCS-3021: Render the technology preview table from the data file

### DIFF
--- a/calico_versioned_docs/version-3.32/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.32/release-notes/index.mdx
@@ -4,6 +4,8 @@ title: Calico Open Source release notes
 sidebar_label: Release notes
 ---
 
+import TechPreviewTable from '@site/src/components/FeatureStatusTable';
+
 # Calico Open Source 3.32 release notes
 
 Learn about the new features, bug fixes, and other updates in this release of $[prodname].
@@ -88,16 +90,7 @@ This release adds support for Kubernetes 1.36.
 This table shows the status of features that were in technology preview at any point in the releases covered here.
 Technology preview features are for evaluation and feedback only and are **not supported for production use**. Behavior, APIs, and configuration may change before a feature reaches general availability.
 
-| Feature | 3.30 | 3.31 | 3.32 |
-| --- | --- | --- | --- |
-| Flow logs API and Whisker | TP | TP | TP |
-| Calico Ingress Gateway | TP | GA | GA |
-| nftables data plane | TP | GA | GA |
-| Native v3 CRDs | – | – | TP |
-| Istio ambient mode | – | – | TP |
-| Selector-scoped Felix configuration | – | – | TP |
-
-TP = technology preview, GA = generally available, – = not available in that release.
+<TechPreviewTable />
 
 ## Deprecated and removed features
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -548,6 +548,7 @@ export default async function createAsyncConfig() {
           editUrl: generateEditUrl,
         },
       ],
+      './src/plugins/docusaurus-plugin-feature-status',
       [
         './src/plugins/docusaurus-plugin-llms-txt',
         {

--- a/src/components/FeatureStatusTable/__test__/featureStatus.test.ts
+++ b/src/components/FeatureStatusTable/__test__/featureStatus.test.ts
@@ -1,0 +1,113 @@
+import fs from 'fs';
+import path from 'path';
+import { parse } from 'yaml';
+
+import { buildLegend, buildRows, cellLabel, releaseWindow } from '../featureStatus';
+import type { Feature } from '../featureStatus';
+
+const features: Feature[] = parse(
+  fs.readFileSync(path.join(__dirname, '../../../../data/feature-status.yaml'), 'utf8')
+).features;
+
+/** Render rows the way the Markdown tables they replace were written. */
+const asMarkdown = (product: string, versions: string[]) =>
+  buildRows(features, product, versions).map((row) => `| ${row.name} | ${row.cells.map(cellLabel).join(' | ')} |`);
+
+describe('releaseWindow', () => {
+  it('returns the three releases ending at the given version, oldest first', () => {
+    expect(releaseWindow('3.32')).toEqual(['3.30', '3.31', '3.32']);
+  });
+
+  it('strips the Docusaurus suffix an Enterprise version carries', () => {
+    expect(releaseWindow('3.24-1')).toEqual(['3.22', '3.23', '3.24']);
+    expect(releaseWindow('3.24-2')).toEqual(['3.22', '3.23', '3.24']);
+  });
+
+  it('returns null for the unversioned current version', () => {
+    expect(releaseWindow('current')).toBeNull();
+  });
+
+  it('returns null for the Calico Cloud scheme, which has no minor to step back through', () => {
+    expect(releaseWindow('23-2')).toBeNull();
+  });
+});
+
+describe('buildRows', () => {
+  const window = ['3.30', '3.31', '3.32'];
+  const names = (product: string, versions: string[]) => buildRows(features, product, versions).map((row) => row.name);
+
+  it('carries a status forward until the next recorded change', () => {
+    // nftables is recorded as tech preview in 3.29 and GA in 3.31, and nothing else.
+    const [row] = buildRows(features, 'calico', window).filter((r) => r.name === 'nftables data plane');
+    expect(row.cells).toEqual(['tech-preview', 'ga', 'ga']);
+  });
+
+  it('reports no status before a feature first appears', () => {
+    const [row] = buildRows(features, 'calico', window).filter((r) => r.name === 'Native v3 CRDs');
+    expect(row.cells).toEqual([null, null, 'tech-preview']);
+  });
+
+  it('drops a feature that was never in preview in the window', () => {
+    // Calico Ingress Gateway reached GA in 3.31, so a window starting after that has
+    // no preview cell for it.
+    expect(names('calico', window)).toContain('Calico Ingress Gateway');
+    expect(names('calico', ['3.31', '3.32'])).not.toContain('Calico Ingress Gateway');
+  });
+
+  it('drops a feature that never had a preview status at all', () => {
+    expect(names('calico', window)).not.toContain('FIPS mode');
+  });
+
+  it('drops a feature that is not confirmed for the product', () => {
+    expect(names('calico-enterprise', ['3.20', '3.21', '3.22'])).not.toContain('Non-cluster hosts and VMs');
+  });
+
+  it('drops a feature the product does not have', () => {
+    expect(names('calico', window)).not.toContain('Workload WAF');
+  });
+
+  it('orders rows by the release the feature first appeared in', () => {
+    expect(names('calico-enterprise', ['3.22', '3.23', '3.24'])).toEqual([
+      'DNS policy for Windows',
+      'Workload WAF',
+      'Gateway WAF',
+      'Istio ambient mode',
+      'Live migration for KubeVirt VMs',
+      'Multi-VRF networking',
+      'Native v3 CRDs',
+      'L2 bridge networking',
+      'Selector-scoped Felix configuration',
+    ]);
+  });
+
+  it('reproduces the Calico Open Source 3.32 technology preview table', () => {
+    expect(asMarkdown('calico', window)).toEqual([
+      '| nftables data plane | TP | GA | GA |',
+      '| Calico Ingress Gateway | TP | GA | GA |',
+      '| Flow logs API and Whisker | TP | TP | TP |',
+      '| Istio ambient mode | – | – | TP |',
+      '| Native v3 CRDs | – | – | TP |',
+      '| Selector-scoped Felix configuration | – | – | TP |',
+    ]);
+  });
+});
+
+describe('buildLegend', () => {
+  const legend = (product: string, versions: string[]) => buildLegend(buildRows(features, product, versions));
+
+  it('glosses only the statuses the table actually uses', () => {
+    expect(legend('calico', ['3.30', '3.31', '3.32'])).toBe(
+      'TP = technology preview, GA = generally available, – = not available in that release.'
+    );
+  });
+
+  it('omits GA when no feature in the window reached it', () => {
+    expect(legend('calico-enterprise', ['3.19', '3.20', '3.21'])).toBe(
+      'TP = technology preview, – = not available in that release.'
+    );
+  });
+
+  it('omits the dash when every feature existed throughout the window', () => {
+    expect(legend('calico-enterprise', ['3.19', '3.20'])).toBe('TP = technology preview.');
+  });
+});

--- a/src/components/FeatureStatusTable/__test__/index.test.tsx
+++ b/src/components/FeatureStatusTable/__test__/index.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react';
+
+import TechPreviewTable from '../index';
+import type { Feature } from '../featureStatus';
+
+const features: Feature[] = [
+  {
+    id: 'nftables-dataplane',
+    name: 'nftables data plane',
+    products: { calico: { '3.29': 'tech-preview', '3.31': 'ga' } },
+  },
+  {
+    id: 'istio-ambient-mode',
+    name: 'Istio ambient mode',
+    products: {
+      calico: { '3.32': 'tech-preview' },
+      'calico-enterprise': { '3.22': 'tech-preview' },
+    },
+  },
+  {
+    id: 'fips-mode',
+    name: 'FIPS mode',
+    products: { calico: { '3.28': 'ga', '3.30': 'deprecated' } },
+  },
+];
+
+const docsVersion = { pluginId: 'calico', version: '3.32' };
+
+// Both modules are aliases that only exist inside a Docusaurus build, so they have to be
+// mocked virtually. The factories close over the fixtures rather than reading them, so
+// they run safely before the fixtures are initialised.
+jest.mock('@docusaurus/useGlobalData', () => ({ usePluginData: () => ({ features }) }), {
+  virtual: true,
+});
+
+jest.mock('@docusaurus/plugin-content-docs/client', () => ({ useDocsVersion: () => docsVersion }), {
+  virtual: true,
+});
+
+const columns = () => screen.getAllByRole('columnheader').map((cell) => cell.textContent);
+
+/** The rows as `[feature, ...cells]`, in render order. */
+const rows = () =>
+  screen
+    .getAllByRole('row')
+    .slice(1)
+    .map((row) => Array.from(row.querySelectorAll('td')).map((cell) => cell.textContent));
+
+describe('<TechPreviewTable/>', () => {
+  beforeEach(() => {
+    docsVersion.pluginId = 'calico';
+    docsVersion.version = '3.32';
+  });
+
+  it('derives the product and the version window from the docs version', () => {
+    render(<TechPreviewTable />);
+
+    expect(columns()).toEqual(['Feature', '3.30', '3.31', '3.32']);
+    expect(rows()).toEqual([
+      ['nftables data plane', 'TP', 'GA', 'GA'],
+      ['Istio ambient mode', '–', '–', 'TP'],
+    ]);
+  });
+
+  it('renders the Enterprise product and window on an Enterprise page', () => {
+    docsVersion.pluginId = 'calico-enterprise';
+    docsVersion.version = '3.24-1';
+    render(<TechPreviewTable />);
+
+    expect(columns()).toEqual(['Feature', '3.22', '3.23', '3.24']);
+    expect(rows()).toEqual([['Istio ambient mode', 'TP', 'TP', 'TP']]);
+  });
+
+  it('renders the legend for the statuses in the table', () => {
+    render(<TechPreviewTable />);
+
+    expect(
+      screen.getByText('TP = technology preview, GA = generally available, – = not available in that release.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing on a version with no release line, and says why', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    docsVersion.version = 'current';
+    const { container } = render(<TechPreviewTable />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('No release window'));
+    warn.mockRestore();
+  });
+
+  it('renders nothing when no feature was in preview during the window', () => {
+    docsVersion.version = '3.28';
+    const { container } = render(<TechPreviewTable />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/FeatureStatusTable/featureStatus.ts
+++ b/src/components/FeatureStatusTable/featureStatus.ts
@@ -1,0 +1,139 @@
+/**
+ * Row derivation for the release-notes technology preview table.
+ *
+ * data/feature-status.yaml records only status *changes*: a status carries forward from
+ * the release it is declared in until the next entry for that feature and product.
+ * Before a feature's first entry it did not exist, which is distinct from any recorded
+ * status and renders as a dash.
+ *
+ * This is pure so the carry-forward and ordering rules can be tested without rendering.
+ */
+
+export type FeatureStatus = 'tech-preview' | 'ga' | 'deprecated' | 'removed';
+
+/** A resolved cell: a status, or `null` where the feature did not yet exist. */
+export type CellStatus = FeatureStatus | null;
+
+export interface Feature {
+  id: string;
+  name: string;
+  /** Per-product history: release line to status, plus an optional `confirmed` flag. */
+  products: Record<string, Record<string, FeatureStatus | boolean>>;
+}
+
+export interface FeatureRow {
+  name: string;
+  /** One entry per version in the requested window, in the same order. */
+  cells: CellStatus[];
+}
+
+/**
+ * Every status, in the order a legend lists them.
+ *
+ * One table drives the cell text, the legend gloss, and which YAML values count as a
+ * status at all, so the three cannot drift apart.
+ */
+const STATUSES: { status: FeatureStatus; label: string; gloss: string }[] = [
+  { status: 'tech-preview', label: 'TP', gloss: 'technology preview' },
+  { status: 'ga', label: 'GA', gloss: 'generally available' },
+  { status: 'deprecated', label: 'Deprecated', gloss: 'scheduled for removal' },
+  { status: 'removed', label: 'Removed', gloss: 'no longer present' },
+];
+
+/** En dash, for a release in which the feature did not exist. */
+export const NOT_AVAILABLE = '–';
+
+/** Release notes show the current release and the two before it. */
+const COLUMN_COUNT = 3;
+
+/** Cell text for a resolved status. */
+export function cellLabel(cell: CellStatus): string {
+  return STATUSES.find((entry) => entry.status === cell)?.label ?? NOT_AVAILABLE;
+}
+
+/** Compare two release lines numerically rather than as text, so 3.9 sorts below 3.10. */
+function compare(a: string, b: string): number {
+  const [aMajor, aMinor] = a.split('.').map(Number);
+  const [bMajor, bMinor] = b.split('.').map(Number);
+  return aMajor - bMajor || aMinor - bMinor;
+}
+
+/**
+ * The three release lines ending at the given docs version, oldest first.
+ *
+ * The leading match also strips the Docusaurus suffix that Enterprise versions carry,
+ * so 3.24-1 and 3.24-2 both resolve to line 3.24. Returns null for any version with no
+ * release line to anchor a window to: the unversioned `current` version, which the site
+ * labels Next, and the Calico Cloud scheme, which has no minor at all.
+ */
+export function releaseWindow(version: string): string[] | null {
+  const match = /^(\d+)\.(\d+)/.exec(version);
+  if (!match) return null;
+
+  const [major, minor] = match.slice(1).map(Number);
+  return Array.from({ length: COLUMN_COUNT }, (_, index) => `${major}.${minor - COLUMN_COUNT + 1 + index}`);
+}
+
+/** A feature's recorded status changes for one product, oldest first. */
+function statusChanges(history: Record<string, FeatureStatus | boolean>) {
+  return Object.entries(history)
+    .filter(([, value]) => STATUSES.some((entry) => entry.status === value))
+    .map(([version, status]) => ({ version, status: status as FeatureStatus }))
+    .sort((a, b) => compare(a.version, b.version));
+}
+
+/** The status in effect at a given release, carrying the last change forward. */
+function statusAt(changes: ReturnType<typeof statusChanges>, version: string): CellStatus {
+  let current: CellStatus = null;
+  for (const change of changes) {
+    if (compare(change.version, version) > 0) break;
+    current = change.status;
+  }
+  return current;
+}
+
+/**
+ * The rows of the technology preview table: every feature that was in preview at some
+ * point in the window.
+ *
+ * Rows are ordered by the release a feature first appeared in, oldest first, so the
+ * table reads as the order features arrived. Features that arrived in the same release
+ * keep their data-file order, which is alphabetical by id.
+ */
+export function buildRows(features: Feature[], product: string, versions: string[]): FeatureRow[] {
+  const rows: (FeatureRow & { since: string; order: number })[] = [];
+
+  features.forEach((feature, order) => {
+    const history = feature.products?.[product];
+
+    // `confirmed: false` keeps an entry in the data file without rendering it.
+    if (!history || history.confirmed === false) return;
+
+    const changes = statusChanges(history);
+    if (!changes.length) return;
+
+    const cells = versions.map((version) => statusAt(changes, version));
+    if (!cells.includes('tech-preview')) return;
+
+    rows.push({ name: feature.name, cells, since: changes[0].version, order });
+  });
+
+  return rows
+    .sort((a, b) => compare(a.since, b.since) || a.order - b.order)
+    .map(({ name, cells }) => ({ name, cells }));
+}
+
+/**
+ * The legend sentence for a set of rows.
+ *
+ * Only statuses that actually appear are glossed, so a table with no GA cells does not
+ * explain what GA means.
+ */
+export function buildLegend(rows: FeatureRow[]): string {
+  const present = new Set<CellStatus>(rows.flatMap((row) => row.cells));
+
+  const parts = STATUSES.filter((entry) => present.has(entry.status)).map((entry) => `${entry.label} = ${entry.gloss}`);
+  if (present.has(null)) parts.push(`${NOT_AVAILABLE} = not available in that release`);
+
+  return `${parts.join(', ')}.`;
+}

--- a/src/components/FeatureStatusTable/index.tsx
+++ b/src/components/FeatureStatusTable/index.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { usePluginData } from '@docusaurus/useGlobalData';
+import { useDocsVersion } from '@docusaurus/plugin-content-docs/client';
+
+import { buildLegend, buildRows, cellLabel, releaseWindow } from './featureStatus';
+import type { Feature } from './featureStatus';
+
+const PLUGIN_NAME = 'docusaurus-plugin-feature-status';
+
+/**
+ * The technology preview table for a release-notes page.
+ *
+ * The product and the three-release window both come from the page's own docs context:
+ * the product is the docs plugin id, which is already the data file's product key, and
+ * the window ends at the page's own version. A versioned snapshot therefore keeps the
+ * window it was cut with, and no version numbers are written into the page.
+ */
+const TechPreviewTable: React.FC = () => {
+  const { features } = usePluginData(PLUGIN_NAME) as { features: Feature[] };
+  const { pluginId, version } = useDocsVersion();
+
+  const versions = releaseWindow(version);
+
+  // The unversioned `current` version, which the site labels Next, has no release line,
+  // so there is no window to derive. Rendering nothing beats inventing a version number
+  // in published release notes.
+  if (!versions) {
+    console.warn(`[${PLUGIN_NAME}] No release window for docs version "${version}", so no table is rendered.`);
+    return null;
+  }
+
+  const rows = buildRows(features, pluginId, versions);
+  if (!rows.length) return null;
+
+  return (
+    <>
+      <table>
+        <thead>
+          <tr>
+            <th>Feature</th>
+            {versions.map((column) => (
+              <th key={column}>{column}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.name}>
+              <td>{row.name}</td>
+              {row.cells.map((cell, index) => (
+                <td key={versions[index]}>{cellLabel(cell)}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p>{buildLegend(rows)}</p>
+    </>
+  );
+};
+
+export default TechPreviewTable;

--- a/src/plugins/docusaurus-plugin-feature-status/index.js
+++ b/src/plugins/docusaurus-plugin-feature-status/index.js
@@ -1,0 +1,48 @@
+/**
+ * docusaurus-plugin-feature-status
+ *
+ * Reads data/feature-status.yaml once per build and exposes it as plugin global data,
+ * so the release-notes tables render from the data file rather than from hand-written
+ * Markdown that has to be re-typed in every release.
+ *
+ * The parse happens here rather than in a webpack loader because the file is a single
+ * build-wide input: loading it once and putting it on global data keeps it out of every
+ * page bundle that does not use it.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { parse } from 'yaml';
+
+export const PLUGIN_NAME = 'docusaurus-plugin-feature-status';
+
+const DATA_FILE = 'data/feature-status.yaml';
+
+export default function featureStatusPlugin(context) {
+  const dataPath = path.join(context.siteDir, DATA_FILE);
+
+  return {
+    name: PLUGIN_NAME,
+
+    // Reload the site when the data file changes, so editing a status during
+    // `yarn start` updates the tables without a restart.
+    getPathsToWatch() {
+      return [dataPath];
+    },
+
+    async loadContent() {
+      const source = await fs.readFile(dataPath, 'utf8');
+      const parsed = parse(source);
+
+      if (!parsed || !Array.isArray(parsed.features)) {
+        throw new Error(`[${PLUGIN_NAME}] ${DATA_FILE} has no top-level "features" list.`);
+      }
+
+      return { features: parsed.features };
+    },
+
+    async contentLoaded({ content, actions }) {
+      actions.setGlobalData(content);
+    },
+  };
+}


### PR DESCRIPTION
First iteration on DOCS-3021. data/feature-status.yaml landed in DOCS-3009 with no consumer, so the same statuses are now maintained twice: once in the data file and once as a hand-typed Markdown table in each version's release notes. Seven tables across two products, retyped every release. They have already drifted — the Enterprise 3.24 table is missing the L2 bridge networking row that the data file records.

This adds the machinery and uses it in one place, the Calico Open Source 3.32 technology preview table.

A build-time plugin, src/plugins/docusaurus-plugin-feature-status, parses the YAML once and puts it on plugin global data. Parsing there rather than in a webpack loader keeps the file out of every page bundle that does not use it, and getPathsToWatch means editing a status during yarn start updates the tables without a restart.

The component is src/components/FeatureStatusTable, registered in MDXComponents so pages need no import. It takes no arguments:

    <TechPreviewTable />

The product and the three-release window both come from the page's own docs context. The product is the docs plugin id, which is already the data file's product key. The window ends at the page's own version, with the Enterprise suffix stripped so 3.24-1 and 3.24-2 both resolve to line 3.24. That means a frozen snapshot keeps the window it was cut with — the 3.31 page still shows 3.29 to 3.31 after 3.33 ships — and no version numbers are written into the page.

The Next version has no release line to derive a window from. Rather than guess at the next minor, the component renders nothing and warns. The Next release notes already have an empty preview section, so nothing regresses there.

Row order is the one thing that could not be taken from the data. The hand-written order was not derivable and the two products disagreed: Open Source put the oldest preview last and Native v3 CRDs before Istio ambient mode, Enterprise did the reverse. Rows are now ordered by the release a feature first appeared in, oldest first, with ties keeping data-file order. The only visible consequence in 3.32 is that nftables data plane moves from the third row to the first.

Cell values, the legend, and row inclusion are unchanged. The legend still glosses only the statuses a given table actually uses, so a table with no GA cells does not explain what GA means — that is not decoration, it is what the Enterprise 3.21 table does today.

Verified against a full build. The Markdown twin of the 3.32 page, generated from the rendered HTML, reads:

    | Feature                             | 3.30 | 3.31 | 3.32 |
    | ----------------------------------- | ---- | ---- | ---- |
    | nftables data plane                 | TP   | GA   | GA   |
    | Calico Ingress Gateway              | TP   | GA   | GA   |
    | Flow logs API and Whisker           | TP   | TP   | TP   |
    | Istio ambient mode                  | –    | –    | TP   |
    | Native v3 CRDs                      | –    | –    | TP   |
    | Selector-scoped Felix configuration | –    | –    | TP   |

    TP = technology preview, GA = generally available, – = not available in that release.

Nineteen unit tests cover the logic module and the component, including a case that asserts the whole 3.32 table and one that pins the Enterprise 3.24 ordering. The logic lives in its own module so the carry-forward and ordering rules are testable without rendering.

Scoped deliberately to what renders this one table. There is no props interface, no configurable column count, and no status filter — those arrive with the second caller that needs them, not before.

Left for follow-ups:

- the deprecated and removed variant, which needs a status filter parameter that this table does not
- the other six tables, once the ordering change has been reviewed once
- whether the Next release notes should carry the table at all

On the deploy preview:

- https://deploy-preview-2968--tigera.netlify.app/calico/latest/release-notes/ — the technology preview table, rendered by the component. The deprecated and removed table below it is still hand-written Markdown, and the two should be indistinguishable.