### PR TITLE
Add a Calico Cloud release note for the dark mode web console update

### DIFF
--- a/calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx
@@ -8,6 +8,15 @@ import IconUser from '/img/icons/user-icon.svg';
 
 # Calico Cloud release notes
 
+<h2 id="august-26-2026">August 26, 2026 (web console update)</h2>
+
+### New features and enhancements
+
+#### Dark mode
+
+The web console now has a dark theme.
+To switch themes, click the sun or moon icon in the top-right corner.
+
 <h2 id="23.0.1">August 14, 2026 (version 23.0.1)</h2>
 
 ### Bug fixes


### PR DESCRIPTION
The Calico Cloud web console update released on 26 August 2026 adds a dark theme to the console. There is no version bump, so this adds a dated web console update entry to the top of the Calico Cloud 23-2 release notes, above the 23.0.1 entry.

The note says that the console now has a dark theme, and that you switch themes with the sun or moon icon in the top-right corner.

Sources:

- The 26 August 2026 entry in the Calico Cloud internal release notes, which lists the update as a UI-only change adding dark mode.
- https://github.com/tigera/cc-portal/pull/1469, which turns on the supportsDarkMode feature flag.
- The ColorThemeToggle component in tigera/ui-modules, which is the sun or moon icon button in the console header.

Only the published 23-2 tree is changed. The release notes under calico-cloud/ are for the unpublished next version and have not carried dated entries for the last several releases.

There is no Jira ticket for this yet, so the title has no DOCS key.

Reviewers: the new entry is the first heading on https://deploy-preview-2969--tigera.netlify.app/calico-cloud/release-notes/