### PR TITLE
Add Calico Cloud release notes for 23.0.2 and 22.5.1

### DIFF
--- a/calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx
@@ -8,14 +8,14 @@ import IconUser from '/img/icons/user-icon.svg';
 
 # Calico Cloud release notes
 
-<h2 id="23.0.2">August 27, 2026 (versions 23.0.2 and 22.5.1)</h2>
+<h2 id="23.0.2">August 28, 2026 (versions 23.0.2 and 22.5.1)</h2>
 
 Versions 23.0.2 and 22.5.1 are patch releases that bring the same fix to $[prodname] 23 and 22.
 
 ### Bug fixes
 
 * Fixed an issue where a change to how Azure Kubernetes Service (AKS) manages Calico could stop an installation from finishing, or stop the operator from managing resources on a cluster you already have.
-  $[prodname] now deploys the additional resources it needs, so installations complete and existing clusters keep running.
+  $[prodname] now detects the changed configurations, so installations complete and existing clusters keep running.
 * Version 23.0.2 only. Fixed an issue where the policy board in the web console returned an error when one of your own default-deny policies covered the `calico-system` namespace.
   $[prodname] now includes a policy that allows traffic from the API server to Guardian, so the board loads without you having to add a policy of your own.
 

--- a/calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx
@@ -8,6 +8,17 @@ import IconUser from '/img/icons/user-icon.svg';
 
 # Calico Cloud release notes
 
+<h2 id="23.0.2">August 27, 2026 (versions 23.0.2 and 22.5.1)</h2>
+
+Versions 23.0.2 and 22.5.1 are patch releases that bring the same fix to $[prodname] 23 and 22.
+
+### Bug fixes
+
+* Fixed an issue where a change to how Azure Kubernetes Service (AKS) manages Calico could stop an installation from finishing, or stop the operator from managing resources on a cluster you already have.
+  $[prodname] now deploys the additional resources it needs, so installations complete and existing clusters keep running.
+* Version 23.0.2 only. Fixed an issue where the policy board in the web console returned an error when one of your own default-deny policies covered the `calico-system` namespace.
+  $[prodname] now includes a policy that allows traffic from the API server to Guardian, so the board loads without you having to add a policy of your own.
+
 <h2 id="august-26-2026">August 26, 2026 (web console update)</h2>
 
 ### New features and enhancements

--- a/src/___new___/data/ccImageLists.js
+++ b/src/___new___/data/ccImageLists.js
@@ -1,8 +1,8 @@
 const ccImageLists = {
-  // TODO(DOCS-3008): placeholder copied from the v23.0.0 list. Replace it with
-  // the v23.0.1 list once the release is in staging:
-  // curl -0 https://installer.calicocloud.io/manifests/<v23.0.1 manifest>/image-list
-  'v23.0.1 (latest)': `quay.io/calico/istio-pilot:v3.32.1
+  // curl -0 https://installer.calicocloud.io/manifests/v3.23.1-5/image-list
+  'v23.0.2 (latest)': `<placeholder>`,
+  // curl -0 https://installer.calicocloud.io/manifests/v3.23.1-4/image-list
+  'v23.0.1': `quay.io/calico/istio-pilot:v3.32.1
 quay.io/calico/istio-install-cni:v3.32.1
 quay.io/calico/istio-ztunnel:v3.32.1
 quay.io/calico/istio-proxyv2:v3.32.1
@@ -58,6 +58,8 @@ quay.io/tigera/cc-core:v0.3.8
 quay.io/tigera/prometheus-operator:v3.23.1
 quay.io/tigera/prometheus-config-reloader:v3.23.1
 quay.io/tigera/cc-cni-config-scanner:v0.7.3`,
+  // curl -0 https://installer.calicocloud.io/manifests/v3.22.6-1/image-list
+  'v22.5.1': `<placeholder>`,
   // curl -0 https://installer.calicocloud.io/manifests/v3.22.6-0/image-list
   'v22.5.0': `quay.io/tigera/apiserver:v3.22.6
 quay.io/tigera/compliance-benchmarker:v3.22.6

--- a/src/___new___/data/ccImageLists.js
+++ b/src/___new___/data/ccImageLists.js
@@ -1,6 +1,61 @@
 const ccImageLists = {
-  // curl -0 https://installer.calicocloud.io/manifests/v3.23.1-5/image-list
-  'v23.0.2 (latest)': `<placeholder>`,
+  // curl -0 https://installer.calicocloud.io/manifests/v3.23.1-4/image-list
+  'v23.0.2 (latest)': `quay.io/calico/istio-pilot:v3.32.1
+quay.io/calico/istio-install-cni:v3.32.1
+quay.io/calico/istio-ztunnel:v3.32.1
+quay.io/calico/istio-proxyv2:v3.32.1
+quay.io/calico/webhooks:v3.32.1
+quay.io/tigera/apiserver:v3.23.1
+quay.io/tigera/compliance-benchmarker:v3.23.1
+quay.io/tigera/compliance-controller:v3.23.1
+quay.io/tigera/compliance-reporter:v3.23.1
+quay.io/tigera/compliance-snapshotter:v3.23.1
+quay.io/tigera/key-cert-provisioner:v3.23.1
+quay.io/tigera/deep-packet-inspection:v3.23.1
+quay.io/tigera/ui-apis:v3.23.1
+quay.io/tigera/fluentd:v3.23.1
+quay.io/tigera/fluentd-windows:v3.23.1
+quay.io/tigera/guardian:v3.23.1
+quay.io/tigera/intrusion-detection-controller:v3.23.1
+quay.io/tigera/waf-http-filter:v3.23.1
+quay.io/tigera/webhooks-processor:v3.23.1
+quay.io/tigera/manager:v3.23.1
+quay.io/tigera/packetcapture:v3.23.1
+quay.io/tigera/policy-recommendation:v3.23.1
+quay.io/tigera/egress-gateway:v3.23.1
+quay.io/tigera/l7-collector:v3.23.1
+quay.io/tigera/gateway-l7-collector:v3.23.1
+quay.io/tigera/envoy:v3.23.1
+quay.io/tigera/prometheus:v3.23.1
+quay.io/tigera/prometheus-service:v3.23.1
+quay.io/tigera/alertmanager:v3.23.1
+quay.io/tigera/queryserver:v3.23.1
+quay.io/tigera/kube-controllers:v3.23.1
+quay.io/tigera/node:v3.23.1
+quay.io/tigera/node-windows:v3.23.1
+quay.io/tigera/typha:v3.23.1
+quay.io/tigera/cni:v3.23.1
+quay.io/tigera/cni-windows:v3.23.1
+quay.io/tigera/es-gateway:v3.23.1
+quay.io/tigera/linseed:v3.23.1
+quay.io/tigera/dikastes:v3.23.1
+quay.io/tigera/l7-admission-controller:v3.23.1
+quay.io/tigera/pod2daemon-flexvol:v3.23.1
+quay.io/tigera/csi:v3.23.1
+quay.io/tigera/node-driver-registrar:v3.23.1
+quay.io/tigera/envoy-gateway:v3.23.1
+quay.io/tigera/envoy-proxy:v3.23.1
+quay.io/tigera/envoy-ratelimit:v3.23.1
+quay.io/tigera/istio-pilot:v3.23.1
+quay.io/tigera/istio-install-cni:v3.23.1
+quay.io/tigera/istio-ztunnel:v3.23.1
+quay.io/tigera/istio-proxyv2:v3.23.1
+quay.io/tigera/webhooks:v3.23.1
+quay.io/tigera/operator:v1.42.4
+quay.io/tigera/cc-core:v0.3.8
+quay.io/tigera/prometheus-operator:v3.23.1
+quay.io/tigera/prometheus-config-reloader:v3.23.1
+quay.io/tigera/cc-cni-config-scanner:v0.7.3`,
   // curl -0 https://installer.calicocloud.io/manifests/v3.23.1-4/image-list
   'v23.0.1': `quay.io/calico/istio-pilot:v3.32.1
 quay.io/calico/istio-install-cni:v3.32.1
@@ -58,8 +113,63 @@ quay.io/tigera/cc-core:v0.3.8
 quay.io/tigera/prometheus-operator:v3.23.1
 quay.io/tigera/prometheus-config-reloader:v3.23.1
 quay.io/tigera/cc-cni-config-scanner:v0.7.3`,
-  // curl -0 https://installer.calicocloud.io/manifests/v3.22.6-1/image-list
-  'v22.5.1': `<placeholder>`,
+  // curl -0 https://installer.calicocloud.io/manifests/v3.22.6-0/image-list
+  'v22.5.1': `quay.io/tigera/apiserver:v3.22.6
+quay.io/tigera/compliance-benchmarker:v3.22.6
+quay.io/tigera/compliance-controller:v3.22.6
+quay.io/tigera/compliance-reporter:v3.22.6
+quay.io/tigera/compliance-snapshotter:v3.22.6
+quay.io/tigera/key-cert-provisioner:v3.22.6
+quay.io/tigera/deep-packet-inspection:v3.22.6
+quay.io/tigera/ui-apis:v3.22.6
+quay.io/tigera/fluentd:v3.22.6
+quay.io/tigera/fluentd-windows:v3.22.6
+quay.io/tigera/guardian:v3.22.6
+quay.io/tigera/intrusion-detection-controller:v3.22.6
+quay.io/tigera/waf-http-filter:v3.22.6
+quay.io/tigera/webhooks-processor:v3.22.6
+quay.io/tigera/manager:v3.22.6
+quay.io/tigera/packetcapture:v3.22.6
+quay.io/tigera/policy-recommendation:v3.22.6
+quay.io/tigera/egress-gateway:v3.22.6
+quay.io/tigera/l7-collector:v3.22.6
+quay.io/tigera/gateway-l7-collector:v3.22.6
+quay.io/tigera/envoy:v3.22.6
+quay.io/tigera/prometheus:v3.22.6
+quay.io/tigera/prometheus-service:v3.22.6
+quay.io/tigera/alertmanager:v3.22.6
+quay.io/tigera/queryserver:v3.22.6
+quay.io/tigera/kube-controllers:v3.22.6
+quay.io/tigera/node:v3.22.6
+quay.io/tigera/node-windows:v3.22.6
+quay.io/tigera/typha:v3.22.6
+quay.io/tigera/cni:v3.22.6
+quay.io/tigera/cni-windows:v3.22.6
+quay.io/tigera/es-gateway:v3.22.6
+quay.io/tigera/linseed:v3.22.6
+quay.io/tigera/dikastes:v3.22.6
+quay.io/tigera/l7-admission-controller:v3.22.6
+quay.io/tigera/pod2daemon-flexvol:v3.22.6
+quay.io/tigera/csi:v3.22.6
+quay.io/tigera/node-driver-registrar:v3.22.6
+quay.io/tigera/envoy-gateway:v3.22.6
+quay.io/tigera/envoy-proxy:v3.22.6
+quay.io/tigera/envoy-ratelimit:v3.22.6
+quay.io/tigera/istio-pilot:v3.22.6
+quay.io/tigera/istio-install-cni:v3.22.6
+quay.io/tigera/istio-ztunnel:v3.22.6
+quay.io/tigera/istio-proxyv2:v3.22.6
+quay.io/tigera/operator:v1.40.12
+quay.io/tigera/image-assurance-admission-controller:v1.22.9
+quay.io/tigera/image-assurance-operator:v1.22.9
+quay.io/tigera/image-assurance-container-runtime-adaptor:v1.22.9
+quay.io/tigera/image-assurance-cluster-scanner:v1.22.9
+quay.io/tigera/runtime-security-operator:v1.23.2
+quay.io/tigera/skimble:v1.23.2
+quay.io/tigera/cc-core:v0.3.6
+quay.io/tigera/prometheus-operator:v3.22.6
+quay.io/tigera/prometheus-config-reloader:v3.22.6
+quay.io/tigera/cc-cni-config-scanner:v0.7.2`,
   // curl -0 https://installer.calicocloud.io/manifests/v3.22.6-0/image-list
   'v22.5.0': `quay.io/tigera/apiserver:v3.22.6
 quay.io/tigera/compliance-benchmarker:v3.22.6


### PR DESCRIPTION
Calico Cloud 23.0.2 and 22.5.1 promote together and carry the same fix, so this adds one dated release-notes entry that names both versions rather than one entry each. 23.0.2 carries a second fix that 22.5.1 does not, called out on its own bullet.

Both versions fix a change in how Azure Kubernetes Service manages Calico, which could stop an installation from finishing or stop the operator from managing resources on an existing cluster.

23.0.2 also adds the policy that lets the API server reach Guardian. This is CI-2048, reported by Insight Investment. The shipped calico-system.apiserver-access policy permits the self-hosted Linseed location but not the Guardian hop that a managed cluster uses, and the tier ends in Pass, so the customer's own default-deny over calico-system was the next thing to match and the policy board returned a 500.

Sources: Erik Stidham in #eng-release-updates on August 21 and August 27, and CI-2048.

Changes:

- Add one release-notes entry dated August 27, 2026 covering versions 23.0.2 and 22.5.1.
- Add private registry image lists for v23.0.2 and v22.5.1, ordered ahead of v23.0.1 and v22.5.0, with the latest marker moved to v23.0.2 so the dropdown defaults to the newest version.
- Drop the TODO(DOCS-3008) comment on the v23.0.1 entry.

The image lists were placeholders when this went up, because no manifest for either patch was being served yet. Erik has since filled them in. Both new entries come from the same manifests as their predecessors, v3.23.1-4 for 23.0.2 and v3.22.6-0 for 22.5.1, and all four entries match what those manifests serve today, confirmed by diffing the curl output against the file. So 23.0.2 and 22.5.1 ship the same images as 23.0.1 and 22.5.0, and the two pairs of identical lists in the file are correct rather than a copy and paste error. That also answers the open question about the old TODO on v23.0.1: it never had a manifest of its own.

One thing still outstanding. The release date in the heading is a placeholder. On August 27 Erik said he was about ready to start promoting both versions to staging and then production, so August 27 is the day he announced it, not the day it ships. Erik, if it lands on a different day, say so and the heading date and the id change with it.

Link to docs preview: https://deploy-preview-2974--tigera.netlify.app/calico-cloud/release-notes

The private registry page is the other changed page, where the version selector should now offer v23.0.2 (latest): https://deploy-preview-2974--tigera.netlify.app/calico-cloud/get-started/setup-private-registry

Merge checklist:
- [ ] Release date confirmed against the actual production promotion
- [x] Image lists added and verified against the served manifests
- [ ] Deploy preview inspected
- [ ] SME approval
- [ ] Docs team approval
