### PR TITLE
DOCS-3022: Point agents somewhere useful from the 404 page

### DIFF
--- a/src/theme/NotFound/Content/__test__/index.test.js
+++ b/src/theme/NotFound/Content/__test__/index.test.js
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+
+// @theme/* and @docusaurus/Translate only resolve inside a Docusaurus build, so they
+// are mocked virtually here. @docusaurus/Link already has a shared mock in
+// jest.config.mjs, but that one renders children without an anchor; the destinations
+// are what this suite is checking, so it needs one that keeps the href.
+jest.mock('@theme/Heading', () => ({ __esModule: true, default: ({ children }) => <h1>{children}</h1> }), {
+  virtual: true,
+});
+jest.mock('@docusaurus/Translate', () => ({ __esModule: true, default: ({ children }) => children }), {
+  virtual: true,
+});
+jest.mock('@docusaurus/Link', () => ({
+  __esModule: true,
+  default: ({ to, children }) => <a href={to}>{children}</a>,
+}));
+
+import NotFoundContent from '../index';
+
+describe('NotFoundContent', () => {
+  beforeEach(() => {
+    render(<NotFoundContent />);
+  });
+
+  it('offers a doc root for each product', () => {
+    expect(screen.getByText('Calico Open Source')).toHaveAttribute('href', '/calico/latest/about');
+    expect(screen.getByText('Calico Enterprise')).toHaveAttribute('href', '/calico-enterprise/latest/about');
+    expect(screen.getByText('Calico Cloud')).toHaveAttribute('href', '/calico-cloud/about');
+  });
+
+  it('points agents at the machine-readable indexes', () => {
+    // The reason this page was rewritten: whoever lands here needs somewhere to go,
+    // and these two files are the only entry points that enumerate the whole site.
+    expect(screen.getByText('llms.txt')).toHaveAttribute('href', '/llms.txt');
+    expect(screen.getByText('sitemap.xml')).toHaveAttribute('href', '/sitemap.xml');
+  });
+
+  it('drops the stock advice to contact whoever linked here', () => {
+    expect(screen.queryByText(/contact the owner of the site/i)).toBeNull();
+  });
+});

--- a/src/theme/NotFound/Content/index.js
+++ b/src/theme/NotFound/Content/index.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+import Heading from '@theme/Heading';
+
+/**
+ * The 404 page body.
+ *
+ * Swizzled from theme-classic to replace the stock text, which tells the reader to
+ * "contact the owner of the site that linked you to the original URL". On a docs site
+ * the reader is nearly always someone who followed a stale link or an agent that
+ * guessed a URL, and neither can act on that advice.
+ *
+ * Docusaurus prerenders this into 404.html, so the links below are in the served
+ * markup rather than only after hydration. That matters because the audience includes
+ * clients that read the HTML and never run the JavaScript.
+ *
+ * llms.txt and sitemap.xml are static files rather than routes, so they are plain
+ * anchors: <Link> would try to resolve them through the client-side router.
+ */
+export default function NotFoundContent({ className }) {
+  return (
+    <main className={clsx('container margin-vert--xl', className)}>
+      <div className='row'>
+        <div className='col col--6 col--offset-3'>
+          <Heading
+            as='h1'
+            className='hero__title'
+          >
+            <Translate
+              id='theme.NotFound.title'
+              description='The title of the 404 page'
+            >
+              Page Not Found
+            </Translate>
+          </Heading>
+          <p>There is no Calico documentation page at this URL.</p>
+          <p>Start from one of these instead:</p>
+          <ul>
+            <li>
+              <Link to='/calico/latest/about'>Calico Open Source</Link>
+            </li>
+            <li>
+              <Link to='/calico-enterprise/latest/about'>Calico Enterprise</Link>
+            </li>
+            <li>
+              <Link to='/calico-cloud/about'>Calico Cloud</Link>
+            </li>
+            <li>
+              <a href='/sitemap.xml'>sitemap.xml</a> — every published URL
+            </li>
+            <li>
+              <a href='/llms.txt'>llms.txt</a> — an index of the documentation, written for agents
+            </li>
+          </ul>
+          <p>
+            Every documentation page also has a Markdown version at its own URL with <code>.md</code> appended.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
A Vercel agent-readiness checker flagged docs.tigera.io for returning 200 with the app shell on nonexistent paths. That part does not apply — the site already returns a real 404 status:

    curl -s -o /dev/null -w "%{http_code}" https://docs.tigera.io/some-path-that-does-not-exist
    404

What the site does not do is give the 404 a body worth reading. Its server-rendered text is the stock "Please contact the owner of the site that linked you to the original URL and let them know their link is broken". Nothing on the page names /llms.txt, /sitemap.xml, or a product doc root, all of which exist and return 200.

This swizzles theme-classic's NotFound/Content to link the three product doc roots, sitemap.xml, and llms.txt, and to mention that every page has a Markdown version at its own URL with .md appended. Docusaurus prerenders the component into 404.html, so the links are in the served markup rather than only after hydration — which is what a client that never runs the JavaScript sees.

Second half of the ticket, serving Markdown for a missing .md URL, is a separate PR stacked on this one.

To review, once the preview builds, open any path that does not exist:

- https://deploy-preview-NNNN--tigera.netlify.app/no-such-page
- view-source on the same URL, to confirm the links are in the served HTML and not only after hydration

Jira: https://tigera.atlassian.net/browse/DOCS-3022