### PR TITLE
DOCS-3022: Answer a missing Markdown URL with Markdown

### DIFF
--- a/netlify/edge-functions/markdown-not-found.js
+++ b/netlify/edge-functions/markdown-not-found.js
@@ -1,0 +1,100 @@
+/**
+ * Answer a missing `.md` URL with a short Markdown body instead of the HTML 404 page.
+ *
+ * Every doc page has a Markdown twin at the same URL with `.md` appended (see
+ * src/plugins/docusaurus-plugin-llms-txt), so `.md` requests come from agents, not
+ * browsers. Netlify already returns a real 404 status for a path that does not exist,
+ * but the body it returns is the 33 KB Docusaurus shell. An agent that guessed a twin
+ * URL wrong learns nothing from that and has no way to recover. This hands it the
+ * entry points it can actually use: llms.txt, the sitemap, and the product doc roots.
+ *
+ * Scoped to `/*.md`, so ordinary page traffic never reaches this function.
+ */
+
+/**
+ * The headers `static/_headers` would have applied to a `.md` URL.
+ *
+ * Netlify does not apply custom headers on a path served by an edge function, so
+ * without this every twin would lose them the moment this function shipped — and the
+ * one that matters is `X-Robots-Tag: noindex`, which is the only thing keeping several
+ * thousand Markdown twins out of the index as duplicates of the HTML pages.
+ *
+ * Duplicating the values is the tradeoff for running here at all. The unit test reads
+ * `static/_headers` and fails if the two ever disagree.
+ */
+export const MARKDOWN_HEADERS = {
+  'cross-origin-opener-policy': 'same-origin',
+  'x-frame-options': 'DENY',
+  'content-security-policy': "frame-ancestors 'none'",
+  'x-robots-tag': 'noindex',
+};
+
+/**
+ * The body served for a missing `.md` URL.
+ *
+ * Links are absolute so an agent can follow them out of a response it may have fetched
+ * without keeping the request URL, and built from the request origin so that deploy
+ * previews point at themselves rather than at production.
+ *
+ * @param {string} origin
+ * @returns {string}
+ */
+export function notFoundMarkdown(origin) {
+  return `# Not found
+
+There is no Calico documentation page at this URL.
+
+Every documentation page has a Markdown version at its own URL with \`.md\` appended,
+so a page that exists is reachable this way. This one does not exist.
+
+## Where to go instead
+
+- [${origin}/llms.txt](${origin}/llms.txt): an index of the documentation, written for agents
+- [${origin}/sitemap.xml](${origin}/sitemap.xml): every published URL
+- [${origin}/calico/latest/about.md](${origin}/calico/latest/about.md): Calico Open Source
+- [${origin}/calico-enterprise/latest/about.md](${origin}/calico-enterprise/latest/about.md): Calico Enterprise
+- [${origin}/calico-cloud/about.md](${origin}/calico-cloud/about.md): Calico Cloud
+`;
+}
+
+/**
+ * A copy of `response` carrying the headers `static/_headers` can no longer add.
+ *
+ * @param {Response} response
+ * @returns {Response}
+ */
+function withMarkdownHeaders(response) {
+  const copy = new Response(response.body, response);
+
+  for (const [name, value] of Object.entries(MARKDOWN_HEADERS)) {
+    copy.headers.set(name, value);
+  }
+
+  return copy;
+}
+
+export default async (request, context) => {
+  const response = await context.next();
+
+  // The twin exists, or a redirect in static/_redirects answered first.
+  if (response.status !== 404) {
+    return withMarkdownHeaders(response);
+  }
+
+  const { origin } = new URL(request.url);
+
+  return withMarkdownHeaders(
+    new Response(notFoundMarkdown(origin), {
+      status: 404,
+      headers: { 'content-type': 'text/markdown; charset=utf-8' },
+    })
+  );
+};
+
+export const config = {
+  path: '/*.md',
+  // GET only, matching markdown-negotiation.js: Netlify's manifest schema has no HEAD
+  // and fails the build if it appears. A HEAD request therefore still gets the HTML
+  // 404, so verify with `curl -sD - -o /dev/null` against a GET.
+  method: 'GET',
+};

--- a/src/__tests__/markdown-not-found.test.js
+++ b/src/__tests__/markdown-not-found.test.js
@@ -1,0 +1,136 @@
+/**
+ * The handler builds and inspects Request and Response objects, which the default
+ * jsdom environment does not provide. Deno gives the real edge runtime both.
+ *
+ * @jest-environment node
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import handler, {
+  MARKDOWN_HEADERS,
+  config,
+  notFoundMarkdown,
+} from '../../netlify/edge-functions/markdown-not-found.js';
+
+/**
+ * The headers `static/_headers` declares for a `.md` URL, lowercased.
+ *
+ * A later rule wins over an earlier wildcard, so the blocks are merged in file order.
+ */
+function declaredHeadersForMarkdown() {
+  const file = readFileSync(join(__dirname, '../../static/_headers'), 'utf8');
+  const merged = {};
+  let applies = false;
+
+  for (const line of file.split('\n')) {
+    if (line.trim().startsWith('#') || line.trim() === '') {
+      continue;
+    }
+
+    if (!/^\s/.test(line)) {
+      applies = line.trim() === '/*' || line.trim() === '/*.md';
+      continue;
+    }
+
+    if (!applies) {
+      continue;
+    }
+
+    const [name, ...rest] = line.trim().split(':');
+    merged[name.toLowerCase()] = rest.join(':').trim();
+  }
+
+  return merged;
+}
+
+describe('notFoundMarkdown', () => {
+  const body = notFoundMarkdown('https://docs.tigera.io');
+
+  it('names the three entry points an agent can recover from', () => {
+    expect(body).toContain('https://docs.tigera.io/llms.txt');
+    expect(body).toContain('https://docs.tigera.io/sitemap.xml');
+    expect(body).toContain('https://docs.tigera.io/calico/latest/about.md');
+  });
+
+  it('stays short enough to be worth reading', () => {
+    // The point of this function is that the 33 KB Docusaurus shell tells an agent
+    // nothing. A long replacement would give up the only advantage it has.
+    expect(body.length).toBeLessThan(1500);
+  });
+
+  it('keeps links on the origin it was asked about', () => {
+    // A deploy preview must link to itself, not to production, or a reviewer
+    // checking the preview silently ends up reading the live site.
+    const preview = notFoundMarkdown('https://deploy-preview-1--tigera.netlify.app');
+
+    expect(preview).not.toContain('docs.tigera.io');
+    expect(preview).toContain('https://deploy-preview-1--tigera.netlify.app/llms.txt');
+  });
+});
+
+describe('handler', () => {
+  const request = new Request('https://docs.tigera.io/calico/latest/nope.md');
+
+  it('replaces the HTML 404 with markdown', async () => {
+    const context = { next: async () => new Response('<html>the shell</html>', { status: 404 }) };
+
+    const response = await handler(request, context);
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('content-type')).toBe('text/markdown; charset=utf-8');
+    expect(await response.text()).toContain('/llms.txt');
+  });
+
+  it('passes a twin that exists straight through', async () => {
+    const context = { next: async () => new Response('# A real page', { status: 200 }) };
+
+    const response = await handler(request, context);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('# A real page');
+  });
+
+  it('leaves a redirect alone', async () => {
+    // `/*/index /:splat 301!` and the version redirects in static/_redirects can
+    // answer a `.md` request; rewriting those to a 404 body would break them.
+    const context = { next: async () => new Response(null, { status: 301, headers: { location: '/elsewhere' } }) };
+
+    const response = await handler(request, context);
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('/elsewhere');
+  });
+
+  it('keeps the twins noindexed on every path through the function', async () => {
+    for (const status of [200, 301, 404]) {
+      const context = { next: async () => new Response(null, { status }) };
+
+      const response = await handler(request, context);
+
+      expect(response.headers.get('x-robots-tag')).toBe('noindex');
+      expect(response.headers.get('x-frame-options')).toBe('DENY');
+    }
+  });
+});
+
+describe('config', () => {
+  it('runs only on markdown URLs', () => {
+    expect(config.path).toBe('/*.md');
+  });
+
+  it('declares only methods Netlify accepts', () => {
+    // Netlify's manifest schema has no HEAD, and rejects the whole manifest if it
+    // appears — see the same note in markdown-negotiation.js.
+    expect(config.method).toBe('GET');
+  });
+});
+
+describe('MARKDOWN_HEADERS', () => {
+  it('matches what static/_headers declares for .md URLs', () => {
+    // Netlify skips custom headers on a path served by an edge function, so these
+    // values are the only thing keeping the twins noindexed once this ships. If a
+    // rule in static/_headers changes and this does not, the twins silently lose it.
+    expect(MARKDOWN_HEADERS).toEqual(declaredHeadersForMarkdown());
+  });
+});

--- a/src/theme/NotFound/Content/__test__/index.test.js
+++ b/src/theme/NotFound/Content/__test__/index.test.js
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+
+// @theme/* and @docusaurus/Translate only resolve inside a Docusaurus build, so they
+// are mocked virtually here. @docusaurus/Link already has a shared mock in
+// jest.config.mjs, but that one renders children without an anchor; the destinations
+// are what this suite is checking, so it needs one that keeps the href.
+jest.mock('@theme/Heading', () => ({ __esModule: true, default: ({ children }) => <h1>{children}</h1> }), {
+  virtual: true,
+});
+jest.mock('@docusaurus/Translate', () => ({ __esModule: true, default: ({ children }) => children }), {
+  virtual: true,
+});
+jest.mock('@docusaurus/Link', () => ({
+  __esModule: true,
+  default: ({ to, children }) => <a href={to}>{children}</a>,
+}));
+
+import NotFoundContent from '../index';
+
+describe('NotFoundContent', () => {
+  beforeEach(() => {
+    render(<NotFoundContent />);
+  });
+
+  it('offers a doc root for each product', () => {
+    expect(screen.getByText('Calico Open Source')).toHaveAttribute('href', '/calico/latest/about');
+    expect(screen.getByText('Calico Enterprise')).toHaveAttribute('href', '/calico-enterprise/latest/about');
+    expect(screen.getByText('Calico Cloud')).toHaveAttribute('href', '/calico-cloud/about');
+  });
+
+  it('points agents at the machine-readable indexes', () => {
+    // The reason this page was rewritten: whoever lands here needs somewhere to go,
+    // and these two files are the only entry points that enumerate the whole site.
+    expect(screen.getByText('llms.txt')).toHaveAttribute('href', '/llms.txt');
+    expect(screen.getByText('sitemap.xml')).toHaveAttribute('href', '/sitemap.xml');
+  });
+
+  it('drops the stock advice to contact whoever linked here', () => {
+    expect(screen.queryByText(/contact the owner of the site/i)).toBeNull();
+  });
+});

--- a/src/theme/NotFound/Content/index.js
+++ b/src/theme/NotFound/Content/index.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+import Heading from '@theme/Heading';
+
+/**
+ * The 404 page body.
+ *
+ * Swizzled from theme-classic to replace the stock text, which tells the reader to
+ * "contact the owner of the site that linked you to the original URL". On a docs site
+ * the reader is nearly always someone who followed a stale link or an agent that
+ * guessed a URL, and neither can act on that advice.
+ *
+ * Docusaurus prerenders this into 404.html, so the links below are in the served
+ * markup rather than only after hydration. That matters because the audience includes
+ * clients that read the HTML and never run the JavaScript.
+ *
+ * llms.txt and sitemap.xml are static files rather than routes, so they are plain
+ * anchors: <Link> would try to resolve them through the client-side router.
+ */
+export default function NotFoundContent({ className }) {
+  return (
+    <main className={clsx('container margin-vert--xl', className)}>
+      <div className='row'>
+        <div className='col col--6 col--offset-3'>
+          <Heading
+            as='h1'
+            className='hero__title'
+          >
+            <Translate
+              id='theme.NotFound.title'
+              description='The title of the 404 page'
+            >
+              Page Not Found
+            </Translate>
+          </Heading>
+          <p>There is no Calico documentation page at this URL.</p>
+          <p>Start from one of these instead:</p>
+          <ul>
+            <li>
+              <Link to='/calico/latest/about'>Calico Open Source</Link>
+            </li>
+            <li>
+              <Link to='/calico-enterprise/latest/about'>Calico Enterprise</Link>
+            </li>
+            <li>
+              <Link to='/calico-cloud/about'>Calico Cloud</Link>
+            </li>
+            <li>
+              <a href='/sitemap.xml'>sitemap.xml</a> — every published URL
+            </li>
+            <li>
+              <a href='/llms.txt'>llms.txt</a> — an index of the documentation, written for agents
+            </li>
+          </ul>
+          <p>
+            Every documentation page also has a Markdown version at its own URL with <code>.md</code> appended.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Stacked on #2975 — review that one first. GitHub cannot base a cross-fork PR on another fork branch, so this one targets main and shows #2975's commit too. Review only the second commit; the diff resolves itself once #2975 merges.

Every doc page has a Markdown twin at its own URL with .md appended, so a .md request comes from an agent rather than a browser. Netlify already returns a real 404 status for a twin that does not exist, but the body is the 33 KB Docusaurus shell, which an agent cannot use and cannot recover from. This adds an edge function scoped to /*.md that answers a 404 with a short text/markdown body naming llms.txt, the sitemap, and the three product doc roots.

One thing worth checking on the preview. Netlify does not apply custom headers on a path served by an edge function — /lynx/* on production shows this today, its responses carry none of the security headers static/_headers sets for /*. Without compensation, shipping this would strip X-Robots-Tag: noindex from every Markdown twin and turn several thousand of them into indexable duplicates of their HTML pages. So the function sets the four rules static/_headers gives a .md URL on every response it returns, including the ones it passes straight through, and a unit test reads static/_headers and fails if the two ever drift.

To review, once the preview builds:

- curl -sD - -o /dev/null https://deploy-preview-NNNN--tigera.netlify.app/calico/latest/about.md — an existing twin, still 200, still noindex, still carrying the security headers
- curl -sD - https://deploy-preview-NNNN--tigera.netlify.app/calico/latest/no-such-page.md — 404, text/markdown, noindex
- curl -s -o /dev/null -w "%{http_code}" https://deploy-preview-NNNN--tigera.netlify.app/no-such-page — unchanged, still the HTML 404

Use GET rather than curl -I for these. Netlify's edge function manifest schema has no HEAD and fails the build if it appears, so a HEAD request bypasses the function.

Jira: https://tigera.atlassian.net/browse/DOCS-3022