### PR TITLE
DOCS-3021: Render the remaining preview tables from the data file

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -4,6 +4,8 @@ title: Calico Enterprise release notes
 sidebar_label: Release notes
 ---
 
+import TechPreviewTable from '@site/src/components/FeatureStatusTable';
+
 # Calico Enterprise 3.21 release notes
 
 Learn about the new features, bug fixes, and other updates in this release of $[prodname].
@@ -73,13 +75,7 @@ From the **Web Application Firewall** page, click the **Rulesets** tab to open a
 This table shows the status of features that were in technology preview at any point in the releases covered here.
 Technology preview features are for evaluation and feedback only and are **not supported for production use**. Behavior, APIs, and configuration may change before a feature reaches general availability.
 
-| Feature | 3.19 | 3.20 | 3.21 |
-| --- | --- | --- | --- |
-| Workload WAF | TP | TP | TP |
-| DNS policy for Windows | TP | TP | TP |
-| Calico Ingress Gateway | – | – | TP |
-
-TP = technology preview, – = not available in that release.
+<TechPreviewTable />
 
 ## Deprecated and removed features
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -4,6 +4,8 @@ title: Calico Enterprise release notes
 sidebar_label: Release notes
 ---
 
+import TechPreviewTable from '@site/src/components/FeatureStatusTable';
+
 # Calico Enterprise 3.22 release notes
 
 Learn about the new features, bug fixes, and other updates in this release of $[prodname].
@@ -119,15 +121,7 @@ that were previously bound to service accounts in those namespaces have been mov
 This table shows the status of features that were in technology preview at any point in the releases covered here.
 Technology preview features are for evaluation and feedback only and are **not supported for production use**. Behavior, APIs, and configuration may change before a feature reaches general availability.
 
-| Feature | 3.20 | 3.21 | 3.22 |
-| --- | --- | --- | --- |
-| Workload WAF | TP | TP | TP |
-| DNS policy for Windows | TP | TP | TP |
-| Calico Ingress Gateway | – | TP | GA |
-| Gateway WAF | – | – | TP |
-| Istio ambient mode | – | – | TP |
-
-TP = technology preview, GA = generally available, – = not available in that release.
+<TechPreviewTable />
 
 ## Deprecated and removed features
 

--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -4,6 +4,8 @@ title: Calico Enterprise release notes
 sidebar_label: Release notes
 ---
 
+import TechPreviewTable from '@site/src/components/FeatureStatusTable';
+
 # Calico Enterprise 3.23 release notes
 
 Learn about the new features, bug fixes, and other updates in this release of $[prodname].
@@ -138,18 +140,7 @@ For more information, see [vSphere Kubernetes Service (VKS)](../getting-started/
 This table shows the status of features that were in technology preview at any point in the releases covered here.
 Technology preview features are for evaluation and feedback only and are **not supported for production use**. Behavior, APIs, and configuration may change before a feature reaches general availability.
 
-| Feature | 3.21 | 3.22 | 3.23 |
-| --- | --- | --- | --- |
-| Workload WAF | TP | TP | TP |
-| DNS policy for Windows | TP | TP | TP |
-| Calico Ingress Gateway | TP | GA | GA |
-| Gateway WAF | – | TP | TP |
-| Istio ambient mode | – | TP | TP |
-| Multi-VRF networking | – | – | TP |
-| Native v3 CRDs | – | – | TP |
-| Live migration for KubeVirt VMs | – | – | TP |
-
-TP = technology preview, GA = generally available, – = not available in that release.
+<TechPreviewTable />
 
 ## Deprecated and removed features
 

--- a/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
@@ -4,6 +4,8 @@ title: Calico Enterprise release notes
 sidebar_label: Release notes
 ---
 
+import TechPreviewTable from '@site/src/components/FeatureStatusTable';
+
 # Calico Enterprise 3.24 release notes
 
 :::info[early preview release]
@@ -64,18 +66,7 @@ For more information, see [L2 reachability for pods and services without BGP](..
 This table shows the status of features that were in technology preview at any point in the releases covered here.
 Technology preview features are for evaluation and feedback only and are **not supported for production use**. Behavior, APIs, and configuration may change before a feature reaches general availability.
 
-| Feature | 3.22 | 3.23 | 3.24 |
-| --- | --- | --- | --- |
-| Workload WAF | TP | TP | TP |
-| DNS policy for Windows | TP | TP | TP |
-| Gateway WAF | TP | TP | TP |
-| Istio ambient mode | TP | TP | TP |
-| Multi-VRF networking | – | TP | TP |
-| Native v3 CRDs | – | TP | GA |
-| Live migration for KubeVirt VMs | – | TP | TP |
-| Selector-scoped Felix configuration | – | – | TP |
-
-TP = technology preview, GA = generally available, – = not available in that release.
+<TechPreviewTable />
 
 ## Deprecated and removed features
 

--- a/calico-enterprise_versioned_docs/version-3.24-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/release-notes/index.mdx
@@ -4,6 +4,8 @@ title: Calico Enterprise release notes
 sidebar_label: Release notes
 ---
 
+import TechPreviewTable from '@site/src/components/FeatureStatusTable';
+
 # Calico Enterprise 3.24 release notes
 
 :::info[early preview release]
@@ -64,18 +66,7 @@ For more information, see [L2 reachability for pods and services without BGP](..
 This table shows the status of features that were in technology preview at any point in the releases covered here.
 Technology preview features are for evaluation and feedback only and are **not supported for production use**. Behavior, APIs, and configuration may change before a feature reaches general availability.
 
-| Feature | 3.22 | 3.23 | 3.24 |
-| --- | --- | --- | --- |
-| Workload WAF | TP | TP | TP |
-| DNS policy for Windows | TP | TP | TP |
-| Gateway WAF | TP | TP | TP |
-| Istio ambient mode | TP | TP | TP |
-| Multi-VRF networking | – | TP | TP |
-| Native v3 CRDs | – | TP | GA |
-| Live migration for KubeVirt VMs | – | TP | TP |
-| Selector-scoped Felix configuration | – | – | TP |
-
-TP = technology preview, GA = generally available, – = not available in that release.
+<TechPreviewTable />
 
 ## Deprecated and removed features
 

--- a/calico_versioned_docs/version-3.30/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.30/release-notes/index.mdx
@@ -4,6 +4,8 @@ title: Calico Open Source release notes
 sidebar_label: Release notes
 ---
 
+import TechPreviewTable from '@site/src/components/FeatureStatusTable';
+
 # Calico Open Source 3.30 release notes
 
 Learn about the new features, bug fixes, and other updates in this release of $[prodname].
@@ -153,13 +155,7 @@ This release adds support for Kubernetes versions 1.32 and 1.33.
 This table shows the status of features that were in technology preview at any point in the releases covered here.
 Technology preview features are for evaluation and feedback only and are **not supported for production use**. Behavior, APIs, and configuration may change before a feature reaches general availability.
 
-| Feature | 3.28 | 3.29 | 3.30 |
-| --- | --- | --- | --- |
-| Flow logs API and Whisker | – | – | TP |
-| Calico Ingress Gateway | – | – | TP |
-| nftables data plane | – | TP | TP |
-
-TP = technology preview, GA = generally available, – = not available in that release.
+<TechPreviewTable />
 
 ## Deprecated and removed features
 

--- a/calico_versioned_docs/version-3.31/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.31/release-notes/index.mdx
@@ -4,6 +4,8 @@ title: Calico Open Source release notes
 sidebar_label: Release notes
 ---
 
+import TechPreviewTable from '@site/src/components/FeatureStatusTable';
+
 # Calico Open Source 3.31 release notes
 
 Learn about the new features, bug fixes, and other updates in this release of $[prodname].
@@ -179,13 +181,7 @@ With this enhancement, Calico responds to all QoS policy and rule changes on the
 This table shows the status of features that were in technology preview at any point in the releases covered here.
 Technology preview features are for evaluation and feedback only and are **not supported for production use**. Behavior, APIs, and configuration may change before a feature reaches general availability.
 
-| Feature | 3.29 | 3.30 | 3.31 |
-| --- | --- | --- | --- |
-| Flow logs API and Whisker | – | TP | TP |
-| Calico Ingress Gateway | – | TP | GA |
-| nftables data plane | TP | TP | GA |
-
-TP = technology preview, GA = generally available, – = not available in that release.
+<TechPreviewTable />
 
 ## Deprecated and removed features
 

--- a/src/components/FeatureStatusTable/__test__/featureStatus.test.ts
+++ b/src/components/FeatureStatusTable/__test__/featureStatus.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { parse } from 'yaml';
 
-import { buildLegend, buildRows, cellLabel, releaseWindow } from '../featureStatus';
+import { buildLegend, buildRows, cellLabel, PREVIEW_LEGEND, releaseWindow } from '../featureStatus';
 import type { Feature } from '../featureStatus';
 
 const features: Feature[] = parse(
@@ -111,21 +111,15 @@ describe('buildRows', () => {
 });
 
 describe('buildLegend', () => {
-  const legend = (product: string, versions: string[]) => buildLegend(buildRows(features, product, versions));
-
-  it('glosses only the statuses the table actually uses', () => {
-    expect(legend('calico', ['3.30', '3.31', '3.32'])).toBe(
+  it('names every status the preview table tracks, reached or not', () => {
+    expect(buildLegend(PREVIEW_LEGEND)).toBe(
       'TP = technology preview, GA = generally available, – = not available in that release.'
     );
   });
 
-  it('omits GA when no feature in the window reached it', () => {
-    expect(legend('calico-enterprise', ['3.19', '3.20', '3.21'])).toBe(
-      'TP = technology preview, – = not available in that release.'
+  it('glosses in progression order and puts the dash last', () => {
+    expect(buildLegend(['removed', 'tech-preview'])).toBe(
+      'TP = technology preview, Removed = no longer present, – = not available in that release.'
     );
-  });
-
-  it('omits the dash when every feature existed throughout the window', () => {
-    expect(legend('calico-enterprise', ['3.19', '3.20'])).toBe('TP = technology preview.');
   });
 });

--- a/src/components/FeatureStatusTable/__test__/featureStatus.test.ts
+++ b/src/components/FeatureStatusTable/__test__/featureStatus.test.ts
@@ -80,6 +80,22 @@ describe('buildRows', () => {
     ]);
   });
 
+  it('reproduces the Calico Open Source 3.30 technology preview table', () => {
+    expect(asMarkdown('calico', ['3.28', '3.29', '3.30'])).toEqual([
+      '| nftables data plane | – | TP | TP |',
+      '| Calico Ingress Gateway | – | – | TP |',
+      '| Flow logs API and Whisker | – | – | TP |',
+    ]);
+  });
+
+  it('reproduces the Calico Open Source 3.31 technology preview table', () => {
+    expect(asMarkdown('calico', ['3.29', '3.30', '3.31'])).toEqual([
+      '| nftables data plane | TP | TP | GA |',
+      '| Calico Ingress Gateway | – | TP | GA |',
+      '| Flow logs API and Whisker | – | TP | TP |',
+    ]);
+  });
+
   it('reproduces the Calico Open Source 3.32 technology preview table', () => {
     expect(asMarkdown('calico', window)).toEqual([
       '| nftables data plane | TP | GA | GA |',

--- a/src/components/FeatureStatusTable/__test__/featureStatus.test.ts
+++ b/src/components/FeatureStatusTable/__test__/featureStatus.test.ts
@@ -66,17 +66,19 @@ describe('buildRows', () => {
     expect(names('calico', window)).not.toContain('Workload WAF');
   });
 
-  it('orders rows by the release the feature first appeared in', () => {
-    expect(names('calico-enterprise', ['3.22', '3.23', '3.24'])).toEqual([
-      'DNS policy for Windows',
-      'Workload WAF',
-      'Gateway WAF',
-      'Istio ambient mode',
-      'Live migration for KubeVirt VMs',
-      'Multi-VRF networking',
-      'Native v3 CRDs',
-      'L2 bridge networking',
-      'Selector-scoped Felix configuration',
+  it('reproduces the Calico Enterprise 3.24 technology preview table', () => {
+    // The widest table there is: features arriving in four different releases, a
+    // status that has moved on to GA, and rows that never existed in the first column.
+    expect(asMarkdown('calico-enterprise', ['3.22', '3.23', '3.24'])).toEqual([
+      '| DNS policy for Windows | TP | TP | TP |',
+      '| Workload WAF | TP | TP | TP |',
+      '| Gateway WAF | TP | TP | TP |',
+      '| Istio ambient mode | TP | TP | TP |',
+      '| Live migration for KubeVirt VMs | – | TP | TP |',
+      '| Multi-VRF networking | – | TP | TP |',
+      '| Native v3 CRDs | – | TP | GA |',
+      '| L2 bridge networking | – | – | TP |',
+      '| Selector-scoped Felix configuration | – | – | TP |',
     ]);
   });
 

--- a/src/components/FeatureStatusTable/featureStatus.ts
+++ b/src/components/FeatureStatusTable/featureStatus.ts
@@ -124,16 +124,28 @@ export function buildRows(features: Feature[], product: string, versions: string
 }
 
 /**
- * The legend sentence for a set of rows.
+ * The statuses the technology preview legend names.
  *
- * Only statuses that actually appear are glossed, so a table with no GA cells does not
- * explain what GA means.
+ * Wider than the rows on purpose: GA is here because a preview feature graduating to GA
+ * is the outcome the table exists to track, so the reader needs it explained even in a
+ * release where nothing has got there yet.
  */
-export function buildLegend(rows: FeatureRow[]): string {
-  const present = new Set<CellStatus>(rows.flatMap((row) => row.cells));
+export const PREVIEW_LEGEND: readonly FeatureStatus[] = ['tech-preview', 'ga'];
 
-  const parts = STATUSES.filter((entry) => present.has(entry.status)).map((entry) => `${entry.label} = ${entry.gloss}`);
-  if (present.has(null)) parts.push(`${NOT_AVAILABLE} = not available in that release`);
+/**
+ * The legend sentence for a table.
+ *
+ * The set is fixed per table rather than derived from the cells on screen. A legend
+ * shows the whole progression a feature travels through, so it has to name the statuses
+ * a release has not reached as well as the ones it has. Trimming it to whatever happens
+ * to be in the table makes the same table read differently from one release to the next.
+ *
+ * Statuses are glossed in progression order, and the dash always comes last.
+ */
+export function buildLegend(statuses: readonly FeatureStatus[]): string {
+  const parts = STATUSES.filter((entry) => statuses.includes(entry.status)).map(
+    (entry) => `${entry.label} = ${entry.gloss}`
+  );
 
-  return `${parts.join(', ')}.`;
+  return `${[...parts, `${NOT_AVAILABLE} = not available in that release`].join(', ')}.`;
 }

--- a/src/components/FeatureStatusTable/index.tsx
+++ b/src/components/FeatureStatusTable/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { usePluginData } from '@docusaurus/useGlobalData';
 import { useDocsVersion } from '@docusaurus/plugin-content-docs/client';
 
-import { buildLegend, buildRows, cellLabel, releaseWindow } from './featureStatus';
+import { buildLegend, buildRows, cellLabel, PREVIEW_LEGEND, releaseWindow } from './featureStatus';
 import type { Feature } from './featureStatus';
 
 const PLUGIN_NAME = 'docusaurus-plugin-feature-status';
@@ -54,7 +54,7 @@ const TechPreviewTable: React.FC = () => {
           ))}
         </tbody>
       </table>
-      <p>{buildLegend(rows)}</p>
+      <p>{buildLegend(PREVIEW_LEGEND)}</p>
     </>
   );
 };


### PR DESCRIPTION
Follows the merged #2968, which rendered one table from data/feature-status.yaml and left the rest. This does the other six, so every published technology preview table now comes from the data file rather than being retyped each release.

Two commits, one per product, in case the Enterprise half wants separate eyes.

Each page derives its own window from its own docs version, so the frozen snapshots keep the window they were cut with: Open Source 3.30 still shows 3.28 to 3.30, and Enterprise 3.23 still shows 3.21 to 3.23. Nothing about the window is written into any page.

The Enterprise pages are the first to exercise the version suffix in a build. A page at docs version 3.23-2 resolves to release line 3.23. The product key comes from the docs plugin id, which is why these tables pick up Workload WAF and DNS policy for Windows and the Open Source ones do not.

Verified by comparing every rendered table against what docs.tigera.io serves today, reading the Markdown twin of each page. Across seven tables there is no difference in any column header, and no difference in any cell. Three things change:

- Row order, on every page. Rows are ordered by the release a feature first appeared in, per the rule agreed in #2968. Every move is a swap within a group of features that arrived in the same release; no row crosses a group boundary on any page.
- Enterprise 3.24 gains a row. The data file records L2 bridge networking as a 3.24 technology preview and the hand-written table omitted it. That omission is the drift this ticket exists to remove, so the table now shows the feature. Worth confirming the data file is right, because if it is not, the fix belongs there and not on the page.
- The Enterprise 3.21 legend gains its GA gloss. Legends are fixed per table rather than derived from the cells on screen, so the preview legend always names technology preview, generally available, and the dash. That is what a legend is for: it shows the whole progression a feature travels through, including the part this release has not reached. Deriving it from the cells present made the same table read differently from one release to the next, and hid the outcome the preview table exists to track.

3.24-2 is edited but not verified in a build, because it is absent from onlyIncludeVersions and so is not published yet. It shares release line 3.24 with 3.24-1, so it will render that same table once it is. It is also being staged on the cut-ce-3.24-2 branch, so this edit may need reconciling with work in flight there.

Added reproduction tests for the Open Source 3.30 and 3.31 tables, and widened the Enterprise 3.24 test from row names to whole rows, since that table is now the widest: four arrival releases, a status that has moved on to GA, and rows absent from the first column. A versioned snapshot's window is fixed, so these assertions stay stable.

On the deploy preview:

- https://deploy-preview-2979--tigera.netlify.app/calico/latest/release-notes/ — Open Source, both tables on one page
- https://deploy-preview-2979--tigera.netlify.app/calico-enterprise/3.24/release-notes/ — Enterprise 3.24, the widest tables and the only ones with a removed feature
- https://deploy-preview-2979--tigera.netlify.app/calico-enterprise/3.22/release-notes/ — Enterprise 3.22, whose deprecated table is the one that loses two legend glosses

The rendered tables should be indistinguishable from hand-written Markdown ones, since they are plain tables picking up the same theme styles.

