### PR TITLE
DOCS-3021: Render the deprecated and removed tables from the data file

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/release-notes/index.mdx
@@ -4,7 +4,7 @@ title: Calico Enterprise release notes
 sidebar_label: Release notes
 ---
 
-import TechPreviewTable from '@site/src/components/FeatureStatusTable';
+import { TechPreviewTable, DeprecatedFeaturesTable } from '@site/src/components/FeatureStatusTable';
 
 # Calico Enterprise 3.21 release notes
 
@@ -83,12 +83,7 @@ Review the following table to see what features have recently been deprecated or
 Deprecated features are still present and supported, but they are scheduled for removal.
 You should consider migrating away from a deprecated feature before it is removed.
 
-| Feature | 3.19 | 3.20 | 3.21 |
-| --- | --- | --- | --- |
-| Compliance reporting | GA | Deprecated | Deprecated |
-| Fortinet integration | Deprecated | Deprecated | Deprecated |
-
-GA = generally available, Deprecated = scheduled for removal, Removed = no longer present.
+<DeprecatedFeaturesTable />
 
 ## Release details
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/release-notes/index.mdx
@@ -4,7 +4,7 @@ title: Calico Enterprise release notes
 sidebar_label: Release notes
 ---
 
-import TechPreviewTable from '@site/src/components/FeatureStatusTable';
+import { TechPreviewTable, DeprecatedFeaturesTable } from '@site/src/components/FeatureStatusTable';
 
 # Calico Enterprise 3.22 release notes
 
@@ -129,12 +129,7 @@ Review the following table to see what features have recently been deprecated or
 Deprecated features are still present and supported, but they are scheduled for removal.
 You should consider migrating away from a deprecated feature before it is removed.
 
-| Feature | 3.20 | 3.21 | 3.22 |
-| --- | --- | --- | --- |
-| Compliance reporting | Deprecated | Deprecated | Deprecated |
-| Fortinet integration | Deprecated | Deprecated | Deprecated |
-
-GA = generally available, Deprecated = scheduled for removal, Removed = no longer present.
+<DeprecatedFeaturesTable />
 
 ## Release details
 

--- a/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/release-notes/index.mdx
@@ -4,7 +4,7 @@ title: Calico Enterprise release notes
 sidebar_label: Release notes
 ---
 
-import TechPreviewTable from '@site/src/components/FeatureStatusTable';
+import { TechPreviewTable, DeprecatedFeaturesTable } from '@site/src/components/FeatureStatusTable';
 
 # Calico Enterprise 3.23 release notes
 
@@ -148,15 +148,7 @@ Review the following table to see what features have recently been deprecated or
 Deprecated features are still present and supported, but they are scheduled for removal.
 You should consider migrating away from a deprecated feature before it is removed.
 
-| Feature | 3.21 | 3.22 | 3.23 |
-| --- | --- | --- | --- |
-| Aggregation API server | GA | GA | Deprecated |
-| Application layer policy based on Envoy | GA | GA | Deprecated |
-| L7 logging with Envoy | GA | GA | Deprecated |
-| Compliance reporting | Deprecated | Deprecated | Deprecated |
-| Fortinet integration | Deprecated | Deprecated | Deprecated |
-
-GA = generally available, Deprecated = scheduled for removal, Removed = no longer present.
+<DeprecatedFeaturesTable />
 
 ### Deprecated and removed features in this release
 

--- a/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/release-notes/index.mdx
@@ -4,7 +4,7 @@ title: Calico Enterprise release notes
 sidebar_label: Release notes
 ---
 
-import TechPreviewTable from '@site/src/components/FeatureStatusTable';
+import { TechPreviewTable, DeprecatedFeaturesTable } from '@site/src/components/FeatureStatusTable';
 
 # Calico Enterprise 3.24 release notes
 
@@ -74,15 +74,7 @@ Review the following table to see what features have recently been deprecated or
 Deprecated features are still present and supported, but they are scheduled for removal.
 You should consider migrating away from a deprecated feature before it is removed.
 
-| Feature | 3.22 | 3.23 | 3.24 |
-| --- | --- | --- | --- |
-| Compliance reporting | Deprecated | Deprecated | Removed |
-| Aggregation API server | GA | Deprecated | Deprecated |
-| Application layer policy based on Envoy | GA | Deprecated | Deprecated |
-| L7 logging with Envoy | GA | Deprecated | Deprecated |
-| Fortinet integration | Deprecated | Deprecated | Deprecated |
-
-GA = generally available, Deprecated = scheduled for removal, Removed = no longer present.
+<DeprecatedFeaturesTable />
 
 ### Deprecated and removed features in this release
 

--- a/calico-enterprise_versioned_docs/version-3.24-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/release-notes/index.mdx
@@ -4,7 +4,7 @@ title: Calico Enterprise release notes
 sidebar_label: Release notes
 ---
 
-import TechPreviewTable from '@site/src/components/FeatureStatusTable';
+import { TechPreviewTable, DeprecatedFeaturesTable } from '@site/src/components/FeatureStatusTable';
 
 # Calico Enterprise 3.24 release notes
 
@@ -74,15 +74,7 @@ Review the following table to see what features have recently been deprecated or
 Deprecated features are still present and supported, but they are scheduled for removal.
 You should consider migrating away from a deprecated feature before it is removed.
 
-| Feature | 3.22 | 3.23 | 3.24 |
-| --- | --- | --- | --- |
-| Compliance reporting | Deprecated | Deprecated | Removed |
-| Aggregation API server | GA | Deprecated | Deprecated |
-| Application layer policy based on Envoy | GA | Deprecated | Deprecated |
-| L7 logging with Envoy | GA | Deprecated | Deprecated |
-| Fortinet integration | Deprecated | Deprecated | Deprecated |
-
-GA = generally available, Deprecated = scheduled for removal, Removed = no longer present.
+<DeprecatedFeaturesTable />
 
 ### Deprecated and removed features in this release
 

--- a/calico_versioned_docs/version-3.30/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.30/release-notes/index.mdx
@@ -4,7 +4,7 @@ title: Calico Open Source release notes
 sidebar_label: Release notes
 ---
 
-import TechPreviewTable from '@site/src/components/FeatureStatusTable';
+import { TechPreviewTable, DeprecatedFeaturesTable } from '@site/src/components/FeatureStatusTable';
 
 # Calico Open Source 3.30 release notes
 
@@ -163,11 +163,7 @@ Review the following table to see what features have recently been deprecated or
 Deprecated features are still present and supported, but they are scheduled for removal.
 You should consider migrating away from a deprecated feature before it is removed.
 
-| Feature | 3.28 | 3.29 | 3.30 |
-| --- | --- | --- | --- |
-| FIPS mode | GA | GA | Deprecated |
-
-GA = generally available, Deprecated = scheduled for removal, Removed = no longer present.
+<DeprecatedFeaturesTable />
 
 ### Deprecated and removed features in this release
 

--- a/calico_versioned_docs/version-3.31/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.31/release-notes/index.mdx
@@ -4,7 +4,7 @@ title: Calico Open Source release notes
 sidebar_label: Release notes
 ---
 
-import TechPreviewTable from '@site/src/components/FeatureStatusTable';
+import { TechPreviewTable, DeprecatedFeaturesTable } from '@site/src/components/FeatureStatusTable';
 
 # Calico Open Source 3.31 release notes
 
@@ -189,11 +189,7 @@ Review the following table to see what features have recently been deprecated or
 Deprecated features are still present and supported, but they are scheduled for removal.
 You should consider migrating away from a deprecated feature before it is removed.
 
-| Feature | 3.29 | 3.30 | 3.31 |
-| --- | --- | --- | --- |
-| FIPS mode | GA | Deprecated | Deprecated |
-
-GA = generally available, Deprecated = scheduled for removal, Removed = no longer present.
+<DeprecatedFeaturesTable />
 
 ## Bug fixes
 

--- a/calico_versioned_docs/version-3.32/release-notes/index.mdx
+++ b/calico_versioned_docs/version-3.32/release-notes/index.mdx
@@ -4,7 +4,7 @@ title: Calico Open Source release notes
 sidebar_label: Release notes
 ---
 
-import TechPreviewTable from '@site/src/components/FeatureStatusTable';
+import { TechPreviewTable, DeprecatedFeaturesTable } from '@site/src/components/FeatureStatusTable';
 
 # Calico Open Source 3.32 release notes
 
@@ -98,12 +98,7 @@ Review the following table to see what features have recently been deprecated or
 Deprecated features are still present and supported, but they are scheduled for removal.
 You should consider migrating away from a deprecated feature before it is removed.
 
-| Feature | 3.30 | 3.31 | 3.32 |
-| --- | --- | --- | --- |
-| Aggregation API server | GA | GA | Deprecated |
-| FIPS mode | Deprecated | Deprecated | Deprecated |
-
-GA = generally available, Deprecated = scheduled for removal, Removed = no longer present.
+<DeprecatedFeaturesTable />
 
 ### Deprecated and removed features in this release
 

--- a/src/components/FeatureStatusTable/__test__/featureStatus.test.ts
+++ b/src/components/FeatureStatusTable/__test__/featureStatus.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { parse } from 'yaml';
 
-import { buildLegend, buildRows, cellLabel, PREVIEW_LEGEND, releaseWindow } from '../featureStatus';
+import { buildLegend, buildRows, cellLabel, DEPRECATION_TABLE, PREVIEW_TABLE, releaseWindow } from '../featureStatus';
 import type { Feature } from '../featureStatus';
 
 const features: Feature[] = parse(
@@ -10,8 +10,10 @@ const features: Feature[] = parse(
 ).features;
 
 /** Render rows the way the Markdown tables they replace were written. */
-const asMarkdown = (product: string, versions: string[]) =>
-  buildRows(features, product, versions).map((row) => `| ${row.name} | ${row.cells.map(cellLabel).join(' | ')} |`);
+const asMarkdown = (product: string, versions: string[], include = PREVIEW_TABLE.include) =>
+  buildRows(features, product, versions, include).map(
+    (row) => `| ${row.name} | ${row.cells.map(cellLabel).join(' | ')} |`
+  );
 
 describe('releaseWindow', () => {
   it('returns the three releases ending at the given version, oldest first', () => {
@@ -34,16 +36,21 @@ describe('releaseWindow', () => {
 
 describe('buildRows', () => {
   const window = ['3.30', '3.31', '3.32'];
-  const names = (product: string, versions: string[]) => buildRows(features, product, versions).map((row) => row.name);
+  const names = (product: string, versions: string[]) =>
+    buildRows(features, product, versions, PREVIEW_TABLE.include).map((row) => row.name);
 
   it('carries a status forward until the next recorded change', () => {
     // nftables is recorded as tech preview in 3.29 and GA in 3.31, and nothing else.
-    const [row] = buildRows(features, 'calico', window).filter((r) => r.name === 'nftables data plane');
+    const [row] = buildRows(features, 'calico', window, PREVIEW_TABLE.include).filter(
+      (r) => r.name === 'nftables data plane'
+    );
     expect(row.cells).toEqual(['tech-preview', 'ga', 'ga']);
   });
 
   it('reports no status before a feature first appears', () => {
-    const [row] = buildRows(features, 'calico', window).filter((r) => r.name === 'Native v3 CRDs');
+    const [row] = buildRows(features, 'calico', window, PREVIEW_TABLE.include).filter(
+      (r) => r.name === 'Native v3 CRDs'
+    );
     expect(row.cells).toEqual([null, null, 'tech-preview']);
   });
 
@@ -112,14 +119,55 @@ describe('buildRows', () => {
 
 describe('buildLegend', () => {
   it('names every status the preview table tracks, reached or not', () => {
-    expect(buildLegend(PREVIEW_LEGEND)).toBe(
+    expect(buildLegend(PREVIEW_TABLE.legend)).toBe(
       'TP = technology preview, GA = generally available, – = not available in that release.'
+    );
+  });
+
+  it('names every status the deprecation table tracks, reached or not', () => {
+    expect(buildLegend(DEPRECATION_TABLE.legend)).toBe(
+      'GA = generally available, Deprecated = scheduled for removal, Removed = no longer present, ' +
+        '– = not available in that release.'
     );
   });
 
   it('glosses in progression order and puts the dash last', () => {
     expect(buildLegend(['removed', 'tech-preview'])).toBe(
       'TP = technology preview, Removed = no longer present, – = not available in that release.'
+    );
+  });
+});
+
+describe('buildRows for the deprecated and removed table', () => {
+  it('reproduces the Calico Open Source 3.32 table', () => {
+    expect(asMarkdown('calico', ['3.30', '3.31', '3.32'], DEPRECATION_TABLE.include)).toEqual([
+      '| Aggregation API server | GA | GA | Deprecated |',
+      '| FIPS mode | Deprecated | Deprecated | Deprecated |',
+    ]);
+  });
+
+  it('reproduces the Calico Enterprise 3.24 table, where a feature is removed inside the window', () => {
+    expect(asMarkdown('calico-enterprise', ['3.22', '3.23', '3.24'], DEPRECATION_TABLE.include)).toEqual([
+      '| Fortinet integration | Deprecated | Deprecated | Deprecated |',
+      '| Aggregation API server | GA | Deprecated | Deprecated |',
+      '| Application layer policy based on Envoy | GA | Deprecated | Deprecated |',
+      '| Compliance reporting | Deprecated | Deprecated | Removed |',
+      '| L7 logging with Envoy | GA | Deprecated | Deprecated |',
+    ]);
+  });
+
+  it('drops a feature that is only ever GA or in preview', () => {
+    const names = buildRows(features, 'calico', ['3.30', '3.31', '3.32'], DEPRECATION_TABLE.include).map(
+      (row) => row.name
+    );
+    expect(names).not.toContain('nftables data plane');
+    expect(names).not.toContain('Flow logs API and Whisker');
+  });
+
+  it('keeps a feature deprecated before the window and still deprecated in it', () => {
+    // Fortinet was deprecated in 3.18, before any window rendered today reaches.
+    expect(asMarkdown('calico-enterprise', ['3.19', '3.20', '3.21'], DEPRECATION_TABLE.include)).toContainEqual(
+      '| Fortinet integration | Deprecated | Deprecated | Deprecated |'
     );
   });
 });

--- a/src/components/FeatureStatusTable/__test__/index.test.tsx
+++ b/src/components/FeatureStatusTable/__test__/index.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-import TechPreviewTable from '../index';
+import { DeprecatedFeaturesTable, TechPreviewTable } from '../index';
 import type { Feature } from '../featureStatus';
 
 const features: Feature[] = [
@@ -92,6 +92,27 @@ describe('<TechPreviewTable/>', () => {
   it('renders nothing when no feature was in preview during the window', () => {
     docsVersion.version = '3.28';
     const { container } = render(<TechPreviewTable />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('<DeprecatedFeaturesTable/>', () => {
+  beforeEach(() => {
+    docsVersion.pluginId = 'calico';
+    docsVersion.version = '3.32';
+  });
+
+  it('selects on deprecated and removed rather than preview', () => {
+    render(<DeprecatedFeaturesTable />);
+
+    expect(columns()).toEqual(['Feature', '3.30', '3.31', '3.32']);
+    expect(rows()).toEqual([['FIPS mode', 'Deprecated', 'Deprecated', 'Deprecated']]);
+  });
+
+  it('shares the empty and legend behaviour of the preview table', () => {
+    docsVersion.version = '3.29';
+    const { container } = render(<DeprecatedFeaturesTable />);
 
     expect(container).toBeEmptyDOMElement();
   });

--- a/src/components/FeatureStatusTable/featureStatus.ts
+++ b/src/components/FeatureStatusTable/featureStatus.ts
@@ -93,14 +93,19 @@ function statusAt(changes: ReturnType<typeof statusChanges>, version: string): C
 }
 
 /**
- * The rows of the technology preview table: every feature that was in preview at some
+ * The rows of one table: every feature that held one of the `include` statuses at some
  * point in the window.
  *
  * Rows are ordered by the release a feature first appeared in, oldest first, so the
  * table reads as the order features arrived. Features that arrived in the same release
  * keep their data-file order, which is alphabetical by id.
  */
-export function buildRows(features: Feature[], product: string, versions: string[]): FeatureRow[] {
+export function buildRows(
+  features: Feature[],
+  product: string,
+  versions: string[],
+  include: readonly FeatureStatus[]
+): FeatureRow[] {
   const rows: (FeatureRow & { since: string; order: number })[] = [];
 
   features.forEach((feature, order) => {
@@ -113,7 +118,7 @@ export function buildRows(features: Feature[], product: string, versions: string
     if (!changes.length) return;
 
     const cells = versions.map((version) => statusAt(changes, version));
-    if (!cells.includes('tech-preview')) return;
+    if (!include.some((status) => cells.includes(status))) return;
 
     rows.push({ name: feature.name, cells, since: changes[0].version, order });
   });
@@ -123,14 +128,30 @@ export function buildRows(features: Feature[], product: string, versions: string
     .map(({ name, cells }) => ({ name, cells }));
 }
 
+export interface TableKind {
+  /** A feature appears as a row when it held one of these somewhere in the window. */
+  include: readonly FeatureStatus[];
+  /** The statuses the legend names, whether or not the table uses them. */
+  legend: readonly FeatureStatus[];
+}
+
 /**
- * The statuses the technology preview legend names.
+ * What each table selects for, and what its legend names.
  *
- * Wider than the rows on purpose: GA is here because a preview feature graduating to GA
- * is the outcome the table exists to track, so the reader needs it explained even in a
- * release where nothing has got there yet.
+ * Each legend is wider than the rows it sits under, on purpose. The preview table names
+ * GA because a preview feature graduating is the outcome that table exists to track,
+ * and the deprecation table names Removed because removal is where a deprecation ends.
+ * A reader needs both explained in a release that has not got there yet.
  */
-export const PREVIEW_LEGEND: readonly FeatureStatus[] = ['tech-preview', 'ga'];
+export const PREVIEW_TABLE: TableKind = {
+  include: ['tech-preview'],
+  legend: ['tech-preview', 'ga'],
+};
+
+export const DEPRECATION_TABLE: TableKind = {
+  include: ['deprecated', 'removed'],
+  legend: ['ga', 'deprecated', 'removed'],
+};
 
 /**
  * The legend sentence for a table.

--- a/src/components/FeatureStatusTable/index.tsx
+++ b/src/components/FeatureStatusTable/index.tsx
@@ -2,20 +2,23 @@ import React from 'react';
 import { usePluginData } from '@docusaurus/useGlobalData';
 import { useDocsVersion } from '@docusaurus/plugin-content-docs/client';
 
-import { buildLegend, buildRows, cellLabel, PREVIEW_LEGEND, releaseWindow } from './featureStatus';
-import type { Feature } from './featureStatus';
+import { buildLegend, buildRows, cellLabel, DEPRECATION_TABLE, PREVIEW_TABLE, releaseWindow } from './featureStatus';
+import type { Feature, TableKind } from './featureStatus';
 
 const PLUGIN_NAME = 'docusaurus-plugin-feature-status';
 
 /**
- * The technology preview table for a release-notes page.
+ * A feature status table for a release-notes page.
  *
  * The product and the three-release window both come from the page's own docs context:
  * the product is the docs plugin id, which is already the data file's product key, and
  * the window ends at the page's own version. A versioned snapshot therefore keeps the
  * window it was cut with, and no version numbers are written into the page.
+ *
+ * The TableKind is the only thing separating the two tables. Everything else — the
+ * window, the product, carry-forward, ordering, rendering — is shared.
  */
-const TechPreviewTable: React.FC = () => {
+const FeatureStatusTable: React.FC<TableKind> = ({ include, legend }) => {
   const { features } = usePluginData(PLUGIN_NAME) as { features: Feature[] };
   const { pluginId, version } = useDocsVersion();
 
@@ -29,7 +32,7 @@ const TechPreviewTable: React.FC = () => {
     return null;
   }
 
-  const rows = buildRows(features, pluginId, versions);
+  const rows = buildRows(features, pluginId, versions, include);
   if (!rows.length) return null;
 
   return (
@@ -54,9 +57,18 @@ const TechPreviewTable: React.FC = () => {
           ))}
         </tbody>
       </table>
-      <p>{buildLegend(PREVIEW_LEGEND)}</p>
+      <p>{buildLegend(legend)}</p>
     </>
   );
 };
 
-export default TechPreviewTable;
+/** Features that were in technology preview at some point in the window. */
+export const TechPreviewTable: React.FC = () => <FeatureStatusTable {...PREVIEW_TABLE} />;
+
+/**
+ * Features that were deprecated or removed at some point in the window.
+ *
+ * Both statuses select a row, so a feature that was deprecated earlier and removed
+ * inside the window stays visible through the release that removed it.
+ */
+export const DeprecatedFeaturesTable: React.FC = () => <FeatureStatusTable {...DEPRECATION_TABLE} />;


### PR DESCRIPTION
Sits on top of #2979 and will shrink to a single commit once that merges. Review the top commit only.

Every release-notes page carries a second hand-typed table, listing what has been deprecated or removed, with the same duplication and drift problem as the preview table. This renders it from data/feature-status.yaml too. With this and #2979 merged, no feature status is typed into a release-notes page anywhere.

Almost nothing new was needed. buildRows gains an include parameter, and the status filter is the only thing separating the two tables: one selects rows that were in preview during the window, the other rows that were deprecated or removed. The window, the product, carry-forward, ordering, and the legend are already shared. That parameter is the one deliberately left out of #2968 as speculative, on the grounds that it should arrive with a second caller rather than before one. This is the second caller.

Both statuses select a row, so a feature deprecated earlier and removed inside the window stays visible through the release that removed it. Enterprise 3.24 is the case that matters: compliance reporting reads Deprecated, Deprecated, Removed.

Both components are now named exports, so a page imports the pair on one line rather than a default and a name:

    import { TechPreviewTable, DeprecatedFeaturesTable } from '@site/src/components/FeatureStatusTable';

Only the table and its legend are replaced. The prose above each table and the per-release list of deprecations below it are untouched.

Verified the same way as #2979, against what docs.tigera.io serves today. Across all seven deprecated tables there is no difference in any column header, in any row, or in any cell. Two things change:

- Row order, on the four Enterprise pages, by the same first-appearance rule as everywhere else. The Open Source tables happen to already be in that order.
- Every deprecated legend gains a gloss for the dash. The legend set is fixed per table, so the deprecation table always names generally available, scheduled for removal, no longer present, and not available in that release. No table published today has a dash cell, but a feature introduced and deprecated inside the same window would produce one, and the reader should not meet a symbol the legend does not name.

The tables already carried the same legend regardless of content, so this keeps them consistent with each other and with the preview tables, which #2979 puts on the same footing.

On the deploy preview:

- https://deploy-preview-2980--tigera.netlify.app/calico/latest/release-notes/ — Open Source, both tables on one page
- https://deploy-preview-2980--tigera.netlify.app/calico-enterprise/3.24/release-notes/ — Enterprise 3.24, the widest tables and the only ones with a removed feature
- https://deploy-preview-2980--tigera.netlify.app/calico-enterprise/3.22/release-notes/ — Enterprise 3.22, whose deprecated table is the one that loses two legend glosses

The rendered tables should be indistinguishable from hand-written Markdown ones, since they are plain tables picking up the same theme styles.

