### PR TITLE
DOCS-2997: Add the Forklift install docs and EP2 release note stubs to Calico Enterprise 3.24-2

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.24-2/networking/kubevirt/install-forklift-kubernetes.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/networking/kubevirt/install-forklift-kubernetes.mdx
@@ -1,0 +1,177 @@
+---
+description: Install the Tigera fork of Forklift on a Kubernetes cluster to migrate vSphere virtual machines onto Calico Enterprise networking.
+---
+
+# Install Forklift on Kubernetes
+
+## Big picture
+
+Install the Tigera fork of Forklift on a Kubernetes cluster and connect it to a vSphere source, so that migrated virtual machines (VMs) keep the IP and MAC addresses they had on vSphere, and can attach to $[prodname] L2 networks.
+
+For OpenShift, see [Install Forklift on OpenShift](./install-forklift-openshift.mdx).
+
+:::note
+
+Upstream Forklift's guest conversion fails on clusters whose nodes carry the runtime default seccomp and AppArmor profiles. This fork can work around it. OpenShift is unaffected. See [Fix guest conversion permissions](#4-fix-guest-conversion-permissions).
+
+:::
+
+## Before you begin
+
+**Required**
+
+- Cluster admin access, and `kubectl`.
+- A cluster running $[prodname] as the CNI, with your Installation's [`spec.calicoNetwork.multiInterfaceMode`](../l2-bridge/connect-vlan.mdx) set to `Multus`.
+- The BPF data plane enabled: `bpfEnabled: true` in the default `FelixConfiguration`. See [Enable eBPF on an existing cluster](../../operations/ebpf/enabling-ebpf.mdx).
+- KubeVirt.
+- IP pools covering the VM addresses. The pod network uses an ordinary pool; each L2 VLAN needs its own pool with `allowedUses: [L2Workload]` and `disableBGPExport: true`. A VM keeps its address only if that address falls inside a pool. See [Connect workloads to an existing VLAN](../l2-bridge/connect-vlan.mdx).
+- Multus, for secondary-NIC attachments and for the auto-created `host` provider, whose connection test queries `NetworkAttachmentDefinition` and reports `ConnectionFailed` without that CRD. Verified with the thick DaemonSet v4.3.0. Pin the daemon container and the `install-multus-binary` init container to the same tag, and raise the daemon memory limit from 50Mi to 512Mi to stop it being OOM-killed.
+- cert-manager, which issues the serving certificates. Without it the `forklift-api`, `forklift-validation`, and `forklift-inventory` pods stay NotReady. OpenShift needs nothing here; its service-ca operator issues the same certificates. No `Issuer` or `ClusterIssuer` setup is needed: the operator creates its own in `konveyor-forklift`, which you can check with `kubectl -n konveyor-forklift get issuers,certificates`.
+
+  ```bash
+  kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.21.1/cert-manager.yaml
+
+  kubectl -n cert-manager wait --for=condition=Available \
+    deploy/cert-manager deploy/cert-manager-webhook deploy/cert-manager-cainjector --timeout=300s
+  ```
+
+- CDI and a default StorageClass, for migrations that import disks. Neither is needed to install Forklift.
+
+## How to
+
+### 1. Install the operator
+
+```bash
+kubectl apply -f $[tutorialFilesURL]/forklift/forklift-operator-kubernetes.yaml
+```
+
+This creates the `konveyor-forklift` namespace, the Forklift custom resource definitions, the RBAC they need, and the operator. Every component image is pinned in the operator's environment, so nothing downstream names an image.
+
+```bash
+kubectl -n konveyor-forklift rollout status deploy/forklift-operator --timeout=300s
+```
+
+### 2. Create the ForkliftController
+
+```bash
+kubectl apply -f $[tutorialFilesURL]/forklift/forklift-controller-kubernetes.yaml
+```
+
+The operator expands this into the full set of Forklift deployments. The console plugin and the CLI download are turned off, because both need the OpenShift console.
+
+```bash
+kubectl -n konveyor-forklift wait --for=condition=Successful \
+  forkliftcontroller/forklift-controller --timeout=300s
+```
+
+### 3. Verify the install
+
+```bash
+kubectl -n konveyor-forklift wait --for=condition=Available deploy --all --timeout=300s
+```
+
+Six deployments become Ready: `forklift-operator`, `forklift-controller`, `forklift-api`, `forklift-validation`, `forklift-ova-proxy`, and `forklift-volume-populator-controller`. The inventory service runs as a second container in `forklift-controller`.
+
+### 4. Fix guest conversion permissions
+
+Upstream Forklift's guest conversion fails on clusters whose nodes confine containers with the runtime default seccomp and AppArmor profiles. Tigera's fork adds four `ForkliftController` fields, naming the seccomp and AppArmor profiles the conversion pods run under, which work around the permissions problem behind that failure.
+
+Every migration from a vSphere source converts its guests, unless the `Plan` sets `skipGuestConversion: true`.
+
+Conversion launches a libguestfs appliance, which networks itself with `passt`. `passt` sandboxes itself by creating a user namespace and remounting `/`, and two node defaults deny that:
+
+| Barrier | Rule | Symptom |
+| --- | --- | --- |
+| seccomp | The runtime default profile allows `unshare(2)` only under `CAP_SYS_ADMIN`. | `Couldn't create user namespace: Operation not permitted` |
+| AppArmor | The runtime default profile carries `deny mount,`. | `Failed to remount /: Permission denied` |
+
+OpenShift hits neither: its nodes permit `unshare` and confine containers with SELinux. Raising the pod's privileges does not help, because `passt` drops root before it sandboxes itself.
+
+Put the profiles on every node that can run a conversion. Use the Security Profiles Operator if you already run it; otherwise you may apply the ConfigMap and DaemonSet patch below, after inspection.
+
+**Note** This is a privileged DaemonSet. It writes both profiles under the kubelet's seccomp directory, and loads the AppArmor one on nodes that have `apparmor_parser`. Its log says which it did on each node:
+
+
+```bash
+kubectl apply -f $[tutorialFilesURL]/forklift/forklift-virt-v2v-profiles.yaml
+
+kubectl -n konveyor-forklift rollout status ds/forklift-virt-v2v-profile-installer
+```
+
+```bash
+kubectl -n konveyor-forklift logs -l service=forklift-virt-v2v-profile-installer -c install
+```
+
+Then name the profiles on the `ForkliftController`:
+
+```bash
+kubectl -n konveyor-forklift patch forkliftcontroller forklift-controller \
+  --type merge -p '{"spec":{
+    "virt_v2v_seccomp_profile_type": "Localhost",
+    "virt_v2v_seccomp_profile_path": "profiles/unshare.json",
+    "virt_v2v_apparmor_profile_type": "Localhost",
+    "virt_v2v_apparmor_profile_path": "forklift-virt-v2v-unshare"}}'
+```
+
+All four fields are unset by default, which leaves every cluster on its runtime default: naming a profile that a node does not carry makes the kubelet refuse the pod outright. A path given without its type is rejected as the CR is saved. On nodes that do not enforce AppArmor, set only the seccomp pair.
+
+### 5. Map a VM's networks to $[prodname]
+
+Configure your `Provider` and its `Secrets`, the `Plan`, `StorageMap` and `NetworkMap` as normal.
+
+$[prodname]'s Forklift fork detects when a `NetworkMap` item references a $[prodname]-backed `NetworkAttachmentDefinition`.
+This leads to $[prodname] address-preservation annotations getting stamped on the migrated VM's `virt-launcher` pod.
+If the NAD also references a Calico `Network`, $[prodname] Forklift will validate that the necessary `IPPools` exist
+in the destination cluster to facilitate address preservation, and the VM's secondary NICs will get attached to
+the Calico L2 bridge.
+
+In the case of `NetworkMap` items of `type: pod`, which do not have a NAD reference, a `calico{}` struct
+can be included to flag that the primary network should also receive address-preservation treatment.
+To additionally force the primary NIC to get attached to a pre-configured Calico `Network`, the struct has
+fields `network` and `vlan` which target the Calico `Network` to use.
+
+```yaml
+      calico:
+        network: mock-l2-net   # cluster-scoped projectcalico.org/v3 Network CR
+        vlan: 100              # must match a vlan.id entry in that Network
+```
+
+| Field | Effect |
+| --- | --- |
+| `calico: {}` | Keep the pod-network NIC on the routed pod network, preserve addresses, using $[prodname]'s default IPAM. The presence of this field also switches KubeVirt networking to bridge mode. |
+| `network` | Name a cluster-scoped `projectcalico.org/v3` `Network` to attach the NIC to an L2 network instead. |
+| `vlan` | The 802.1Q VLAN within that `Network`. Required once `network` is set, and must match one of its VLAN IDs. |
+
+
+Note: The MAC is always carried over; the addresses follow when the `Plan` sets `preserveStaticIPs`. Definitions that use another CNI are left untouched. The values are set before the VM starts, so each interface is created already holding them.
+
+```yaml
+  map:
+  - source:
+      id: <secondary-portgroup-id>
+    destination:
+      type: multus
+      name: my-network-vlan10
+      namespace: vms
+```
+
+
+### Verify address preservation worked
+
+Inspect the `virt-launcher` pod, or the VM template created post-migration.
+It should contain annotations for Calico address preservation, for each NIC
+in the NetworkMap:
+
+```yaml
+cni.projectcalico.org/<interface>.hwAddr: ...
+cni.projectcalico.org/<interface>.ipAddrs: ...
+```
+
+
+See [Connect workloads to an existing VLAN](../l2-bridge/connect-vlan.mdx) for the `Network`, IP pool and attachment definition, and [Set a VM's IP and MAC address](../l2-bridge/vm-identity.mdx) for the annotations themselves.
+
+## Next steps
+
+- [Connect workloads to an existing VLAN](../l2-bridge/connect-vlan.mdx)
+- [Set a VM's IP and MAC address](../l2-bridge/vm-identity.mdx)
+- [KubeVirt networking](./kubevirt-networking.mdx)

--- a/calico-enterprise_versioned_docs/version-3.24-2/networking/kubevirt/install-forklift-openshift.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/networking/kubevirt/install-forklift-openshift.mdx
@@ -1,0 +1,162 @@
+---
+description: Install the Tigera fork of Forklift on an OpenShift cluster to migrate vSphere virtual machines onto Calico Enterprise networking.
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Install Forklift on OpenShift
+
+## Big picture
+
+Install the Tigera fork of Forklift on an OpenShift cluster and connect it to a **vSphere** source, so that migrated virtual machines (VMs) keep the IP and MAC addresses they had on vSphere, and can attach to $[prodname] L2 networks.
+
+## Before you begin
+
+**Required**
+
+- Cluster admin access, and `kubectl` or `oc`.
+- A cluster running $[prodname] as the CNI, and Multus for secondary-NIC attachments, with your Installation's [`spec.calicoNetwork.multiInterfaceMode`](../l2-bridge/connect-vlan.mdx) set to `Multus`.
+- The BPF data plane enabled: `bpfEnabled: true` in the default `FelixConfiguration`. See [Enable eBPF on an existing cluster](../../operations/ebpf/enabling-ebpf.mdx).
+- OpenShift Virtualization (KubeVirt and CDI) installed, with `HyperConverged` Available.
+- A StorageClass for the migrated VM disks.
+- IP pools covering the VM addresses. The pod network uses an ordinary pool; each L2 VLAN needs its own pool with `allowedUses: [L2Workload]` and `disableBGPExport: true`. A VM keeps its address only if that address falls inside a pool. See [Connect workloads to an existing VLAN](../l2-bridge/connect-vlan.mdx).
+
+## How to
+
+### 1. Check your OpenShift version
+
+The Forklift UI plugin is built against the console it runs on, so this decides which manifest to apply.
+
+```bash
+kubectl get clusterversion version -o jsonpath='{.status.desired.version}'
+```
+
+### 2. Install the operator
+
+<Tabs>
+<TabItem value="ocp421" label="OpenShift 4.21 and earlier" default>
+
+```bash
+kubectl apply -f $[tutorialFilesURL]/forklift/forklift-operator-ocp421.yaml
+```
+
+</TabItem>
+<TabItem value="ocp422" label="OpenShift 4.22 and later">
+
+```bash
+kubectl apply -f $[tutorialFilesURL]/forklift/forklift-operator-ocp422.yaml
+```
+
+</TabItem>
+</Tabs>
+
+This creates the `konveyor-forklift` namespace, the Forklift custom resource definitions, the RBAC they need, and the operator.
+
+```bash
+kubectl -n konveyor-forklift rollout status deploy/forklift-operator --timeout=300s
+```
+
+### 3. Create the ForkliftController
+
+<Tabs>
+<TabItem value="ocp421" label="OpenShift 4.21 and earlier" default>
+
+```bash
+kubectl apply -f $[tutorialFilesURL]/forklift/forklift-controller-ocp421.yaml
+```
+
+</TabItem>
+<TabItem value="ocp422" label="OpenShift 4.22 and later">
+
+```bash
+kubectl apply -f $[tutorialFilesURL]/forklift/forklift-controller-ocp422.yaml
+```
+
+</TabItem>
+</Tabs>
+
+The operator expands this into the full set of Forklift deployments.
+
+```bash
+kubectl -n konveyor-forklift wait --for=condition=Successful \
+  forkliftcontroller/forklift-controller
+```
+
+### 4. Verify the install
+
+```bash
+kubectl -n konveyor-forklift wait --for=condition=Available deploy --all
+```
+
+Eight deployments should become Ready:
+ - `forklift-operator`,
+ - `forklift-controller`,
+ - `forklift-api`,
+ - `forklift-validation`,
+ - `forklift-ova-proxy`,
+ - `forklift-ui-plugin`,
+ - `forklift-cli-download`,
+ - `forklift-volume-populator-controller`.
+ 
+
+### 5. Map a VM's networks to $[prodname]
+
+Configure your `Provider` and its `Secrets`, the `Plan`, `StorageMap` and `NetworkMap` as normal.
+
+$[prodname]'s Forklift fork detects when a `NetworkMap` item references a $[prodname]-backed `NetworkAttachmentDefinition`.
+This leads to $[prodname] address-preservation annotations getting stamped on the migrated VM's `virt-launcher` pod.
+If the NAD also references a Calico `Network`, $[prodname] Forklift will validate that the necessary `IPPools` exist
+in the destination cluster to facilitate address preservation, and the VM's secondary NICs will get attached to
+the Calico L2 bridge.
+
+In the case of `NetworkMap` items of `type: pod`, which do not have a NAD reference, a `calico{}` struct
+can be included to flag that the primary network should also receive address-preservation treatment.
+To additionally force the primary NIC to get attached to a pre-configured Calico `Network`, the struct has
+fields `network` and `vlan` which target the Calico `Network` to use.
+
+```yaml
+      calico:
+        network: mock-l2-net   # cluster-scoped projectcalico.org/v3 Network CR
+        vlan: 100              # must match a vlan.id entry in that Network
+```
+
+| Field | Effect |
+| --- | --- |
+| `calico: {}` | Keep the pod-network NIC on the routed pod network, preserve addresses, using $[prodname]'s default IPAM. The presence of this field also switches KubeVirt networking to bridge mode. |
+| `network` | Name a cluster-scoped `projectcalico.org/v3` `Network` to attach the NIC to an L2 network instead. |
+| `vlan` | The 802.1Q VLAN within that `Network`. Required once `network` is set, and must match one of its VLAN IDs. |
+
+
+Note: The MAC is always carried over; the addresses follow when the `Plan` sets `preserveStaticIPs`. Definitions that use another CNI are left untouched. The values are set before the VM starts, so each interface is created already holding them.
+
+```yaml
+  map:
+  - source:
+      id: <secondary-portgroup-id>
+    destination:
+      type: multus
+      name: my-network-vlan10
+      namespace: vms
+```
+
+
+### Verify address preservation worked
+
+Inspect the `virt-launcher` pod, or the VM template created post-migration.
+It should contain annotations for Calico address preservation, for each NIC
+in the NetworkMap:
+
+```yaml
+cni.projectcalico.org/<interface>.hwAddr: ...
+cni.projectcalico.org/<interface>.ipAddrs: ...
+```
+
+
+See [Connect workloads to an existing VLAN](../l2-bridge/connect-vlan.mdx) for the `Network`, IP pool and attachment definition, and [Set a VM's IP and MAC address](../l2-bridge/vm-identity.mdx) for the annotations themselves.
+
+## Next steps
+
+- [Connect workloads to an existing VLAN](../l2-bridge/connect-vlan.mdx)
+- [Set a VM's IP and MAC address](../l2-bridge/vm-identity.mdx)
+- [KubeVirt networking](./kubevirt-networking.mdx)

--- a/calico-enterprise_versioned_docs/version-3.24-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/release-notes/index.mdx
@@ -21,6 +21,22 @@ This version of Calico Enterprise is based on [Calico Open Source $[openSourceVe
 
 ## New features and enhancements
 
+{/* Start 3.24.0-2.0 features */}
+
+### L2 bridge networking (tech preview)
+
+$[prodname] can attach KubeVirt VMs and pods to a VLAN your physical network already carries, using a VLAN-aware Linux bridge on each node.
+A workload keeps the IP address and MAC address it arrives with, and shares a broadcast domain with the machines already on that VLAN, so DNS entries, firewall rules, and licenses bound to its address keep working.
+Because the workload's interface is a $[prodname] interface, it still gets network policy and flow visibility on that L2 link.
+
+To migrate VMs from vSphere with their addresses intact, install the Tigera fork of Forklift and map the VM's networks to $[prodname].
+
+For more information, see [L2 bridge networking](../networking/l2-bridge/index.mdx), [Install Forklift on OpenShift](../networking/kubevirt/install-forklift-openshift.mdx), and [Install Forklift on Kubernetes](../networking/kubevirt/install-forklift-kubernetes.mdx).
+
+{/* TODO: add the remaining 3.24.0-2.0 features here, one ### subsection each. */}
+
+{/* End 3.24.0-2.0 features */}
+
 {/* Start 3.24.0-1.0 features */}
 
 ### Per-namespace deployment for Calico Ingress Gateway
@@ -112,6 +128,16 @@ Migrate in this order:
 3. After the upgrade, re-point monitoring, RBAC, and external DNS from `tigera-gateway` to each Gateway's namespace. If you used merged gateways, plan for one load balancer, DNS record, and certificate per gateway.
 
 ## Release details
+
+### Calico Enterprise 3.24.0-2.0 (early preview)
+
+{/* TODO: release date */}
+
+Calico Enterprise 3.24.0-2.0 is now available as an early preview release.
+This release is for previewing and testing purposes only.
+It is not supported for use in production.
+
+{/* TODO: fill in subsections for 3.24.0-2.0 — #### Upgrade notes, #### Enhancements, #### Bug fixes, #### Known issues. Omit any subsection with no items. */}
 
 ### Calico Enterprise 3.24.0-1.0 (early preview)
 

--- a/calico-enterprise_versioned_sidebars/version-3.24-2-sidebars.json
+++ b/calico-enterprise_versioned_sidebars/version-3.24-2-sidebars.json
@@ -259,7 +259,9 @@
           },
           "items": [
             "networking/kubevirt/kubevirt-networking",
-            "networking/kubevirt/live-migration-bgp"
+            "networking/kubevirt/live-migration-bgp",
+            "networking/kubevirt/install-forklift-openshift",
+            "networking/kubevirt/install-forklift-kubernetes"
           ]
         },
         {


### PR DESCRIPTION
Copies the Forklift install docs that merged to main into the Calico Enterprise 3.24-2 version, and stubs the EP2 release notes.

Product versions: Calico Enterprise 3.24-2 (EP2).

Issue: https://tigera.atlassian.net/browse/DOCS-2997. The upstream Forklift PR (#2982) carried no ticket, so this is filed under the L2 bridge docs ticket. Happy to re-title if there is a better one.

What is here, as two commits:

- Copy install-forklift-kubernetes.mdx and install-forklift-openshift.mdx from calico-enterprise into calico-enterprise_versioned_docs/version-3.24-2, and add both to the KubeVirt category in the 3.24-2 sidebar, in the same order as the next-version sidebar.
- Stub the EP2 release notes: a 3.24.0-2.0 feature block above the 3.24.0-1.0 one, and a 3.24.0-2.0 entry at the top of Release details.

The feature block has two entries rather than one. L2 bridge networking gets an entry that says what it is for and who it is for: teams moving VMs onto Kubernetes that cannot be re-addressed, and flat on-premises and edge networks. It names the eBPF and Multus requirements, and the policy enforcement you would lose on a bridge you built yourself.

Forklift gets its own entry, because it is a VM migration tool in its own right rather than part of the L2 bridge feature. Forklift reads from several source platforms, so the entry names vSphere as one of them rather than framing the tool around it. Worth noting separately: the two install guides are vSphere-framed throughout, including their frontmatter descriptions. That is a mismatch worth fixing on the pages themselves, but not in this PR.

- Set baseUrl to /calico-enterprise/3.24 in the 3.24-1 and 3.24-2 variables.js. Both said /calico-enterprise/latest, but latest is 3.23-2, and the docusaurus path for both 3.24 early previews is 3.24. This renders nowhere today, since $[baseUrl] does not appear anywhere in the repo. 3.24-1 is fixed alongside 3.24-2 so the wrong value is not carried into the next version cut.

Nothing was copied under static/files/forklift. Those manifests are unversioned, so the merge to main already put them where $[tutorialFilesURL] points, and tutorialFilesURL is defined in the 3.24-2 variables.js.

The 3.24 release note itself needed no copying. The version cut had already carried it over from 3.24-1 unchanged.

L2 bridge networking is new in EP2. There is no l2-bridge directory under version-3.24-1, which is why the feature block is new rather than moved.

No change to data/feature-status.yaml. It already records l2-bridge-networking as tech-preview at Calico Enterprise 3.24, so the tech preview table picks it up.

Link to docs preview: none is possible for this PR. In docusaurus.config.js, the Calico Enterprise onlyIncludeVersions list still names 3.24-1 rather than 3.24-2, and both map to the same 3.24 path, so 3.24-2 is not built. These pages start rendering when 3.24-2 replaces 3.24-1 in that list as part of publishing EP2. Please review from the diff. The two Forklift pages are copies of the files already on main, so they can be read at their source paths under calico-enterprise/networking/kubevirt.

Left as TODO markers for whoever publishes EP2:

- The 3.24.0-2.0 release date.
- The remaining EP2 features, one subsection each.
- The Upgrade notes, Enhancements, Bug fixes, and Known issues subsections under the 3.24.0-2.0 release details entry.

Still to do when EP2 is published, beyond the TODO markers in the release notes:

- Regenerate calico-enterprise_versioned_docs/version-3.24-2/releases.json. It is currently 3.24-1's file with the version string rewritten, so it names 3.24-1's operator (v1.43.0) and 3.24-1's third-party pins. Run make version/autogen/3.24-2 once the EP2 build exists in calico-private.
- Regenerate reference/installation/_api.mdx for 3.24-2. It is 3.24-1's file unchanged, so it documents operator v1.43.0.
- Add 3.24-2 to the Calico Enterprise onlyIncludeVersions list in docusaurus.config.js, in place of 3.24-1.

The rest of 3.24-2's variables.js is already correct: releaseTitle, helmPre, filesUrl, and chart_version_name all name v3.24.0-2.0. calico.minor_version stays at v3.32.

Checks done locally: the 3.24-2 sidebar JSON parses, every doc ID in it resolves to a file, and all relative links in the two copied pages resolve inside 3.24-2. I did not run a full build.
