### PR TITLE
DOCS-3018: Mark the Forklift docs as tech preview

### DIFF
--- a/calico-enterprise/networking/kubevirt/install-forklift-kubernetes.mdx
+++ b/calico-enterprise/networking/kubevirt/install-forklift-kubernetes.mdx
@@ -4,6 +4,13 @@ description: Install the Tigera fork of Forklift on a Kubernetes cluster to migr
 
 # Install Forklift on Kubernetes
 
+:::note
+
+The $[prodname] fork of Forklift is a tech preview feature.
+APIs and behavior may change before GA.
+
+:::
+
 ## Big picture
 
 Install the Tigera fork of Forklift on a Kubernetes cluster and connect it to a vSphere source, so that migrated virtual machines (VMs) keep the IP and MAC addresses they had on vSphere, and can attach to $[prodname] L2 networks.

--- a/calico-enterprise/networking/kubevirt/install-forklift-openshift.mdx
+++ b/calico-enterprise/networking/kubevirt/install-forklift-openshift.mdx
@@ -7,6 +7,13 @@ import TabItem from '@theme/TabItem';
 
 # Install Forklift on OpenShift
 
+:::note
+
+The $[prodname] fork of Forklift is a tech preview feature.
+APIs and behavior may change before GA.
+
+:::
+
 ## Big picture
 
 Install the Tigera fork of Forklift on an OpenShift cluster and connect it to a **vSphere** source, so that migrated virtual machines (VMs) keep the IP and MAC addresses they had on vSphere, and can attach to $[prodname] L2 networks.

--- a/calico-enterprise_versioned_docs/version-3.24-2/networking/kubevirt/install-forklift-kubernetes.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/networking/kubevirt/install-forklift-kubernetes.mdx
@@ -4,6 +4,13 @@ description: Install the Tigera fork of Forklift on a Kubernetes cluster to migr
 
 # Install Forklift on Kubernetes
 
+:::note
+
+The $[prodname] fork of Forklift is a tech preview feature.
+APIs and behavior may change before GA.
+
+:::
+
 ## Big picture
 
 Install the Tigera fork of Forklift on a Kubernetes cluster and connect it to a vSphere source, so that migrated virtual machines (VMs) keep the IP and MAC addresses they had on vSphere, and can attach to $[prodname] L2 networks.

--- a/calico-enterprise_versioned_docs/version-3.24-2/networking/kubevirt/install-forklift-openshift.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/networking/kubevirt/install-forklift-openshift.mdx
@@ -7,6 +7,13 @@ import TabItem from '@theme/TabItem';
 
 # Install Forklift on OpenShift
 
+:::note
+
+The $[prodname] fork of Forklift is a tech preview feature.
+APIs and behavior may change before GA.
+
+:::
+
 ## Big picture
 
 Install the Tigera fork of Forklift on an OpenShift cluster and connect it to a **vSphere** source, so that migrated virtual machines (VMs) keep the IP and MAC addresses they had on vSphere, and can attach to $[prodname] L2 networks.

--- a/calico-enterprise_versioned_docs/version-3.24-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/release-notes/index.mdx
@@ -40,7 +40,7 @@ It requires the eBPF data plane, and Multus where an L2 network is an additional
 
 For more information, see [L2 bridge networking](../networking/l2-bridge/index.mdx) and [L2 bridge support and limitations](../reference/l2-bridge-support.mdx).
 
-### Forklift, for migrating VMs onto $[prodname]
+### Forklift, for migrating VMs onto $[prodname] (tech preview)
 
 $[prodname] now publishes a fork of Forklift, the tool that migrates virtual machines from an existing virtualization platform onto KubeVirt.
 Forklift reads from several source platforms, vSphere among them.


### PR DESCRIPTION
The two Forklift install guides carry no tech preview marking, and neither does the Forklift entry in the CE 3.24.0-2.0 release notes, even though Forklift cannot be used without L2 bridge networking, which is tech preview.

Adds the standard L2 bridge admonition to both install guides in next and version-3.24-2, and suffixes the release note heading to match the L2 bridge one.

To do

- Confirm the intended status with the L2 feature owner. If Forklift is deliberately GA, close this and leave the release note as it was.
- Filed under DOCS-3018 for want of a dedicated ticket.

Flags

- 3.24-2 is not in onlyIncludeVersions, so the versioned pages and the release note change do not appear on the preview. Review those from the diff.

Preview

- https://deploy-preview-2988--calico-docs-preview-next.netlify.app/calico-enterprise/next/networking/kubevirt/install-forklift-openshift
- https://deploy-preview-2988--calico-docs-preview-next.netlify.app/calico-enterprise/next/networking/kubevirt/install-forklift-kubernetes
