### PR TITLE
DOCS-2962: Publish Calico Enterprise 3.24 early preview 2

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.24-2/getting-started/bare-metal/about.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/getting-started/bare-metal/about.mdx
@@ -120,7 +120,7 @@ cluster will use nftables, but can be configured to use iptables.
 1. Download the Calico Enterprise repository to work with your Linux distro.
    <Tabs groupId="linux-distro">
    <TabItem label="RHEL" value="rhel-0">
-   1. Download the repo file for Calico Enterprise
+   1. Download the repo file for Calico Enterprise (as root or using `sudo`)
    ```bash
    curl -sfL $[rhelPkgUrl]/calico_enterprise.repo -o /etc/yum.repos.d/calico-enterprise.repo
    ```
@@ -131,7 +131,7 @@ cluster will use nftables, but can be configured to use iptables.
 
    :::note
 
-   The repository is signed with a GPG to ensure its integrity. The first time `dnf` downloads
+   The repository is signed with a GPG key to ensure its integrity. The first time `dnf` downloads
    the repository information it will prompt you to accept the Tigera release signing key.
 
    If you encounter issues with the GPG signature not matching, the most likely cause is the repository

--- a/calico-enterprise_versioned_docs/version-3.24-2/getting-started/bare-metal/about.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/getting-started/bare-metal/about.mdx
@@ -120,9 +120,26 @@ cluster will use nftables, but can be configured to use iptables.
 1. Download the Calico Enterprise repository to work with your Linux distro.
    <Tabs groupId="linux-distro">
    <TabItem label="RHEL" value="rhel-0">
+   1. Download the repo file for Calico Enterprise
    ```bash
    curl -sfL $[rhelPkgUrl]/calico_enterprise.repo -o /etc/yum.repos.d/calico-enterprise.repo
    ```
+   2. Trigger `dnf` to update the repository metadata
+   ```bash
+   dnf makecache
+   ```
+
+   :::note
+
+   The repository is signed with a GPG to ensure its integrity. The first time `dnf` downloads
+   the repository information it will prompt you to accept the Tigera release signing key.
+
+   If you encounter issues with the GPG signature not matching, the most likely cause is the repository
+   GPG key was rotated. Repeat step 1 to download an updated `calico_enterprise.repo` file, which will
+   contain the updated GPG key information.
+
+   :::
+
    </TabItem>
    <TabItem label="Debian/Ubuntu" value="ubuntu-1">
    1. Download the appropriate sources file for your operating system:
@@ -145,6 +162,18 @@ cluster will use nftables, but can be configured to use iptables.
    ```bash
    dnf install calico-node calico-fluent-bit
    ```
+
+   :::note
+
+   The RPMs themselves are also signed with the same GPG key as the repository itself. The first
+   time `dnf` downloads an RPM from the repository it will prompt you again to accept the Tigera
+   release signing key, this time for the RPMs themselves.
+
+   As above, if you encounter issues with the GPG signature for RPMs not matching you should fetch
+   the latest `calico_enterprise.repo` file and attempt the update again.
+
+   :::
+
    </TabItem>
    <TabItem label="Debian/Ubuntu" value="ubuntu-1">
    ```bash

--- a/calico-enterprise_versioned_docs/version-3.24-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/release-notes/index.mdx
@@ -151,13 +151,20 @@ Migrate in this order:
 
 ### Calico Enterprise 3.24.0-2.0 (early preview)
 
-{/* TODO: release date */}
+September 1, 2026
 
 Calico Enterprise 3.24.0-2.0 is now available as an early preview release.
 This release is for previewing and testing purposes only.
 It is not supported for use in production.
 
-{/* TODO: fill in subsections for 3.24.0-2.0 — #### Upgrade notes, #### Enhancements, #### Bug fixes, #### Known issues. Omit any subsection with no items. */}
+:::note
+
+Release notes for this version of Calico Enterprise will be published shortly.
+
+:::
+
+
+{/* TODO: fill in subsections for 3.24.0-2.0 — #### Upgrade notes, #### Enhancements, #### Bug fixes, #### Known issues. Omit any subsection with no items. */ }
 
 ### Calico Enterprise 3.24.0-1.0 (early preview)
 

--- a/calico-enterprise_versioned_docs/version-3.24-2/releases.json
+++ b/calico-enterprise_versioned_docs/version-3.24-2/releases.json
@@ -2,7 +2,7 @@
   {
     "title": "v3.24.0-2.0",
     "tigera-operator": {
-      "version": "v1.43.0",
+      "version": "v1.43.1",
       "image": "tigera/operator",
       "registry": "quay.io"
     },
@@ -28,10 +28,10 @@
         "image": "tigera/compliance-benchmarker"
       },
       "coreos-alertmanager": {
-        "version": "v0.33.0"
+        "version": "v0.34.0"
       },
       "coreos-config-reloader": {
-        "version": "v0.91.0"
+        "version": "v0.93.1"
       },
       "coreos-dex": {
         "version": "v2.45.1"
@@ -40,10 +40,10 @@
         "version": "1.19.3"
       },
       "coreos-prometheus": {
-        "version": "v3.12.0"
+        "version": "v3.13.2"
       },
       "coreos-prometheus-operator": {
-        "version": "v0.91.0"
+        "version": "v0.93.1"
       },
       "deep-packet-inspection": {
         "version": "v3.24.0-2.0",
@@ -58,13 +58,13 @@
         "image": "tigera/dikastes"
       },
       "eck-elasticsearch": {
-        "version": "8.19.19"
+        "version": "8.19.20"
       },
       "eck-elasticsearch-operator": {
-        "version": "3.4.1"
+        "version": "3.5.0"
       },
       "eck-kibana": {
-        "version": "8.19.19"
+        "version": "8.19.20"
       },
       "egress-gateway": {
         "version": "v3.24.0-2.0",
@@ -142,6 +142,10 @@
         "version": "v3.24.0-2.0",
         "image": "tigera/manager"
       },
+      "manager-proxy": {
+        "version": "v3.24.0-2.0",
+        "image": "tigera/manager-proxy"
+      },
       "node": {
         "version": "v3.24.0-2.0",
         "image": "tigera/node"
@@ -171,7 +175,7 @@
         "image": "third-party-cni-plugins"
       },
       "upstream-istio": {
-        "version": "1.29.2"
+        "version": "1.29.6"
       }
     }
   }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -464,7 +464,7 @@ export default async function createAsyncConfig() {
           path: 'calico-enterprise',
           routeBasePath: 'calico-enterprise',
           editCurrentVersion: true,
-          onlyIncludeVersions: [...nextVersion, '3.24-1', '3.23-2', '3.22-2', '3.21-2'],
+          onlyIncludeVersions: [...nextVersion, '3.24-2', '3.23-2', '3.22-2', '3.21-2'],
           lastVersion: '3.23-2',
           versions: {
             current: {


### PR DESCRIPTION
Publishes the Calico Enterprise 3.24 early preview 2 docs in place of early preview 1, which shared the same 3.24 path.

https://tigera.atlassian.net/browse/DOCS-2962

Changes:

- Swap 3.24-1 for 3.24-2 in the Enterprise onlyIncludeVersions. lastVersion stays 3.23-2.
- Populate version-3.24-2/releases.json with the real v3.24.0-2.0 pins: operator v1.43.1, the new manager-proxy image, and third-party bumps.

Flags:

- The pins come from the build-v3.24.0-2.0 branch of calico-private. release-calient-v3.24-2 still carries only v3.24.0-1.0, so make version/autogen/3.24-2 cannot find the release yet.
- Regenerating the operator API reference produces no change, so none is committed. Operator v1.43.1 is not tagged yet, so I generated from release-v1.43.
- variables.js needs no edit. The Envoy Gateway pin on the release branch is still 1.8.2.

Verified with a local production build. The 3.24 tree builds from 3.24-2, renders operator v1.43.1, and has no broken internal links.

Preview: https://deploy-preview-2989--calico-docs-preview-next.netlify.app/calico-enterprise/3.24/getting-started/manifest-archive