### PR TITLE
DOCS-3025: Document empty match fields in entity rules

### DIFF
--- a/calico-cloud/_includes/content/_entityrule.mdx
+++ b/calico-cloud/_includes/content/_entityrule.mdx
@@ -31,6 +31,17 @@ You cannot mix IPv4 and IPv6 CIDRs in a single rule using `nets` or `notNets`. I
 
 :::
 
+#### Empty match fields
+
+An empty value in a match field is treated as if the field were not set at all, not as an empty set that matches nothing.
+For example, `nets: []` does not stop the rule from matching.
+It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
+The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
+$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
+
+To block traffic, write an explicit `Deny` rule.
+Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+
 #### Selector performance in EntityRules
 
 When rendering policy into the data plane, $[prodname] must identify the endpoints that match the selectors

--- a/calico-cloud/_includes/content/_entityrule.mdx
+++ b/calico-cloud/_includes/content/_entityrule.mdx
@@ -37,10 +37,7 @@ An empty value in a match field is treated as if the field were not set at all, 
 For example, `nets: []` does not stop the rule from matching.
 It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
 The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
-$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
-
-To block traffic, write an explicit `Deny` rule.
-Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+$[prodname] typically drops the empty value when it stores the resource, so the field is absent when you read the policy back.
 
 #### Selector performance in EntityRules
 

--- a/calico-cloud_versioned_docs/version-23-2/_includes/content/_entityrule.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/_includes/content/_entityrule.mdx
@@ -31,6 +31,17 @@ You cannot mix IPv4 and IPv6 CIDRs in a single rule using `nets` or `notNets`. I
 
 :::
 
+#### Empty match fields
+
+An empty value in a match field is treated as if the field were not set at all, not as an empty set that matches nothing.
+For example, `nets: []` does not stop the rule from matching.
+It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
+The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
+$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
+
+To block traffic, write an explicit `Deny` rule.
+Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+
 #### Selector performance in EntityRules
 
 When rendering policy into the data plane, $[prodname] must identify the endpoints that match the selectors

--- a/calico-cloud_versioned_docs/version-23-2/_includes/content/_entityrule.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/_includes/content/_entityrule.mdx
@@ -37,10 +37,7 @@ An empty value in a match field is treated as if the field were not set at all, 
 For example, `nets: []` does not stop the rule from matching.
 It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
 The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
-$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
-
-To block traffic, write an explicit `Deny` rule.
-Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+$[prodname] typically drops the empty value when it stores the resource, so the field is absent when you read the policy back.
 
 #### Selector performance in EntityRules
 

--- a/calico-enterprise/_includes/content/_entityrule.mdx
+++ b/calico-enterprise/_includes/content/_entityrule.mdx
@@ -31,6 +31,17 @@ You cannot mix IPv4 and IPv6 CIDRs in a single rule using `nets` or `notNets`. I
 
 :::
 
+#### Empty match fields
+
+An empty value in a match field is treated as if the field were not set at all, not as an empty set that matches nothing.
+For example, `nets: []` does not stop the rule from matching.
+It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
+The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
+$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
+
+To block traffic, write an explicit `Deny` rule.
+Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+
 #### Selector performance in EntityRules
 
 When rendering policy into the data plane, $[prodname] must identify the endpoints that match the selectors

--- a/calico-enterprise/_includes/content/_entityrule.mdx
+++ b/calico-enterprise/_includes/content/_entityrule.mdx
@@ -37,10 +37,7 @@ An empty value in a match field is treated as if the field were not set at all, 
 For example, `nets: []` does not stop the rule from matching.
 It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
 The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
-$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
-
-To block traffic, write an explicit `Deny` rule.
-Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+$[prodname] typically drops the empty value when it stores the resource, so the field is absent when you read the policy back.
 
 #### Selector performance in EntityRules
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/content/_entityrule.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/content/_entityrule.mdx
@@ -31,6 +31,17 @@ You cannot mix IPv4 and IPv6 CIDRs in a single rule using `nets` or `notNets`. I
 
 :::
 
+#### Empty match fields
+
+An empty value in a match field is treated as if the field were not set at all, not as an empty set that matches nothing.
+For example, `nets: []` does not stop the rule from matching.
+It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
+The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
+$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
+
+To block traffic, write an explicit `Deny` rule.
+Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+
 #### Selector performance in EntityRules
 
 When rendering policy into the data plane, $[prodname] must identify the endpoints that match the selectors

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/content/_entityrule.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/content/_entityrule.mdx
@@ -37,10 +37,7 @@ An empty value in a match field is treated as if the field were not set at all, 
 For example, `nets: []` does not stop the rule from matching.
 It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
 The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
-$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
-
-To block traffic, write an explicit `Deny` rule.
-Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+$[prodname] typically drops the empty value when it stores the resource, so the field is absent when you read the policy back.
 
 #### Selector performance in EntityRules
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/_includes/content/_entityrule.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/_includes/content/_entityrule.mdx
@@ -31,6 +31,17 @@ You cannot mix IPv4 and IPv6 CIDRs in a single rule using `nets` or `notNets`. I
 
 :::
 
+#### Empty match fields
+
+An empty value in a match field is treated as if the field were not set at all, not as an empty set that matches nothing.
+For example, `nets: []` does not stop the rule from matching.
+It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
+The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
+$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
+
+To block traffic, write an explicit `Deny` rule.
+Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+
 #### Selector performance in EntityRules
 
 When rendering policy into the data plane, $[prodname] must identify the endpoints that match the selectors

--- a/calico-enterprise_versioned_docs/version-3.22-2/_includes/content/_entityrule.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/_includes/content/_entityrule.mdx
@@ -37,10 +37,7 @@ An empty value in a match field is treated as if the field were not set at all, 
 For example, `nets: []` does not stop the rule from matching.
 It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
 The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
-$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
-
-To block traffic, write an explicit `Deny` rule.
-Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+$[prodname] typically drops the empty value when it stores the resource, so the field is absent when you read the policy back.
 
 #### Selector performance in EntityRules
 

--- a/calico-enterprise_versioned_docs/version-3.23-2/_includes/content/_entityrule.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/_includes/content/_entityrule.mdx
@@ -31,6 +31,17 @@ You cannot mix IPv4 and IPv6 CIDRs in a single rule using `nets` or `notNets`. I
 
 :::
 
+#### Empty match fields
+
+An empty value in a match field is treated as if the field were not set at all, not as an empty set that matches nothing.
+For example, `nets: []` does not stop the rule from matching.
+It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
+The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
+$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
+
+To block traffic, write an explicit `Deny` rule.
+Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+
 #### Selector performance in EntityRules
 
 When rendering policy into the data plane, $[prodname] must identify the endpoints that match the selectors

--- a/calico-enterprise_versioned_docs/version-3.23-2/_includes/content/_entityrule.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/_includes/content/_entityrule.mdx
@@ -37,10 +37,7 @@ An empty value in a match field is treated as if the field were not set at all, 
 For example, `nets: []` does not stop the rule from matching.
 It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
 The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
-$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
-
-To block traffic, write an explicit `Deny` rule.
-Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+$[prodname] typically drops the empty value when it stores the resource, so the field is absent when you read the policy back.
 
 #### Selector performance in EntityRules
 

--- a/calico-enterprise_versioned_docs/version-3.24-1/_includes/content/_entityrule.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/_includes/content/_entityrule.mdx
@@ -31,6 +31,17 @@ You cannot mix IPv4 and IPv6 CIDRs in a single rule using `nets` or `notNets`. I
 
 :::
 
+#### Empty match fields
+
+An empty value in a match field is treated as if the field were not set at all, not as an empty set that matches nothing.
+For example, `nets: []` does not stop the rule from matching.
+It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
+The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
+$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
+
+To block traffic, write an explicit `Deny` rule.
+Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+
 #### Selector performance in EntityRules
 
 When rendering policy into the data plane, $[prodname] must identify the endpoints that match the selectors

--- a/calico-enterprise_versioned_docs/version-3.24-1/_includes/content/_entityrule.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/_includes/content/_entityrule.mdx
@@ -37,10 +37,7 @@ An empty value in a match field is treated as if the field were not set at all, 
 For example, `nets: []` does not stop the rule from matching.
 It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
 The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
-$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
-
-To block traffic, write an explicit `Deny` rule.
-Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+$[prodname] typically drops the empty value when it stores the resource, so the field is absent when you read the policy back.
 
 #### Selector performance in EntityRules
 

--- a/calico-enterprise_versioned_docs/version-3.24-2/_includes/content/_entityrule.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/_includes/content/_entityrule.mdx
@@ -31,6 +31,17 @@ You cannot mix IPv4 and IPv6 CIDRs in a single rule using `nets` or `notNets`. I
 
 :::
 
+#### Empty match fields
+
+An empty value in a match field is treated as if the field were not set at all, not as an empty set that matches nothing.
+For example, `nets: []` does not stop the rule from matching.
+It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
+The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
+$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
+
+To block traffic, write an explicit `Deny` rule.
+Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+
 #### Selector performance in EntityRules
 
 When rendering policy into the data plane, $[prodname] must identify the endpoints that match the selectors

--- a/calico-enterprise_versioned_docs/version-3.24-2/_includes/content/_entityrule.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/_includes/content/_entityrule.mdx
@@ -37,10 +37,7 @@ An empty value in a match field is treated as if the field were not set at all, 
 For example, `nets: []` does not stop the rule from matching.
 It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
 The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
-$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
-
-To block traffic, write an explicit `Deny` rule.
-Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+$[prodname] typically drops the empty value when it stores the resource, so the field is absent when you read the policy back.
 
 #### Selector performance in EntityRules
 

--- a/calico/_includes/content/_entityrule.mdx
+++ b/calico/_includes/content/_entityrule.mdx
@@ -26,6 +26,17 @@ When using selectors in network policy, remember that selectors only match (know
 packets. A rule with a selector `all()` won't match "all packets", it will match "packets from all in-scope
 endpoints and network sets". To match all packets, do not include a selector in the rule at all.
 
+#### Empty match fields
+
+An empty value in a match field is treated as if the field were not set at all, not as an empty set that matches nothing.
+For example, `nets: []` does not stop the rule from matching.
+It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
+The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
+$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
+
+To block traffic, write an explicit `Deny` rule.
+Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+
 #### Understanding `notSelector`
 
 `notSelector` is somewhat subtle because the `not` in `notSelector` negates the packet match

--- a/calico/_includes/content/_entityrule.mdx
+++ b/calico/_includes/content/_entityrule.mdx
@@ -32,10 +32,7 @@ An empty value in a match field is treated as if the field were not set at all, 
 For example, `nets: []` does not stop the rule from matching.
 It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
 The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
-$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
-
-To block traffic, write an explicit `Deny` rule.
-Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+$[prodname] typically drops the empty value when it stores the resource, so the field is absent when you read the policy back.
 
 #### Understanding `notSelector`
 

--- a/calico_versioned_docs/version-3.30/_includes/content/_entityrule.mdx
+++ b/calico_versioned_docs/version-3.30/_includes/content/_entityrule.mdx
@@ -26,6 +26,17 @@ When using selectors in network policy, remember that selectors only match (know
 packets. A rule with a selector `all()` won't match "all packets", it will match "packets from all in-scope
 endpoints and network sets". To match all packets, do not include a selector in the rule at all.
 
+#### Empty match fields
+
+An empty value in a match field is treated as if the field were not set at all, not as an empty set that matches nothing.
+For example, `nets: []` does not stop the rule from matching.
+It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
+The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
+$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
+
+To block traffic, write an explicit `Deny` rule.
+Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+
 #### Understanding `notSelector`
 
 `notSelector` is somewhat subtle because the `not` in `notSelector` negates the packet match

--- a/calico_versioned_docs/version-3.30/_includes/content/_entityrule.mdx
+++ b/calico_versioned_docs/version-3.30/_includes/content/_entityrule.mdx
@@ -32,10 +32,7 @@ An empty value in a match field is treated as if the field were not set at all, 
 For example, `nets: []` does not stop the rule from matching.
 It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
 The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
-$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
-
-To block traffic, write an explicit `Deny` rule.
-Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+$[prodname] typically drops the empty value when it stores the resource, so the field is absent when you read the policy back.
 
 #### Understanding `notSelector`
 

--- a/calico_versioned_docs/version-3.31/_includes/content/_entityrule.mdx
+++ b/calico_versioned_docs/version-3.31/_includes/content/_entityrule.mdx
@@ -26,6 +26,17 @@ When using selectors in network policy, remember that selectors only match (know
 packets. A rule with a selector `all()` won't match "all packets", it will match "packets from all in-scope
 endpoints and network sets". To match all packets, do not include a selector in the rule at all.
 
+#### Empty match fields
+
+An empty value in a match field is treated as if the field were not set at all, not as an empty set that matches nothing.
+For example, `nets: []` does not stop the rule from matching.
+It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
+The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
+$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
+
+To block traffic, write an explicit `Deny` rule.
+Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+
 #### Understanding `notSelector`
 
 `notSelector` is somewhat subtle because the `not` in `notSelector` negates the packet match

--- a/calico_versioned_docs/version-3.31/_includes/content/_entityrule.mdx
+++ b/calico_versioned_docs/version-3.31/_includes/content/_entityrule.mdx
@@ -32,10 +32,7 @@ An empty value in a match field is treated as if the field were not set at all, 
 For example, `nets: []` does not stop the rule from matching.
 It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
 The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
-$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
-
-To block traffic, write an explicit `Deny` rule.
-Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+$[prodname] typically drops the empty value when it stores the resource, so the field is absent when you read the policy back.
 
 #### Understanding `notSelector`
 

--- a/calico_versioned_docs/version-3.32/_includes/content/_entityrule.mdx
+++ b/calico_versioned_docs/version-3.32/_includes/content/_entityrule.mdx
@@ -26,6 +26,17 @@ When using selectors in network policy, remember that selectors only match (know
 packets. A rule with a selector `all()` won't match "all packets", it will match "packets from all in-scope
 endpoints and network sets". To match all packets, do not include a selector in the rule at all.
 
+#### Empty match fields
+
+An empty value in a match field is treated as if the field were not set at all, not as an empty set that matches nothing.
+For example, `nets: []` does not stop the rule from matching.
+It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
+The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
+$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
+
+To block traffic, write an explicit `Deny` rule.
+Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+
 #### Understanding `notSelector`
 
 `notSelector` is somewhat subtle because the `not` in `notSelector` negates the packet match

--- a/calico_versioned_docs/version-3.32/_includes/content/_entityrule.mdx
+++ b/calico_versioned_docs/version-3.32/_includes/content/_entityrule.mdx
@@ -32,10 +32,7 @@ An empty value in a match field is treated as if the field were not set at all, 
 For example, `nets: []` does not stop the rule from matching.
 It leaves the rule unconstrained by IP address, so the rule matches any source or destination address.
 The same is true of `notNets`, `ports`, and `notPorts`, and of an empty string in `selector`, `notSelector`, and `namespaceSelector`.
-$[prodname] drops the empty value when it stores the resource, so the field is absent when you read the policy back.
-
-To block traffic, write an explicit `Deny` rule.
-Rules are evaluated in order, so a `Deny` rule states the intent directly instead of relying on an `Allow` rule that you expect not to match.
+$[prodname] typically drops the empty value when it stores the resource, so the field is absent when you read the policy back.
 
 #### Understanding `notSelector`
 


### PR DESCRIPTION
Documents that an empty list or empty string in an entity rule match field is treated as an absent field, so the rule matches everything rather than nothing.

https://tigera.atlassian.net/browse/DOCS-3025
https://github.com/projectcalico/calico/issues/13616

Applied to Next and all published versions for Calico Open Source, Calico Enterprise, and Calico Cloud, plus the Enterprise 3.24-2 cut. The same change repeats in every copy of the entity rule include, so these are representative pages:

https://deploy-preview-2990--tigera.netlify.app/calico/latest/reference/resources/globalnetworkpolicy/
https://deploy-preview-2990--tigera.netlify.app/calico-enterprise/latest/reference/resources/globalnetworkpolicy/
https://deploy-preview-2990--tigera.netlify.app/calico-cloud/reference/resources/globalnetworkpolicy/
https://deploy-preview-2990--calico-docs-preview-next.netlify.app/calico/next/reference/resources/globalnetworkpolicy/

Flags:

- The Enterprise and Cloud copies of the include are missing two selector sections that the Open Source copy has. Tracked separately in DOCS-3026.
