### PR TITLE
docs: point 3.24-2 Forklift installs at the release bucket

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.24-2/networking/kubevirt/install-forklift-kubernetes.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/networking/kubevirt/install-forklift-kubernetes.mdx
@@ -49,7 +49,7 @@ Upstream Forklift's guest conversion fails on clusters whose nodes carry the run
 ### 1. Install the operator
 
 ```bash
-kubectl apply -f $[tutorialFilesURL]/forklift/forklift-operator-kubernetes.yaml
+kubectl apply -f $[filesUrl]/forklift/forklift-operator-kubernetes.yaml
 ```
 
 This creates the `konveyor-forklift` namespace, the Forklift custom resource definitions, the RBAC they need, and the operator. Every component image is pinned in the operator's environment, so nothing downstream names an image.
@@ -61,7 +61,7 @@ kubectl -n konveyor-forklift rollout status deploy/forklift-operator --timeout=3
 ### 2. Create the ForkliftController
 
 ```bash
-kubectl apply -f $[tutorialFilesURL]/forklift/forklift-controller-kubernetes.yaml
+kubectl apply -f $[filesUrl]/forklift/forklift-controller-kubernetes.yaml
 ```
 
 The operator expands this into the full set of Forklift deployments. The console plugin and the CLI download are turned off, because both need the OpenShift console.
@@ -100,7 +100,7 @@ Put the profiles on every node that can run a conversion. Use the Security Profi
 
 
 ```bash
-kubectl apply -f $[tutorialFilesURL]/forklift/forklift-virt-v2v-profiles.yaml
+kubectl apply -f $[filesUrl]/forklift/forklift-virt-v2v-profiles.yaml
 
 kubectl -n konveyor-forklift rollout status ds/forklift-virt-v2v-profile-installer
 ```

--- a/calico-enterprise_versioned_docs/version-3.24-2/networking/kubevirt/install-forklift-openshift.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/networking/kubevirt/install-forklift-openshift.mdx
@@ -45,14 +45,14 @@ kubectl get clusterversion version -o jsonpath='{.status.desired.version}'
 <TabItem value="ocp421" label="OpenShift 4.21 and earlier" default>
 
 ```bash
-kubectl apply -f $[tutorialFilesURL]/forklift/forklift-operator-ocp421.yaml
+kubectl apply -f $[filesUrl]/forklift/forklift-operator-ocp421.yaml
 ```
 
 </TabItem>
 <TabItem value="ocp422" label="OpenShift 4.22 and later">
 
 ```bash
-kubectl apply -f $[tutorialFilesURL]/forklift/forklift-operator-ocp422.yaml
+kubectl apply -f $[filesUrl]/forklift/forklift-operator-ocp422.yaml
 ```
 
 </TabItem>
@@ -70,14 +70,14 @@ kubectl -n konveyor-forklift rollout status deploy/forklift-operator --timeout=3
 <TabItem value="ocp421" label="OpenShift 4.21 and earlier" default>
 
 ```bash
-kubectl apply -f $[tutorialFilesURL]/forklift/forklift-controller-ocp421.yaml
+kubectl apply -f $[filesUrl]/forklift/forklift-controller-ocp421.yaml
 ```
 
 </TabItem>
 <TabItem value="ocp422" label="OpenShift 4.22 and later">
 
 ```bash
-kubectl apply -f $[tutorialFilesURL]/forklift/forklift-controller-ocp422.yaml
+kubectl apply -f $[filesUrl]/forklift/forklift-controller-ocp422.yaml
 ```
 
 </TabItem>


### PR DESCRIPTION
Product Version(s):
Calico Enterprise v3.24.0-2.0

Issue:
The 3.24-2 install pages were snapshotted before the Forklift manifests moved to the release bucket, so every install command on them points at a file that was removed. Found while testing the EP2 install.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] An SME has approved this change. 
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

DOCS review:
- [ ] A member of the docs team has approved this change.
<!-- The Docs team must review and approve all changes. -->

Additional information:
`filesUrl` in `version-3.24-2` already resolves to the right release path, so this only swaps the variable. All seven manifests return 200.

Merge checklist:
<!--- Mandatory for docs team members before merging code --->
- [ ] Deploy preview inspected wherever changes were made 
- [ ] Build completed successfully
- [ ] Test have passed 
