### PR TITLE
DOCS-2962: Remove the placeholder note from the CE 3.24.0-2.0 release notes

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.24-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/release-notes/index.mdx
@@ -157,13 +157,6 @@ Calico Enterprise 3.24.0-2.0 is now available as an early preview release.
 This release is for previewing and testing purposes only.
 It is not supported for use in production.
 
-:::note
-
-Release notes for this version of Calico Enterprise will be published shortly.
-
-:::
-
-
 {/* TODO: fill in subsections for 3.24.0-2.0 — #### Upgrade notes, #### Enhancements, #### Bug fixes, #### Known issues. Omit any subsection with no items. */ }
 
 ### Calico Enterprise 3.24.0-1.0 (early preview)


### PR DESCRIPTION
The 3.24.0-2.0 release notes say that release notes will be published shortly, but the features section is already written.

Removes the note.