### PR TITLE
Sharpen the Forklift entry in the CE 3.24 EP2 release notes

### DIFF
--- a/calico-enterprise_versioned_docs/version-3.24-2/release-notes/index.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/release-notes/index.mdx
@@ -40,16 +40,13 @@ It requires the eBPF data plane, and Multus where an L2 network is an additional
 
 For more information, see [L2 bridge networking](../networking/l2-bridge/index.mdx) and [L2 bridge support and limitations](../reference/l2-bridge-support.mdx).
 
-### Forklift, for migrating VMs onto $[prodname] (tech preview)
+### Forklift VM migration (tech preview)
 
-$[prodname] now publishes a fork of Forklift, the tool that migrates virtual machines from an existing virtualization platform onto KubeVirt.
-Forklift reads from several source platforms, vSphere among them.
+Forklift reads your existing virtualization platform, including vSphere, and migrates its VMs to KubeVirt with $[prodname] networking.
+Your VMs come across with their IP and MAC addresses intact, onto a $[prodname] L2 network, under the same network policy and flow visibility as your pods.
+Every DNS record, firewall rule, and license tied to a VM's address survives the move.
 
-The fork adds address preservation.
-When a migration maps a VM's network to a $[prodname]-backed network attachment, the VM arrives holding the IP and MAC addresses it had before, and can attach to a $[prodname] L2 network.
-Without that, a migrated VM comes up on a new address, and everything bound to the old one has to change with it.
-
-Install it from the manifests in the guides below. It does not ship with the $[prodname] operator.
+Install Forklift from the manifests in the guides below; it does not ship with the $[prodname] operator.
 
 For more information, see [Install Forklift on OpenShift](../networking/kubevirt/install-forklift-openshift.mdx) and [Install Forklift on Kubernetes](../networking/kubevirt/install-forklift-kubernetes.mdx).
 


### PR DESCRIPTION
Rewrites the Forklift feature entry in the Calico Enterprise 3.24 EP2 release notes so it leads with what a reader can now do, names vSphere as a source platform, and sells address preservation instead of explaining the alternative. Also renames the heading to match the plain feature-name style of the entries around it.

Split out of the DOCS-2962 known-issues PR, which touches the same file but a different section.

To do

- Confirm the claim that a migrated VM gets the same network policy and flow visibility as a pod. It is inferred from the L2 bridge entry above it, not verified against Forklift.

Preview: https://deploy-preview-3000--calico-docs-preview-next.netlify.app/calico-enterprise/3.24/release-notes/