### PR TITLE
EV-6699: Document license agent removal in 3.24.0-3

### DIFF
--- a/calico-enterprise/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx
@@ -54,6 +54,28 @@ owned resources being garbage collected by Kubernetes.
 
 $[prodname] creates a default-deny for the calico-system namespace. If you deploy workloads into the calico-system namespace, you must create policy that allows the required traffic for your workloads prior to upgrade.
 
+### License agent removed
+
+The license agent has been removed in $[prodname] v3.24.0-3. If you previously installed
+it, uninstall it using the manifest from the version you are upgrading
+**from** — it is still available at its versioned URL. For example, if upgrading from v3.23.2:
+
+  ```bash
+  kubectl delete -f https://downloads.tigera.io/ee/v3.23.2/manifests/licenseagent.yaml
+  ```
+
+If you no longer have that manifest:
+
+  ```bash
+  kubectl delete servicemonitor calico-lic-monitor -n tigera-prometheus --ignore-not-found
+  kubectl delete networkpolicies.projectcalico.org calico-system.tigera-license-agent-access -n tigera-license-agent --ignore-not-found
+  kubectl delete networkpolicies.projectcalico.org allow-tigera.tigera-license-agent-access -n tigera-license-agent --ignore-not-found
+  kubectl delete clusterrole,clusterrolebinding tigera-license-agent --ignore-not-found
+  kubectl delete namespace tigera-license-agent --ignore-not-found
+  ```
+
+To learn about the license metrics, see [Operator metrics](../../../../operations/monitor/metrics/operator-metrics.mdx).
+
 ## Upgrade from 3.19 or later
 
 :::note

--- a/calico-enterprise/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/operator.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/operator.mdx
@@ -77,6 +77,28 @@ These steps differ based on your cluster type. If you are unsure of your cluster
 
 :::
 
+### License agent removed
+
+The license agent has been removed in $[prodname] v3.24.0-3. If you previously installed
+it, uninstall it using the manifest from the version you are upgrading
+**from** — it is still available at its versioned URL. For example, if upgrading from v3.23.2:
+
+  ```bash
+  kubectl delete -f https://downloads.tigera.io/ee/v3.23.2/manifests/licenseagent.yaml
+  ```
+
+If you no longer have that manifest:
+
+  ```bash
+  kubectl delete servicemonitor calico-lic-monitor -n tigera-prometheus --ignore-not-found
+  kubectl delete networkpolicies.projectcalico.org calico-system.tigera-license-agent-access -n tigera-license-agent --ignore-not-found
+  kubectl delete networkpolicies.projectcalico.org allow-tigera.tigera-license-agent-access -n tigera-license-agent --ignore-not-found
+  kubectl delete clusterrole,clusterrolebinding tigera-license-agent --ignore-not-found
+  kubectl delete namespace tigera-license-agent --ignore-not-found
+  ```
+
+To learn about the license metrics, see [Operator metrics](../../../../operations/monitor/metrics/operator-metrics.mdx).
+
 ## Upgrade Calico Enterprise
 
 <Tabs>

--- a/calico-enterprise/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx
@@ -87,6 +87,28 @@ pod-security.kubernetes.io/enforce-version: latest
 security.openshift.io/scc.podSecurityLabelSync: "false"
 ```
 
+### License agent removed
+
+The license agent has been removed in $[prodname] v3.24.0-3. If you previously installed
+it, uninstall it using the manifest from the version you are upgrading
+**from** — it is still available at its versioned URL. For example, if upgrading from v3.23.2:
+
+   ```bash
+   kubectl delete -f https://downloads.tigera.io/ee/v3.23.2/manifests/licenseagent.yaml
+   ```
+
+If you no longer have that manifest:
+
+   ```bash
+   kubectl delete servicemonitor calico-lic-monitor -n tigera-prometheus --ignore-not-found
+   kubectl delete networkpolicies.projectcalico.org calico-system.tigera-license-agent-access -n tigera-license-agent --ignore-not-found
+   kubectl delete networkpolicies.projectcalico.org allow-tigera.tigera-license-agent-access -n tigera-license-agent --ignore-not-found
+   kubectl delete clusterrole,clusterrolebinding tigera-license-agent --ignore-not-found
+   kubectl delete namespace tigera-license-agent --ignore-not-found
+   ```
+
+To learn about the license metrics, see [Operator metrics](../../../operations/monitor/metrics/operator-metrics.mdx).
+
 ## Download the new manifests
 
 Make a manifests directory.

--- a/calico-enterprise/release-notes/index.mdx
+++ b/calico-enterprise/release-notes/index.mdx
@@ -30,6 +30,7 @@ This version of Calico Enterprise is based on [Calico Open Source $[openSourceVe
 
 - The compliance reporting feature has been removed from the $[prodname] web console.
 - $[prodname] is moving the `projectcalico.org/v3` API from the aggregated API server to native Kubernetes CRDs. Both mechanisms will be supported until native v3 CRDs are compatible with all supported platforms, after which the aggregated API server will be removed.
+- The license agent has been removed and is no longer maintained.
 
 ## Technology Preview features
 
@@ -52,6 +53,14 @@ Migrate in this order:
 3. After the upgrade, re-point monitoring, RBAC, and external DNS from `tigera-gateway` to each Gateway's namespace. If you used merged gateways, plan for one load balancer, DNS record, and certificate per gateway.
 
 :::
+
+### License agent removed
+
+If you previously installed the license agent, remove it from your cluster before or after upgrading.
+No `license-agent` image is published for this release or later.
+For platform-specific steps, see the upgrade guides for [Helm](../getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/helm.mdx#license-agent-removed),
+[the operator](../getting-started/upgrading/upgrading-enterprise/kubernetes-upgrade-tsee/operator.mdx#license-agent-removed),
+or [OpenShift](../getting-started/upgrading/upgrading-enterprise/openshift-upgrade.mdx#license-agent-removed).
 
 ## Release details
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -197,6 +197,10 @@
 
 # Removed features
 
+# License agent
+/calico-enterprise/latest/operations/monitor/metrics/license-agent /calico-enterprise/latest/operations/license-options 301
+/calico-enterprise/3.24/operations/monitor/metrics/license-agent /calico-enterprise/3.24/operations/license-options 301
+
 #FIPS
 /calico-enterprise/latest/operations/fips /calico-enterprise/latest/operations 301
 /calico-enterprise/3.19/operations/fips /calico-enterprise/3.19/operations 301


### PR DESCRIPTION
The license agent is removed in Calico Enterprise 3.24.0-3.0 and is no longer maintained. No license-agent image is published for this release or later.

- Release notes: add a "Deprecated and removed features" entry, plus an "Upgrade notes" subsection pointing to the platform-specific cleanup steps.
- Upgrade guides (helm, operator, openshift): document how to uninstall the agent, preferring the versioned manifest from the release being upgraded from, with a manual resource cleanup fallback. Each links to the license metrics documentation.
- Redirects: point the removed license-agent metrics page at the license options page for the latest and 3.24 paths. These are non-forced 301s, so they stay dormant while 3.23 remains latest and activate once 3.24.0-3.0 ships.
