### PR TITLE
[DE-4474]: Proxy Calico OSS e2e test binaries from S3

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -144,6 +144,17 @@ command = "[[ $PREVIEW_TYPE == cloudpreview ]] && echo Building deploy preview f
    status = 200
    headers = {X-From = "Netlify"}
 
+# Version-matched Kubernetes e2e test binaries for Calico Open Source, proxied
+# from the same bucket as the charts above. Calico releases publish these under
+# <version>/files/e2e/, matching the layout Calico Enterprise serves from
+# downloads.tigera.io, so a consumer resolves a binary the same way for either
+# product.
+[[redirects]]
+   from = "/calico/:version/files/e2e/*"
+   to = "https://calico-public.s3.amazonaws.com/:version/files/e2e/:splat"
+   status = 200
+   headers = {X-From = "Netlify"}
+
 # FOSSA attribution reports for Calico Enterprise (proxied from S3)
 [[redirects]]
    from = "/calico-enterprise/fossa-reports/:version/attribution-report.html"


### PR DESCRIPTION
Product Version(s):
Calico Open Source only — any release that publishes e2e test binaries, i.e. master onward once projectcalico/calico#13566 lands. Not applicable to Calico Enterprise or Calico Cloud.

Issue:
- projectcalico/calico#13566 (the publish side)
- DE-4474

Link to docs preview:
https://deploy-preview-3007--calico-docs-preview-next.netlify.app

Nothing is published at the proxied path yet, so the preview cannot return a binary — but it does prove the routing, and the distinction is the whole point of this PR. Verified on the preview above:

| Path | Result | Meaning |
| --- | --- | --- |
| `/calico/v3.31.1/files/e2e/e2e-linux-amd64.test` | `403 application/xml` | **proxied to S3**; 403 is how a public-read-objects bucket answers a key that is not published yet |
| `/calico/charts/index.yaml` | `200 application/yaml` | existing charts rule unaffected |
| `/calico/v3.31.1/files/other/thing.txt` | `404 text/html` | correctly **not** proxied — confirms the rule is scoped to `files/e2e/` only |

Before this change the first path returned the docs `404` HTML, i.e. the request never reached S3. Once a Calico release publishes, it becomes `200`.

SME review:
- [ ] An SME has approved this change.

DOCS review:
- [ ] A member of the docs team has approved this change.

Additional information:

Calico releases will publish version-matched Kubernetes e2e test binaries to `s3://calico-public/<version>/files/e2e/`, so a consumer can fetch the one architecture it needs (~71 MB) rather than unpacking the ~1.2 GB release archive that also contains them.

That bucket only reaches the web through the per-prefix proxies in `netlify.toml`, and `/calico/charts/*` was the only one — so those objects are currently unreachable from `docs.tigera.io`. Calico Enterprise needs no equivalent rule because `downloads.tigera.io` maps to its bucket root; this asymmetry is why a docs change is needed for Calico Open Source and not for Enterprise.

Two deliberate choices:

- **Narrow, not broad.** `/calico/:version/files/e2e/*` rather than `/calico/:version/files/*`, to keep the proxied surface to what is actually published today.
- **No `force`.** Matching the charts rule, so a real docs file always wins over the proxy. The paths cannot collide anyway: docs versions are `latest` / `3.30`-style, while release versions carry a `v` prefix.

The path deliberately mirrors the Enterprise layout, so a consumer resolves a binary the same way for either product.

Ordering: harmless to merge before projectcalico/calico#13566 (the path simply has nothing behind it yet), and there is no benefit until that lands either. Happy either way — landing this first gives the publish side somewhere to point.

Merge checklist:
- [ ] Deploy preview inspected wherever changes were made
- [ ] Build completed successfully
- [ ] Test have passed


