### PR TITLE
Correct what survives the switch to eBPF mode

### DIFF
--- a/calico-cloud/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-cloud/operations/ebpf/enabling-ebpf.mdx
@@ -240,8 +240,17 @@ resource to `"BPF"`.
 kubectl patch installation.operator.tigera.io default --type merge -p '{"spec":{"calicoNetwork":{"linuxDataplane":"BPF"}}}'
 ```
 
-When enabling eBPF mode, preexisting connections continue to use the non-BPF datapath; such connections should
-not be disrupted, but they do not benefit from eBPF mode’s advantages.
+When enabling eBPF mode, preexisting connections keep using the non-eBPF datapath. They do not benefit from
+eBPF mode’s advantages, and whether they survive the switch depends on the protocol:
+
+- **TCP connections continue to work**, including any address translation applied to them. The translation
+  lives in the Linux conntrack entry rather than in the `kube-proxy` rules that $[prodname] removes, so a
+  connection through a service keeps reaching the backend it was already using.
+- **Traffic that is not TCP is treated as new.** eBPF mode cannot tell a packet from an established UDP flow
+  apart from a fresh one, so it applies policy and picks a service backend again. A UDP flow to a service
+  with several backends can move to a different backend.
+- **Connections over a VXLAN overlay do not survive.** $[prodname] recreates the VXLAN device when it
+  switches to eBPF mode, and the kernel drops the conntrack state for the flows through it.
 
 :::note
 

--- a/calico-cloud_versioned_docs/version-23-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/operations/ebpf/enabling-ebpf.mdx
@@ -240,8 +240,17 @@ resource to `"BPF"`.
 kubectl patch installation.operator.tigera.io default --type merge -p '{"spec":{"calicoNetwork":{"linuxDataplane":"BPF"}}}'
 ```
 
-When enabling eBPF mode, preexisting connections continue to use the non-BPF datapath; such connections should
-not be disrupted, but they do not benefit from eBPF mode’s advantages.
+When enabling eBPF mode, preexisting connections keep using the non-eBPF datapath. They do not benefit from
+eBPF mode’s advantages, and whether they survive the switch depends on the protocol:
+
+- **TCP connections continue to work**, including any address translation applied to them. The translation
+  lives in the Linux conntrack entry rather than in the `kube-proxy` rules that $[prodname] removes, so a
+  connection through a service keeps reaching the backend it was already using.
+- **Traffic that is not TCP is treated as new.** eBPF mode cannot tell a packet from an established UDP flow
+  apart from a fresh one, so it applies policy and picks a service backend again. A UDP flow to a service
+  with several backends can move to a different backend.
+- **Connections over a VXLAN overlay do not survive.** $[prodname] recreates the VXLAN device when it
+  switches to eBPF mode, and the kernel drops the conntrack state for the flows through it.
 
 :::note
 

--- a/calico-enterprise/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise/operations/ebpf/enabling-ebpf.mdx
@@ -227,8 +227,17 @@ resource to `"BPF"`.
 kubectl patch installation.operator.tigera.io default --type merge -p '{"spec":{"calicoNetwork":{"linuxDataplane":"BPF"}}}'
 ```
 
-When enabling eBPF mode, preexisting connections continue to use the non-BPF datapath; such connections should
-not be disrupted, but they do not benefit from eBPF mode’s advantages.
+When enabling eBPF mode, preexisting connections keep using the non-eBPF datapath. They do not benefit from
+eBPF mode’s advantages, and whether they survive the switch depends on the protocol:
+
+- **TCP connections continue to work**, including any address translation applied to them. The translation
+  lives in the Linux conntrack entry rather than in the `kube-proxy` rules that $[prodname] removes, so a
+  connection through a service keeps reaching the backend it was already using.
+- **Traffic that is not TCP is treated as new.** eBPF mode cannot tell a packet from an established UDP flow
+  apart from a fresh one, so it applies policy and picks a service backend again. A UDP flow to a service
+  with several backends can move to a different backend.
+- **Connections over a VXLAN overlay do not survive.** $[prodname] recreates the VXLAN device when it
+  switches to eBPF mode, and the kernel drops the conntrack state for the flows through it.
 
 :::note
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/operations/ebpf/enabling-ebpf.mdx
@@ -195,8 +195,17 @@ resource to `"BPF"`.
 kubectl patch installation.operator.tigera.io default --type merge -p '{"spec":{"calicoNetwork":{"linuxDataplane":"BPF"}}}'
 ```
 
-When enabling eBPF mode, preexisting connections continue to use the non-BPF datapath; such connections should
-not be disrupted, but they do not benefit from eBPF mode’s advantages.
+When enabling eBPF mode, preexisting connections keep using the non-eBPF datapath. They do not benefit from
+eBPF mode’s advantages, and whether they survive the switch depends on the protocol:
+
+- **TCP connections continue to work**, including any address translation applied to them. The translation
+  lives in the Linux conntrack entry rather than in the `kube-proxy` rules that $[prodname] removes, so a
+  connection through a service keeps reaching the backend it was already using.
+- **Traffic that is not TCP is treated as new.** eBPF mode cannot tell a packet from an established UDP flow
+  apart from a fresh one, so it applies policy and picks a service backend again. A UDP flow to a service
+  with several backends can move to a different backend.
+- **Connections over a VXLAN overlay do not survive.** $[prodname] recreates the VXLAN device when it
+  switches to eBPF mode, and the kernel drops the conntrack state for the flows through it.
 
 :::note
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/ebpf/enabling-ebpf.mdx
@@ -195,8 +195,17 @@ resource to `"BPF"`.
 kubectl patch installation.operator.tigera.io default --type merge -p '{"spec":{"calicoNetwork":{"linuxDataplane":"BPF"}}}'
 ```
 
-When enabling eBPF mode, preexisting connections continue to use the non-BPF datapath; such connections should
-not be disrupted, but they do not benefit from eBPF mode’s advantages.
+When enabling eBPF mode, preexisting connections keep using the non-eBPF datapath. They do not benefit from
+eBPF mode’s advantages, and whether they survive the switch depends on the protocol:
+
+- **TCP connections continue to work**, including any address translation applied to them. The translation
+  lives in the Linux conntrack entry rather than in the `kube-proxy` rules that $[prodname] removes, so a
+  connection through a service keeps reaching the backend it was already using.
+- **Traffic that is not TCP is treated as new.** eBPF mode cannot tell a packet from an established UDP flow
+  apart from a fresh one, so it applies policy and picks a service backend again. A UDP flow to a service
+  with several backends can move to a different backend.
+- **Connections over a VXLAN overlay do not survive.** $[prodname] recreates the VXLAN device when it
+  switches to eBPF mode, and the kernel drops the conntrack state for the flows through it.
 
 :::note
 

--- a/calico-enterprise_versioned_docs/version-3.23-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/operations/ebpf/enabling-ebpf.mdx
@@ -227,8 +227,17 @@ resource to `"BPF"`.
 kubectl patch installation.operator.tigera.io default --type merge -p '{"spec":{"calicoNetwork":{"linuxDataplane":"BPF"}}}'
 ```
 
-When enabling eBPF mode, preexisting connections continue to use the non-BPF datapath; such connections should
-not be disrupted, but they do not benefit from eBPF mode’s advantages.
+When enabling eBPF mode, preexisting connections keep using the non-eBPF datapath. They do not benefit from
+eBPF mode’s advantages, and whether they survive the switch depends on the protocol:
+
+- **TCP connections continue to work**, including any address translation applied to them. The translation
+  lives in the Linux conntrack entry rather than in the `kube-proxy` rules that $[prodname] removes, so a
+  connection through a service keeps reaching the backend it was already using.
+- **Traffic that is not TCP is treated as new.** eBPF mode cannot tell a packet from an established UDP flow
+  apart from a fresh one, so it applies policy and picks a service backend again. A UDP flow to a service
+  with several backends can move to a different backend.
+- **Connections over a VXLAN overlay do not survive.** $[prodname] recreates the VXLAN device when it
+  switches to eBPF mode, and the kernel drops the conntrack state for the flows through it.
 
 :::note
 

--- a/calico-enterprise_versioned_docs/version-3.24-1/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/operations/ebpf/enabling-ebpf.mdx
@@ -227,8 +227,17 @@ resource to `"BPF"`.
 kubectl patch installation.operator.tigera.io default --type merge -p '{"spec":{"calicoNetwork":{"linuxDataplane":"BPF"}}}'
 ```
 
-When enabling eBPF mode, preexisting connections continue to use the non-BPF datapath; such connections should
-not be disrupted, but they do not benefit from eBPF mode’s advantages.
+When enabling eBPF mode, preexisting connections keep using the non-eBPF datapath. They do not benefit from
+eBPF mode’s advantages, and whether they survive the switch depends on the protocol:
+
+- **TCP connections continue to work**, including any address translation applied to them. The translation
+  lives in the Linux conntrack entry rather than in the `kube-proxy` rules that $[prodname] removes, so a
+  connection through a service keeps reaching the backend it was already using.
+- **Traffic that is not TCP is treated as new.** eBPF mode cannot tell a packet from an established UDP flow
+  apart from a fresh one, so it applies policy and picks a service backend again. A UDP flow to a service
+  with several backends can move to a different backend.
+- **Connections over a VXLAN overlay do not survive.** $[prodname] recreates the VXLAN device when it
+  switches to eBPF mode, and the kernel drops the conntrack state for the flows through it.
 
 :::note
 

--- a/calico-enterprise_versioned_docs/version-3.24-2/operations/ebpf/enabling-ebpf.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/operations/ebpf/enabling-ebpf.mdx
@@ -227,8 +227,17 @@ resource to `"BPF"`.
 kubectl patch installation.operator.tigera.io default --type merge -p '{"spec":{"calicoNetwork":{"linuxDataplane":"BPF"}}}'
 ```
 
-When enabling eBPF mode, preexisting connections continue to use the non-BPF datapath; such connections should
-not be disrupted, but they do not benefit from eBPF mode’s advantages.
+When enabling eBPF mode, preexisting connections keep using the non-eBPF datapath. They do not benefit from
+eBPF mode’s advantages, and whether they survive the switch depends on the protocol:
+
+- **TCP connections continue to work**, including any address translation applied to them. The translation
+  lives in the Linux conntrack entry rather than in the `kube-proxy` rules that $[prodname] removes, so a
+  connection through a service keeps reaching the backend it was already using.
+- **Traffic that is not TCP is treated as new.** eBPF mode cannot tell a packet from an established UDP flow
+  apart from a fresh one, so it applies policy and picks a service backend again. A UDP flow to a service
+  with several backends can move to a different backend.
+- **Connections over a VXLAN overlay do not survive.** $[prodname] recreates the VXLAN device when it
+  switches to eBPF mode, and the kernel drops the conntrack state for the flows through it.
 
 :::note
 

--- a/calico/operations/ebpf/enabling-ebpf.mdx
+++ b/calico/operations/ebpf/enabling-ebpf.mdx
@@ -391,8 +391,17 @@ calicoctl patch felixconfiguration default --patch='{"spec": {"bpfEnabled": true
 
 </Tabs>
 
-When enabling eBPF mode, preexisting connections continue to use the non-BPF datapath; such connections should
-not be disrupted, but they do not benefit from eBPF mode’s advantages.
+When enabling eBPF mode, preexisting connections keep using the non-eBPF datapath. They do not benefit from
+eBPF mode’s advantages, and whether they survive the switch depends on the protocol:
+
+- **TCP connections continue to work**, including any address translation applied to them. The translation
+  lives in the Linux conntrack entry rather than in the `kube-proxy` rules that $[prodname] removes, so a
+  connection through a service keeps reaching the backend it was already using.
+- **Traffic that is not TCP is treated as new.** eBPF mode cannot tell a packet from an established UDP flow
+  apart from a fresh one, so it applies policy and picks a service backend again. A UDP flow to a service
+  with several backends can move to a different backend.
+- **Connections over a VXLAN overlay do not survive.** $[prodname] recreates the VXLAN device when it
+  switches to eBPF mode, and the kernel drops the conntrack state for the flows through it.
 
 ### Next steps
 

--- a/calico/operations/ebpf/enabling-ebpf.mdx
+++ b/calico/operations/ebpf/enabling-ebpf.mdx
@@ -391,15 +391,15 @@ calicoctl patch felixconfiguration default --patch='{"spec": {"bpfEnabled": true
 
 </Tabs>
 
-When enabling eBPF mode, preexisting connections keep using the non-eBPF datapath. They do not benefit from
-eBPF mode’s advantages, and whether they survive the switch depends on the protocol:
+When enabling eBPF mode, preexisting connections keep using the standard data plane. They do not benefit from
+eBPF mode's advantages, and whether they survive the switch depends on the protocol:
 
 - **TCP connections continue to work**, including any address translation applied to them. The translation
   lives in the Linux conntrack entry rather than in the `kube-proxy` rules that $[prodname] removes, so a
   connection through a service keeps reaching the backend it was already using.
-- **Traffic that is not TCP is treated as new.** eBPF mode cannot tell a packet from an established UDP flow
-  apart from a fresh one, so it applies policy and picks a service backend again. A UDP flow to a service
-  with several backends can move to a different backend.
+- **Traffic that is not TCP is treated as new.** eBPF mode has no record of an established UDP
+  flow, so it applies policy and picks a service backend again. A UDP flow to a service with several
+  backends can move to a different backend.
 - **Connections over a VXLAN overlay do not survive.** $[prodname] recreates the VXLAN device when it
   switches to eBPF mode, and the kernel drops the conntrack state for the flows through it.
 

--- a/calico_versioned_docs/version-3.30/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.30/operations/ebpf/enabling-ebpf.mdx
@@ -358,8 +358,17 @@ calicoctl patch felixconfiguration default --patch='{"spec": {"bpfEnabled": true
 
 </Tabs>
 
-When enabling eBPF mode, preexisting connections continue to use the non-BPF datapath; such connections should
-not be disrupted, but they do not benefit from eBPF mode’s advantages.
+When enabling eBPF mode, preexisting connections keep using the non-eBPF datapath. They do not benefit from
+eBPF mode’s advantages, and whether they survive the switch depends on the protocol:
+
+- **TCP connections continue to work**, including any address translation applied to them. The translation
+  lives in the Linux conntrack entry rather than in the `kube-proxy` rules that $[prodname] removes, so a
+  connection through a service keeps reaching the backend it was already using.
+- **Traffic that is not TCP is treated as new.** eBPF mode cannot tell a packet from an established UDP flow
+  apart from a fresh one, so it applies policy and picks a service backend again. A UDP flow to a service
+  with several backends can move to a different backend.
+- **Connections over a VXLAN overlay do not survive.** $[prodname] recreates the VXLAN device when it
+  switches to eBPF mode, and the kernel drops the conntrack state for the flows through it.
 
 ### Try out direct server return mode
 

--- a/calico_versioned_docs/version-3.30/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.30/operations/ebpf/enabling-ebpf.mdx
@@ -358,15 +358,17 @@ calicoctl patch felixconfiguration default --patch='{"spec": {"bpfEnabled": true
 
 </Tabs>
 
-When enabling eBPF mode, preexisting connections keep using the non-eBPF datapath. They do not benefit from
-eBPF mode’s advantages, and whether they survive the switch depends on the protocol:
+When enabling eBPF mode, preexisting connections keep using the standard data plane. They do not benefit from
+eBPF mode's advantages, and whether they survive the switch depends on the protocol:
 
 - **TCP connections continue to work**, including any address translation applied to them. The translation
   lives in the Linux conntrack entry rather than in the `kube-proxy` rules that $[prodname] removes, so a
-  connection through a service keeps reaching the backend it was already using.
-- **Traffic that is not TCP is treated as new.** eBPF mode cannot tell a packet from an established UDP flow
-  apart from a fresh one, so it applies policy and picks a service backend again. A UDP flow to a service
-  with several backends can move to a different backend.
+  connection through a service keeps reaching the backend it was already using. A connection to a node port
+  with a backend on another node is an exception: on a node whose `FORWARD` policy in the `filter` table is
+  DROP, it is lost.
+- **Traffic that is not TCP is treated as new.** eBPF mode has no record of an established UDP
+  flow, so it applies policy and picks a service backend again. A UDP flow to a service with several
+  backends can move to a different backend.
 - **Connections over a VXLAN overlay do not survive.** $[prodname] recreates the VXLAN device when it
   switches to eBPF mode, and the kernel drops the conntrack state for the flows through it.
 

--- a/calico_versioned_docs/version-3.31/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.31/operations/ebpf/enabling-ebpf.mdx
@@ -392,8 +392,17 @@ calicoctl patch felixconfiguration default --patch='{"spec": {"bpfEnabled": true
 
 </Tabs>
 
-When enabling eBPF mode, preexisting connections continue to use the non-BPF datapath; such connections should
-not be disrupted, but they do not benefit from eBPF mode’s advantages.
+When enabling eBPF mode, preexisting connections keep using the non-eBPF datapath. They do not benefit from
+eBPF mode’s advantages, and whether they survive the switch depends on the protocol:
+
+- **TCP connections continue to work**, including any address translation applied to them. The translation
+  lives in the Linux conntrack entry rather than in the `kube-proxy` rules that $[prodname] removes, so a
+  connection through a service keeps reaching the backend it was already using.
+- **Traffic that is not TCP is treated as new.** eBPF mode cannot tell a packet from an established UDP flow
+  apart from a fresh one, so it applies policy and picks a service backend again. A UDP flow to a service
+  with several backends can move to a different backend.
+- **Connections over a VXLAN overlay do not survive.** $[prodname] recreates the VXLAN device when it
+  switches to eBPF mode, and the kernel drops the conntrack state for the flows through it.
 
 ### Next steps
 

--- a/calico_versioned_docs/version-3.31/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.31/operations/ebpf/enabling-ebpf.mdx
@@ -392,15 +392,17 @@ calicoctl patch felixconfiguration default --patch='{"spec": {"bpfEnabled": true
 
 </Tabs>
 
-When enabling eBPF mode, preexisting connections keep using the non-eBPF datapath. They do not benefit from
-eBPF mode’s advantages, and whether they survive the switch depends on the protocol:
+When enabling eBPF mode, preexisting connections keep using the standard data plane. They do not benefit from
+eBPF mode's advantages, and whether they survive the switch depends on the protocol:
 
 - **TCP connections continue to work**, including any address translation applied to them. The translation
   lives in the Linux conntrack entry rather than in the `kube-proxy` rules that $[prodname] removes, so a
-  connection through a service keeps reaching the backend it was already using.
-- **Traffic that is not TCP is treated as new.** eBPF mode cannot tell a packet from an established UDP flow
-  apart from a fresh one, so it applies policy and picks a service backend again. A UDP flow to a service
-  with several backends can move to a different backend.
+  connection through a service keeps reaching the backend it was already using. A connection to a node port
+  with a backend on another node is an exception: on a node whose `FORWARD` policy in the `filter` table is
+  DROP, it is lost.
+- **Traffic that is not TCP is treated as new.** eBPF mode has no record of an established UDP
+  flow, so it applies policy and picks a service backend again. A UDP flow to a service with several
+  backends can move to a different backend.
 - **Connections over a VXLAN overlay do not survive.** $[prodname] recreates the VXLAN device when it
   switches to eBPF mode, and the kernel drops the conntrack state for the flows through it.
 

--- a/calico_versioned_docs/version-3.32/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.32/operations/ebpf/enabling-ebpf.mdx
@@ -391,8 +391,17 @@ calicoctl patch felixconfiguration default --patch='{"spec": {"bpfEnabled": true
 
 </Tabs>
 
-When enabling eBPF mode, preexisting connections continue to use the non-BPF datapath; such connections should
-not be disrupted, but they do not benefit from eBPF mode’s advantages.
+When enabling eBPF mode, preexisting connections keep using the non-eBPF datapath. They do not benefit from
+eBPF mode’s advantages, and whether they survive the switch depends on the protocol:
+
+- **TCP connections continue to work**, including any address translation applied to them. The translation
+  lives in the Linux conntrack entry rather than in the `kube-proxy` rules that $[prodname] removes, so a
+  connection through a service keeps reaching the backend it was already using.
+- **Traffic that is not TCP is treated as new.** eBPF mode cannot tell a packet from an established UDP flow
+  apart from a fresh one, so it applies policy and picks a service backend again. A UDP flow to a service
+  with several backends can move to a different backend.
+- **Connections over a VXLAN overlay do not survive.** $[prodname] recreates the VXLAN device when it
+  switches to eBPF mode, and the kernel drops the conntrack state for the flows through it.
 
 ### Next steps
 

--- a/calico_versioned_docs/version-3.32/operations/ebpf/enabling-ebpf.mdx
+++ b/calico_versioned_docs/version-3.32/operations/ebpf/enabling-ebpf.mdx
@@ -391,15 +391,15 @@ calicoctl patch felixconfiguration default --patch='{"spec": {"bpfEnabled": true
 
 </Tabs>
 
-When enabling eBPF mode, preexisting connections keep using the non-eBPF datapath. They do not benefit from
-eBPF mode’s advantages, and whether they survive the switch depends on the protocol:
+When enabling eBPF mode, preexisting connections keep using the standard data plane. They do not benefit from
+eBPF mode's advantages, and whether they survive the switch depends on the protocol:
 
 - **TCP connections continue to work**, including any address translation applied to them. The translation
   lives in the Linux conntrack entry rather than in the `kube-proxy` rules that $[prodname] removes, so a
   connection through a service keeps reaching the backend it was already using.
-- **Traffic that is not TCP is treated as new.** eBPF mode cannot tell a packet from an established UDP flow
-  apart from a fresh one, so it applies policy and picks a service backend again. A UDP flow to a service
-  with several backends can move to a different backend.
+- **Traffic that is not TCP is treated as new.** eBPF mode has no record of an established UDP
+  flow, so it applies policy and picks a service backend again. A UDP flow to a service with several
+  backends can move to a different backend.
 - **Connections over a VXLAN overlay do not survive.** $[prodname] recreates the VXLAN device when it
   switches to eBPF mode, and the kernel drops the conntrack state for the flows through it.
 


### PR DESCRIPTION
The *Enable eBPF mode* section says preexisting connections "should not be disrupted". That holds only for TCP, so the page currently promises more than the dataplane delivers.

Replaced with what actually happens, per protocol: TCP connections survive including any address translation, because the translation lives in the Linux conntrack entry rather than in the `kube-proxy` rules Calico removes; non-TCP traffic is treated as new, so a UDP flow to a service with several backends can move to a different one; and connections over a VXLAN overlay do not survive, because the device is recreated in eBPF mode and the kernel drops the conntrack state with it.

Verified against the dataplane code and covered by a new functional verification test in projectcalico/calico#13778, which holds a TCP connection through a service across the switch and confirms it survives the removal of the `kube-proxy` rules.

Product Version(s): all — the sentence is identical and equally wrong in every version directory, so all 12 copies are corrected. Open Source 3.31 and 3.30 additionally note that a connection to a node port with a backend on another node is lost where the filter FORWARD policy is DROP: the fix for that (projectcalico/calico#13778) is in 3.33 and 3.32 but was not backported further.

Issue: CORE-12056

Link to docs preview: https://deploy-preview-3009--tigera.netlify.app

SME review:
- [ ] An SME has approved this change.

DOCS review:
- [ ] A member of the docs team has approved this change.

Additional information: the wording change came out of an investigation into which connections survive the iptables to eBPF switch. Written with Claude Code; I have reviewed every line and can explain the change.

