### PR TITLE
DOCS-3034: Add alertexception page to CE and CC sidebars

### DIFF
--- a/calico-cloud_versioned_sidebars/version-23-2-sidebars.json
+++ b/calico-cloud_versioned_sidebars/version-23-2-sidebars.json
@@ -580,6 +580,7 @@
           },
           "items": [
             "reference/resources/overview",
+            "reference/resources/alertexception",
             "reference/resources/bfdconfig",
             "reference/resources/bgpconfig",
             "reference/resources/bgppeer",

--- a/calico-enterprise_versioned_sidebars/version-3.21-2-sidebars.json
+++ b/calico-enterprise_versioned_sidebars/version-3.21-2-sidebars.json
@@ -915,6 +915,7 @@
           },
           "items": [
             "reference/resources/overview",
+            "reference/resources/alertexception",
             "reference/resources/bfdconfig",
             "reference/resources/bgpconfig",
             "reference/resources/bgppeer",

--- a/calico-enterprise_versioned_sidebars/version-3.22-2-sidebars.json
+++ b/calico-enterprise_versioned_sidebars/version-3.22-2-sidebars.json
@@ -939,6 +939,7 @@
           },
           "items": [
             "reference/resources/overview",
+            "reference/resources/alertexception",
             "reference/resources/bfdconfig",
             "reference/resources/bgpconfig",
             "reference/resources/bgppeer",

--- a/calico-enterprise_versioned_sidebars/version-3.23-2-sidebars.json
+++ b/calico-enterprise_versioned_sidebars/version-3.23-2-sidebars.json
@@ -952,6 +952,7 @@
           },
           "items": [
             "reference/resources/overview",
+            "reference/resources/alertexception",
             "reference/resources/bfdconfig",
             "reference/resources/bgpconfig",
             "reference/resources/bgppeer",

--- a/calico-enterprise_versioned_sidebars/version-3.24-2-sidebars.json
+++ b/calico-enterprise_versioned_sidebars/version-3.24-2-sidebars.json
@@ -1009,6 +1009,7 @@
           },
           "items": [
             "reference/resources/overview",
+            "reference/resources/alertexception",
             "reference/resources/bfdconfig",
             "reference/resources/bgpconfig",
             "reference/resources/bgppeer",

--- a/sidebars-calico-cloud.js
+++ b/sidebars-calico-cloud.js
@@ -453,6 +453,7 @@ module.exports = {
           link: { type: 'doc', id: 'reference/resources/index' },
           items: [
             'reference/resources/overview',
+            'reference/resources/alertexception',
             'reference/resources/bfdconfig',
             'reference/resources/bgpconfig',
             'reference/resources/bgppeer',

--- a/sidebars-calico-enterprise.js
+++ b/sidebars-calico-enterprise.js
@@ -775,6 +775,7 @@ module.exports = {
           link: { type: 'doc', id: 'reference/resources/index' },
           items: [
             'reference/resources/overview',
+            'reference/resources/alertexception',
             'reference/resources/bfdconfig',
             'reference/resources/bgpconfig',
             'reference/resources/bgppeer',


### PR DESCRIPTION
The AlertException resource reference page exists in Calico Enterprise and Calico Cloud but is not listed in any sidebar; it is only reachable from the resources overview page. This adds it to the Resource definitions category, after overview and matching alphabetical order, in both products' sidebars: next plus CE 3.21-2 through 3.24-2 and CC 23-2.

https://tigera.atlassian.net/browse/DOCS-3034

Representative pages on the deploy preview:

- https://deploy-preview-3013--calico-docs-preview-next.netlify.app/calico-enterprise/next/reference/resources/alertexception
- https://deploy-preview-3013--calico-docs-preview-next.netlify.app/calico-cloud/next/reference/resources/alertexception
