### PR TITLE
DOCS-3005: Update Vale to add native MDX processing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -219,7 +219,6 @@ scripts/                          # Build and automation scripts
 1. **Vale linting** (`.github/workflows/vale.yml`)
    - Lints all markdown/MDX content  
    - Uses ripgrep to preprocess variable substitutions
-   - Requires `mdx2vast` global npm package
 2. **React validation** (`.github/workflows/validate.yml`)
    - Runs Jest unit tests with `yarn test:components:ci`
 

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Install dependencies
         if: steps.changed.outputs.skip == 'false'
         run: yarn install --immutable
-      - name: Install mdx2vast globally
-        if: steps.changed.outputs.skip == 'false'
-        run: npm install -g mdx2vast
       - name: Swap stuff
         if: steps.changed.outputs.skip == 'false'
         run: |

--- a/.vale.ini
+++ b/.vale.ini
@@ -2,8 +2,6 @@ StylesPath = .github/styles
 
 MinAlertLevel = warning
 
-Packages = MDX
-
 Vocab = CalicoDocs, CalicoBrands, CalicoTerminology, CalicoTools, CalicoAcronyms
 
 [*.{md,mdx}]
@@ -13,7 +11,7 @@ BasedOnStyles = Vale, CalicoStyle
 # The built-in Vale.Terms check generates many false positives because it flags
 # lowercase technical terms (nginx, kubernetes, bgp, etc.) in table cells,
 # parenthetical component lists, and other code-adjacent contexts.
-# TokenIgnores cannot fix this because it runs BEFORE the MDX parser (mdx2vast),
+# TokenIgnores cannot fix this because it runs BEFORE the MDX parser,
 # and broad patterns (hyphenated words, camelCase, URLs) corrupt the MDX AST
 # when they match inside fenced code blocks.
 Vale.Terms = warning

--- a/scripts/vale-lint.sh
+++ b/scripts/vale-lint.sh
@@ -3,13 +3,12 @@
 # Vale wrapper that handles the $[variable] syntax used in these docs.
 #
 # MDX files use $[prodname], $[manifestsUrl], etc. for Docusaurus variable
-# interpolation. mdx2vast (Vale's MDX parser) uses acorn which crashes on
-# this non-standard JS syntax. This script temporarily replaces $[...] with
+# interpolation. Vale's spell checker flags the interpolated names (e.g.
+# "prodname") as misspellings. This script temporarily replaces $[...] with
 # a placeholder before running Vale, then restores the original files.
 #
 # Prerequisites:
 #   brew install vale ripgrep
-#   npm install -g mdx2vast
 #   vale sync
 #
 # Usage:
@@ -32,7 +31,7 @@ if ! mkdir "$LOCKDIR" 2>/dev/null; then
 fi
 
 # Check dependencies
-for cmd in vale mdx2vast rg perl; do
+for cmd in vale rg perl; do
   if ! command -v "$cmd" &>/dev/null; then
     echo "Error: $cmd is not installed." >&2
     rm -rf "$LOCKDIR"


### PR DESCRIPTION
Vale 3.18 added native MDX parsing, so the community MDX package and mdx2vast are no longer required.

- Remove `Packages = MDX` from `.vale.ini`.
- Drop the `Install mdx2vast globally` CI step and its mention in `.github/copilot-instructions.md`.
- Drop the `mdx2vast` prerequisite from `scripts/vale-lint.sh`.

Verified locally that lint output is identical with and without `Packages = MDX` across `calico/`, `calico-enterprise/`, and `calico-cloud/`.

https://tigera.atlassian.net/browse/DOCS-3005