### PR TITLE
DOCS-3036: Rename Installation reference to Tigera Operator API reference

### DIFF
--- a/calico-cloud/get-started/operator-checklist.mdx
+++ b/calico-cloud/get-started/operator-checklist.mdx
@@ -366,7 +366,7 @@ NAME            AGE
 tigera-secure   98m
 ```
 
-For more information on operator custom resources see the [Installation API reference](../reference/installation/api.mdx).
+For more information on operator custom resources see the [Tigera Operator API reference](../reference/installation/api.mdx).
 
 ### Deep dive into custom resources
 

--- a/calico-cloud/networking/egress/egress-gateway-aws.mdx
+++ b/calico-cloud/networking/egress/egress-gateway-aws.mdx
@@ -233,7 +233,7 @@ spec:
 ```
 
 If `nodeAddressAutodetectionV4` is set to `firstFound: true` or is not specified, then you must change it to another method by editing the
-resource. The NodeAddressAutodetection options, `canReach` and `cidrs` are suitable. See [Installation reference](../../reference/installation/api.mdx). If using the `cidrs` option, set the CIDRs list to include only the
+resource. The NodeAddressAutodetection options, `canReach` and `cidrs` are suitable. See [Tigera Operator API reference](../../reference/installation/api.mdx). If using the `cidrs` option, set the CIDRs list to include only the
 CIDRs from which your primary ENI IPs are chosen (do not include the dedicated VPC subnets chosen below).
 
 ### Ensure Kubernetes VPC has free CIDR range

--- a/calico-cloud/networking/ingress-gateway/customize-ingress-gateway.mdx
+++ b/calico-cloud/networking/ingress-gateway/customize-ingress-gateway.mdx
@@ -241,5 +241,5 @@ To use a custom Envoy configuration, you can modify and apply a copy of the defa
 
 ## Additional resources
 
-* `GatewayAPI` spec in the [Installation API documentation](../../reference/installation/api.mdx#gatewayapi)
+* `GatewayAPI` spec in the [Tigera Operator API reference](../../reference/installation/api.mdx#gatewayapi)
 * [Envoy Gateway documentation](https://gateway.envoyproxy.io/docs/)

--- a/calico-cloud/networking/ipam/ip-autodetection.mdx
+++ b/calico-cloud/networking/ipam/ip-autodetection.mdx
@@ -49,7 +49,7 @@ By default, $[prodname] uses the **firstFound** method; the first valid IP addre
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the Tigera Operator API reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-cloud/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-cloud/operations/monitor/prometheus/byo-prometheus.mdx
@@ -57,7 +57,7 @@ The following example shows a Prometheus server installed in namespace `external
           labels:
             k8s-app: tigera-external-prometheus
     ```
-    For a list of all configuration options, see the [Installation API reference](../../../reference/installation/api.mdx).
+    For a list of all configuration options, see the [Tigera Operator API reference](../../../reference/installation/api.mdx).
 
 2. Apply the manifest to your cluster.
 

--- a/calico-cloud/reference/installation/api.mdx
+++ b/calico-cloud/reference/installation/api.mdx
@@ -1,8 +1,8 @@
 ---
-description: Installation API reference for Calico Cloud listing the operator-managed custom resources used to configure connected cluster installation.
+description: Tigera Operator API reference for Calico Cloud listing the operator-managed custom resources used to configure connected cluster installation.
 ---
 
-# Installation reference
+# Tigera Operator API reference
 
 import API from '@site/calico-cloud/reference/installation/_api.mdx';
 

--- a/calico-cloud/release-notes/index.mdx
+++ b/calico-cloud/release-notes/index.mdx
@@ -437,7 +437,7 @@ For more information, see [Optimize egress networking for workloads with long-li
 
 We've added support for XFF to propagate the original IP address when proxying application layer traffic with Envoy within a Kubernetes cluster.
 
-For more information, see [Installation reference](../reference/installation/api.mdx#envoysettings).
+For more information, see [Tigera Operator API reference](../reference/installation/api.mdx#envoysettings).
 
 #### Alert-only mode for workload-based Web Application Firewall (WAF)
 

--- a/calico-cloud_versioned_docs/version-23-2/get-started/operator-checklist.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/get-started/operator-checklist.mdx
@@ -366,7 +366,7 @@ NAME            AGE
 tigera-secure   98m
 ```
 
-For more information on operator custom resources see the [Installation API reference](../reference/installation/api.mdx).
+For more information on operator custom resources see the [Tigera Operator API reference](../reference/installation/api.mdx).
 
 ### Deep dive into custom resources
 

--- a/calico-cloud_versioned_docs/version-23-2/networking/egress/egress-gateway-aws.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/networking/egress/egress-gateway-aws.mdx
@@ -233,7 +233,7 @@ spec:
 ```
 
 If `nodeAddressAutodetectionV4` is set to `firstFound: true` or is not specified, then you must change it to another method by editing the
-resource. The NodeAddressAutodetection options, `canReach` and `cidrs` are suitable. See [Installation reference](../../reference/installation/api.mdx). If using the `cidrs` option, set the CIDRs list to include only the
+resource. The NodeAddressAutodetection options, `canReach` and `cidrs` are suitable. See [Tigera Operator API reference](../../reference/installation/api.mdx). If using the `cidrs` option, set the CIDRs list to include only the
 CIDRs from which your primary ENI IPs are chosen (do not include the dedicated VPC subnets chosen below).
 
 ### Ensure Kubernetes VPC has free CIDR range

--- a/calico-cloud_versioned_docs/version-23-2/networking/ingress-gateway/customize-ingress-gateway.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/networking/ingress-gateway/customize-ingress-gateway.mdx
@@ -241,5 +241,5 @@ To use a custom Envoy configuration, you can modify and apply a copy of the defa
 
 ## Additional resources
 
-* `GatewayAPI` spec in the [Installation API documentation](../../reference/installation/api.mdx#gatewayapi)
+* `GatewayAPI` spec in the [Tigera Operator API reference](../../reference/installation/api.mdx#gatewayapi)
 * [Envoy Gateway documentation](https://gateway.envoyproxy.io/docs/)

--- a/calico-cloud_versioned_docs/version-23-2/networking/ipam/ip-autodetection.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/networking/ipam/ip-autodetection.mdx
@@ -49,7 +49,7 @@ By default, $[prodname] uses the **firstFound** method; the first valid IP addre
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the Tigera Operator API reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-cloud_versioned_docs/version-23-2/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/operations/monitor/prometheus/byo-prometheus.mdx
@@ -57,7 +57,7 @@ The following example shows a Prometheus server installed in namespace "external
           labels:
             k8s-app: tigera-external-prometheus
     ```
-    For a list of all configuration options, see the [Installation API reference](../../../reference/installation/api.mdx).
+    For a list of all configuration options, see the [Tigera Operator API reference](../../../reference/installation/api.mdx).
 
 2. Apply the manifest to your cluster.
 

--- a/calico-cloud_versioned_docs/version-23-2/reference/installation/api.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/reference/installation/api.mdx
@@ -1,8 +1,8 @@
 ---
-description: Installation API reference for Calico Cloud listing the operator-managed custom resources used to configure connected cluster installation.
+description: Tigera Operator API reference for Calico Cloud listing the operator-managed custom resources used to configure connected cluster installation.
 ---
 
-# Installation reference
+# Tigera Operator API reference
 
 import API from '@site/calico-cloud_versioned_docs/version-23-2/reference/installation/_api.mdx';
 

--- a/calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/release-notes/index.mdx
@@ -998,7 +998,7 @@ For more information, see [Optimize egress networking for workloads with long-li
 
 We've added support for XFF to propagate the original IP address when proxying application layer traffic with Envoy within a Kubernetes cluster.
 
-For more information, see [Installation reference](../reference/installation/api.mdx#envoysettings).
+For more information, see [Tigera Operator API reference](../reference/installation/api.mdx#envoysettings).
 
 #### Alert-only mode for workload-based Web Application Firewall (WAF)
 

--- a/calico-enterprise/_includes/components/GettingStartedInstallOnClustersKubernetesHelm.js
+++ b/calico-enterprise/_includes/components/GettingStartedInstallOnClustersKubernetesHelm.js
@@ -27,7 +27,7 @@ export default function GettingStartedInstallOnClustersKubernetesHelm() {
           <p>
             If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the{' '}
             <code>kubernetesProvider</code> as described in the{' '}
-            <a href='../../../reference/installation/api#operator.tigera.io/v1.Provider'>Installation reference</a>. For
+            <a href='../../../reference/installation/api#operator.tigera.io/v1.Provider'>Tigera Operator API reference</a>. For
             example:
           </p>
         </li>

--- a/calico-enterprise/_includes/components/InstallAKS.js
+++ b/calico-enterprise/_includes/components/InstallAKS.js
@@ -57,7 +57,7 @@ export default function InstallAKS(props) {
           <li>
             <p>
               Download the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/aks/custom-resources.yaml</CodeBlock>
             <p>
@@ -95,7 +95,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/aks/custom-resources.yaml</CodeBlock>
             <p>You can now monitor progress with the following command:</p>
@@ -168,7 +168,7 @@ spec:
           <li>
             <p>
               Download the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/aks/custom-resources-calico-cni.yaml</CodeBlock>
             <p>
@@ -206,7 +206,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/aks/custom-resources-calico-cni.yaml</CodeBlock>
             <p>You can now monitor progress with the following command:</p>

--- a/calico-enterprise/_includes/components/InstallEKS.js
+++ b/calico-enterprise/_includes/components/InstallEKS.js
@@ -60,7 +60,7 @@ export default function InstallEKS(props) {
             <li>
               <p>
                 Download the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/eks/custom-resources.yaml</CodeBlock>
               <p>
@@ -105,7 +105,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/eks/custom-resources.yaml</CodeBlock>
             <p>You can now monitor progress with the following command:</p>
@@ -221,7 +221,7 @@ spec:
             resource that has <code>spec.cni.type: Calico</code>. Install the{' '}
             <code>custom-resources-calico-cni.yaml</code> manifest, which includes this configuration. For more
             information on configuration options available in this manifest, see{' '}
-            <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+            <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
           </p>
           {props.clusterType !== 'managed' && (
             <CodeBlock>kubectl create -f {filesUrl}/manifests/eks/custom-resources-calico-cni.yaml</CodeBlock>
@@ -232,7 +232,7 @@ spec:
             <li>
               <p>
                 Download the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock language='bash'>
                 curl -O -L {filesUrl}/manifests/eks/custom-resources-calico-cni.yaml

--- a/calico-enterprise/_includes/components/InstallGKE.js
+++ b/calico-enterprise/_includes/components/InstallGKE.js
@@ -59,7 +59,7 @@ export default function InstallGKE(props) {
             <li>
               <p>
                 Download the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
               <p>
@@ -102,7 +102,7 @@ spec:
             <li>
               <p>
                 Install the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock>kubectl create -f {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
               <p>You can now monitor progress with the following command:</p>

--- a/calico-enterprise/_includes/components/InstallGeneric.js
+++ b/calico-enterprise/_includes/components/InstallGeneric.js
@@ -72,7 +72,7 @@ export default function InstallGeneric(props) {
           <li>
             <p>
               Download the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
             <p>
@@ -109,7 +109,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available, see{' '}
-              <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
           </li>

--- a/calico-enterprise/_includes/components/InstallOpenShift.js
+++ b/calico-enterprise/_includes/components/InstallOpenShift.js
@@ -225,7 +225,7 @@ spec:
         <>
           <p>
             Download the Tigera custom resources. For more information on configuration options available in this
-            manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+            manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
           </p>
           <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/ocp/tigera-enterprise-resources.yaml</CodeBlock>
           <p>

--- a/calico-enterprise/_includes/components/UpgradeOperatorSimple.js
+++ b/calico-enterprise/_includes/components/UpgradeOperatorSimple.js
@@ -126,7 +126,7 @@ export default function UpgradeOperatorSimple(props) {
               <li>
                 <p>
                   Apply the Tigera custom resources manifest. For more information on configuration options available in this
-                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
                 </p>
                 <CodeBlock language='bash'>kubectl apply -f custom-resources.yaml</CodeBlock>
               </li>
@@ -135,7 +135,7 @@ export default function UpgradeOperatorSimple(props) {
               <li>
                 <p>
                   Install the Tigera custom resources. For more information on configuration options available in this
-                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
                 </p>
                 <CodeBlock language='bash'>
                   {props.provider === 'EKS'

--- a/calico-enterprise/getting-started/install-on-clusters/docker-enterprise.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/docker-enterprise.mdx
@@ -107,7 +107,7 @@ The geeky details of what you get:
 
 1. Install any extra [$[prodname] resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml

--- a/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -48,7 +48,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise/getting-started/install-on-clusters/kubernetes/quickstart.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/kubernetes/quickstart.mdx
@@ -131,7 +131,7 @@ A Linux host that meets the following requirements.
    curl -O -L $[filesUrl]/manifests/custom-resources.yaml
    ```
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml

--- a/calico-enterprise/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/rancher.mdx
@@ -95,7 +95,7 @@ The geeky details of what you get:
 
 1. Install any extra [$[prodname] resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml

--- a/calico-enterprise/getting-started/install-on-clusters/rke2.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/rke2.mdx
@@ -92,7 +92,7 @@ The geeky details of what you get:
 
 1. Install any extra [Calico resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/rancher/custom-resources-rke2.yaml

--- a/calico-enterprise/getting-started/install-on-clusters/windows-calico/rancher.mdx
+++ b/calico-enterprise/getting-started/install-on-clusters/windows-calico/rancher.mdx
@@ -91,7 +91,7 @@ The following steps will outline the installation of $[prodname] networking on t
 
    :::note
 
-   For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+   For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::
 

--- a/calico-enterprise/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
+++ b/calico-enterprise/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
@@ -70,7 +70,7 @@ mkdir manifests
 
 2. Optional: If your cluster architecture requires any custom [Calico resources](../../../reference/resources/index.mdx) to function at startup, install them now using [calicoctl](../../../reference/clis/calicoctl/overview.mdx).
 
-3. Create the custom resources for $[prodname] features, see [the installation reference](../../../reference/installation/api.mdx).
+3. Create the custom resources for $[prodname] features, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    ```bash
    oc apply -f $[filesUrl]/manifests/ocp/tigera-enterprise-resources.yaml

--- a/calico-enterprise/installation/install-calico-enterprise-mke-4k.mdx
+++ b/calico-enterprise/installation/install-calico-enterprise-mke-4k.mdx
@@ -124,7 +124,7 @@ In a new terminal, install the $[prodname] CNI.
    ```
 
 1. Install the Tigera custom resources.
-   For more information on configuration options available in this manifest, see [the installation reference](../reference/installation/api.mdx).
+   For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../reference/installation/api.mdx).
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml
    ```

--- a/calico-enterprise/multicluster/change-cluster-type.mdx
+++ b/calico-enterprise/multicluster/change-cluster-type.mdx
@@ -172,7 +172,7 @@ If you wish to retain LogStorage data for your managed cluster, verify that the 
    ```
 
 1. Install the Tigera custom resources.
-   For more information, see [the installation reference](../reference/installation/api.mdx).
+   For more information, see [the Tigera Operator API reference](../reference/installation/api.mdx).
    ```bash
    kubectl apply -f $[filesUrl]/manifests/custom-resources.yaml
    ```

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -48,7 +48,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -55,7 +55,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise/networking/egress/egress-gateway-aws.mdx
+++ b/calico-enterprise/networking/egress/egress-gateway-aws.mdx
@@ -234,7 +234,7 @@ spec:
 ```
 
 If `nodeAddressAutodetectionV4` is set to `firstFound: true` or is not specified, then you must change it to another method by editing the
-resource. The NodeAddressAutodetection options, `canReach` and `cidrs` are suitable. See [Installation reference](../../reference/installation/api.mdx). If using the `cidrs` option, set the CIDRs list to include only the
+resource. The NodeAddressAutodetection options, `canReach` and `cidrs` are suitable. See [Tigera Operator API reference](../../reference/installation/api.mdx). If using the `cidrs` option, set the CIDRs list to include only the
 CIDRs from which your primary ENI IPs are chosen (do not include the dedicated VPC subnets chosen below).
 
 ### Ensure Kubernetes VPC has free CIDR range

--- a/calico-enterprise/networking/ingress-gateway/customize-ingress-gateway.mdx
+++ b/calico-enterprise/networking/ingress-gateway/customize-ingress-gateway.mdx
@@ -253,5 +253,5 @@ To use a custom Envoy configuration, you can modify and apply a copy of the defa
 
 ## Additional resources
 
-* `GatewayAPI` spec in the [Installation API documentation](../../reference/installation/api.mdx#gatewayapi)
+* `GatewayAPI` spec in the [Tigera Operator API reference](../../reference/installation/api.mdx#gatewayapi)
 * [Envoy Gateway documentation](https://gateway.envoyproxy.io/docs/)

--- a/calico-enterprise/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise/networking/ipam/ip-autodetection.mdx
@@ -49,7 +49,7 @@ By default, $[prodname] uses the **firstFound** method; the first valid IP addre
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the Tigera Operator API reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-enterprise/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-enterprise/operations/monitor/prometheus/byo-prometheus.mdx
@@ -58,7 +58,7 @@ The following example shows a Prometheus server installed in namespace `external
           labels:
             k8s-app: tigera-external-prometheus
     ```
-    For a list of all configuration options, see the [Installation API reference](../../../reference/installation/api.mdx).
+    For a list of all configuration options, see the [Tigera Operator API reference](../../../reference/installation/api.mdx).
 
 2. Apply the manifest to your cluster.
 

--- a/calico-enterprise/operations/nftables.mdx
+++ b/calico-enterprise/operations/nftables.mdx
@@ -154,7 +154,7 @@ If you're using Kubernetes 1.33 or later, you can create a cluster with kubeadm 
         linuxDataplane: Nftables
       ```
       If you have other customizations for your installation, you can add them now.
-      For more information about configuration options , see [the installation reference](../reference/installation/api.mdx).
+      For more information about configuration options , see [the Tigera Operator API reference](../reference/installation/api.mdx).
 
    1. To install $[prodname], create the modified `custom-resources.yaml` file:
       ```bash

--- a/calico-enterprise/reference/installation/api.mdx
+++ b/calico-enterprise/reference/installation/api.mdx
@@ -1,8 +1,8 @@
 ---
-description: Installation API reference for Calico Enterprise listing the operator-managed custom resources used to configure cluster installation.
+description: Tigera Operator API reference for Calico Enterprise listing the operator-managed custom resources used to configure cluster installation.
 ---
 
-# Installation reference
+# Tigera Operator API reference
 
 import API from '@site/calico-enterprise/reference/installation/_api.mdx';
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/GettingStartedInstallOnClustersKubernetesHelm.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/GettingStartedInstallOnClustersKubernetesHelm.js
@@ -27,7 +27,7 @@ export default function GettingStartedInstallOnClustersKubernetesHelm() {
           <p>
             If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the{' '}
             <code>kubernetesProvider</code> as described in the{' '}
-            <a href='../../../reference/installation/api#operator.tigera.io/v1.Provider'>Installation reference</a>. For
+            <a href='../../../reference/installation/api#operator.tigera.io/v1.Provider'>Tigera Operator API reference</a>. For
             example:
           </p>
         </li>

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallAKS.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallAKS.js
@@ -57,7 +57,7 @@ export default function InstallAKS(props) {
           <li>
             <p>
               Download the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/aks/custom-resources.yaml</CodeBlock>
             <p>
@@ -95,7 +95,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/aks/custom-resources.yaml</CodeBlock>
             <p>You can now monitor progress with the following command:</p>
@@ -168,7 +168,7 @@ spec:
           <li>
             <p>
               Download the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/aks/custom-resources-calico-cni.yaml</CodeBlock>
             <p>
@@ -206,7 +206,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/aks/custom-resources-calico-cni.yaml</CodeBlock>
             <p>You can now monitor progress with the following command:</p>

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallEKS.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallEKS.js
@@ -60,7 +60,7 @@ export default function InstallEKS(props) {
             <li>
               <p>
                 Download the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/eks/custom-resources.yaml</CodeBlock>
               <p>
@@ -105,7 +105,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/eks/custom-resources.yaml</CodeBlock>
             <p>You can now monitor progress with the following command:</p>
@@ -221,7 +221,7 @@ spec:
             resource that has <code>spec.cni.type: Calico</code>. Install the{' '}
             <code>custom-resources-calico-cni.yaml</code> manifest, which includes this configuration. For more
             information on configuration options available in this manifest, see{' '}
-            <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+            <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
           </p>
           {props.clusterType !== 'managed' && (
             <CodeBlock>kubectl create -f {filesUrl}/manifests/eks/custom-resources-calico-cni.yaml</CodeBlock>
@@ -232,7 +232,7 @@ spec:
             <li>
               <p>
                 Download the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock language='bash'>
                 curl -O -L {filesUrl}/manifests/eks/custom-resources-calico-cni.yaml

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallGKE.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallGKE.js
@@ -59,7 +59,7 @@ export default function InstallGKE(props) {
             <li>
               <p>
                 Download the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
               <p>
@@ -102,7 +102,7 @@ spec:
             <li>
               <p>
                 Install the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock>kubectl create -f {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
               <p>You can now monitor progress with the following command:</p>

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallGeneric.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallGeneric.js
@@ -72,7 +72,7 @@ export default function InstallGeneric(props) {
           <li>
             <p>
               Download the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
             <p>
@@ -109,7 +109,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available, see{' '}
-              <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
           </li>

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallOpenShift.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/InstallOpenShift.js
@@ -225,7 +225,7 @@ spec:
         <>
           <p>
             Download the Tigera custom resources. For more information on configuration options available in this
-            manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+            manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
           </p>
           <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/ocp/tigera-enterprise-resources.yaml</CodeBlock>
           <p>

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/UpgradeOperatorSimple.js
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/UpgradeOperatorSimple.js
@@ -126,7 +126,7 @@ export default function UpgradeOperatorSimple(props) {
               <li>
                 <p>
                   Apply the Tigera custom resources manifest. For more information on configuration options available in this
-                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
                 </p>
                 <CodeBlock language='bash'>kubectl apply -f custom-resources.yaml</CodeBlock>
               </li>
@@ -135,7 +135,7 @@ export default function UpgradeOperatorSimple(props) {
               <li>
                 <p>
                   Install the Tigera custom resources. For more information on configuration options available in this
-                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
                 </p>
                 <CodeBlock language='bash'>
                   {props.provider === 'EKS'

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/docker-enterprise.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/docker-enterprise.mdx
@@ -98,7 +98,7 @@ The geeky details of what you get:
 
 1. Install any extra [$[prodname] resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -47,7 +47,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/kubernetes/quickstart.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/kubernetes/quickstart.mdx
@@ -122,7 +122,7 @@ A Linux host that meets the following requirements.
    curl -O -L $[filesUrl]/manifests/custom-resources.yaml
    ```
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/rancher.mdx
@@ -86,7 +86,7 @@ The geeky details of what you get:
 
 1. Install any extra [$[prodname] resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/rke2.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/rke2.mdx
@@ -83,7 +83,7 @@ The geeky details of what you get:
 
 1. Install any extra [Calico resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/rancher/custom-resources-rke2.yaml

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/windows-calico/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/install-on-clusters/windows-calico/rancher.mdx
@@ -82,7 +82,7 @@ The following steps will outline the installation of $[prodname] networking on t
 
    :::note
 
-   For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+   For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
@@ -70,7 +70,7 @@ mkdir manifests
 
 2. Optional: If your cluster architecture requires any custom [Calico resources](../../../reference/resources/index.mdx) to function at startup, install them now using [calicoctl](../../../reference/clis/calicoctl/overview.mdx).
 
-3. Create the custom resources for $[prodname] features, see [the installation reference](../../../reference/installation/api.mdx).
+3. Create the custom resources for $[prodname] features, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    ```bash
    oc apply -f $[filesUrl]/manifests/ocp/tigera-enterprise-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.21-2/multicluster/change-cluster-type.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/multicluster/change-cluster-type.mdx
@@ -172,7 +172,7 @@ If you wish to retain LogStorage data for your managed cluster, verify that the 
    ```
 
 1. Install the Tigera custom resources.
-   For more information, see [the installation reference](../reference/installation/api.mdx).
+   For more information, see [the Tigera Operator API reference](../reference/installation/api.mdx).
    ```bash
    kubectl apply -f $[filesUrl]/manifests/custom-resources.yaml
    ```

--- a/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -47,7 +47,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -53,7 +53,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.21-2/networking/egress/egress-gateway-aws.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/networking/egress/egress-gateway-aws.mdx
@@ -234,7 +234,7 @@ spec:
 ```
 
 If `nodeAddressAutodetectionV4` is set to `firstFound: true` or is not specified, then you must change it to another method by editing the
-resource. The NodeAddressAutodetection options, `canReach` and `cidrs` are suitable. See [Installation reference](../../reference/installation/api.mdx). If using the `cidrs` option, set the CIDRs list to include only the
+resource. The NodeAddressAutodetection options, `canReach` and `cidrs` are suitable. See [Tigera Operator API reference](../../reference/installation/api.mdx). If using the `cidrs` option, set the CIDRs list to include only the
 CIDRs from which your primary ENI IPs are chosen (do not include the dedicated VPC subnets chosen below).
 
 ### Ensure Kubernetes VPC has free CIDR range

--- a/calico-enterprise_versioned_docs/version-3.21-2/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/networking/ipam/ip-autodetection.mdx
@@ -49,7 +49,7 @@ By default, $[prodname] uses the **firstFound** method; the first valid IP addre
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the Tigera Operator API reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-enterprise_versioned_docs/version-3.21-2/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/operations/monitor/prometheus/byo-prometheus.mdx
@@ -57,7 +57,7 @@ The following example shows a Prometheus server installed in namespace "external
           labels:
             k8s-app: tigera-external-prometheus
     ```
-    For a list of all configuration options, see the [Installation API reference](../../../reference/installation/api.mdx).
+    For a list of all configuration options, see the [Tigera Operator API reference](../../../reference/installation/api.mdx).
 
 2. Apply the manifest to your cluster.
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/installation/api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/installation/api.mdx
@@ -1,8 +1,8 @@
 ---
-description: Installation API reference
+description: Tigera Operator API reference
 ---
 
-# Installation reference
+# Tigera Operator API reference
 
 import API from '@site/calico-enterprise_versioned_docs/version-3.21-2/reference/installation/_api.mdx';
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/GettingStartedInstallOnClustersKubernetesHelm.js
+++ b/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/GettingStartedInstallOnClustersKubernetesHelm.js
@@ -27,7 +27,7 @@ export default function GettingStartedInstallOnClustersKubernetesHelm() {
           <p>
             If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the{' '}
             <code>kubernetesProvider</code> as described in the{' '}
-            <a href='../../../reference/installation/api#operator.tigera.io/v1.Provider'>Installation reference</a>. For
+            <a href='../../../reference/installation/api#operator.tigera.io/v1.Provider'>Tigera Operator API reference</a>. For
             example:
           </p>
         </li>

--- a/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/InstallAKS.js
+++ b/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/InstallAKS.js
@@ -57,7 +57,7 @@ export default function InstallAKS(props) {
           <li>
             <p>
               Download the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/aks/custom-resources.yaml</CodeBlock>
             <p>
@@ -95,7 +95,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/aks/custom-resources.yaml</CodeBlock>
             <p>You can now monitor progress with the following command:</p>
@@ -168,7 +168,7 @@ spec:
           <li>
             <p>
               Download the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/aks/custom-resources-calico-cni.yaml</CodeBlock>
             <p>
@@ -206,7 +206,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/aks/custom-resources-calico-cni.yaml</CodeBlock>
             <p>You can now monitor progress with the following command:</p>

--- a/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/InstallEKS.js
+++ b/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/InstallEKS.js
@@ -60,7 +60,7 @@ export default function InstallEKS(props) {
             <li>
               <p>
                 Download the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/eks/custom-resources.yaml</CodeBlock>
               <p>
@@ -105,7 +105,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/eks/custom-resources.yaml</CodeBlock>
             <p>You can now monitor progress with the following command:</p>
@@ -221,7 +221,7 @@ spec:
             resource that has <code>spec.cni.type: Calico</code>. Install the{' '}
             <code>custom-resources-calico-cni.yaml</code> manifest, which includes this configuration. For more
             information on configuration options available in this manifest, see{' '}
-            <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+            <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
           </p>
           {props.clusterType !== 'managed' && (
             <CodeBlock>kubectl create -f {filesUrl}/manifests/eks/custom-resources-calico-cni.yaml</CodeBlock>
@@ -232,7 +232,7 @@ spec:
             <li>
               <p>
                 Download the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock language='bash'>
                 curl -O -L {filesUrl}/manifests/eks/custom-resources-calico-cni.yaml

--- a/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/InstallGKE.js
+++ b/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/InstallGKE.js
@@ -59,7 +59,7 @@ export default function InstallGKE(props) {
             <li>
               <p>
                 Download the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
               <p>
@@ -102,7 +102,7 @@ spec:
             <li>
               <p>
                 Install the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock>kubectl create -f {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
               <p>You can now monitor progress with the following command:</p>

--- a/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/InstallGeneric.js
+++ b/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/InstallGeneric.js
@@ -72,7 +72,7 @@ export default function InstallGeneric(props) {
           <li>
             <p>
               Download the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
             <p>
@@ -109,7 +109,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available, see{' '}
-              <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
           </li>

--- a/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/InstallOpenShift.js
+++ b/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/InstallOpenShift.js
@@ -225,7 +225,7 @@ spec:
         <>
           <p>
             Download the Tigera custom resources. For more information on configuration options available in this
-            manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+            manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
           </p>
           <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/ocp/tigera-enterprise-resources.yaml</CodeBlock>
           <p>

--- a/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/UpgradeOperatorSimple.js
+++ b/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/UpgradeOperatorSimple.js
@@ -126,7 +126,7 @@ export default function UpgradeOperatorSimple(props) {
               <li>
                 <p>
                   Apply the Tigera custom resources manifest. For more information on configuration options available in this
-                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
                 </p>
                 <CodeBlock language='bash'>kubectl apply -f custom-resources.yaml</CodeBlock>
               </li>
@@ -135,7 +135,7 @@ export default function UpgradeOperatorSimple(props) {
               <li>
                 <p>
                   Install the Tigera custom resources. For more information on configuration options available in this
-                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
                 </p>
                 <CodeBlock language='bash'>
                   {props.provider === 'EKS'

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/docker-enterprise.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/docker-enterprise.mdx
@@ -98,7 +98,7 @@ The geeky details of what you get:
 
 1. Install any extra [$[prodname] resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -47,7 +47,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/kubernetes/quickstart.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/kubernetes/quickstart.mdx
@@ -122,7 +122,7 @@ A Linux host that meets the following requirements.
    curl -O -L $[filesUrl]/manifests/custom-resources.yaml
    ```
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/rancher.mdx
@@ -86,7 +86,7 @@ The geeky details of what you get:
 
 1. Install any extra [$[prodname] resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/rke2.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/rke2.mdx
@@ -83,7 +83,7 @@ The geeky details of what you get:
 
 1. Install any extra [Calico resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/rancher/custom-resources-rke2.yaml

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/windows-calico/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/install-on-clusters/windows-calico/rancher.mdx
@@ -82,7 +82,7 @@ The following steps will outline the installation of $[prodname] networking on t
 
    :::note
 
-   For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+   For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
@@ -70,7 +70,7 @@ mkdir manifests
 
 2. Optional: If your cluster architecture requires any custom [Calico resources](../../../reference/resources/index.mdx) to function at startup, install them now using [calicoctl](../../../reference/clis/calicoctl/overview.mdx).
 
-3. Create the custom resources for $[prodname] features, see [the installation reference](../../../reference/installation/api.mdx).
+3. Create the custom resources for $[prodname] features, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    ```bash
    oc apply -f $[filesUrl]/manifests/ocp/tigera-enterprise-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.22-2/installation/install-calico-enterprise-mke-4k.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/installation/install-calico-enterprise-mke-4k.mdx
@@ -115,7 +115,7 @@ In a new terminal, install the $[prodname] CNI.
    ```
 
 1. Install the Tigera custom resources.
-   For more information on configuration options available in this manifest, see [the installation reference](../reference/installation/api.mdx).
+   For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../reference/installation/api.mdx).
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml
    ```

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/change-cluster-type.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/change-cluster-type.mdx
@@ -172,7 +172,7 @@ If you wish to retain LogStorage data for your managed cluster, verify that the 
    ```
 
 1. Install the Tigera custom resources.
-   For more information, see [the installation reference](../reference/installation/api.mdx).
+   For more information, see [the Tigera Operator API reference](../reference/installation/api.mdx).
    ```bash
    kubectl apply -f $[filesUrl]/manifests/custom-resources.yaml
    ```

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -47,7 +47,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -53,7 +53,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/egress-gateway-aws.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/egress/egress-gateway-aws.mdx
@@ -234,7 +234,7 @@ spec:
 ```
 
 If `nodeAddressAutodetectionV4` is set to `firstFound: true` or is not specified, then you must change it to another method by editing the
-resource. The NodeAddressAutodetection options, `canReach` and `cidrs` are suitable. See [Installation reference](../../reference/installation/api.mdx). If using the `cidrs` option, set the CIDRs list to include only the
+resource. The NodeAddressAutodetection options, `canReach` and `cidrs` are suitable. See [Tigera Operator API reference](../../reference/installation/api.mdx). If using the `cidrs` option, set the CIDRs list to include only the
 CIDRs from which your primary ENI IPs are chosen (do not include the dedicated VPC subnets chosen below).
 
 ### Ensure Kubernetes VPC has free CIDR range

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ingress-gateway/customize-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ingress-gateway/customize-ingress-gateway.mdx
@@ -241,5 +241,5 @@ To use a custom Envoy configuration, you can modify and apply a copy of the defa
 
 ## Additional resources
 
-* `GatewayAPI` spec in the [Installation API documentation](../../reference/installation/api.mdx#gatewayapi)
+* `GatewayAPI` spec in the [Tigera Operator API reference](../../reference/installation/api.mdx#gatewayapi)
 * [Envoy Gateway documentation](https://gateway.envoyproxy.io/docs/)

--- a/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/networking/ipam/ip-autodetection.mdx
@@ -49,7 +49,7 @@ By default, $[prodname] uses the **firstFound** method; the first valid IP addre
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the Tigera Operator API reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/monitor/prometheus/byo-prometheus.mdx
@@ -57,7 +57,7 @@ The following example shows a Prometheus server installed in namespace "external
           labels:
             k8s-app: tigera-external-prometheus
     ```
-    For a list of all configuration options, see the [Installation API reference](../../../reference/installation/api.mdx).
+    For a list of all configuration options, see the [Tigera Operator API reference](../../../reference/installation/api.mdx).
 
 2. Apply the manifest to your cluster.
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/operations/nftables.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/operations/nftables.mdx
@@ -145,7 +145,7 @@ If you're using Kubernetes 1.33 or later, you can create a cluster with kubeadm 
         linuxDataplane: Nftables
       ```
       If you have other customizations for your installation, you can add them now.
-      For more information about configuration options , see [the installation reference](../reference/installation/api.mdx).
+      For more information about configuration options , see [the Tigera Operator API reference](../reference/installation/api.mdx).
 
    1. To install $[prodname], create the modified `custom-resources.yaml` file:
       ```bash

--- a/calico-enterprise_versioned_docs/version-3.22-2/reference/installation/api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/reference/installation/api.mdx
@@ -1,8 +1,8 @@
 ---
-description: Installation API reference for Calico Enterprise listing the operator-managed custom resources used to configure cluster installation.
+description: Tigera Operator API reference for Calico Enterprise listing the operator-managed custom resources used to configure cluster installation.
 ---
 
-# Installation reference
+# Tigera Operator API reference
 
 import API from '@site/calico-enterprise_versioned_docs/version-3.22-2/reference/installation/_api.mdx';
 

--- a/calico-enterprise_versioned_docs/version-3.23-2/_includes/components/GettingStartedInstallOnClustersKubernetesHelm.js
+++ b/calico-enterprise_versioned_docs/version-3.23-2/_includes/components/GettingStartedInstallOnClustersKubernetesHelm.js
@@ -27,7 +27,7 @@ export default function GettingStartedInstallOnClustersKubernetesHelm() {
           <p>
             If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the{' '}
             <code>kubernetesProvider</code> as described in the{' '}
-            <a href='../../../reference/installation/api#operator.tigera.io/v1.Provider'>Installation reference</a>. For
+            <a href='../../../reference/installation/api#operator.tigera.io/v1.Provider'>Tigera Operator API reference</a>. For
             example:
           </p>
         </li>

--- a/calico-enterprise_versioned_docs/version-3.23-2/_includes/components/InstallAKS.js
+++ b/calico-enterprise_versioned_docs/version-3.23-2/_includes/components/InstallAKS.js
@@ -57,7 +57,7 @@ export default function InstallAKS(props) {
           <li>
             <p>
               Download the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/aks/custom-resources.yaml</CodeBlock>
             <p>
@@ -95,7 +95,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/aks/custom-resources.yaml</CodeBlock>
             <p>You can now monitor progress with the following command:</p>
@@ -168,7 +168,7 @@ spec:
           <li>
             <p>
               Download the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/aks/custom-resources-calico-cni.yaml</CodeBlock>
             <p>
@@ -206,7 +206,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/aks/custom-resources-calico-cni.yaml</CodeBlock>
             <p>You can now monitor progress with the following command:</p>

--- a/calico-enterprise_versioned_docs/version-3.23-2/_includes/components/InstallEKS.js
+++ b/calico-enterprise_versioned_docs/version-3.23-2/_includes/components/InstallEKS.js
@@ -60,7 +60,7 @@ export default function InstallEKS(props) {
             <li>
               <p>
                 Download the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/eks/custom-resources.yaml</CodeBlock>
               <p>
@@ -105,7 +105,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/eks/custom-resources.yaml</CodeBlock>
             <p>You can now monitor progress with the following command:</p>
@@ -221,7 +221,7 @@ spec:
             resource that has <code>spec.cni.type: Calico</code>. Install the{' '}
             <code>custom-resources-calico-cni.yaml</code> manifest, which includes this configuration. For more
             information on configuration options available in this manifest, see{' '}
-            <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+            <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
           </p>
           {props.clusterType !== 'managed' && (
             <CodeBlock>kubectl create -f {filesUrl}/manifests/eks/custom-resources-calico-cni.yaml</CodeBlock>
@@ -232,7 +232,7 @@ spec:
             <li>
               <p>
                 Download the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock language='bash'>
                 curl -O -L {filesUrl}/manifests/eks/custom-resources-calico-cni.yaml

--- a/calico-enterprise_versioned_docs/version-3.23-2/_includes/components/InstallGKE.js
+++ b/calico-enterprise_versioned_docs/version-3.23-2/_includes/components/InstallGKE.js
@@ -59,7 +59,7 @@ export default function InstallGKE(props) {
             <li>
               <p>
                 Download the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
               <p>
@@ -102,7 +102,7 @@ spec:
             <li>
               <p>
                 Install the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock>kubectl create -f {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
               <p>You can now monitor progress with the following command:</p>

--- a/calico-enterprise_versioned_docs/version-3.23-2/_includes/components/InstallGeneric.js
+++ b/calico-enterprise_versioned_docs/version-3.23-2/_includes/components/InstallGeneric.js
@@ -72,7 +72,7 @@ export default function InstallGeneric(props) {
           <li>
             <p>
               Download the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
             <p>
@@ -109,7 +109,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available, see{' '}
-              <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
           </li>

--- a/calico-enterprise_versioned_docs/version-3.23-2/_includes/components/InstallOpenShift.js
+++ b/calico-enterprise_versioned_docs/version-3.23-2/_includes/components/InstallOpenShift.js
@@ -225,7 +225,7 @@ spec:
         <>
           <p>
             Download the Tigera custom resources. For more information on configuration options available in this
-            manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+            manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
           </p>
           <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/ocp/tigera-enterprise-resources.yaml</CodeBlock>
           <p>

--- a/calico-enterprise_versioned_docs/version-3.23-2/_includes/components/UpgradeOperatorSimple.js
+++ b/calico-enterprise_versioned_docs/version-3.23-2/_includes/components/UpgradeOperatorSimple.js
@@ -126,7 +126,7 @@ export default function UpgradeOperatorSimple(props) {
               <li>
                 <p>
                   Apply the Tigera custom resources manifest. For more information on configuration options available in this
-                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
                 </p>
                 <CodeBlock language='bash'>kubectl apply -f custom-resources.yaml</CodeBlock>
               </li>
@@ -135,7 +135,7 @@ export default function UpgradeOperatorSimple(props) {
               <li>
                 <p>
                   Install the Tigera custom resources. For more information on configuration options available in this
-                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
                 </p>
                 <CodeBlock language='bash'>
                   {props.provider === 'EKS'

--- a/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/docker-enterprise.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/docker-enterprise.mdx
@@ -98,7 +98,7 @@ The geeky details of what you get:
 
 1. Install any extra [$[prodname] resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -48,7 +48,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/kubernetes/quickstart.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/kubernetes/quickstart.mdx
@@ -122,7 +122,7 @@ A Linux host that meets the following requirements.
    curl -O -L $[filesUrl]/manifests/custom-resources.yaml
    ```
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/rancher.mdx
@@ -86,7 +86,7 @@ The geeky details of what you get:
 
 1. Install any extra [$[prodname] resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/rke2.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/rke2.mdx
@@ -83,7 +83,7 @@ The geeky details of what you get:
 
 1. Install any extra [Calico resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/rancher/custom-resources-rke2.yaml

--- a/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/windows-calico/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/getting-started/install-on-clusters/windows-calico/rancher.mdx
@@ -82,7 +82,7 @@ The following steps will outline the installation of $[prodname] networking on t
 
    :::note
 
-   For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+   For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::
 

--- a/calico-enterprise_versioned_docs/version-3.23-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
@@ -70,7 +70,7 @@ mkdir manifests
 
 2. Optional: If your cluster architecture requires any custom [Calico resources](../../../reference/resources/index.mdx) to function at startup, install them now using [calicoctl](../../../reference/clis/calicoctl/overview.mdx).
 
-3. Create the custom resources for $[prodname] features, see [the installation reference](../../../reference/installation/api.mdx).
+3. Create the custom resources for $[prodname] features, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    ```bash
    oc apply -f $[filesUrl]/manifests/ocp/tigera-enterprise-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.23-2/installation/install-calico-enterprise-mke-4k.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/installation/install-calico-enterprise-mke-4k.mdx
@@ -115,7 +115,7 @@ In a new terminal, install the $[prodname] CNI.
    ```
 
 1. Install the Tigera custom resources.
-   For more information on configuration options available in this manifest, see [the installation reference](../reference/installation/api.mdx).
+   For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../reference/installation/api.mdx).
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml
    ```

--- a/calico-enterprise_versioned_docs/version-3.23-2/multicluster/change-cluster-type.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/multicluster/change-cluster-type.mdx
@@ -172,7 +172,7 @@ If you wish to retain LogStorage data for your managed cluster, verify that the 
    ```
 
 1. Install the Tigera custom resources.
-   For more information, see [the installation reference](../reference/installation/api.mdx).
+   For more information, see [the Tigera Operator API reference](../reference/installation/api.mdx).
    ```bash
    kubectl apply -f $[filesUrl]/manifests/custom-resources.yaml
    ```

--- a/calico-enterprise_versioned_docs/version-3.23-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -48,7 +48,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.23-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -55,7 +55,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.23-2/networking/egress/egress-gateway-aws.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/networking/egress/egress-gateway-aws.mdx
@@ -234,7 +234,7 @@ spec:
 ```
 
 If `nodeAddressAutodetectionV4` is set to `firstFound: true` or is not specified, then you must change it to another method by editing the
-resource. The NodeAddressAutodetection options, `canReach` and `cidrs` are suitable. See [Installation reference](../../reference/installation/api.mdx). If using the `cidrs` option, set the CIDRs list to include only the
+resource. The NodeAddressAutodetection options, `canReach` and `cidrs` are suitable. See [Tigera Operator API reference](../../reference/installation/api.mdx). If using the `cidrs` option, set the CIDRs list to include only the
 CIDRs from which your primary ENI IPs are chosen (do not include the dedicated VPC subnets chosen below).
 
 ### Ensure Kubernetes VPC has free CIDR range

--- a/calico-enterprise_versioned_docs/version-3.23-2/networking/ingress-gateway/customize-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/networking/ingress-gateway/customize-ingress-gateway.mdx
@@ -241,5 +241,5 @@ To use a custom Envoy configuration, you can modify and apply a copy of the defa
 
 ## Additional resources
 
-* `GatewayAPI` spec in the [Installation API documentation](../../reference/installation/api.mdx#gatewayapi)
+* `GatewayAPI` spec in the [Tigera Operator API reference](../../reference/installation/api.mdx#gatewayapi)
 * [Envoy Gateway documentation](https://gateway.envoyproxy.io/docs/)

--- a/calico-enterprise_versioned_docs/version-3.23-2/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/networking/ipam/ip-autodetection.mdx
@@ -49,7 +49,7 @@ By default, $[prodname] uses the **firstFound** method; the first valid IP addre
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the Tigera Operator API reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-enterprise_versioned_docs/version-3.23-2/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/operations/monitor/prometheus/byo-prometheus.mdx
@@ -57,7 +57,7 @@ The following example shows a Prometheus server installed in namespace "external
           labels:
             k8s-app: tigera-external-prometheus
     ```
-    For a list of all configuration options, see the [Installation API reference](../../../reference/installation/api.mdx).
+    For a list of all configuration options, see the [Tigera Operator API reference](../../../reference/installation/api.mdx).
 
 2. Apply the manifest to your cluster.
 

--- a/calico-enterprise_versioned_docs/version-3.23-2/operations/nftables.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/operations/nftables.mdx
@@ -145,7 +145,7 @@ If you're using Kubernetes 1.33 or later, you can create a cluster with kubeadm 
         linuxDataplane: Nftables
       ```
       If you have other customizations for your installation, you can add them now.
-      For more information about configuration options , see [the installation reference](../reference/installation/api.mdx).
+      For more information about configuration options , see [the Tigera Operator API reference](../reference/installation/api.mdx).
 
    1. To install $[prodname], create the modified `custom-resources.yaml` file:
       ```bash

--- a/calico-enterprise_versioned_docs/version-3.23-2/reference/installation/api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/reference/installation/api.mdx
@@ -1,8 +1,8 @@
 ---
-description: Installation API reference for Calico Enterprise listing the operator-managed custom resources used to configure cluster installation.
+description: Tigera Operator API reference for Calico Enterprise listing the operator-managed custom resources used to configure cluster installation.
 ---
 
-# Installation reference
+# Tigera Operator API reference
 
 import API from '@site/calico-enterprise_versioned_docs/version-3.23-2/reference/installation/_api.mdx';
 

--- a/calico-enterprise_versioned_docs/version-3.24-1/_includes/components/GettingStartedInstallOnClustersKubernetesHelm.js
+++ b/calico-enterprise_versioned_docs/version-3.24-1/_includes/components/GettingStartedInstallOnClustersKubernetesHelm.js
@@ -27,7 +27,7 @@ export default function GettingStartedInstallOnClustersKubernetesHelm() {
           <p>
             If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the{' '}
             <code>kubernetesProvider</code> as described in the{' '}
-            <a href='../../../reference/installation/api#operator.tigera.io/v1.Provider'>Installation reference</a>. For
+            <a href='../../../reference/installation/api#operator.tigera.io/v1.Provider'>Tigera Operator API reference</a>. For
             example:
           </p>
         </li>

--- a/calico-enterprise_versioned_docs/version-3.24-1/_includes/components/InstallAKS.js
+++ b/calico-enterprise_versioned_docs/version-3.24-1/_includes/components/InstallAKS.js
@@ -57,7 +57,7 @@ export default function InstallAKS(props) {
           <li>
             <p>
               Download the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/aks/custom-resources.yaml</CodeBlock>
             <p>
@@ -95,7 +95,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/aks/custom-resources.yaml</CodeBlock>
             <p>You can now monitor progress with the following command:</p>
@@ -168,7 +168,7 @@ spec:
           <li>
             <p>
               Download the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/aks/custom-resources-calico-cni.yaml</CodeBlock>
             <p>
@@ -206,7 +206,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/aks/custom-resources-calico-cni.yaml</CodeBlock>
             <p>You can now monitor progress with the following command:</p>

--- a/calico-enterprise_versioned_docs/version-3.24-1/_includes/components/InstallEKS.js
+++ b/calico-enterprise_versioned_docs/version-3.24-1/_includes/components/InstallEKS.js
@@ -60,7 +60,7 @@ export default function InstallEKS(props) {
             <li>
               <p>
                 Download the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/eks/custom-resources.yaml</CodeBlock>
               <p>
@@ -105,7 +105,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/eks/custom-resources.yaml</CodeBlock>
             <p>You can now monitor progress with the following command:</p>
@@ -221,7 +221,7 @@ spec:
             resource that has <code>spec.cni.type: Calico</code>. Install the{' '}
             <code>custom-resources-calico-cni.yaml</code> manifest, which includes this configuration. For more
             information on configuration options available in this manifest, see{' '}
-            <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+            <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
           </p>
           {props.clusterType !== 'managed' && (
             <CodeBlock>kubectl create -f {filesUrl}/manifests/eks/custom-resources-calico-cni.yaml</CodeBlock>
@@ -232,7 +232,7 @@ spec:
             <li>
               <p>
                 Download the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock language='bash'>
                 curl -O -L {filesUrl}/manifests/eks/custom-resources-calico-cni.yaml

--- a/calico-enterprise_versioned_docs/version-3.24-1/_includes/components/InstallGKE.js
+++ b/calico-enterprise_versioned_docs/version-3.24-1/_includes/components/InstallGKE.js
@@ -59,7 +59,7 @@ export default function InstallGKE(props) {
             <li>
               <p>
                 Download the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
               <p>
@@ -102,7 +102,7 @@ spec:
             <li>
               <p>
                 Install the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock>kubectl create -f {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
               <p>You can now monitor progress with the following command:</p>

--- a/calico-enterprise_versioned_docs/version-3.24-1/_includes/components/InstallGeneric.js
+++ b/calico-enterprise_versioned_docs/version-3.24-1/_includes/components/InstallGeneric.js
@@ -72,7 +72,7 @@ export default function InstallGeneric(props) {
           <li>
             <p>
               Download the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
             <p>
@@ -109,7 +109,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available, see{' '}
-              <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
           </li>

--- a/calico-enterprise_versioned_docs/version-3.24-1/_includes/components/InstallOpenShift.js
+++ b/calico-enterprise_versioned_docs/version-3.24-1/_includes/components/InstallOpenShift.js
@@ -225,7 +225,7 @@ spec:
         <>
           <p>
             Download the Tigera custom resources. For more information on configuration options available in this
-            manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+            manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
           </p>
           <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/ocp/tigera-enterprise-resources.yaml</CodeBlock>
           <p>

--- a/calico-enterprise_versioned_docs/version-3.24-1/_includes/components/UpgradeOperatorSimple.js
+++ b/calico-enterprise_versioned_docs/version-3.24-1/_includes/components/UpgradeOperatorSimple.js
@@ -126,7 +126,7 @@ export default function UpgradeOperatorSimple(props) {
               <li>
                 <p>
                   Apply the Tigera custom resources manifest. For more information on configuration options available in this
-                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
                 </p>
                 <CodeBlock language='bash'>kubectl apply -f custom-resources.yaml</CodeBlock>
               </li>
@@ -135,7 +135,7 @@ export default function UpgradeOperatorSimple(props) {
               <li>
                 <p>
                   Install the Tigera custom resources. For more information on configuration options available in this
-                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
                 </p>
                 <CodeBlock language='bash'>
                   {props.provider === 'EKS'

--- a/calico-enterprise_versioned_docs/version-3.24-1/getting-started/install-on-clusters/docker-enterprise.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/getting-started/install-on-clusters/docker-enterprise.mdx
@@ -98,7 +98,7 @@ The geeky details of what you get:
 
 1. Install any extra [$[prodname] resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.24-1/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -48,7 +48,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.24-1/getting-started/install-on-clusters/kubernetes/quickstart.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/getting-started/install-on-clusters/kubernetes/quickstart.mdx
@@ -122,7 +122,7 @@ A Linux host that meets the following requirements.
    curl -O -L $[filesUrl]/manifests/custom-resources.yaml
    ```
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.24-1/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/getting-started/install-on-clusters/rancher.mdx
@@ -86,7 +86,7 @@ The geeky details of what you get:
 
 1. Install any extra [$[prodname] resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.24-1/getting-started/install-on-clusters/rke2.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/getting-started/install-on-clusters/rke2.mdx
@@ -83,7 +83,7 @@ The geeky details of what you get:
 
 1. Install any extra [Calico resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/rancher/custom-resources-rke2.yaml

--- a/calico-enterprise_versioned_docs/version-3.24-1/getting-started/install-on-clusters/windows-calico/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/getting-started/install-on-clusters/windows-calico/rancher.mdx
@@ -82,7 +82,7 @@ The following steps will outline the installation of $[prodname] networking on t
 
    :::note
 
-   For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+   For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::
 

--- a/calico-enterprise_versioned_docs/version-3.24-1/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
@@ -70,7 +70,7 @@ mkdir manifests
 
 2. Optional: If your cluster architecture requires any custom [Calico resources](../../../reference/resources/index.mdx) to function at startup, install them now using [calicoctl](../../../reference/clis/calicoctl/overview.mdx).
 
-3. Create the custom resources for $[prodname] features, see [the installation reference](../../../reference/installation/api.mdx).
+3. Create the custom resources for $[prodname] features, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    ```bash
    oc apply -f $[filesUrl]/manifests/ocp/tigera-enterprise-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.24-1/installation/install-calico-enterprise-mke-4k.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/installation/install-calico-enterprise-mke-4k.mdx
@@ -115,7 +115,7 @@ In a new terminal, install the $[prodname] CNI.
    ```
 
 1. Install the Tigera custom resources.
-   For more information on configuration options available in this manifest, see [the installation reference](../reference/installation/api.mdx).
+   For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../reference/installation/api.mdx).
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml
    ```

--- a/calico-enterprise_versioned_docs/version-3.24-1/multicluster/change-cluster-type.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/multicluster/change-cluster-type.mdx
@@ -172,7 +172,7 @@ If you wish to retain LogStorage data for your managed cluster, verify that the 
    ```
 
 1. Install the Tigera custom resources.
-   For more information, see [the installation reference](../reference/installation/api.mdx).
+   For more information, see [the Tigera Operator API reference](../reference/installation/api.mdx).
    ```bash
    kubectl apply -f $[filesUrl]/manifests/custom-resources.yaml
    ```

--- a/calico-enterprise_versioned_docs/version-3.24-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -48,7 +48,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.24-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -55,7 +55,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.24-1/networking/egress/egress-gateway-aws.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/networking/egress/egress-gateway-aws.mdx
@@ -234,7 +234,7 @@ spec:
 ```
 
 If `nodeAddressAutodetectionV4` is set to `firstFound: true` or is not specified, then you must change it to another method by editing the
-resource. The NodeAddressAutodetection options, `canReach` and `cidrs` are suitable. See [Installation reference](../../reference/installation/api.mdx). If using the `cidrs` option, set the CIDRs list to include only the
+resource. The NodeAddressAutodetection options, `canReach` and `cidrs` are suitable. See [Tigera Operator API reference](../../reference/installation/api.mdx). If using the `cidrs` option, set the CIDRs list to include only the
 CIDRs from which your primary ENI IPs are chosen (do not include the dedicated VPC subnets chosen below).
 
 ### Ensure Kubernetes VPC has free CIDR range

--- a/calico-enterprise_versioned_docs/version-3.24-1/networking/ingress-gateway/customize-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/networking/ingress-gateway/customize-ingress-gateway.mdx
@@ -253,5 +253,5 @@ To use a custom Envoy configuration, you can modify and apply a copy of the defa
 
 ## Additional resources
 
-* `GatewayAPI` spec in the [Installation API documentation](../../reference/installation/api.mdx#gatewayapi)
+* `GatewayAPI` spec in the [Tigera Operator API reference](../../reference/installation/api.mdx#gatewayapi)
 * [Envoy Gateway documentation](https://gateway.envoyproxy.io/docs/)

--- a/calico-enterprise_versioned_docs/version-3.24-1/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/networking/ipam/ip-autodetection.mdx
@@ -49,7 +49,7 @@ By default, $[prodname] uses the **firstFound** method; the first valid IP addre
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the Tigera Operator API reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-enterprise_versioned_docs/version-3.24-1/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/operations/monitor/prometheus/byo-prometheus.mdx
@@ -58,7 +58,7 @@ The following example shows a Prometheus server installed in namespace "external
           labels:
             k8s-app: tigera-external-prometheus
     ```
-    For a list of all configuration options, see the [Installation API reference](../../../reference/installation/api.mdx).
+    For a list of all configuration options, see the [Tigera Operator API reference](../../../reference/installation/api.mdx).
 
 2. Apply the manifest to your cluster.
 

--- a/calico-enterprise_versioned_docs/version-3.24-1/operations/nftables.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/operations/nftables.mdx
@@ -145,7 +145,7 @@ If you're using Kubernetes 1.33 or later, you can create a cluster with kubeadm 
         linuxDataplane: Nftables
       ```
       If you have other customizations for your installation, you can add them now.
-      For more information about configuration options , see [the installation reference](../reference/installation/api.mdx).
+      For more information about configuration options , see [the Tigera Operator API reference](../reference/installation/api.mdx).
 
    1. To install $[prodname], create the modified `custom-resources.yaml` file:
       ```bash

--- a/calico-enterprise_versioned_docs/version-3.24-1/reference/installation/api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/reference/installation/api.mdx
@@ -1,8 +1,8 @@
 ---
-description: Installation API reference for Calico Enterprise listing the operator-managed custom resources used to configure cluster installation.
+description: Tigera Operator API reference for Calico Enterprise listing the operator-managed custom resources used to configure cluster installation.
 ---
 
-# Installation reference
+# Tigera Operator API reference
 
 import API from '@site/calico-enterprise_versioned_docs/version-3.24-1/reference/installation/_api.mdx';
 

--- a/calico-enterprise_versioned_docs/version-3.24-2/_includes/components/GettingStartedInstallOnClustersKubernetesHelm.js
+++ b/calico-enterprise_versioned_docs/version-3.24-2/_includes/components/GettingStartedInstallOnClustersKubernetesHelm.js
@@ -27,7 +27,7 @@ export default function GettingStartedInstallOnClustersKubernetesHelm() {
           <p>
             If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the{' '}
             <code>kubernetesProvider</code> as described in the{' '}
-            <a href='../../../reference/installation/api#operator.tigera.io/v1.Provider'>Installation reference</a>. For
+            <a href='../../../reference/installation/api#operator.tigera.io/v1.Provider'>Tigera Operator API reference</a>. For
             example:
           </p>
         </li>

--- a/calico-enterprise_versioned_docs/version-3.24-2/_includes/components/InstallAKS.js
+++ b/calico-enterprise_versioned_docs/version-3.24-2/_includes/components/InstallAKS.js
@@ -57,7 +57,7 @@ export default function InstallAKS(props) {
           <li>
             <p>
               Download the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/aks/custom-resources.yaml</CodeBlock>
             <p>
@@ -95,7 +95,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/aks/custom-resources.yaml</CodeBlock>
             <p>You can now monitor progress with the following command:</p>
@@ -168,7 +168,7 @@ spec:
           <li>
             <p>
               Download the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/aks/custom-resources-calico-cni.yaml</CodeBlock>
             <p>
@@ -206,7 +206,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/aks/custom-resources-calico-cni.yaml</CodeBlock>
             <p>You can now monitor progress with the following command:</p>

--- a/calico-enterprise_versioned_docs/version-3.24-2/_includes/components/InstallEKS.js
+++ b/calico-enterprise_versioned_docs/version-3.24-2/_includes/components/InstallEKS.js
@@ -60,7 +60,7 @@ export default function InstallEKS(props) {
             <li>
               <p>
                 Download the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/eks/custom-resources.yaml</CodeBlock>
               <p>
@@ -105,7 +105,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/eks/custom-resources.yaml</CodeBlock>
             <p>You can now monitor progress with the following command:</p>
@@ -221,7 +221,7 @@ spec:
             resource that has <code>spec.cni.type: Calico</code>. Install the{' '}
             <code>custom-resources-calico-cni.yaml</code> manifest, which includes this configuration. For more
             information on configuration options available in this manifest, see{' '}
-            <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+            <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
           </p>
           {props.clusterType !== 'managed' && (
             <CodeBlock>kubectl create -f {filesUrl}/manifests/eks/custom-resources-calico-cni.yaml</CodeBlock>
@@ -232,7 +232,7 @@ spec:
             <li>
               <p>
                 Download the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock language='bash'>
                 curl -O -L {filesUrl}/manifests/eks/custom-resources-calico-cni.yaml

--- a/calico-enterprise_versioned_docs/version-3.24-2/_includes/components/InstallGKE.js
+++ b/calico-enterprise_versioned_docs/version-3.24-2/_includes/components/InstallGKE.js
@@ -59,7 +59,7 @@ export default function InstallGKE(props) {
             <li>
               <p>
                 Download the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
               <p>
@@ -102,7 +102,7 @@ spec:
             <li>
               <p>
                 Install the Tigera custom resources. For more information on configuration options available in this
-                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
               </p>
               <CodeBlock>kubectl create -f {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
               <p>You can now monitor progress with the following command:</p>

--- a/calico-enterprise_versioned_docs/version-3.24-2/_includes/components/InstallGeneric.js
+++ b/calico-enterprise_versioned_docs/version-3.24-2/_includes/components/InstallGeneric.js
@@ -72,7 +72,7 @@ export default function InstallGeneric(props) {
           <li>
             <p>
               Download the Tigera custom resources. For more information on configuration options available in this
-              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
             <p>
@@ -109,7 +109,7 @@ spec:
           <li>
             <p>
               Install the Tigera custom resources. For more information on configuration options available, see{' '}
-              <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+              <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
             </p>
             <CodeBlock>kubectl create -f {filesUrl}/manifests/custom-resources.yaml</CodeBlock>
           </li>

--- a/calico-enterprise_versioned_docs/version-3.24-2/_includes/components/InstallOpenShift.js
+++ b/calico-enterprise_versioned_docs/version-3.24-2/_includes/components/InstallOpenShift.js
@@ -225,7 +225,7 @@ spec:
         <>
           <p>
             Download the Tigera custom resources. For more information on configuration options available in this
-            manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+            manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
           </p>
           <CodeBlock language='bash'>curl -O -L {filesUrl}/manifests/ocp/tigera-enterprise-resources.yaml</CodeBlock>
           <p>

--- a/calico-enterprise_versioned_docs/version-3.24-2/_includes/components/UpgradeOperatorSimple.js
+++ b/calico-enterprise_versioned_docs/version-3.24-2/_includes/components/UpgradeOperatorSimple.js
@@ -126,7 +126,7 @@ export default function UpgradeOperatorSimple(props) {
               <li>
                 <p>
                   Apply the Tigera custom resources manifest. For more information on configuration options available in this
-                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
                 </p>
                 <CodeBlock language='bash'>kubectl apply -f custom-resources.yaml</CodeBlock>
               </li>
@@ -135,7 +135,7 @@ export default function UpgradeOperatorSimple(props) {
               <li>
                 <p>
                   Install the Tigera custom resources. For more information on configuration options available in this
-                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the installation reference</Link>.
+                  manifest, see <Link href={`${baseUrl}/reference/installation/api`}>the Tigera Operator API reference</Link>.
                 </p>
                 <CodeBlock language='bash'>
                   {props.provider === 'EKS'

--- a/calico-enterprise_versioned_docs/version-3.24-2/getting-started/install-on-clusters/docker-enterprise.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/getting-started/install-on-clusters/docker-enterprise.mdx
@@ -98,7 +98,7 @@ The geeky details of what you get:
 
 1. Install any extra [$[prodname] resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.24-2/getting-started/install-on-clusters/kubernetes/helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/getting-started/install-on-clusters/kubernetes/helm.mdx
@@ -48,7 +48,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.24-2/getting-started/install-on-clusters/kubernetes/quickstart.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/getting-started/install-on-clusters/kubernetes/quickstart.mdx
@@ -122,7 +122,7 @@ A Linux host that meets the following requirements.
    curl -O -L $[filesUrl]/manifests/custom-resources.yaml
    ```
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.24-2/getting-started/install-on-clusters/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/getting-started/install-on-clusters/rancher.mdx
@@ -86,7 +86,7 @@ The geeky details of what you get:
 
 1. Install any extra [$[prodname] resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.24-2/getting-started/install-on-clusters/rke2.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/getting-started/install-on-clusters/rke2.mdx
@@ -83,7 +83,7 @@ The geeky details of what you get:
 
 1. Install any extra [Calico resources](../../reference/resources/index.mdx) needed at cluster start using [calicoctl](../../reference/clis/calicoctl/overview.mdx).
 
-1. Install the Tigera custom resources. For more information on configuration options available, see [the installation reference](../../reference/installation/api.mdx).
+1. Install the Tigera custom resources. For more information on configuration options available, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    kubectl create -f $[filesUrl]/manifests/rancher/custom-resources-rke2.yaml

--- a/calico-enterprise_versioned_docs/version-3.24-2/getting-started/install-on-clusters/windows-calico/rancher.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/getting-started/install-on-clusters/windows-calico/rancher.mdx
@@ -82,7 +82,7 @@ The following steps will outline the installation of $[prodname] networking on t
 
    :::note
 
-   For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+   For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::
 

--- a/calico-enterprise_versioned_docs/version-3.24-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/getting-started/upgrading/upgrading-calico-to-calico-enterprise/upgrade-to-tsee-openshift.mdx
@@ -70,7 +70,7 @@ mkdir manifests
 
 2. Optional: If your cluster architecture requires any custom [Calico resources](../../../reference/resources/index.mdx) to function at startup, install them now using [calicoctl](../../../reference/clis/calicoctl/overview.mdx).
 
-3. Create the custom resources for $[prodname] features, see [the installation reference](../../../reference/installation/api.mdx).
+3. Create the custom resources for $[prodname] features, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    ```bash
    oc apply -f $[filesUrl]/manifests/ocp/tigera-enterprise-resources.yaml

--- a/calico-enterprise_versioned_docs/version-3.24-2/installation/install-calico-enterprise-mke-4k.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/installation/install-calico-enterprise-mke-4k.mdx
@@ -115,7 +115,7 @@ In a new terminal, install the $[prodname] CNI.
    ```
 
 1. Install the Tigera custom resources.
-   For more information on configuration options available in this manifest, see [the installation reference](../reference/installation/api.mdx).
+   For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../reference/installation/api.mdx).
    ```bash
    kubectl create -f $[filesUrl]/manifests/custom-resources.yaml
    ```

--- a/calico-enterprise_versioned_docs/version-3.24-2/multicluster/change-cluster-type.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/multicluster/change-cluster-type.mdx
@@ -172,7 +172,7 @@ If you wish to retain LogStorage data for your managed cluster, verify that the 
    ```
 
 1. Install the Tigera custom resources.
-   For more information, see [the installation reference](../reference/installation/api.mdx).
+   For more information, see [the Tigera Operator API reference](../reference/installation/api.mdx).
    ```bash
    kubectl apply -f $[filesUrl]/manifests/custom-resources.yaml
    ```

--- a/calico-enterprise_versioned_docs/version-3.24-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-managed-cluster-helm.mdx
@@ -48,7 +48,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.24-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/multicluster/set-up-multi-cluster-management/helm-install/create-a-management-cluster-helm.mdx
@@ -55,7 +55,7 @@ Some important configurations you might need to provide to the installer (via `v
 
 Here are some examples for updating `values.yaml` with your configurations:
 
-Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Installation reference](../../../reference/installation/api.mdx#provider)
+Example 1. Providing `kubernetesProvider`:  if you are installing on a cluster installed by EKS, set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../../reference/installation/api.mdx#provider)
 
   ```bash
   echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico-enterprise_versioned_docs/version-3.24-2/networking/egress/egress-gateway-aws.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/networking/egress/egress-gateway-aws.mdx
@@ -234,7 +234,7 @@ spec:
 ```
 
 If `nodeAddressAutodetectionV4` is set to `firstFound: true` or is not specified, then you must change it to another method by editing the
-resource. The NodeAddressAutodetection options, `canReach` and `cidrs` are suitable. See [Installation reference](../../reference/installation/api.mdx). If using the `cidrs` option, set the CIDRs list to include only the
+resource. The NodeAddressAutodetection options, `canReach` and `cidrs` are suitable. See [Tigera Operator API reference](../../reference/installation/api.mdx). If using the `cidrs` option, set the CIDRs list to include only the
 CIDRs from which your primary ENI IPs are chosen (do not include the dedicated VPC subnets chosen below).
 
 ### Ensure Kubernetes VPC has free CIDR range

--- a/calico-enterprise_versioned_docs/version-3.24-2/networking/ingress-gateway/customize-ingress-gateway.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/networking/ingress-gateway/customize-ingress-gateway.mdx
@@ -253,5 +253,5 @@ To use a custom Envoy configuration, you can modify and apply a copy of the defa
 
 ## Additional resources
 
-* `GatewayAPI` spec in the [Installation API documentation](../../reference/installation/api.mdx#gatewayapi)
+* `GatewayAPI` spec in the [Tigera Operator API reference](../../reference/installation/api.mdx#gatewayapi)
 * [Envoy Gateway documentation](https://gateway.envoyproxy.io/docs/)

--- a/calico-enterprise_versioned_docs/version-3.24-2/networking/ipam/ip-autodetection.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/networking/ipam/ip-autodetection.mdx
@@ -49,7 +49,7 @@ By default, $[prodname] uses the **firstFound** method; the first valid IP addre
 - A list of IP ranges in CIDR format to determine valid IP addresses on the node to choose from (**cidrs**)
 
 For help on autodetection methods, see
-[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the operator Installation reference
+[NodeAddressAutodetection](../../reference/installation/api.mdx#nodeaddressautodetection) in the Tigera Operator API reference
 and for more details see the [node configuration](../../reference/component-resources/node/configuration.mdx#ip-autodetection-methods) reference.
 
 ### Manually configure IP address and subnet

--- a/calico-enterprise_versioned_docs/version-3.24-2/operations/monitor/prometheus/byo-prometheus.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/operations/monitor/prometheus/byo-prometheus.mdx
@@ -58,7 +58,7 @@ The following example shows a Prometheus server installed in namespace "external
           labels:
             k8s-app: tigera-external-prometheus
     ```
-    For a list of all configuration options, see the [Installation API reference](../../../reference/installation/api.mdx).
+    For a list of all configuration options, see the [Tigera Operator API reference](../../../reference/installation/api.mdx).
 
 2. Apply the manifest to your cluster.
 

--- a/calico-enterprise_versioned_docs/version-3.24-2/operations/nftables.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/operations/nftables.mdx
@@ -145,7 +145,7 @@ If you're using Kubernetes 1.33 or later, you can create a cluster with kubeadm 
         linuxDataplane: Nftables
       ```
       If you have other customizations for your installation, you can add them now.
-      For more information about configuration options , see [the installation reference](../reference/installation/api.mdx).
+      For more information about configuration options , see [the Tigera Operator API reference](../reference/installation/api.mdx).
 
    1. To install $[prodname], create the modified `custom-resources.yaml` file:
       ```bash

--- a/calico-enterprise_versioned_docs/version-3.24-2/reference/installation/api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/reference/installation/api.mdx
@@ -1,8 +1,8 @@
 ---
-description: Installation API reference for Calico Enterprise listing the operator-managed custom resources used to configure cluster installation.
+description: Tigera Operator API reference for Calico Enterprise listing the operator-managed custom resources used to configure cluster installation.
 ---
 
-# Installation reference
+# Tigera Operator API reference
 
 import API from '@site/calico-enterprise_versioned_docs/version-3.24-2/reference/installation/_api.mdx';
 

--- a/calico/getting-started/kubernetes/helm.mdx
+++ b/calico/getting-started/kubernetes/helm.mdx
@@ -47,7 +47,7 @@ helm repo add projectcalico https://docs.tigera.io/calico/charts
 
 If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), or you need to customize TLS certificates, you **must** customize this Helm chart by creating a `values.yaml` file. Otherwise, you can skip this step.
 
-1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#provider). For example:
+1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../reference/installation/api.mdx#provider). For example:
 
    ```
    echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico/getting-started/kubernetes/k3s/multi-node-install.mdx
+++ b/calico/getting-started/kubernetes/k3s/multi-node-install.mdx
@@ -114,7 +114,7 @@ Install the Tigera Operator.
 kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
 ```
 
-Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
 ```bash
 kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml

--- a/calico/getting-started/kubernetes/k3s/quickstart.mdx
+++ b/calico/getting-started/kubernetes/k3s/quickstart.mdx
@@ -85,7 +85,7 @@ kubectl create -f $[manifestsUrl]/manifests/v3_projectcalico_org-v1beta1.yaml
 kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
 ```
 
-3. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+3. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
 ```bash
 kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml

--- a/calico/getting-started/kubernetes/k8s-single-node.mdx
+++ b/calico/getting-started/kubernetes/k8s-single-node.mdx
@@ -109,7 +109,7 @@ The geeky details of what you get:
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 
-1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/custom-resources-bpf.yaml

--- a/calico/getting-started/kubernetes/kind.mdx
+++ b/calico/getting-started/kubernetes/kind.mdx
@@ -99,7 +99,7 @@ kubectl create -f $[manifestsUrl]/manifests/v3_projectcalico_org-v1beta1.yaml
 kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
 ```
 
-3. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+3. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
 :::note
 

--- a/calico/getting-started/kubernetes/minikube.mdx
+++ b/calico/getting-started/kubernetes/minikube.mdx
@@ -78,7 +78,7 @@ minikube start --cni=calico
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 
-4. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+4. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    :::note
 

--- a/calico/getting-started/kubernetes/nftables.mdx
+++ b/calico/getting-started/kubernetes/nftables.mdx
@@ -119,7 +119,7 @@ mode: nftables
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 
-1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    cat > custom-resources.yaml <<EOF

--- a/calico/getting-started/kubernetes/rancher.mdx
+++ b/calico/getting-started/kubernetes/rancher.mdx
@@ -63,7 +63,7 @@ The geeky details of what you get:
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 
-1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml

--- a/calico/getting-started/kubernetes/vpp/getting-started.mdx
+++ b/calico/getting-started/kubernetes/vpp/getting-started.mdx
@@ -106,7 +106,7 @@ Before you get started, make sure you have downloaded and configured the [necess
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 
-1. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+1. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::note
 
@@ -182,7 +182,7 @@ DPDK provides better performance compared to the standard install but it require
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 
-3. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+3. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::note
 
@@ -290,7 +290,7 @@ For some hardware, the following hugepages configuration may enable VPP to use m
    kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
    ```
 
-1. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for VPP. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+1. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for VPP. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::note
 

--- a/calico/getting-started/kubernetes/windows-calico/rancher.mdx
+++ b/calico/getting-started/kubernetes/windows-calico/rancher.mdx
@@ -101,7 +101,7 @@ The following steps will outline the installation of $[prodname] networking on t
 
    :::note
 
-   For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+   For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::
 

--- a/calico/networking/ingress-gateway/customize-ingress-gateway.mdx
+++ b/calico/networking/ingress-gateway/customize-ingress-gateway.mdx
@@ -248,5 +248,5 @@ To use a custom Envoy configuration, you can modify and apply a copy of the defa
 
 ## Additional resources
 
-* `GatewayAPI` spec in the [Installation API documentation](../../reference/installation/api.mdx#gatewayapi)
+* `GatewayAPI` spec in the [Tigera Operator API reference](../../reference/installation/api.mdx#gatewayapi)
 * [Envoy Gateway documentation](https://gateway.envoyproxy.io/docs/)

--- a/calico/reference/installation/api.mdx
+++ b/calico/reference/installation/api.mdx
@@ -1,8 +1,8 @@
 ---
-description: Installation API reference for Calico Open Source listing the operator-managed custom resources used to configure cluster installation.
+description: Tigera Operator API reference for Calico Open Source listing the operator-managed custom resources used to configure cluster installation.
 ---
 
-# Installation reference
+# Tigera Operator API reference
 
 import API from '@site/calico/reference/installation/_api.mdx';
 

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/helm.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/helm.mdx
@@ -47,7 +47,7 @@ helm repo add projectcalico https://docs.tigera.io/calico/charts
 
 If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), or you need to customize TLS certificates, you **must** customize this Helm chart by creating a `values.yaml` file. Otherwise, you can skip this step.
 
-1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#provider). For example:
+1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../reference/installation/api.mdx#provider). For example:
 
    ```
    echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/k3s/multi-node-install.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/k3s/multi-node-install.mdx
@@ -107,7 +107,7 @@ Due to the large size of the CRD bundle, `kubectl apply` might exceed request li
 
 :::
 
-Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
 ```bash
 kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/k3s/quickstart.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/k3s/quickstart.mdx
@@ -78,7 +78,7 @@ Due to the large size of the CRD bundle, `kubectl apply` might exceed request li
 
 :::
 
-2. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+2. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
 ```bash
 kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/k8s-single-node.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/k8s-single-node.mdx
@@ -102,7 +102,7 @@ The geeky details of what you get:
 
    :::
 
-1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/kind.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/kind.mdx
@@ -86,7 +86,7 @@ kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
 kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
 ```
 
-2. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+2. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
 :::note
 

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/minikube.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/minikube.mdx
@@ -71,7 +71,7 @@ minikube start --cni=calico
 
    :::
 
-3. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+3. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    :::note
 

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/nftables.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/nftables.mdx
@@ -117,7 +117,7 @@ mode: nftables
 
    :::
 
-1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    cat > custom-resources.yaml <<EOF

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/rancher.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/rancher.mdx
@@ -56,7 +56,7 @@ The geeky details of what you get:
 
    :::
 
-1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/vpp/getting-started.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/vpp/getting-started.mdx
@@ -99,7 +99,7 @@ Before you get started, make sure you have downloaded and configured the [necess
 
    :::
 
-1. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+1. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::note
 
@@ -168,7 +168,7 @@ DPDK provides better performance compared to the standard install but it require
 
    :::
 
-2. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+2. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::note
 
@@ -269,7 +269,7 @@ For some hardware, the following hugepages configuration may enable VPP to use m
 
    :::
 
-1. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for VPP. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+1. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for VPP. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::note
 

--- a/calico_versioned_docs/version-3.30/getting-started/kubernetes/windows-calico/rancher.mdx
+++ b/calico_versioned_docs/version-3.30/getting-started/kubernetes/windows-calico/rancher.mdx
@@ -94,7 +94,7 @@ The following steps will outline the installation of $[prodname] networking on t
 
    :::note
 
-   For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+   For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::
 

--- a/calico_versioned_docs/version-3.30/operations/fips.mdx
+++ b/calico_versioned_docs/version-3.30/operations/fips.mdx
@@ -61,6 +61,6 @@ Follow [the installation steps](../getting-started/index.mdx) for your platform.
      fipsMode: Enabled
    ```
 
-   - For more information on configuration options available in this manifest, see [the installation reference](../reference/installation/api.mdx).
+   - For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../reference/installation/api.mdx).
 
 After you apply the YAML, FIPS mode is fully operational.

--- a/calico_versioned_docs/version-3.30/reference/installation/api.mdx
+++ b/calico_versioned_docs/version-3.30/reference/installation/api.mdx
@@ -1,8 +1,8 @@
 ---
-description: Installation API reference
+description: Tigera Operator API reference
 ---
 
-# Installation reference
+# Tigera Operator API reference
 
 import API from '@site/calico_versioned_docs/version-3.30/reference/installation/_api.mdx';
 

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/helm.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/helm.mdx
@@ -47,7 +47,7 @@ helm repo add projectcalico https://docs.tigera.io/calico/charts
 
 If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), or you need to customize TLS certificates, you **must** customize this Helm chart by creating a `values.yaml` file. Otherwise, you can skip this step.
 
-1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#provider). For example:
+1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../reference/installation/api.mdx#provider). For example:
 
    ```
    echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/k3s/multi-node-install.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/k3s/multi-node-install.mdx
@@ -107,7 +107,7 @@ Due to the large size of the CRD bundle, `kubectl apply` might exceed request li
 
 :::
 
-Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
 ```bash
 kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/k3s/quickstart.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/k3s/quickstart.mdx
@@ -78,7 +78,7 @@ Due to the large size of the CRD bundle, `kubectl apply` might exceed request li
 
 :::
 
-2. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+2. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
 ```bash
 kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/k8s-single-node.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/k8s-single-node.mdx
@@ -102,7 +102,7 @@ The geeky details of what you get:
 
    :::
 
-1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/custom-resources-bpf.yaml

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/kind.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/kind.mdx
@@ -86,7 +86,7 @@ kubectl create -f $[manifestsUrl]/manifests/operator-crds.yaml
 kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
 ```
 
-2. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+2. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
 :::note
 

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/minikube.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/minikube.mdx
@@ -71,7 +71,7 @@ minikube start --cni=calico
 
    :::
 
-3. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+3. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    :::note
 

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/nftables.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/nftables.mdx
@@ -112,7 +112,7 @@ mode: nftables
 
    :::
 
-1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    cat > custom-resources.yaml <<EOF

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/rancher.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/rancher.mdx
@@ -56,7 +56,7 @@ The geeky details of what you get:
 
    :::
 
-1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/vpp/getting-started.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/vpp/getting-started.mdx
@@ -99,7 +99,7 @@ Before you get started, make sure you have downloaded and configured the [necess
 
    :::
 
-1. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+1. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::note
 
@@ -168,7 +168,7 @@ DPDK provides better performance compared to the standard install but it require
 
    :::
 
-2. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+2. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::note
 
@@ -269,7 +269,7 @@ For some hardware, the following hugepages configuration may enable VPP to use m
 
    :::
 
-1. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for VPP. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+1. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for VPP. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::note
 

--- a/calico_versioned_docs/version-3.31/getting-started/kubernetes/windows-calico/rancher.mdx
+++ b/calico_versioned_docs/version-3.31/getting-started/kubernetes/windows-calico/rancher.mdx
@@ -94,7 +94,7 @@ The following steps will outline the installation of $[prodname] networking on t
 
    :::note
 
-   For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+   For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::
 

--- a/calico_versioned_docs/version-3.31/networking/ingress-gateway/customize-ingress-gateway.mdx
+++ b/calico_versioned_docs/version-3.31/networking/ingress-gateway/customize-ingress-gateway.mdx
@@ -241,5 +241,5 @@ To use a custom Envoy configuration, you can modify and apply a copy of the defa
 
 ## Additional resources
 
-* `GatewayAPI` spec in the [Installation API documentation](../../reference/installation/api.mdx#gatewayapi)
+* `GatewayAPI` spec in the [Tigera Operator API reference](../../reference/installation/api.mdx#gatewayapi)
 * [Envoy Gateway documentation](https://gateway.envoyproxy.io/docs/)

--- a/calico_versioned_docs/version-3.31/operations/fips.mdx
+++ b/calico_versioned_docs/version-3.31/operations/fips.mdx
@@ -61,6 +61,6 @@ Follow [the installation steps](../getting-started/index.mdx) for your platform.
      fipsMode: Enabled
    ```
 
-   - For more information on configuration options available in this manifest, see [the installation reference](../reference/installation/api.mdx).
+   - For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../reference/installation/api.mdx).
 
 After you apply the YAML, FIPS mode is fully operational.

--- a/calico_versioned_docs/version-3.31/reference/installation/api.mdx
+++ b/calico_versioned_docs/version-3.31/reference/installation/api.mdx
@@ -1,8 +1,8 @@
 ---
-description: Installation API reference
+description: Tigera Operator API reference
 ---
 
-# Installation reference
+# Tigera Operator API reference
 
 import API from '@site/calico_versioned_docs/version-3.31/reference/installation/_api.mdx';
 

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/helm.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/helm.mdx
@@ -47,7 +47,7 @@ helm repo add projectcalico https://docs.tigera.io/calico/charts
 
 If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), or you need to customize TLS certificates, you **must** customize this Helm chart by creating a `values.yaml` file. Otherwise, you can skip this step.
 
-1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Installation reference](../../reference/installation/api.mdx#provider). For example:
+1. If you are installing on a cluster installed by EKS, GKE, AKS or Mirantis Kubernetes Engine (MKE), set the `kubernetesProvider` as described in the [Tigera Operator API reference](../../reference/installation/api.mdx#provider). For example:
 
    ```
    echo '{ installation: {kubernetesProvider: EKS }}' > values.yaml

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/k3s/multi-node-install.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/k3s/multi-node-install.mdx
@@ -107,7 +107,7 @@ Due to the large size of the CRD bundle, `kubectl apply` might exceed request li
 
 :::
 
-Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
 ```bash
 kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/k3s/quickstart.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/k3s/quickstart.mdx
@@ -78,7 +78,7 @@ Due to the large size of the CRD bundle, `kubectl apply` might exceed request li
 
 :::
 
-2. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+2. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
 ```bash
 kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/k8s-single-node.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/k8s-single-node.mdx
@@ -102,7 +102,7 @@ The geeky details of what you get:
 
    :::
 
-1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/custom-resources-bpf.yaml

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/kind.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/kind.mdx
@@ -86,7 +86,7 @@ kubectl create -f $[manifestsUrl]/manifests/v1_crd_projectcalico_org.yaml
 kubectl create -f $[manifestsUrl]/manifests/tigera-operator.yaml
 ```
 
-2. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+2. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
 :::note
 

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/minikube.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/minikube.mdx
@@ -71,7 +71,7 @@ minikube start --cni=calico
 
    :::
 
-3. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+3. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    :::note
 

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/nftables.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/nftables.mdx
@@ -112,7 +112,7 @@ mode: nftables
 
    :::
 
-1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```bash
    cat > custom-resources.yaml <<EOF

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/rancher.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/rancher.mdx
@@ -56,7 +56,7 @@ The geeky details of what you get:
 
    :::
 
-1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the installation reference](../../reference/installation/api.mdx).
+1. Install $[prodname] by creating the necessary custom resource. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../reference/installation/api.mdx).
 
    ```
    kubectl create -f $[manifestsUrl]/manifests/custom-resources.yaml

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/vpp/getting-started.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/vpp/getting-started.mdx
@@ -99,7 +99,7 @@ Before you get started, make sure you have downloaded and configured the [necess
 
    :::
 
-1. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+1. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::note
 
@@ -168,7 +168,7 @@ DPDK provides better performance compared to the standard install but it require
 
    :::
 
-2. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+2. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for EKS. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::note
 
@@ -269,7 +269,7 @@ For some hardware, the following hugepages configuration may enable VPP to use m
 
    :::
 
-1. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for VPP. For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+1. Then, you need to configure the $[prodname] installation for the VPP data plane. The yaml in the link below contains a minimal viable configuration for VPP. For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::note
 

--- a/calico_versioned_docs/version-3.32/getting-started/kubernetes/windows-calico/rancher.mdx
+++ b/calico_versioned_docs/version-3.32/getting-started/kubernetes/windows-calico/rancher.mdx
@@ -94,7 +94,7 @@ The following steps will outline the installation of $[prodname] networking on t
 
    :::note
 
-   For more information on configuration options available in this manifest, see [the installation reference](../../../reference/installation/api.mdx).
+   For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../../../reference/installation/api.mdx).
 
    :::
 

--- a/calico_versioned_docs/version-3.32/networking/ingress-gateway/customize-ingress-gateway.mdx
+++ b/calico_versioned_docs/version-3.32/networking/ingress-gateway/customize-ingress-gateway.mdx
@@ -241,5 +241,5 @@ To use a custom Envoy configuration, you can modify and apply a copy of the defa
 
 ## Additional resources
 
-* `GatewayAPI` spec in the [Installation API documentation](../../reference/installation/api.mdx#gatewayapi)
+* `GatewayAPI` spec in the [Tigera Operator API reference](../../reference/installation/api.mdx#gatewayapi)
 * [Envoy Gateway documentation](https://gateway.envoyproxy.io/docs/)

--- a/calico_versioned_docs/version-3.32/operations/fips.mdx
+++ b/calico_versioned_docs/version-3.32/operations/fips.mdx
@@ -61,6 +61,6 @@ Follow [the installation steps](../getting-started/index.mdx) for your platform.
      fipsMode: Enabled
    ```
 
-   - For more information on configuration options available in this manifest, see [the installation reference](../reference/installation/api.mdx).
+   - For more information on configuration options available in this manifest, see [the Tigera Operator API reference](../reference/installation/api.mdx).
 
 After you apply the YAML, FIPS mode is fully operational.

--- a/calico_versioned_docs/version-3.32/reference/installation/api.mdx
+++ b/calico_versioned_docs/version-3.32/reference/installation/api.mdx
@@ -1,8 +1,8 @@
 ---
-description: Installation API reference for Calico Open Source listing the operator-managed custom resources used to configure cluster installation.
+description: Tigera Operator API reference for Calico Open Source listing the operator-managed custom resources used to configure cluster installation.
 ---
 
-# Installation reference
+# Tigera Operator API reference
 
 import API from '@site/calico_versioned_docs/version-3.32/reference/installation/_api.mdx';
 

--- a/calico_versioned_sidebars/version-3.30-sidebars.json
+++ b/calico_versioned_sidebars/version-3.30-sidebars.json
@@ -561,7 +561,7 @@
         {
           "type": "doc",
           "id": "reference/installation/api",
-          "label": "Installation API"
+          "label": "Tigera Operator API reference"
         },
         "reference/installation/helm_customization",
         {

--- a/calico_versioned_sidebars/version-3.31-sidebars.json
+++ b/calico_versioned_sidebars/version-3.31-sidebars.json
@@ -573,7 +573,7 @@
         {
           "type": "doc",
           "id": "reference/installation/api",
-          "label": "Installation API"
+          "label": "Tigera Operator API reference"
         },
         "reference/installation/helm_customization",
         {

--- a/calico_versioned_sidebars/version-3.32-sidebars.json
+++ b/calico_versioned_sidebars/version-3.32-sidebars.json
@@ -598,7 +598,7 @@
         {
           "type": "doc",
           "id": "reference/installation/api",
-          "label": "Installation API"
+          "label": "Tigera Operator API reference"
         },
         "reference/installation/helm_customization",
         {

--- a/sidebars-calico.js
+++ b/sidebars-calico.js
@@ -604,7 +604,7 @@ module.exports = {
         {
           type: 'doc',
           id: 'reference/installation/api',
-          label: 'Installation API',
+          label: 'Tigera Operator API reference',
         },
         'reference/installation/helm_customization',
         // TODO: 'Installation' category needs to be collapsed into single Operator API page


### PR DESCRIPTION
Renames the operator API reference page from Installation reference to Tigera Operator API reference in all three products and all published versions, following Shaun's suggestion. Installation is now one of many resources on that API. URLs are unchanged, so no redirects are needed.

Jira: https://tigera.atlassian.net/browse/DOCS-3036

Changes:
- H1 and description in reference/installation/api.mdx for each product and version
- Sidebar label overrides in sidebars-calico.js and the Calico versioned sidebars
- Link text in pages and install components that pointed to the page

Left alone:
- Helm installation reference links (different page)
- Generated _api.mdx text about the Installation resource itself

Representative preview pages:
- https://deploy-preview-3015--calico-docs-preview-next.netlify.app/calico/next/reference/installation/api
- https://deploy-preview-3015--calico-docs-preview-next.netlify.app/calico-enterprise/next/reference/installation/api
- https://deploy-preview-3015--calico-docs-preview-next.netlify.app/calico-cloud/next/reference/installation/api
- https://deploy-preview-3015--calico-docs-preview-next.netlify.app/calico/latest/reference/installation/api