### PR TITLE
DOCS-3036: Rewrite the Tigera Operator API reference opening

### DIFF
--- a/calico-cloud/reference/installation/api.mdx
+++ b/calico-cloud/reference/installation/api.mdx
@@ -1,11 +1,17 @@
 ---
-description: Tigera Operator API reference for Calico Cloud listing the operator-managed custom resources used to configure connected cluster installation.
+description: Tigera Operator API reference for Calico Cloud, covering all operator.tigera.io custom resources for installing and managing your connected cluster.
 ---
 
 # Tigera Operator API reference
 
 import API from '@site/calico-cloud/reference/installation/_api.mdx';
 
-The Kubernetes resources below configure $[prodname] installation when using the operator. Each resource is responsible for installing and configuring a different subsystem of $[prodname] during installation. Most options can be modified on a running cluster using `kubectl`.
+The Tigera Operator installs and manages $[prodname] by watching the custom resources in the `operator.tigera.io/v1` API group.
+This page documents every resource in that group.
+The `Installation` resource sets cluster-wide options at install time, and other resources, such as `APIServer`, `LogStorage`, and `IntrusionDetection`, configure individual components.
+You can change most settings on a running cluster by using `kubectl`, and the operator reconciles the cluster to match.
+
+This API group is separate from the `projectcalico.org/v3` resources that you use for day-to-day networking and policy.
+For those, see [Resource definitions](../resources/overview.mdx).
 
 <API />

--- a/calico-cloud_versioned_docs/version-23-2/reference/installation/api.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/reference/installation/api.mdx
@@ -1,11 +1,17 @@
 ---
-description: Tigera Operator API reference for Calico Cloud listing the operator-managed custom resources used to configure connected cluster installation.
+description: Tigera Operator API reference for Calico Cloud, covering all operator.tigera.io custom resources for installing and managing your connected cluster.
 ---
 
 # Tigera Operator API reference
 
 import API from '@site/calico-cloud_versioned_docs/version-23-2/reference/installation/_api.mdx';
 
-The Kubernetes resources below configure $[prodname] installation when using the operator. Each resource is responsible for installing and configuring a different subsystem of $[prodname] during installation. Most options can be modified on a running cluster using `kubectl`.
+The Tigera Operator installs and manages $[prodname] by watching the custom resources in the `operator.tigera.io/v1` API group.
+This page documents every resource in that group.
+The `Installation` resource sets cluster-wide options at install time, and other resources, such as `APIServer`, `LogStorage`, and `IntrusionDetection`, configure individual components.
+You can change most settings on a running cluster by using `kubectl`, and the operator reconciles the cluster to match.
+
+This API group is separate from the `projectcalico.org/v3` resources that you use for day-to-day networking and policy.
+For those, see [Resource definitions](../resources/overview.mdx).
 
 <API />

--- a/calico-enterprise/reference/installation/api.mdx
+++ b/calico-enterprise/reference/installation/api.mdx
@@ -1,11 +1,17 @@
 ---
-description: Tigera Operator API reference for Calico Enterprise listing the operator-managed custom resources used to configure cluster installation.
+description: Tigera Operator API reference for Calico Enterprise, covering all operator.tigera.io custom resources for installing and managing your cluster.
 ---
 
 # Tigera Operator API reference
 
 import API from '@site/calico-enterprise/reference/installation/_api.mdx';
 
-The Kubernetes resources below configure $[prodname] installation when using the operator. Each resource is responsible for installing and configuring a different subsystem of $[prodname] during installation. Most options can be modified on a running cluster using `kubectl`.
+The Tigera Operator installs and manages $[prodname] by watching the custom resources in the `operator.tigera.io/v1` API group.
+This page documents every resource in that group.
+The `Installation` resource sets cluster-wide options at install time, and other resources, such as `APIServer`, `LogStorage`, and `ManagementCluster`, configure individual components.
+You can change most settings on a running cluster by using `kubectl`, and the operator reconciles the cluster to match.
+
+This API group is separate from the `projectcalico.org/v3` resources that you use for day-to-day networking and policy.
+For those, see [Resource definitions](../resources/overview.mdx).
 
 <API />

--- a/calico-enterprise_versioned_docs/version-3.21-2/reference/installation/api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/reference/installation/api.mdx
@@ -6,6 +6,12 @@ description: Tigera Operator API reference
 
 import API from '@site/calico-enterprise_versioned_docs/version-3.21-2/reference/installation/_api.mdx';
 
-The Kubernetes resources below configure $[prodname] installation when using the operator. Each resource is responsible for installing and configuring a different subsystem of $[prodname] during installation. Most options can be modified on a running cluster using `kubectl`.
+The Tigera Operator installs and manages $[prodname] by watching the custom resources in the `operator.tigera.io/v1` API group.
+This page documents every resource in that group.
+The `Installation` resource sets cluster-wide options at install time, and other resources, such as `APIServer`, `LogStorage`, and `ManagementCluster`, configure individual components.
+You can change most settings on a running cluster by using `kubectl`, and the operator reconciles the cluster to match.
+
+This API group is separate from the `projectcalico.org/v3` resources that you use for day-to-day networking and policy.
+For those, see [Resource definitions](../resources/overview.mdx).
 
 <API />

--- a/calico-enterprise_versioned_docs/version-3.22-2/reference/installation/api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/reference/installation/api.mdx
@@ -1,11 +1,17 @@
 ---
-description: Tigera Operator API reference for Calico Enterprise listing the operator-managed custom resources used to configure cluster installation.
+description: Tigera Operator API reference for Calico Enterprise, covering all operator.tigera.io custom resources for installing and managing your cluster.
 ---
 
 # Tigera Operator API reference
 
 import API from '@site/calico-enterprise_versioned_docs/version-3.22-2/reference/installation/_api.mdx';
 
-The Kubernetes resources below configure $[prodname] installation when using the operator. Each resource is responsible for installing and configuring a different subsystem of $[prodname] during installation. Most options can be modified on a running cluster using `kubectl`.
+The Tigera Operator installs and manages $[prodname] by watching the custom resources in the `operator.tigera.io/v1` API group.
+This page documents every resource in that group.
+The `Installation` resource sets cluster-wide options at install time, and other resources, such as `APIServer`, `LogStorage`, and `ManagementCluster`, configure individual components.
+You can change most settings on a running cluster by using `kubectl`, and the operator reconciles the cluster to match.
+
+This API group is separate from the `projectcalico.org/v3` resources that you use for day-to-day networking and policy.
+For those, see [Resource definitions](../resources/overview.mdx).
 
 <API />

--- a/calico-enterprise_versioned_docs/version-3.23-2/reference/installation/api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/reference/installation/api.mdx
@@ -1,11 +1,17 @@
 ---
-description: Tigera Operator API reference for Calico Enterprise listing the operator-managed custom resources used to configure cluster installation.
+description: Tigera Operator API reference for Calico Enterprise, covering all operator.tigera.io custom resources for installing and managing your cluster.
 ---
 
 # Tigera Operator API reference
 
 import API from '@site/calico-enterprise_versioned_docs/version-3.23-2/reference/installation/_api.mdx';
 
-The Kubernetes resources below configure $[prodname] installation when using the operator. Each resource is responsible for installing and configuring a different subsystem of $[prodname] during installation. Most options can be modified on a running cluster using `kubectl`.
+The Tigera Operator installs and manages $[prodname] by watching the custom resources in the `operator.tigera.io/v1` API group.
+This page documents every resource in that group.
+The `Installation` resource sets cluster-wide options at install time, and other resources, such as `APIServer`, `LogStorage`, and `ManagementCluster`, configure individual components.
+You can change most settings on a running cluster by using `kubectl`, and the operator reconciles the cluster to match.
+
+This API group is separate from the `projectcalico.org/v3` resources that you use for day-to-day networking and policy.
+For those, see [Resource definitions](../resources/overview.mdx).
 
 <API />

--- a/calico-enterprise_versioned_docs/version-3.24-1/reference/installation/api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/reference/installation/api.mdx
@@ -1,11 +1,17 @@
 ---
-description: Tigera Operator API reference for Calico Enterprise listing the operator-managed custom resources used to configure cluster installation.
+description: Tigera Operator API reference for Calico Enterprise, covering all operator.tigera.io custom resources for installing and managing your cluster.
 ---
 
 # Tigera Operator API reference
 
 import API from '@site/calico-enterprise_versioned_docs/version-3.24-1/reference/installation/_api.mdx';
 
-The Kubernetes resources below configure $[prodname] installation when using the operator. Each resource is responsible for installing and configuring a different subsystem of $[prodname] during installation. Most options can be modified on a running cluster using `kubectl`.
+The Tigera Operator installs and manages $[prodname] by watching the custom resources in the `operator.tigera.io/v1` API group.
+This page documents every resource in that group.
+The `Installation` resource sets cluster-wide options at install time, and other resources, such as `APIServer`, `LogStorage`, and `ManagementCluster`, configure individual components.
+You can change most settings on a running cluster by using `kubectl`, and the operator reconciles the cluster to match.
+
+This API group is separate from the `projectcalico.org/v3` resources that you use for day-to-day networking and policy.
+For those, see [Resource definitions](../resources/overview.mdx).
 
 <API />

--- a/calico-enterprise_versioned_docs/version-3.24-2/reference/installation/api.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/reference/installation/api.mdx
@@ -1,11 +1,17 @@
 ---
-description: Tigera Operator API reference for Calico Enterprise listing the operator-managed custom resources used to configure cluster installation.
+description: Tigera Operator API reference for Calico Enterprise, covering all operator.tigera.io custom resources for installing and managing your cluster.
 ---
 
 # Tigera Operator API reference
 
 import API from '@site/calico-enterprise_versioned_docs/version-3.24-2/reference/installation/_api.mdx';
 
-The Kubernetes resources below configure $[prodname] installation when using the operator. Each resource is responsible for installing and configuring a different subsystem of $[prodname] during installation. Most options can be modified on a running cluster using `kubectl`.
+The Tigera Operator installs and manages $[prodname] by watching the custom resources in the `operator.tigera.io/v1` API group.
+This page documents every resource in that group.
+The `Installation` resource sets cluster-wide options at install time, and other resources, such as `APIServer`, `LogStorage`, and `ManagementCluster`, configure individual components.
+You can change most settings on a running cluster by using `kubectl`, and the operator reconciles the cluster to match.
+
+This API group is separate from the `projectcalico.org/v3` resources that you use for day-to-day networking and policy.
+For those, see [Resource definitions](../resources/overview.mdx).
 
 <API />

--- a/calico/reference/installation/api.mdx
+++ b/calico/reference/installation/api.mdx
@@ -1,11 +1,17 @@
 ---
-description: Tigera Operator API reference for Calico Open Source listing the operator-managed custom resources used to configure cluster installation.
+description: Tigera Operator API reference for Calico Open Source, covering all operator.tigera.io custom resources for installing and managing your cluster.
 ---
 
 # Tigera Operator API reference
 
 import API from '@site/calico/reference/installation/_api.mdx';
 
-The Kubernetes resources below configure $[prodname] installation when using the operator. Each resource is responsible for installing and configuring a different subsystem of $[prodname] during installation. Most options can be modified on a running cluster using `kubectl`.
+The Tigera Operator installs and manages $[prodname] by watching the custom resources in the `operator.tigera.io/v1` API group.
+This page documents every resource in that group.
+The `Installation` resource sets cluster-wide options at install time, and other resources, such as `APIServer`, `Goldmane`, and `Whisker`, configure individual components.
+You can change most settings on a running cluster by using `kubectl`, and the operator reconciles the cluster to match.
+
+This API group is separate from the `projectcalico.org/v3` resources that you use for day-to-day networking and policy.
+For those, see [Resource definitions](../resources/overview.mdx).
 
 <API />

--- a/calico_versioned_docs/version-3.30/reference/installation/api.mdx
+++ b/calico_versioned_docs/version-3.30/reference/installation/api.mdx
@@ -6,6 +6,12 @@ description: Tigera Operator API reference
 
 import API from '@site/calico_versioned_docs/version-3.30/reference/installation/_api.mdx';
 
-The Kubernetes resources below configure $[prodname] installation when using the operator. Each resource is responsible for installing and configuring a different subsystem of $[prodname] during installation. Most options can be modified on a running cluster using `kubectl`.
+The Tigera Operator installs and manages $[prodname] by watching the custom resources in the `operator.tigera.io/v1` API group.
+This page documents every resource in that group.
+The `Installation` resource sets cluster-wide options at install time, and other resources, such as `APIServer`, `Goldmane`, and `Whisker`, configure individual components.
+You can change most settings on a running cluster by using `kubectl`, and the operator reconciles the cluster to match.
+
+This API group is separate from the `projectcalico.org/v3` resources that you use for day-to-day networking and policy.
+For those, see [Resource definitions](../resources/overview.mdx).
 
 <API />

--- a/calico_versioned_docs/version-3.31/reference/installation/api.mdx
+++ b/calico_versioned_docs/version-3.31/reference/installation/api.mdx
@@ -6,6 +6,12 @@ description: Tigera Operator API reference
 
 import API from '@site/calico_versioned_docs/version-3.31/reference/installation/_api.mdx';
 
-The Kubernetes resources below configure $[prodname] installation when using the operator. Each resource is responsible for installing and configuring a different subsystem of $[prodname] during installation. Most options can be modified on a running cluster using `kubectl`.
+The Tigera Operator installs and manages $[prodname] by watching the custom resources in the `operator.tigera.io/v1` API group.
+This page documents every resource in that group.
+The `Installation` resource sets cluster-wide options at install time, and other resources, such as `APIServer`, `Goldmane`, and `Whisker`, configure individual components.
+You can change most settings on a running cluster by using `kubectl`, and the operator reconciles the cluster to match.
+
+This API group is separate from the `projectcalico.org/v3` resources that you use for day-to-day networking and policy.
+For those, see [Resource definitions](../resources/overview.mdx).
 
 <API />

--- a/calico_versioned_docs/version-3.32/reference/installation/api.mdx
+++ b/calico_versioned_docs/version-3.32/reference/installation/api.mdx
@@ -6,6 +6,12 @@ description: Tigera Operator API reference for Calico Open Source listing the op
 
 import API from '@site/calico_versioned_docs/version-3.32/reference/installation/_api.mdx';
 
-The Kubernetes resources below configure $[prodname] installation when using the operator. Each resource is responsible for installing and configuring a different subsystem of $[prodname] during installation. Most options can be modified on a running cluster using `kubectl`.
+The Tigera Operator installs and manages $[prodname] by watching the custom resources in the `operator.tigera.io/v1` API group.
+This page documents every resource in that group.
+The `Installation` resource sets cluster-wide options at install time, and other resources, such as `APIServer`, `Goldmane`, and `Whisker`, configure individual components.
+You can change most settings on a running cluster by using `kubectl`, and the operator reconciles the cluster to match.
+
+This API group is separate from the `projectcalico.org/v3` resources that you use for day-to-day networking and policy.
+For those, see [Resource definitions](../resources/overview.mdx).
 
 <API />


### PR DESCRIPTION
Follow-up to #3015. Rewrites the opening of the Tigera Operator API reference so it matches the new name. The old lead described the page as installation configuration only. The new lead names the operator.tigera.io/v1 API group, positions Installation as one resource among several, and points readers who want networking and policy resources to Resource definitions.

Jira: https://tigera.atlassian.net/browse/DOCS-3036

To do:
- Updates the lead and frontmatter description for all three products
- Applies the same lead to all published versions, with component examples matched to what each version documents

Flags:
- Vale warns on lowercase tigera in operator.tigera.io, which is the correct API group name
- Five versioned pages carried the full frontmatter description, which still said the page covers installation only, so it is updated there too. The other four versioned pages have a short one-line description, which is unchanged.

Preview pages:
- https://deploy-preview-3018--calico-docs-preview-next.netlify.app/calico/next/reference/installation/api
- https://deploy-preview-3018--calico-docs-preview-next.netlify.app/calico/latest/reference/installation/api
- https://deploy-preview-3018--calico-docs-preview-next.netlify.app/calico-enterprise/latest/reference/installation/api
- https://deploy-preview-3018--calico-docs-preview-next.netlify.app/calico-cloud/latest/reference/installation/api