### PR TITLE
DOCS-3043: Add override mechanism for known-stale upstream Felix config doc text

### DIFF
--- a/calico-cloud/_includes/components/FelixConfig/config-params.json
+++ b/calico-cloud/_includes/components/FelixConfig/config-params.json
@@ -6440,8 +6440,8 @@
           "Required": false,
           "OnParseFailure": "ReplaceWithDefault",
           "AllowedConfigSources": "All",
-          "Description": "Used to enable/disable dynamically changing aggregation levels. Default is true.",
-          "DescriptionHTML": "<p>Used to enable/disable dynamically changing aggregation levels. Default is true.</p>",
+          "Description": "Used to enable/disable dynamically changing aggregation levels. Default is false.",
+          "DescriptionHTML": "<p>Used to enable/disable dynamically changing aggregation levels. Default is false.</p>",
           "UserEditable": true,
           "GoType": "*bool",
           "OpenSourceOnly": false

--- a/calico-cloud_versioned_docs/version-23-2/_includes/components/FelixConfig/config-params.json
+++ b/calico-cloud_versioned_docs/version-23-2/_includes/components/FelixConfig/config-params.json
@@ -6440,8 +6440,8 @@
           "Required": false,
           "OnParseFailure": "ReplaceWithDefault",
           "AllowedConfigSources": "All",
-          "Description": "Used to enable/disable dynamically changing aggregation levels. Default is true.",
-          "DescriptionHTML": "<p>Used to enable/disable dynamically changing aggregation levels. Default is true.</p>",
+          "Description": "Used to enable/disable dynamically changing aggregation levels. Default is false.",
+          "DescriptionHTML": "<p>Used to enable/disable dynamically changing aggregation levels. Default is false.</p>",
           "UserEditable": true,
           "GoType": "*bool",
           "OpenSourceOnly": false

--- a/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/FelixConfig/config-params.json
+++ b/calico-enterprise_versioned_docs/version-3.21-2/_includes/components/FelixConfig/config-params.json
@@ -5799,8 +5799,8 @@
           "Required": false,
           "OnParseFailure": "ReplaceWithDefault",
           "AllowedConfigSources": "All",
-          "Description": "Used to enable/disable dynamically changing aggregation levels. Default is true.",
-          "DescriptionHTML": "<p>Used to enable/disable dynamically changing aggregation levels. Default is true.</p>",
+          "Description": "Used to enable/disable dynamically changing aggregation levels. Default is false.",
+          "DescriptionHTML": "<p>Used to enable/disable dynamically changing aggregation levels. Default is false.</p>",
           "UserEditable": true,
           "GoType": "*bool",
           "OpenSourceOnly": false

--- a/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/FelixConfig/config-params.json
+++ b/calico-enterprise_versioned_docs/version-3.22-2/_includes/components/FelixConfig/config-params.json
@@ -5976,8 +5976,8 @@
           "Required": false,
           "OnParseFailure": "ReplaceWithDefault",
           "AllowedConfigSources": "All",
-          "Description": "Used to enable/disable dynamically changing aggregation levels. Default is true.",
-          "DescriptionHTML": "<p>Used to enable/disable dynamically changing aggregation levels. Default is true.</p>",
+          "Description": "Used to enable/disable dynamically changing aggregation levels. Default is false.",
+          "DescriptionHTML": "<p>Used to enable/disable dynamically changing aggregation levels. Default is false.</p>",
           "UserEditable": true,
           "GoType": "*bool",
           "OpenSourceOnly": false

--- a/calico-enterprise_versioned_docs/version-3.23-2/_includes/components/FelixConfig/config-params.json
+++ b/calico-enterprise_versioned_docs/version-3.23-2/_includes/components/FelixConfig/config-params.json
@@ -6440,8 +6440,8 @@
           "Required": false,
           "OnParseFailure": "ReplaceWithDefault",
           "AllowedConfigSources": "All",
-          "Description": "Used to enable/disable dynamically changing aggregation levels. Default is true.",
-          "DescriptionHTML": "<p>Used to enable/disable dynamically changing aggregation levels. Default is true.</p>",
+          "Description": "Used to enable/disable dynamically changing aggregation levels. Default is false.",
+          "DescriptionHTML": "<p>Used to enable/disable dynamically changing aggregation levels. Default is false.</p>",
           "UserEditable": true,
           "GoType": "*bool",
           "OpenSourceOnly": false

--- a/calico-enterprise_versioned_docs/version-3.24-1/_includes/components/FelixConfig/config-params.json
+++ b/calico-enterprise_versioned_docs/version-3.24-1/_includes/components/FelixConfig/config-params.json
@@ -6440,8 +6440,8 @@
           "Required": false,
           "OnParseFailure": "ReplaceWithDefault",
           "AllowedConfigSources": "All",
-          "Description": "Used to enable/disable dynamically changing aggregation levels. Default is true.",
-          "DescriptionHTML": "<p>Used to enable/disable dynamically changing aggregation levels. Default is true.</p>",
+          "Description": "Used to enable/disable dynamically changing aggregation levels. Default is false.",
+          "DescriptionHTML": "<p>Used to enable/disable dynamically changing aggregation levels. Default is false.</p>",
           "UserEditable": true,
           "GoType": "*bool",
           "OpenSourceOnly": false

--- a/calico-enterprise_versioned_docs/version-3.24-2/_includes/components/FelixConfig/config-params.json
+++ b/calico-enterprise_versioned_docs/version-3.24-2/_includes/components/FelixConfig/config-params.json
@@ -6440,8 +6440,8 @@
           "Required": false,
           "OnParseFailure": "ReplaceWithDefault",
           "AllowedConfigSources": "All",
-          "Description": "Used to enable/disable dynamically changing aggregation levels. Default is true.",
-          "DescriptionHTML": "<p>Used to enable/disable dynamically changing aggregation levels. Default is true.</p>",
+          "Description": "Used to enable/disable dynamically changing aggregation levels. Default is false.",
+          "DescriptionHTML": "<p>Used to enable/disable dynamically changing aggregation levels. Default is false.</p>",
           "UserEditable": true,
           "GoType": "*bool",
           "OpenSourceOnly": false

--- a/scripts/felix-config-overrides.json
+++ b/scripts/felix-config-overrides.json
@@ -1,0 +1,18 @@
+[
+  {
+    "field": "FlowLogsDynamicAggregationEnabled",
+    "reason": "felix/config/config_params.go tags this field `bool;false` (unchanged across all versions), but the doc comment in api/pkg/apis/projectcalico/v3/felixconfig.go has always said 'Default is true.' -- a long-standing stale comment, not a behavior change. Corrected on tigera/calico-private master via PR #12538 (merged 2026-07-16, incidental to an unrelated fluentd-removal change) but not yet backported to any release branch. Remove this entry once a synced file no longer needs it -- a WARNING below will announce that automatically.",
+    "patches": [
+      {
+        "key": "Description",
+        "expected": "Used to enable/disable dynamically changing aggregation levels. Default is true.",
+        "value": "Used to enable/disable dynamically changing aggregation levels. Default is false."
+      },
+      {
+        "key": "DescriptionHTML",
+        "expected": "<p>Used to enable/disable dynamically changing aggregation levels. Default is true.</p>",
+        "value": "<p>Used to enable/disable dynamically changing aggregation levels. Default is false.</p>"
+      }
+    ]
+  }
+]

--- a/scripts/patch-felix-config-overrides.sh
+++ b/scripts/patch-felix-config-overrides.sh
@@ -46,7 +46,31 @@ if ! jq -e . "$OVERRIDES_FILE" >/dev/null 2>&1; then
     exit 1
 fi
 
+# --- Decide every patch's status against the ORIGINAL document, once, then apply exactly
+# those decisions. The notices and the applied document come from the same "ops" list
+# inside a single jq invocation, so they cannot disagree with each other, and the
+# (multi-thousand-line) target file is only parsed once. ---
+result=$(jq --slurpfile overrides "$OVERRIDES_FILE" '
+    ($overrides[0]) as $ovs
+    | . as $orig
+    | [ .Groups | to_entries[] as {key: $gi, value: $g}
+        | $g.Fields | to_entries[] as {key: $fi, value: $f}
+        | $ovs[] as $ov
+        | select($ov.field == $f.NameConfigFile)
+        | $ov.patches[] as $p
+        | ($f[$p.key]) as $cur
+        | { path: ["Groups", $gi, "Fields", $fi, $p.key],
+            status: (if $cur == $p.expected then "patched"
+                     elif $cur == $p.value then "already-correct"
+                     else "stale" end),
+            field: $ov.field, key: $p.key, reason: $ov.reason, value: $p.value }
+      ] as $ops
+    | { doc: (reduce $ops[] as $o ($orig; if $o.status == "patched" then setpath($o.path; $o.value) else . end)),
+        notices: ($ops | map({status, field, key, reason})) }
+' "$target")
+
 # --- Report what each override did: applied, already unnecessary, or no longer matches ---
+notices=$(jq -r '.notices[] | [.status, .field, .key, .reason] | @tsv' <<< "$result")
 while IFS=$'\t' read -r status field key reason; do
     case "$status" in
         patched)
@@ -59,36 +83,10 @@ while IFS=$'\t' read -r status field key reason; do
             echo "WARNING: override for ${field}.${key} did not apply -- upstream text matches neither the known-buggy nor the corrected value. Needs review in ${OVERRIDES_FILE}. (${reason})" >&2
             ;;
     esac
-done < <(jq -r --slurpfile overrides "$OVERRIDES_FILE" '
-    $overrides[0] as $ovs
-    | [ .Groups[].Fields[] as $f
-        | $ovs[] as $ov
-        | select($ov.field == $f.NameConfigFile)
-        | $ov.patches[] as $p
-        | ($f[$p.key]) as $cur
-        | { status: (if $cur == $p.expected then "patched"
-                     elif $cur == $p.value then "already-correct"
-                     else "stale" end),
-            field: $ov.field, key: $p.key, reason: $ov.reason }
-      ]
-    | .[]
-    | [.status, .field, .key, .reason] | @tsv
-' "$target")
+done <<< "$notices"
 
-# --- Apply the patches: field-scoped by NameConfigFile, key-scoped by an expected-value guard ---
+# --- Write the patched document ---
 patched=$(mktemp -t felix-config-patched.XXXXXX)
-jq --slurpfile overrides "$OVERRIDES_FILE" '
-    $overrides[0] as $ovs
-    | .Groups |= map(.Fields |= map(
-        . as $f
-        | reduce ($ovs[] | select(.field == $f.NameConfigFile)) as $ov
-            ( $f
-            ; reduce ($ov.patches[]) as $p
-                ( .
-                ; if (.[$p.key] == $p.expected) then .[$p.key] = $p.value else . end
-                )
-            )
-      ))
-' "$target" > "$patched"
+jq '.doc' <<< "$result" > "$patched"
 
 mv "$patched" "$target"

--- a/scripts/patch-felix-config-overrides.sh
+++ b/scripts/patch-felix-config-overrides.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# Patches known-stale upstream Felix config doc text into a freshly-synced
+# config-params.json, in place. Overrides are declared in felix-config-overrides.json,
+# scoped by NameConfigFile so a patch can never touch an unrelated field that happens
+# to share the same description text.
+#
+# Called from update_felix_config() in update-felix-config.sh, after the fetched file
+# has been validated as JSON and before it replaces the checked-in copy.
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly OVERRIDES_FILE="${SCRIPT_DIR}/felix-config-overrides.json"
+
+target=$1
+patched=""
+
+cleanup() {
+    [[ -n "$patched" && -f "$patched" ]] && rm -f "$patched"
+}
+trap cleanup EXIT
+
+if [[ ! -f "$OVERRIDES_FILE" ]]; then
+    echo "Error: overrides file not found: $OVERRIDES_FILE" >&2
+    exit 1
+fi
+
+if ! jq -e . "$OVERRIDES_FILE" >/dev/null 2>&1; then
+    echo "Error: $OVERRIDES_FILE is not valid JSON." >&2
+    exit 1
+fi
+
+# --- Report what each override did: applied, already unnecessary, or no longer matches ---
+while IFS=$'\t' read -r status field key reason; do
+    case "$status" in
+        patched)
+            echo "NOTICE: patched ${field}.${key} (${reason})"
+            ;;
+        already-correct)
+            echo "WARNING: override for ${field}.${key} is a no-op -- upstream text already matches. Safe to remove from ${OVERRIDES_FILE}. (${reason})" >&2
+            ;;
+        stale)
+            echo "WARNING: override for ${field}.${key} did not apply -- upstream text matches neither the known-buggy nor the corrected value. Needs review in ${OVERRIDES_FILE}. (${reason})" >&2
+            ;;
+    esac
+done < <(jq -r --slurpfile overrides "$OVERRIDES_FILE" '
+    $overrides[0] as $ovs
+    | [ .Groups[].Fields[] as $f
+        | $ovs[] as $ov
+        | select($ov.field == $f.NameConfigFile)
+        | $ov.patches[] as $p
+        | ($f[$p.key]) as $cur
+        | { status: (if $cur == $p.expected then "patched"
+                     elif $cur == $p.value then "already-correct"
+                     else "stale" end),
+            field: $ov.field, key: $p.key, reason: $ov.reason }
+      ]
+    | .[]
+    | [.status, .field, .key, .reason] | @tsv
+' "$target")
+
+# --- Apply the patches: field-scoped by NameConfigFile, key-scoped by an expected-value guard ---
+patched=$(mktemp -t felix-config-patched.XXXXXX)
+jq --slurpfile overrides "$OVERRIDES_FILE" '
+    $overrides[0] as $ovs
+    | .Groups |= map(.Fields |= map(
+        . as $f
+        | reduce ($ovs[] | select(.field == $f.NameConfigFile)) as $ov
+            ( $f
+            ; reduce ($ov.patches[]) as $p
+                ( .
+                ; if (.[$p.key] == $p.expected) then .[$p.key] = $p.value else . end
+                )
+            )
+      ))
+' "$target" > "$patched"
+
+mv "$patched" "$target"

--- a/scripts/patch-felix-config-overrides.sh
+++ b/scripts/patch-felix-config-overrides.sh
@@ -13,6 +13,11 @@ set -euo pipefail
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly OVERRIDES_FILE="${SCRIPT_DIR}/felix-config-overrides.json"
 
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $(basename "${BASH_SOURCE[0]}") <target-json-file>" >&2
+    exit 1
+fi
+
 target=$1
 patched=""
 
@@ -20,6 +25,16 @@ cleanup() {
     [[ -n "$patched" && -f "$patched" ]] && rm -f "$patched"
 }
 trap cleanup EXIT
+
+if [[ ! -f "$target" ]]; then
+    echo "Error: target file not found: $target" >&2
+    exit 1
+fi
+
+if ! jq -e . "$target" >/dev/null 2>&1; then
+    echo "Error: $target is not valid JSON." >&2
+    exit 1
+fi
 
 if [[ ! -f "$OVERRIDES_FILE" ]]; then
     echo "Error: overrides file not found: $OVERRIDES_FILE" >&2

--- a/scripts/update-felix-config.sh
+++ b/scripts/update-felix-config.sh
@@ -69,6 +69,8 @@ update_felix_config() {
         exit "$E_INVALID_JSON"
     fi
 
+    "$(dirname "${BASH_SOURCE[0]}")/patch-felix-config-overrides.sh" "$tmpfile"
+
     mv "$tmpfile" "$LOCAL_PATH"
     echo -e "Finished processing ${VERSION}.\n\n"
 }


### PR DESCRIPTION
FlowLogsDynamicAggregationEnabled has always defaulted to false in Felix, but the doc comment feeding config-params.json said "Default is true." on every release branch -- a table-vs-prose contradiction visible on the live reference page. tigera/calico-private#12538 fixed the comment on master only, incidental to unrelated fluentd-removal work, and it was never backported to any release branch.

This adds a small, reusable mechanism so update-felix-config.sh can patch known upstream doc-text bugs like this at sync time, instead of silently re-importing them on every run:

- scripts/felix-config-overrides.json: known upstream doc-text bugs, keyed by NameConfigFile
- scripts/patch-felix-config-overrides.sh: jq-based, field-scoped patch that also warns if an override becomes a no-op (upstream already fixed it) or stale (upstream reworded it differently) -- both signal it's safe to review/remove
- Wired into the shared update_felix_config() function, right before the file replaces the checked-in copy

Also applies the fix now to every currently-published version that has it (CE 3.21-2 through 3.24-2, CC 23-2, and CC/CE "next").

Separately (DOCS-3043 doesn't cover this): the one-line comment fix needs to be cherry-picked from calico-private master into release-calient-v3.24-1, release-calient-v3.24, and other active branches, so this override eventually becomes unnecessary.

Jira: https://tigera.atlassian.net/browse/DOCS-3043

Preview (once it builds): https://deploy-preview-3019--tigera.netlify.app/calico-enterprise/latest/reference/resources/felixconfig#flowLogsDynamicAggregationEnabled