### PR TITLE
DOCS-3045: Fix dead owasp.org links breaking the link checker

### DIFF
--- a/calico-cloud/threat/web-application-firewall.mdx
+++ b/calico-cloud/threat/web-application-firewall.mdx
@@ -16,7 +16,7 @@ Protect cloud-native applications from application layer attacks with $[prodname
 
 ## Value
 
-Our workload-centric Web Application Firewall (WAF) protects your workloads from a variety of application layer attacks originating from within your cluster such as [SQL injection](https://owasp.org/www-community/attacks/SQL_Injection). Given that attacks on apps are the [leading cause of breaches](https://www.f5.com/labs/articles/threat-intelligence/application-protection-report-2019--episode-2--2018-breach-trend), you need to secure the HTTP traffic inside your cluster.
+Our workload-centric Web Application Firewall (WAF) protects your workloads from a variety of application layer attacks originating from within your cluster such as [SQL injection](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html). Given that attacks on apps are the [leading cause of breaches](https://www.f5.com/labs/articles/threat-intelligence/application-protection-report-2019--episode-2--2018-breach-trend), you need to secure the HTTP traffic inside your cluster.
 
 Historically, web application firewalls (WAFs) were deployed at the edge of your cluster to filter incoming traffic. Our workload-based WAF solution takes a unique, cloud-native approach to web security by allowing you to implement zero-trust rules for workloads inside your cluster.
 
@@ -25,7 +25,7 @@ Historically, web application firewalls (WAFs) were deployed at the edge of your
 ### About $[prodname] WAF
 
 WAF is deployed in your cluster with Envoy as a sidecar container on your pods. $[prodname] proxies traffic through Envoy, checking HTTP requests using the industry-standard
-[ModSecurity](https://owasp.org/www-project-modsecurity-core-rule-set/) with OWASP Core Rule Set `v4.7.0` with some modifications for Kubernetes workloads.
+[ModSecurity](https://coreruleset.org/) with OWASP Core Rule Set `v4.7.0` with some modifications for Kubernetes workloads.
 
 You simply enable WAF in the web console, and determine the deployments that you want to enable for WAF protection. By default WAF is set to `DetectionOnly` so no traffic will be denied until you are ready to turn on blocking mode.
 

--- a/calico-cloud_versioned_docs/version-23-2/threat/web-application-firewall.mdx
+++ b/calico-cloud_versioned_docs/version-23-2/threat/web-application-firewall.mdx
@@ -16,7 +16,7 @@ Protect cloud-native applications from application layer attacks with $[prodname
 
 ## Value
 
-Our workload-centric Web Application Firewall (WAF) protects your workloads from a variety of application layer attacks originating from within your cluster such as [SQL injection](https://owasp.org/www-community/attacks/SQL_Injection). Given that attacks on apps are the [leading cause of breaches](https://www.f5.com/labs/articles/threat-intelligence/application-protection-report-2019--episode-2--2018-breach-trend), you need to secure the HTTP traffic inside your cluster.
+Our workload-centric Web Application Firewall (WAF) protects your workloads from a variety of application layer attacks originating from within your cluster such as [SQL injection](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html). Given that attacks on apps are the [leading cause of breaches](https://www.f5.com/labs/articles/threat-intelligence/application-protection-report-2019--episode-2--2018-breach-trend), you need to secure the HTTP traffic inside your cluster.
 
 Historically, web application firewalls (WAFs) were deployed at the edge of your cluster to filter incoming traffic. Our workload-based WAF solution takes a unique, cloud-native approach to web security by allowing you to implement zero-trust rules for workloads inside your cluster.
 
@@ -25,7 +25,7 @@ Historically, web application firewalls (WAFs) were deployed at the edge of your
 ### About $[prodname] WAF
 
 WAF is deployed in your cluster with Envoy as a sidecar container on your pods. $[prodname] proxies traffic through Envoy, checking HTTP requests using the industry-standard
-[ModSecurity](https://owasp.org/www-project-modsecurity-core-rule-set/) with OWASP Core Rule Set `v4.7.0` with some modifications for Kubernetes workloads.
+[ModSecurity](https://coreruleset.org/) with OWASP Core Rule Set `v4.7.0` with some modifications for Kubernetes workloads.
 
 You simply enable WAF in the web console, and determine the deployments that you want to enable for WAF protection. By default WAF is set to `DetectionOnly` so no traffic will be denied until you are ready to turn on blocking mode.
 

--- a/calico-enterprise/threat/gateway-waf/overview.mdx
+++ b/calico-enterprise/threat/gateway-waf/overview.mdx
@@ -18,7 +18,7 @@ Protect the traffic entering your cluster through $[prodname] Ingress Gateway wi
 
 Edge WAFs traditionally apply one ruleset to everything behind the gateway. Gateway WAF takes a Kubernetes-native, multi-tenant approach: a cluster operator sets a security baseline once, and each application team layers its own rules and exceptions on top — scoped to their own Gateways and `HTTPRoute`s, within guardrails the cluster operator defines.
 
-Gateway WAF runs the industry-standard [OWASP ModSecurity Core Rule Set v4](https://owasp.org/www-project-modsecurity-core-rule-set/) as a [Coraza](https://coraza.io/) WebAssembly filter inside Envoy Gateway — no sidecars, and no traffic ever leaves the proxy for inspection.
+Gateway WAF runs the industry-standard [OWASP ModSecurity Core Rule Set v4](https://coreruleset.org/) as a [Coraza](https://coraza.io/) WebAssembly filter inside Envoy Gateway — no sidecars, and no traffic ever leaves the proxy for inspection.
 
 ## How it works
 

--- a/calico-enterprise/threat/web-application-firewall.mdx
+++ b/calico-enterprise/threat/web-application-firewall.mdx
@@ -16,7 +16,7 @@ Protect cloud-native applications from application layer attacks with $[prodname
 
 ## Value
 
-Our workload-centric Web Application Firewall (WAF) protects your workloads from a variety of application layer attacks originating from within your cluster such as [SQL injection](https://owasp.org/www-community/attacks/SQL_Injection). Given that attacks on apps are the [leading cause of breaches](https://www.f5.com/labs/articles/threat-intelligence/application-protection-report-2019--episode-2--2018-breach-trend), you need to secure the HTTP traffic inside your cluster.
+Our workload-centric Web Application Firewall (WAF) protects your workloads from a variety of application layer attacks originating from within your cluster such as [SQL injection](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html). Given that attacks on apps are the [leading cause of breaches](https://www.f5.com/labs/articles/threat-intelligence/application-protection-report-2019--episode-2--2018-breach-trend), you need to secure the HTTP traffic inside your cluster.
 
 Historically, web application firewalls (WAFs) were deployed at the edge of your cluster to filter incoming traffic. Our workload-based WAF solution takes a unique, cloud-native approach to web security by allowing you to implement zero-trust rules for workloads inside your cluster.
 
@@ -25,7 +25,7 @@ Historically, web application firewalls (WAFs) were deployed at the edge of your
 ### About $[prodname] WAF
 
 WAF is deployed in your cluster with Envoy as a sidecar container on your pods. $[prodname] proxies traffic through Envoy, checking HTTP requests using the industry-standard
-[ModSecurity](https://owasp.org/www-project-modsecurity-core-rule-set/) with OWASP Core Rule Set `v4.7.0` with some modifications for Kubernetes workloads.
+[ModSecurity](https://coreruleset.org/) with OWASP Core Rule Set `v4.7.0` with some modifications for Kubernetes workloads.
 
 You simply enable WAF in the web console, and determine the deployments that you want to enable for WAF protection. By default WAF is set to `DetectionOnly` so no traffic will be denied until you are ready to turn on blocking mode.
 

--- a/calico-enterprise_versioned_docs/version-3.21-2/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.21-2/threat/web-application-firewall.mdx
@@ -16,7 +16,7 @@ Protect cloud-native applications from application layer attacks with $[prodname
 
 ## Value
 
-Our workload-centric Web Application Firewall (WAF) protects your workloads from a variety of application layer attacks originating from within your cluster such as [SQL injection](https://owasp.org/www-community/attacks/SQL_Injection). Given that attacks on apps are the [leading cause of breaches](https://www.f5.com/labs/articles/threat-intelligence/application-protection-report-2019--episode-2--2018-breach-trend), you need to secure the HTTP traffic inside your cluster.
+Our workload-centric Web Application Firewall (WAF) protects your workloads from a variety of application layer attacks originating from within your cluster such as [SQL injection](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html). Given that attacks on apps are the [leading cause of breaches](https://www.f5.com/labs/articles/threat-intelligence/application-protection-report-2019--episode-2--2018-breach-trend), you need to secure the HTTP traffic inside your cluster.
 
 Historically, web application firewalls (WAFs) were deployed at the edge of your cluster to filter incoming traffic. Our workload-based WAF solution takes a unique, cloud-native approach to web security by allowing you to implement zero-trust rules for workloads inside your cluster.
 
@@ -25,7 +25,7 @@ Historically, web application firewalls (WAFs) were deployed at the edge of your
 ### About $[prodname] WAF
 
 WAF is deployed in your cluster with Envoy as a sidecar container on your pods. $[prodname] proxies traffic through Envoy, checking HTTP requests using the industry-standard
-[ModSecurity](https://owasp.org/www-project-modsecurity-core-rule-set/) with OWASP Core Rule Set `v4.7.0` with some modifications for Kubernetes workloads.
+[ModSecurity](https://coreruleset.org/) with OWASP Core Rule Set `v4.7.0` with some modifications for Kubernetes workloads.
 
 You simply enable WAF in the web console, and determine the deployments that you want to enable for WAF protection. By default WAF is set to `DetectionOnly` so no traffic will be denied until you are ready to turn on blocking mode.
 

--- a/calico-enterprise_versioned_docs/version-3.22-2/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.22-2/threat/web-application-firewall.mdx
@@ -16,7 +16,7 @@ Protect cloud-native applications from application layer attacks with $[prodname
 
 ## Value
 
-Our workload-centric Web Application Firewall (WAF) protects your workloads from a variety of application layer attacks originating from within your cluster such as [SQL injection](https://owasp.org/www-community/attacks/SQL_Injection). Given that attacks on apps are the [leading cause of breaches](https://www.f5.com/labs/articles/threat-intelligence/application-protection-report-2019--episode-2--2018-breach-trend), you need to secure the HTTP traffic inside your cluster.
+Our workload-centric Web Application Firewall (WAF) protects your workloads from a variety of application layer attacks originating from within your cluster such as [SQL injection](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html). Given that attacks on apps are the [leading cause of breaches](https://www.f5.com/labs/articles/threat-intelligence/application-protection-report-2019--episode-2--2018-breach-trend), you need to secure the HTTP traffic inside your cluster.
 
 Historically, web application firewalls (WAFs) were deployed at the edge of your cluster to filter incoming traffic. Our workload-based WAF solution takes a unique, cloud-native approach to web security by allowing you to implement zero-trust rules for workloads inside your cluster.
 
@@ -25,7 +25,7 @@ Historically, web application firewalls (WAFs) were deployed at the edge of your
 ### About $[prodname] WAF
 
 WAF is deployed in your cluster with Envoy as a sidecar container on your pods. $[prodname] proxies traffic through Envoy, checking HTTP requests using the industry-standard
-[ModSecurity](https://owasp.org/www-project-modsecurity-core-rule-set/) with OWASP Core Rule Set `v4.7.0` with some modifications for Kubernetes workloads.
+[ModSecurity](https://coreruleset.org/) with OWASP Core Rule Set `v4.7.0` with some modifications for Kubernetes workloads.
 
 You simply enable WAF in the web console, and determine the deployments that you want to enable for WAF protection. By default WAF is set to `DetectionOnly` so no traffic will be denied until you are ready to turn on blocking mode.
 

--- a/calico-enterprise_versioned_docs/version-3.23-2/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.23-2/threat/web-application-firewall.mdx
@@ -16,7 +16,7 @@ Protect cloud-native applications from application layer attacks with $[prodname
 
 ## Value
 
-Our workload-centric Web Application Firewall (WAF) protects your workloads from a variety of application layer attacks originating from within your cluster such as [SQL injection](https://owasp.org/www-community/attacks/SQL_Injection). Given that attacks on apps are the [leading cause of breaches](https://www.f5.com/labs/articles/threat-intelligence/application-protection-report-2019--episode-2--2018-breach-trend), you need to secure the HTTP traffic inside your cluster.
+Our workload-centric Web Application Firewall (WAF) protects your workloads from a variety of application layer attacks originating from within your cluster such as [SQL injection](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html). Given that attacks on apps are the [leading cause of breaches](https://www.f5.com/labs/articles/threat-intelligence/application-protection-report-2019--episode-2--2018-breach-trend), you need to secure the HTTP traffic inside your cluster.
 
 Historically, web application firewalls (WAFs) were deployed at the edge of your cluster to filter incoming traffic. Our workload-based WAF solution takes a unique, cloud-native approach to web security by allowing you to implement zero-trust rules for workloads inside your cluster.
 
@@ -25,7 +25,7 @@ Historically, web application firewalls (WAFs) were deployed at the edge of your
 ### About $[prodname] WAF
 
 WAF is deployed in your cluster with Envoy as a sidecar container on your pods. $[prodname] proxies traffic through Envoy, checking HTTP requests using the industry-standard
-[ModSecurity](https://owasp.org/www-project-modsecurity-core-rule-set/) with OWASP Core Rule Set `v4.7.0` with some modifications for Kubernetes workloads.
+[ModSecurity](https://coreruleset.org/) with OWASP Core Rule Set `v4.7.0` with some modifications for Kubernetes workloads.
 
 You simply enable WAF in the web console, and determine the deployments that you want to enable for WAF protection. By default WAF is set to `DetectionOnly` so no traffic will be denied until you are ready to turn on blocking mode.
 

--- a/calico-enterprise_versioned_docs/version-3.24-1/threat/gateway-waf/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/threat/gateway-waf/overview.mdx
@@ -18,7 +18,7 @@ Protect the traffic entering your cluster through $[prodname] Ingress Gateway wi
 
 Edge WAFs traditionally apply one ruleset to everything behind the gateway. Gateway WAF takes a Kubernetes-native, multi-tenant approach: a cluster operator sets a security baseline once, and each application team layers its own rules and exceptions on top — scoped to their own Gateways and `HTTPRoute`s, within guardrails the cluster operator defines.
 
-Gateway WAF runs the industry-standard [OWASP ModSecurity Core Rule Set v4](https://owasp.org/www-project-modsecurity-core-rule-set/) as a [Coraza](https://coraza.io/) WebAssembly filter inside Envoy Gateway — no sidecars, and no traffic ever leaves the proxy for inspection.
+Gateway WAF runs the industry-standard [OWASP ModSecurity Core Rule Set v4](https://coreruleset.org/) as a [Coraza](https://coraza.io/) WebAssembly filter inside Envoy Gateway — no sidecars, and no traffic ever leaves the proxy for inspection.
 
 ## How it works
 

--- a/calico-enterprise_versioned_docs/version-3.24-1/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-1/threat/web-application-firewall.mdx
@@ -16,7 +16,7 @@ Protect cloud-native applications from application layer attacks with $[prodname
 
 ## Value
 
-Our workload-centric Web Application Firewall (WAF) protects your workloads from a variety of application layer attacks originating from within your cluster such as [SQL injection](https://owasp.org/www-community/attacks/SQL_Injection). Given that attacks on apps are the [leading cause of breaches](https://www.f5.com/labs/articles/threat-intelligence/application-protection-report-2019--episode-2--2018-breach-trend), you need to secure the HTTP traffic inside your cluster.
+Our workload-centric Web Application Firewall (WAF) protects your workloads from a variety of application layer attacks originating from within your cluster such as [SQL injection](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html). Given that attacks on apps are the [leading cause of breaches](https://www.f5.com/labs/articles/threat-intelligence/application-protection-report-2019--episode-2--2018-breach-trend), you need to secure the HTTP traffic inside your cluster.
 
 Historically, web application firewalls (WAFs) were deployed at the edge of your cluster to filter incoming traffic. Our workload-based WAF solution takes a unique, cloud-native approach to web security by allowing you to implement zero-trust rules for workloads inside your cluster.
 
@@ -25,7 +25,7 @@ Historically, web application firewalls (WAFs) were deployed at the edge of your
 ### About $[prodname] WAF
 
 WAF is deployed in your cluster with Envoy as a sidecar container on your pods. $[prodname] proxies traffic through Envoy, checking HTTP requests using the industry-standard
-[ModSecurity](https://owasp.org/www-project-modsecurity-core-rule-set/) with OWASP Core Rule Set `v4.7.0` with some modifications for Kubernetes workloads.
+[ModSecurity](https://coreruleset.org/) with OWASP Core Rule Set `v4.7.0` with some modifications for Kubernetes workloads.
 
 You simply enable WAF in the web console, and determine the deployments that you want to enable for WAF protection. By default WAF is set to `DetectionOnly` so no traffic will be denied until you are ready to turn on blocking mode.
 

--- a/calico-enterprise_versioned_docs/version-3.24-2/threat/gateway-waf/overview.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/threat/gateway-waf/overview.mdx
@@ -18,7 +18,7 @@ Protect the traffic entering your cluster through $[prodname] Ingress Gateway wi
 
 Edge WAFs traditionally apply one ruleset to everything behind the gateway. Gateway WAF takes a Kubernetes-native, multi-tenant approach: a cluster operator sets a security baseline once, and each application team layers its own rules and exceptions on top — scoped to their own Gateways and `HTTPRoute`s, within guardrails the cluster operator defines.
 
-Gateway WAF runs the industry-standard [OWASP ModSecurity Core Rule Set v4](https://owasp.org/www-project-modsecurity-core-rule-set/) as a [Coraza](https://coraza.io/) WebAssembly filter inside Envoy Gateway — no sidecars, and no traffic ever leaves the proxy for inspection.
+Gateway WAF runs the industry-standard [OWASP ModSecurity Core Rule Set v4](https://coreruleset.org/) as a [Coraza](https://coraza.io/) WebAssembly filter inside Envoy Gateway — no sidecars, and no traffic ever leaves the proxy for inspection.
 
 ## How it works
 

--- a/calico-enterprise_versioned_docs/version-3.24-2/threat/web-application-firewall.mdx
+++ b/calico-enterprise_versioned_docs/version-3.24-2/threat/web-application-firewall.mdx
@@ -16,7 +16,7 @@ Protect cloud-native applications from application layer attacks with $[prodname
 
 ## Value
 
-Our workload-centric Web Application Firewall (WAF) protects your workloads from a variety of application layer attacks originating from within your cluster such as [SQL injection](https://owasp.org/www-community/attacks/SQL_Injection). Given that attacks on apps are the [leading cause of breaches](https://www.f5.com/labs/articles/threat-intelligence/application-protection-report-2019--episode-2--2018-breach-trend), you need to secure the HTTP traffic inside your cluster.
+Our workload-centric Web Application Firewall (WAF) protects your workloads from a variety of application layer attacks originating from within your cluster such as [SQL injection](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html). Given that attacks on apps are the [leading cause of breaches](https://www.f5.com/labs/articles/threat-intelligence/application-protection-report-2019--episode-2--2018-breach-trend), you need to secure the HTTP traffic inside your cluster.
 
 Historically, web application firewalls (WAFs) were deployed at the edge of your cluster to filter incoming traffic. Our workload-based WAF solution takes a unique, cloud-native approach to web security by allowing you to implement zero-trust rules for workloads inside your cluster.
 
@@ -25,7 +25,7 @@ Historically, web application firewalls (WAFs) were deployed at the edge of your
 ### About $[prodname] WAF
 
 WAF is deployed in your cluster with Envoy as a sidecar container on your pods. $[prodname] proxies traffic through Envoy, checking HTTP requests using the industry-standard
-[ModSecurity](https://owasp.org/www-project-modsecurity-core-rule-set/) with OWASP Core Rule Set `v4.7.0` with some modifications for Kubernetes workloads.
+[ModSecurity](https://coreruleset.org/) with OWASP Core Rule Set `v4.7.0` with some modifications for Kubernetes workloads.
 
 You simply enable WAF in the web console, and determine the deployments that you want to enable for WAF protection. By default WAF is set to `DetectionOnly` so no traffic will be denied until you are ready to turn on blocking mode.
 

--- a/calico/network-policy/istio/enforce-policy-istio.mdx
+++ b/calico/network-policy/istio/enforce-policy-istio.mdx
@@ -133,7 +133,7 @@ for what we actually want to be confident of: that the party on the other end
 really is the authorized workload we want to communicate with. Keeping the
 private key a secret is vital to this confidence, and occasionally attackers
 can find ways to trick applications into giving up secrets they should not.
-For example, the [Heartbleed](https://owasp.org/www-community/vulnerabilities/Heartbleed_Bug) vulnerability in OpenSSL allowed attackers to
+For example, the [Heartbleed](https://heartbleed.com/) vulnerability in OpenSSL allowed attackers to
 trick an affected application into reading out portions of its memory,
 compromising private keys.
 

--- a/calico_versioned_docs/version-3.30/network-policy/istio/enforce-policy-istio.mdx
+++ b/calico_versioned_docs/version-3.30/network-policy/istio/enforce-policy-istio.mdx
@@ -133,7 +133,7 @@ for what we actually want to be confident of: that the party on the other end
 really is the authorized workload we want to communicate with. Keeping the
 private key a secret is vital to this confidence, and occasionally attackers
 can find ways to trick applications into giving up secrets they should not.
-For example, the [Heartbleed](https://owasp.org/www-community/vulnerabilities/Heartbleed_Bug) vulnerability in OpenSSL allowed attackers to
+For example, the [Heartbleed](https://heartbleed.com/) vulnerability in OpenSSL allowed attackers to
 trick an affected application into reading out portions of its memory,
 compromising private keys.
 

--- a/calico_versioned_docs/version-3.31/network-policy/istio/enforce-policy-istio.mdx
+++ b/calico_versioned_docs/version-3.31/network-policy/istio/enforce-policy-istio.mdx
@@ -133,7 +133,7 @@ for what we actually want to be confident of: that the party on the other end
 really is the authorized workload we want to communicate with. Keeping the
 private key a secret is vital to this confidence, and occasionally attackers
 can find ways to trick applications into giving up secrets they should not.
-For example, the [Heartbleed](https://owasp.org/www-community/vulnerabilities/Heartbleed_Bug) vulnerability in OpenSSL allowed attackers to
+For example, the [Heartbleed](https://heartbleed.com/) vulnerability in OpenSSL allowed attackers to
 trick an affected application into reading out portions of its memory,
 compromising private keys.
 

--- a/calico_versioned_docs/version-3.32/network-policy/istio/enforce-policy-istio.mdx
+++ b/calico_versioned_docs/version-3.32/network-policy/istio/enforce-policy-istio.mdx
@@ -133,7 +133,7 @@ for what we actually want to be confident of: that the party on the other end
 really is the authorized workload we want to communicate with. Keeping the
 private key a secret is vital to this confidence, and occasionally attackers
 can find ways to trick applications into giving up secrets they should not.
-For example, the [Heartbleed](https://owasp.org/www-community/vulnerabilities/Heartbleed_Bug) vulnerability in OpenSSL allowed attackers to
+For example, the [Heartbleed](https://heartbleed.com/) vulnerability in OpenSSL allowed attackers to
 trick an affected application into reading out portions of its memory,
 compromising private keys.
 


### PR DESCRIPTION
OWASP retired the old wiki-style URL scheme on owasp.org (`www-community/*`, `www-project-*`), so three links across the repo now 404 and fail the site-wide link checker on every PR.

Jira: https://tigera.atlassian.net/browse/DOCS-3045

Replacements:
- SQL injection: https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
- Heartbleed: https://heartbleed.com/
- OWASP ModSecurity Core Rule Set: https://coreruleset.org/ (the project's own site)

Representative pages:
- https://docs.tigera.io/calico-enterprise/latest/threat/web-application-firewall
- https://docs.tigera.io/calico/latest/network-policy/istio/enforce-policy-istio

Verified locally: `make netlify` (build + link-checker crawl) now passes with zero dead links.